### PR TITLE
[comgr][hotswap] Close finite materialized-call components

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -552,9 +552,8 @@ getSetPcGatewayLayoutSize(uint64_t FromOffset, uint64_t TargetOffset,
   return PrefixBytes + *SetPcBytes;
 }
 
-static bool gatewayRangeIsOccupied(
-    uint64_t Begin, uint64_t Size,
-    const DenseSet<uint64_t> *Occupied) {
+static bool gatewayRangeIsOccupied(uint64_t Begin, uint64_t Size,
+                                   const DenseSet<uint64_t> *Occupied) {
   if (!Occupied)
     return false;
   for (uint64_t Offset = 0; Offset < Size; Offset += MinInstSize)
@@ -624,8 +623,7 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
 std::optional<EncodedSplitVccGateway>
 findSplitVccGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                     uint64_t FromOffset, uint64_t TargetOffset,
-                    unsigned SaveSgpr,
-                    const DenseSet<uint64_t> *Occupied) {
+                    unsigned SaveSgpr, const DenseSet<uint64_t> *Occupied) {
   constexpr uint64_t PrimaryBytes = 2 * MinInstSize;
   constexpr uint64_t SecondaryBytes = SetPcForwardSequenceBytes - MinInstSize;
   SmallVector<size_t, 32> PrimaryCandidates;
@@ -1020,8 +1018,7 @@ static bool instructionWritesRegister(const InternalDecodedInst &DI,
 }
 
 bool instructionFullyWritesRegister(const InternalDecodedInst &DI,
-                                    const LLVMState &LS,
-                                    MCRegister Register) {
+                                    const LLVMState &LS, MCRegister Register) {
   auto DefinitionCoversRegister = [&](MCRegister Def) {
     return Def.isValid() && LS.MRI->isSubRegisterEq(Def, Register);
   };
@@ -1146,20 +1143,20 @@ static bool isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx,
   return true;
 }
 
-std::optional<DenseSet<uint64_t>> computeIncomingRegisterNeeds(
-    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-    uint64_t FunctionBegin, uint64_t FunctionEnd, MCRegister Register) {
+std::optional<DenseSet<uint64_t>>
+computeIncomingRegisterNeeds(ArrayRef<InternalDecodedInst> Decoded,
+                             const LLVMState &LS, uint64_t FunctionBegin,
+                             uint64_t FunctionEnd, MCRegister Register) {
   if (!LS.MIA || FunctionBegin >= FunctionEnd)
     return std::nullopt;
 
-  auto Begin = llvm::lower_bound(
-      Decoded, FunctionBegin,
-      [](const InternalDecodedInst &DI, uint64_t Offset) {
-        return DI.Offset < Offset;
-      });
+  auto Begin =
+      llvm::lower_bound(Decoded, FunctionBegin,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
   auto End = llvm::lower_bound(
-      Decoded, FunctionEnd,
-      [](const InternalDecodedInst &DI, uint64_t Offset) {
+      Decoded, FunctionEnd, [](const InternalDecodedInst &DI, uint64_t Offset) {
         return DI.Offset < Offset;
       });
   if (Begin == End)
@@ -1174,8 +1171,7 @@ std::optional<DenseSet<uint64_t>> computeIncomingRegisterNeeds(
     if (Offset < FunctionBegin || Offset >= FunctionEnd)
       return std::nullopt;
     auto It = std::lower_bound(
-        Begin, End, Offset,
-        [](const InternalDecodedInst &DI, uint64_t Target) {
+        Begin, End, Offset, [](const InternalDecodedInst &DI, uint64_t Target) {
           return DI.Offset < Target;
         });
     if (It == End || It->Offset != Offset)
@@ -1216,8 +1212,7 @@ std::optional<DenseSet<uint64_t>> computeIncomingRegisterNeeds(
     };
 
     if (LS.MIA->isBranch(DI.Inst)) {
-      std::optional<uint64_t> Target =
-          evaluateDirectControlFlowTarget(DI, LS);
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
       if (Target)
         AddSuccessor(*Target);
       else
@@ -1245,8 +1240,7 @@ std::optional<DenseSet<uint64_t>> computeIncomingRegisterNeeds(
   while (!Worklist.empty()) {
     size_t Successor = Worklist.pop_back_val();
     for (size_t Predecessor : Predecessors[Successor]) {
-      if (NeedsIncoming.test(Predecessor) ||
-          FullDefinitions.test(Predecessor))
+      if (NeedsIncoming.test(Predecessor) || FullDefinitions.test(Predecessor))
         continue;
       NeedsIncoming.set(Predecessor);
       Worklist.push_back(Predecessor);
@@ -1438,8 +1432,8 @@ struct BatchedSgprContinuationAnalysis {
   unsigned WordsPerRow = 0;
   std::vector<uint64_t> UnsafeRows;
 
-  std::optional<BitVector>
-  query(ArrayRef<InternalDecodedInst> Decoded, uint64_t Continuation) const {
+  std::optional<BitVector> query(ArrayRef<InternalDecodedInst> Decoded,
+                                 uint64_t Continuation) const {
     if (Continuation < FunctionBegin || Continuation >= FunctionEnd)
       return std::nullopt;
     auto Begin = Decoded.begin() + BeginIndex;
@@ -1453,8 +1447,7 @@ struct BatchedSgprContinuationAnalysis {
         It->Offset != Continuation)
       return std::nullopt;
     size_t LocalIndex = It - Begin;
-    const uint64_t *Row =
-        UnsafeRows.data() + LocalIndex * WordsPerRow;
+    const uint64_t *Row = UnsafeRows.data() + LocalIndex * WordsPerRow;
     BitVector Result(RegisterCount);
     for (unsigned Register = 0; Register != RegisterCount; ++Register)
       if ((Row[Register / 64] >> (Register % 64)) & 1)
@@ -1464,20 +1457,20 @@ struct BatchedSgprContinuationAnalysis {
 };
 
 static std::optional<BatchedSgprContinuationAnalysis>
-computeBatchedSgprContinuationAnalysis(
-    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-    uint64_t FunctionBegin, uint64_t FunctionEnd,
-    ArrayRef<MCRegister> NumberedSgprs) {
+computeBatchedSgprContinuationAnalysis(ArrayRef<InternalDecodedInst> Decoded,
+                                       const LLVMState &LS,
+                                       uint64_t FunctionBegin,
+                                       uint64_t FunctionEnd,
+                                       ArrayRef<MCRegister> NumberedSgprs) {
   if (!LS.MIA || FunctionBegin >= FunctionEnd)
     return std::nullopt;
-  auto Begin = llvm::lower_bound(
-      Decoded, FunctionBegin,
-      [](const InternalDecodedInst &DI, uint64_t Offset) {
-        return DI.Offset < Offset;
-      });
+  auto Begin =
+      llvm::lower_bound(Decoded, FunctionBegin,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
   auto End = llvm::lower_bound(
-      Decoded, FunctionEnd,
-      [](const InternalDecodedInst &DI, uint64_t Offset) {
+      Decoded, FunctionEnd, [](const InternalDecodedInst &DI, uint64_t Offset) {
         return DI.Offset < Offset;
       });
   if (Begin == End)
@@ -1507,11 +1500,11 @@ computeBatchedSgprContinuationAnalysis(
   auto FindLocalIndex = [&](uint64_t Offset) -> std::optional<size_t> {
     if (Offset < FunctionBegin || Offset >= FunctionEnd)
       return std::nullopt;
-    auto It = llvm::lower_bound(
-        ArrayRef<InternalDecodedInst>(Begin, End), Offset,
-        [](const InternalDecodedInst &DI, uint64_t Target) {
-          return DI.Offset < Target;
-        });
+    auto It =
+        llvm::lower_bound(ArrayRef<InternalDecodedInst>(Begin, End), Offset,
+                          [](const InternalDecodedInst &DI, uint64_t Target) {
+                            return DI.Offset < Target;
+                          });
     if (It == ArrayRef<InternalDecodedInst>(Begin, End).end() ||
         It->Offset != Offset)
       return std::nullopt;
@@ -1590,8 +1583,7 @@ computeBatchedSgprContinuationAnalysis(
     Queued.reset(I);
     const uint64_t *Uses = UsesRows.data() + I * Result.WordsPerRow;
     const uint64_t *Defs = DefsRows.data() + I * Result.WordsPerRow;
-    uint64_t *Unsafe =
-        Result.UnsafeRows.data() + I * Result.WordsPerRow;
+    uint64_t *Unsafe = Result.UnsafeRows.data() + I * Result.WordsPerRow;
     bool Changed = false;
     for (unsigned Word = 0; Word != Result.WordsPerRow; ++Word) {
       uint64_t SuccessorUnsafe =
@@ -1599,10 +1591,8 @@ computeBatchedSgprContinuationAnalysis(
       for (size_t Successor : Successors[I])
         SuccessorUnsafe |=
             Result.UnsafeRows[Successor * Result.WordsPerRow + Word];
-      uint64_t NewUnsafe =
-          Uses[Word] | (SuccessorUnsafe & ~Defs[Word]);
-      if (Word + 1 == Result.WordsPerRow &&
-          Result.RegisterCount % 64 != 0)
+      uint64_t NewUnsafe = Uses[Word] | (SuccessorUnsafe & ~Defs[Word]);
+      if (Word + 1 == Result.WordsPerRow && Result.RegisterCount % 64 != 0)
         NewUnsafe &= (uint64_t{1} << (Result.RegisterCount % 64)) - 1;
       uint64_t Added = NewUnsafe & ~Unsafe[Word];
       if (Added != 0) {
@@ -1621,20 +1611,18 @@ computeBatchedSgprContinuationAnalysis(
   return Result;
 }
 
-BatchedSgprContinuationTestResult
-runBatchedSgprContinuationAnalysisForTest(
+BatchedSgprContinuationTestResult runBatchedSgprContinuationAnalysisForTest(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t FunctionBegin, uint64_t FunctionEnd,
-    ArrayRef<uint64_t> Continuations,
-    ArrayRef<MCRegister> NumberedSgprs) {
+    ArrayRef<uint64_t> Continuations, ArrayRef<MCRegister> NumberedSgprs) {
   BatchedSgprContinuationTestResult Result;
   std::optional<BatchedSgprContinuationAnalysis> Analysis =
-      computeBatchedSgprContinuationAnalysis(
-          Decoded, LS, FunctionBegin, FunctionEnd, NumberedSgprs);
+      computeBatchedSgprContinuationAnalysis(Decoded, LS, FunctionBegin,
+                                             FunctionEnd, NumberedSgprs);
   Result.Analyses = 1;
   for (uint64_t Continuation : Continuations)
-    Result.Queries.push_back(
-        Analysis ? Analysis->query(Decoded, Continuation) : std::nullopt);
+    Result.Queries.push_back(Analysis ? Analysis->query(Decoded, Continuation)
+                                      : std::nullopt);
   return Result;
 }
 
@@ -1696,8 +1684,8 @@ using BatchedSgprContinuationCache =
 static std::optional<unsigned> findLocallyDeadSgprPairWithCache(
     PatchContext &Ctx, const ElfView::FunctionTextRange &FunctionRange,
     uint64_t InstOffset, uint32_t InstSize, ArrayRef<uint8_t> Replacement,
-    ArrayRef<MCRegister> NumberedSgprs,
-    BatchedSgprContinuationCache &Cache, uint64_t &AnalysisCount) {
+    ArrayRef<MCRegister> NumberedSgprs, BatchedSgprContinuationCache &Cache,
+    uint64_t &AnalysisCount) {
   std::optional<uint64_t> Continuation = checkedAddUint64(
       InstOffset, InstSize, "cached far-return SGPR liveness continuation");
   if (!Continuation)
@@ -6583,8 +6571,7 @@ struct BranchIslandFailure {
   bool Forward = false;
 };
 
-using BranchIslandPromoter =
-    std::function<bool(const BranchIslandFailure &)>;
+using BranchIslandPromoter = std::function<bool(const BranchIslandFailure &)>;
 
 using BranchGatewayHead = std::pair<uint64_t, size_t>;
 using BranchGatewayHeadSet = std::set<BranchGatewayHead>;
@@ -6652,8 +6639,7 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
   if (!PersistentOccupied)
     PersistentOccupied = &LocalOccupied;
   if (!PersistentHeads) {
-    LocalHeads =
-        buildBranchGatewayHeads(Gateways, *PersistentOccupied);
+    LocalHeads = buildBranchGatewayHeads(Gateways, *PersistentOccupied);
     PersistentHeads = &LocalHeads;
   }
   BranchGatewayHeadSet &Heads = *PersistentHeads;
@@ -6675,15 +6661,13 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
       auto It =
           TargetOffset <= ReachEnd
               ? Heads.lower_bound({Upper, 0})
-              : Heads.upper_bound(
-                    {Upper, std::numeric_limits<size_t>::max()});
+              : Heads.upper_bound({Upper, std::numeric_limits<size_t>::max()});
       while (It != Heads.begin()) {
         --It;
         if (It->first <= Current)
           break;
         const NopSled &Sled = Gateways[It->second];
-        if (FromOffset < Sled.FunctionStart ||
-            FromOffset >= Sled.FunctionEnd ||
+        if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd ||
             Sled.WritePos != It->first ||
             !isSBranchReachable(Current, It->first))
           continue;
@@ -6694,16 +6678,14 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
     } else {
       uint64_t ReachBegin =
           Current > MaxSledDistance ? Current - MaxSledDistance : 0;
-      uint64_t Lower =
-          TargetOffset == std::numeric_limits<uint64_t>::max()
-              ? TargetOffset
-              : TargetOffset + 1;
+      uint64_t Lower = TargetOffset == std::numeric_limits<uint64_t>::max()
+                           ? TargetOffset
+                           : TargetOffset + 1;
       Lower = std::max(Lower, ReachBegin);
       for (auto It = Heads.lower_bound({Lower, 0});
            It != Heads.end() && It->first < Current; ++It) {
         const NopSled &Sled = Gateways[It->second];
-        if (FromOffset < Sled.FunctionStart ||
-            FromOffset >= Sled.FunctionEnd ||
+        if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd ||
             Sled.WritePos != It->first ||
             !isSBranchReachable(Current, It->first))
           continue;
@@ -6714,18 +6696,15 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
     }
 
     if (BestIndex == Gateways.size()) {
-      uint64_t Corridor =
-          Forward ? std::numeric_limits<uint64_t>::max() : 0;
+      uint64_t Corridor = Forward ? std::numeric_limits<uint64_t>::max() : 0;
       if (Forward) {
-        uint64_t AfterCurrent =
-            Current == std::numeric_limits<uint64_t>::max()
-                ? Current
-                : Current + 1;
+        uint64_t AfterCurrent = Current == std::numeric_limits<uint64_t>::max()
+                                    ? Current
+                                    : Current + 1;
         for (auto It = Heads.lower_bound({AfterCurrent, 0});
              It != Heads.end() && It->first < TargetOffset; ++It) {
           const NopSled &Sled = Gateways[It->second];
-          if (FromOffset < Sled.FunctionStart ||
-              FromOffset >= Sled.FunctionEnd)
+          if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
             continue;
           Corridor = It->first;
           break;
@@ -6737,8 +6716,7 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
           if (It->first <= TargetOffset)
             break;
           const NopSled &Sled = Gateways[It->second];
-          if (FromOffset < Sled.FunctionStart ||
-              FromOffset >= Sled.FunctionEnd)
+          if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
             continue;
           Corridor = It->first;
           break;
@@ -6748,8 +6726,7 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
         Corridor = TargetOffset;
       if (!Forward && Corridor == 0)
         Corridor = TargetOffset;
-      BranchIslandFailure ThisFailure{Current, TargetOffset, Corridor,
-                                      Forward};
+      BranchIslandFailure ThisFailure{Current, TargetOffset, Corridor, Forward};
       if (Failure)
         *Failure = ThisFailure;
       // No Gateways reference or Heads iterator survives this call. The
@@ -6769,8 +6746,7 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
 
     auto AliasBegin = Heads.lower_bound({BestOffset, 0});
     auto AliasEnd =
-        Heads.upper_bound(
-            {BestOffset, std::numeric_limits<size_t>::max()});
+        Heads.upper_bound({BestOffset, std::numeric_limits<size_t>::max()});
     for (auto It = AliasBegin; It != AliasEnd; ++It) {
       NopSled &Alias = Gateways[It->second];
       Allocations.push_back({It->second, Alias.WritePos});
@@ -6783,8 +6759,7 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
   }
   for (const Allocation &A : Allocations) {
     NopSled &Sled = Gateways[A.SledIndex];
-    while (hasFreeBranchGatewaySlot(Sled) &&
-           Occupied.contains(Sled.WritePos))
+    while (hasFreeBranchGatewaySlot(Sled) && Occupied.contains(Sled.WritePos))
       Sled.WritePos += MinInstSize;
     if (hasFreeBranchGatewaySlot(Sled))
       Heads.insert({Gateways[A.SledIndex].WritePos, A.SledIndex});
@@ -6849,8 +6824,7 @@ class FunctionRangeUniquenessIndex {
 
 public:
   FunctionRangeUniquenessIndex(
-      ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-      uint64_t TextAddr) {
+      ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr) {
     Ranges.reserve(FunctionRanges.size());
     for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
       if (Range.Begin < TextAddr || Range.End < TextAddr)
@@ -6865,8 +6839,7 @@ public:
     Prefix.reserve(Ranges.size());
     PrefixMaximums Top;
     for (size_t I = 0; I != Ranges.size(); ++I) {
-      if (Top.First == NoRange ||
-          Ranges[I].second > Ranges[Top.First].second) {
+      if (Top.First == NoRange || Ranges[I].second > Ranges[Top.First].second) {
         Top.Second = Top.First;
         Top.First = I;
       } else if (Top.Second == NoRange ||
@@ -6880,9 +6853,9 @@ public:
   bool hasUniqueFunctionRange(const Trampoline &T) const {
     if (!T.HasFunctionRange || T.FunctionStart >= T.FunctionEnd)
       return false;
-    std::optional<uint64_t> SourceEnd = checkedAddUint64(
-        T.OriginalOffset, T.OriginalSize,
-        "indexed source-tail unique function end");
+    std::optional<uint64_t> SourceEnd =
+        checkedAddUint64(T.OriginalOffset, T.OriginalSize,
+                         "indexed source-tail unique function end");
     if (!SourceEnd || T.FunctionStart > T.OriginalOffset ||
         T.FunctionEnd < *SourceEnd)
       return false;
@@ -6892,18 +6865,17 @@ public:
     if (SelectedIt == Ranges.end() || *SelectedIt != Selected)
       return false;
 
-    auto PrefixEnd = std::upper_bound(
-        Ranges.begin(), Ranges.end(), T.OriginalOffset,
-        [](uint64_t Offset, const Bounds &Range) {
-          return Offset < Range.first;
-        });
+    auto PrefixEnd =
+        std::upper_bound(Ranges.begin(), Ranges.end(), T.OriginalOffset,
+                         [](uint64_t Offset, const Bounds &Range) {
+                           return Offset < Range.first;
+                         });
     if (PrefixEnd == Ranges.begin())
       return false;
     const PrefixMaximums &Top = Prefix[PrefixEnd - Ranges.begin() - 1];
-    size_t Other =
-        Top.First != NoRange && Ranges[Top.First] == Selected
-            ? Top.Second
-            : Top.First;
+    size_t Other = Top.First != NoRange && Ranges[Top.First] == Selected
+                       ? Top.Second
+                       : Top.First;
     return Other == NoRange || Ranges[Other].second < *SourceEnd;
   }
 };
@@ -7029,10 +7001,10 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
         Ctx.LS, T.OriginalOffset, ThisTP, T.LongBranchSgprBase);
     if (Direct && Direct->size() <= T.OriginalSize)
       continue;
-    std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
-        Ctx, T.OriginalOffset, /*Count=*/4,
-        /*Alignment=*/2, "shared far-dispatch gateway",
-        /*ReportNoSpace=*/false);
+    std::optional<SafeSgprScratchBlock> Scratch =
+        findSafeSgprScratchBlock(Ctx, T.OriginalOffset, /*Count=*/4,
+                                 /*Alignment=*/2, "shared far-dispatch gateway",
+                                 /*ReportNoSpace=*/false);
     if (Scratch) {
       Candidates.push_back({I, Scratch->Base});
     } else {
@@ -7058,10 +7030,9 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
   const std::vector<ElfView::FunctionTextRange> FunctionRanges =
       Ctx.Elf.functionTextRanges();
   const FunctionRangeUniquenessIndex FunctionRangeIndex(FunctionRanges,
-                                                          Ctx.Elf.textAddr());
+                                                        Ctx.Elf.textAddr());
   auto HasSafeTail = [&](const Trampoline &T, uint64_t Begin, uint64_t End) {
-    bool HasUniqueFunctionRange =
-        FunctionRangeIndex.hasUniqueFunctionRange(T);
+    bool HasUniqueFunctionRange = FunctionRangeIndex.hasUniqueFunctionRange(T);
     return isSafeSourceTailRange(T, Ctx.DirectControlFlow,
                                  HasUniqueFunctionRange, Begin, End);
   };
@@ -7759,14 +7730,12 @@ static bool emitSharedDispatchers(PatchContext &Ctx) {
   return true;
 }
 
-static std::optional<SmallVector<uint64_t, 4>>
-allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
-                              uint64_t OwnerOffset, uint64_t FromOffset,
-                              uint64_t TargetOffset,
-                              BranchIslandFailure *Failure = nullptr,
-                              BranchGatewayHeadSet *PersistentHeads = nullptr,
-                              DenseSet<uint64_t> *PersistentOccupied = nullptr,
-                              BranchIslandPromoter Promote = {}) {
+static std::optional<SmallVector<uint64_t, 4>> allocateBackwardBranchIslands(
+    std::vector<NopSled> &Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
+    uint64_t TargetOffset, BranchIslandFailure *Failure = nullptr,
+    BranchGatewayHeadSet *PersistentHeads = nullptr,
+    DenseSet<uint64_t> *PersistentOccupied = nullptr,
+    BranchIslandPromoter Promote = {}) {
   struct Allocation {
     size_t SledIndex = 0;
     uint64_t PreviousWritePos = 0;
@@ -7776,8 +7745,7 @@ allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
   if (!PersistentOccupied)
     PersistentOccupied = &LocalOccupied;
   if (!PersistentHeads) {
-    LocalHeads =
-        buildBranchGatewayHeads(Gateways, *PersistentOccupied);
+    LocalHeads = buildBranchGatewayHeads(Gateways, *PersistentOccupied);
     PersistentHeads = &LocalHeads;
   }
   BranchGatewayHeadSet &Heads = *PersistentHeads;
@@ -7791,17 +7759,15 @@ allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
     uint64_t BestOffset = std::numeric_limits<uint64_t>::max();
     uint64_t ReachBegin =
         Current > MaxSledDistance ? Current - MaxSledDistance : 0;
-    uint64_t Lower =
-        TargetOffset == std::numeric_limits<uint64_t>::max()
-            ? TargetOffset
-            : TargetOffset + 1;
+    uint64_t Lower = TargetOffset == std::numeric_limits<uint64_t>::max()
+                         ? TargetOffset
+                         : TargetOffset + 1;
     Lower = std::max(Lower, ReachBegin);
     for (auto It = Heads.lower_bound({Lower, 0});
          It != Heads.end() && It->first < Current; ++It) {
       const NopSled &Sled = Gateways[It->second];
-      if (OwnerOffset < Sled.FunctionStart ||
-          OwnerOffset >= Sled.FunctionEnd || Sled.WritePos != It->first ||
-          !isSBranchReachable(Current, It->first))
+      if (OwnerOffset < Sled.FunctionStart || OwnerOffset >= Sled.FunctionEnd ||
+          Sled.WritePos != It->first || !isSBranchReachable(Current, It->first))
         continue;
       BestIndex = It->second;
       BestOffset = It->first;
@@ -7816,8 +7782,7 @@ allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
         if (CorridorIt->first <= TargetOffset)
           break;
         const NopSled &Sled = Gateways[CorridorIt->second];
-        if (OwnerOffset < Sled.FunctionStart ||
-            OwnerOffset >= Sled.FunctionEnd)
+        if (OwnerOffset < Sled.FunctionStart || OwnerOffset >= Sled.FunctionEnd)
           continue;
         Corridor = CorridorIt->first;
         break;
@@ -7842,8 +7807,7 @@ allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
       uint64_t HighestReachableToTarget = 0;
       for (const BranchGatewayHead &Head : Heads) {
         const NopSled &Sled = Gateways[Head.second];
-        if (OwnerOffset < Sled.FunctionStart ||
-            OwnerOffset >= Sled.FunctionEnd)
+        if (OwnerOffset < Sled.FunctionStart || OwnerOffset >= Sled.FunctionEnd)
           continue;
         ++EligibleOwnerSleds;
         if (Head.first <= TargetOffset || Head.first >= Current)
@@ -7867,9 +7831,8 @@ allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
                     HighestCorridor ? HighestCorridor : TargetOffset,
                     /*Forward=*/false};
       log() << "hotswap: backward return allocator stranded owner 0x"
-            << utohexstr(OwnerOffset) << ": from=0x"
-            << utohexstr(FromOffset) << ", current=0x"
-            << utohexstr(Current) << ", target=0x"
+            << utohexstr(OwnerOffset) << ": from=0x" << utohexstr(FromOffset)
+            << ", current=0x" << utohexstr(Current) << ", target=0x"
             << utohexstr(TargetOffset) << ", selected=" << Islands.size()
             << ", owner-sleds=" << EligibleOwnerSleds
             << ", free-corridor=" << FreeCorridorSleds
@@ -7897,8 +7860,7 @@ allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
 
     auto AliasBegin = Heads.lower_bound({BestOffset, 0});
     auto AliasEnd =
-        Heads.upper_bound(
-            {BestOffset, std::numeric_limits<size_t>::max()});
+        Heads.upper_bound({BestOffset, std::numeric_limits<size_t>::max()});
     for (auto It = AliasBegin; It != AliasEnd; ++It) {
       NopSled &Alias = Gateways[It->second];
       Allocations.push_back({It->second, Alias.WritePos});
@@ -7911,8 +7873,7 @@ allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
   }
   for (const Allocation &A : Allocations) {
     NopSled &Sled = Gateways[A.SledIndex];
-    while (hasFreeBranchGatewaySlot(Sled) &&
-           Occupied.contains(Sled.WritePos))
+    while (hasFreeBranchGatewaySlot(Sled) && Occupied.contains(Sled.WritePos))
       Sled.WritePos += MinInstSize;
     if (hasFreeBranchGatewaySlot(Sled))
       Heads.insert({Gateways[A.SledIndex].WritePos, A.SledIndex});
@@ -7923,16 +7884,14 @@ allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
 BranchIslandAllocatorTestResult runBranchIslandAllocatorForTest(
     std::vector<NopSled> Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
     uint64_t TargetOffset, bool Backward, DenseSet<uint64_t> Occupied) {
-  BranchGatewayHeadSet Heads =
-      buildBranchGatewayHeads(Gateways, Occupied);
+  BranchGatewayHeadSet Heads = buildBranchGatewayHeads(Gateways, Occupied);
   std::optional<SmallVector<uint64_t, 4>> Islands =
       Backward
-          ? allocateBackwardBranchIslands(
-                Gateways, OwnerOffset, FromOffset, TargetOffset, nullptr,
-                &Heads, &Occupied)
-          : allocateForwardBranchIslands(
-                Gateways, FromOffset, TargetOffset, nullptr, &Heads,
-                &Occupied);
+          ? allocateBackwardBranchIslands(Gateways, OwnerOffset, FromOffset,
+                                          TargetOffset, nullptr, &Heads,
+                                          &Occupied)
+          : allocateForwardBranchIslands(Gateways, FromOffset, TargetOffset,
+                                         nullptr, &Heads, &Occupied);
   BranchIslandAllocatorTestResult Result;
   Result.Success = Islands.has_value();
   if (Islands)
@@ -7942,13 +7901,11 @@ BranchIslandAllocatorTestResult runBranchIslandAllocatorForTest(
   return Result;
 }
 
-BranchIslandAllocatorTestResult
-runBranchIslandAllocatorWithPromotionsForTest(
+BranchIslandAllocatorTestResult runBranchIslandAllocatorWithPromotionsForTest(
     std::vector<NopSled> Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
     uint64_t TargetOffset, bool Backward, ArrayRef<NopSled> Promotions) {
   DenseSet<uint64_t> Occupied;
-  BranchGatewayHeadSet Heads =
-      buildBranchGatewayHeads(Gateways, Occupied);
+  BranchGatewayHeadSet Heads = buildBranchGatewayHeads(Gateways, Occupied);
   SmallVector<size_t, 4> HeldCounts;
   size_t NextPromotion = 0;
   BranchIslandPromoter Promote = [&](const BranchIslandFailure &) {
@@ -7958,8 +7915,7 @@ runBranchIslandAllocatorWithPromotionsForTest(
     size_t Index = Gateways.size();
     Gateways.push_back(Promotions[NextPromotion++]);
     NopSled &Added = Gateways.back();
-    while (hasFreeBranchGatewaySlot(Added) &&
-           Occupied.contains(Added.WritePos))
+    while (hasFreeBranchGatewaySlot(Added) && Occupied.contains(Added.WritePos))
       Added.WritePos += MinInstSize;
     if (hasFreeBranchGatewaySlot(Added))
       Heads.insert({Added.WritePos, Index});
@@ -7967,12 +7923,11 @@ runBranchIslandAllocatorWithPromotionsForTest(
   };
   std::optional<SmallVector<uint64_t, 4>> Islands =
       Backward
-          ? allocateBackwardBranchIslands(
-                Gateways, OwnerOffset, FromOffset, TargetOffset, nullptr,
-                &Heads, &Occupied, Promote)
-          : allocateForwardBranchIslands(
-                Gateways, FromOffset, TargetOffset, nullptr, &Heads,
-                &Occupied, Promote);
+          ? allocateBackwardBranchIslands(Gateways, OwnerOffset, FromOffset,
+                                          TargetOffset, nullptr, &Heads,
+                                          &Occupied, Promote)
+          : allocateForwardBranchIslands(Gateways, FromOffset, TargetOffset,
+                                         nullptr, &Heads, &Occupied, Promote);
   BranchIslandAllocatorTestResult Result;
   Result.Success = Islands.has_value();
   if (Islands)
@@ -7983,8 +7938,9 @@ runBranchIslandAllocatorWithPromotionsForTest(
   return Result;
 }
 
-std::vector<NopSled> subtractOccupiedBranchGatewaySlotsForTest(
-    std::vector<NopSled> Gateways, const DenseSet<uint64_t> &Occupied) {
+std::vector<NopSled>
+subtractOccupiedBranchGatewaySlotsForTest(std::vector<NopSled> Gateways,
+                                          const DenseSet<uint64_t> &Occupied) {
   subtractOccupiedBranchGatewaySlots(Gateways, Occupied);
   return Gateways;
 }
@@ -7992,12 +7948,10 @@ std::vector<NopSled> subtractOccupiedBranchGatewaySlotsForTest(
 std::pair<uint64_t, uint64_t>
 branchPromotionSearchRangeForTest(uint64_t CurrentOffset,
                                   uint64_t CorridorOffset, bool Forward) {
-  constexpr uint64_t MinSourceBytes =
-      SetPcForwardSequenceBytes + MinInstSize;
+  constexpr uint64_t MinSourceBytes = SetPcForwardSequenceBytes + MinInstSize;
   if (Forward) {
     uint64_t ReachEnd =
-        CurrentOffset >
-                std::numeric_limits<uint64_t>::max() - MaxSledDistance
+        CurrentOffset > std::numeric_limits<uint64_t>::max() - MaxSledDistance
             ? std::numeric_limits<uint64_t>::max()
             : CurrentOffset + MaxSledDistance;
     return {CurrentOffset, std::min(CorridorOffset, ReachEnd)};
@@ -8034,8 +7988,7 @@ static int findNextPromotionCandidateIndex(
     else if (BeginIndex == 0)
       Found = StillPossible.find_first();
     else
-      Found =
-          StillPossible.find_next(static_cast<unsigned>(BeginIndex - 1));
+      Found = StillPossible.find_next(static_cast<unsigned>(BeginIndex - 1));
     if (Found < 0 || static_cast<size_t>(Found) >= EndIndex)
       return -1;
   }
@@ -8053,8 +8006,8 @@ SmallVector<size_t, 8> promotionCandidateOrderForTest(
   SmallVector<size_t, 8> Order;
   std::optional<size_t> Previous;
   while (true) {
-    int Found = findNextPromotionCandidateIndex(
-        StillPossible, BeginIndex, EndIndex, Forward, Previous);
+    int Found = findNextPromotionCandidateIndex(StillPossible, BeginIndex,
+                                                EndIndex, Forward, Previous);
     if (Found < 0)
       break;
     size_t Index = static_cast<size_t>(Found);
@@ -8149,10 +8102,9 @@ static bool emitMirroredStubGateways(PatchContext &Ctx) {
   return true;
 }
 
-static std::optional<uint64_t>
-sourceTailBranchTarget(const Trampoline &T, uint64_t Offset) {
-  for (const auto &[RelayOffset, TargetOffset] :
-       T.SourceTailBranchIslands)
+static std::optional<uint64_t> sourceTailBranchTarget(const Trampoline &T,
+                                                      uint64_t Offset) {
+  for (const auto &[RelayOffset, TargetOffset] : T.SourceTailBranchIslands)
     if (RelayOffset == Offset)
       return TargetOffset;
   return std::nullopt;
@@ -8160,8 +8112,7 @@ sourceTailBranchTarget(const Trampoline &T, uint64_t Offset) {
 
 static bool recordSourceTailBranchIsland(Trampoline &T, uint64_t Offset,
                                          uint64_t Target) {
-  if (std::optional<uint64_t> Existing =
-          sourceTailBranchTarget(T, Offset))
+  if (std::optional<uint64_t> Existing = sourceTailBranchTarget(T, Offset))
     return *Existing == Target;
   T.SourceTailBranchIslands.push_back({Offset, Target});
   return true;
@@ -8186,10 +8137,9 @@ assignLongBranchGateways(PatchContext &Ctx,
   const std::vector<ElfView::FunctionTextRange> FunctionRanges =
       Ctx.Elf.functionTextRanges();
   const FunctionRangeUniquenessIndex FunctionRangeIndex(FunctionRanges,
-                                                          Ctx.Elf.textAddr());
+                                                        Ctx.Elf.textAddr());
   auto HasSafeTail = [&](const Trampoline &T, uint64_t Begin, uint64_t End) {
-    bool HasUniqueFunctionRange =
-        FunctionRangeIndex.hasUniqueFunctionRange(T);
+    bool HasUniqueFunctionRange = FunctionRangeIndex.hasUniqueFunctionRange(T);
     return isSafeSourceTailRange(T, Ctx.DirectControlFlow,
                                  HasUniqueFunctionRange, Begin, End);
   };
@@ -8262,8 +8212,7 @@ assignLongBranchGateways(PatchContext &Ctx,
     // Collect pair-backed source tails into one sparse backbone. These tails
     // are withheld from affine planning below, then reactivated after
     // forward-mode selection proves that their second dword is unreachable.
-    SmallVector<std::pair<uint64_t, uint64_t>, 64>
-        SourceTailBackboneCandidates;
+    SmallVector<std::pair<uint64_t, uint64_t>, 64> SourceTailBackboneCandidates;
 
     // Shared-dispatch sources can also use one-dword direct calls: their link
     // pair is exactly the source-PC identity consumed by the dispatcher. Keep
@@ -8595,8 +8544,7 @@ assignLongBranchGateways(PatchContext &Ctx,
         RelativeOffset == MinInstSize &&
         (OwnerT.UsesSharedDispatcherForward ||
          (OwnerT.UsesSetPCBack && !OwnerT.UsesDirectSetPCForward));
-    if (!OwnerT.Long || OwnerT.LongBranchPreservesVcc ||
-        !HasOneDwordForward ||
+    if (!OwnerT.Long || OwnerT.LongBranchPreservesVcc || !HasOneDwordForward ||
         !HasSafeTail(OwnerT, KV.first, KV.first + MinInstSize) ||
         sourceTailBranchTarget(OwnerT, KV.first))
       continue;
@@ -8708,8 +8656,7 @@ assignLongBranchGateways(PatchContext &Ctx,
       collectIndirectControlFlowFunctions(
           Ctx.Decoded, Ctx.LS, Ctx.Elf,
           Ctx.DirectControlFlow.BoundedIndirectTransfers);
-  DenseMap<std::pair<uint64_t, uint64_t>,
-           std::optional<DenseSet<uint64_t>>>
+  DenseMap<std::pair<uint64_t, uint64_t>, std::optional<DenseSet<uint64_t>>>
       PromotionVccNeedsCache;
   std::optional<SmallVector<MCRegister, 128>> PromotionNumberedSgprs =
       resolveNumberedSgprRegisters(*Ctx.LS.MRI, Ctx.Config.MaxSgprs);
@@ -8743,23 +8690,21 @@ assignLongBranchGateways(PatchContext &Ctx,
     return It->second > Begin;
   };
   for (const Trampoline &T : Ctx.OutTrampolines)
-    ReservePromotionRange(T.OriginalOffset,
-                          T.OriginalOffset + T.OriginalSize);
+    ReservePromotionRange(T.OriginalOffset, T.OriginalOffset + T.OriginalSize);
   for (const NopSled &Gateway : Gateways)
     ReservePromotionRange(Gateway.Start, Gateway.End);
-  auto IsVccDeadAtContinuation =
-      [&](const ElfView::FunctionTextRange &Function, uint64_t Start,
-          uint32_t Size) {
-    std::optional<uint64_t> Continuation = checkedAddUint64(
-        Start, Size, "promoted VCC liveness continuation");
+  auto IsVccDeadAtContinuation = [&](const ElfView::FunctionTextRange &Function,
+                                     uint64_t Start, uint32_t Size) {
+    std::optional<uint64_t> Continuation =
+        checkedAddUint64(Start, Size, "promoted VCC liveness continuation");
     if (!Continuation || *Continuation < Function.Begin ||
         *Continuation >= Function.End)
       return false;
-    auto ContinuationIt = llvm::lower_bound(
-        Ctx.Decoded, *Continuation,
-        [](const InternalDecodedInst &DI, uint64_t Offset) {
-          return DI.Offset < Offset;
-        });
+    auto ContinuationIt =
+        llvm::lower_bound(Ctx.Decoded, *Continuation,
+                          [](const InternalDecodedInst &DI, uint64_t Offset) {
+                            return DI.Offset < Offset;
+                          });
     if (ContinuationIt == Ctx.Decoded.end() ||
         ContinuationIt->Offset != *Continuation)
       return false;
@@ -8770,15 +8715,12 @@ assignLongBranchGateways(PatchContext &Ctx,
       std::optional<DenseSet<uint64_t>> Needs =
           computeIncomingRegisterNeeds(Ctx.Decoded, Ctx.LS, Function.Begin,
                                        Function.End, Ctx.LS.VCCRegister);
-      CacheIt =
-          PromotionVccNeedsCache.try_emplace(Key, std::move(Needs)).first;
+      CacheIt = PromotionVccNeedsCache.try_emplace(Key, std::move(Needs)).first;
     }
-    return CacheIt->second &&
-           !CacheIt->second->contains(*Continuation);
+    return CacheIt->second && !CacheIt->second->contains(*Continuation);
   };
   uint64_t PromotedBranchCapacityRelays = 0;
-  SmallVector<std::pair<size_t, uint64_t>, 8>
-      ReturnPromotionBranchOnlyRanges;
+  SmallVector<std::pair<size_t, uint64_t>, 8> ReturnPromotionBranchOnlyRanges;
   bool PlanningRegisterlessReturns = true;
   constexpr uint64_t MinBranchCapacitySourceBytes =
       SetPcForwardSequenceBytes + MinInstSize;
@@ -8789,16 +8731,16 @@ assignLongBranchGateways(PatchContext &Ctx,
     if (SearchBegin >= SearchEnd)
       return false;
     auto TryPromote = [&](bool AllowLocalPair) -> bool {
-      auto Begin = llvm::lower_bound(
-          Ctx.Decoded, SearchBegin,
-          [](const InternalDecodedInst &DI, uint64_t Offset) {
-            return DI.Offset < Offset;
-          });
-      auto End = llvm::lower_bound(
-          Ctx.Decoded, SearchEnd,
-          [](const InternalDecodedInst &DI, uint64_t Offset) {
-            return DI.Offset < Offset;
-          });
+      auto Begin =
+          llvm::lower_bound(Ctx.Decoded, SearchBegin,
+                            [](const InternalDecodedInst &DI, uint64_t Offset) {
+                              return DI.Offset < Offset;
+                            });
+      auto End =
+          llvm::lower_bound(Ctx.Decoded, SearchEnd,
+                            [](const InternalDecodedInst &DI, uint64_t Offset) {
+                              return DI.Offset < Offset;
+                            });
       size_t BeginIndex = static_cast<size_t>(Begin - Ctx.Decoded.begin());
       size_t EndIndex = static_cast<size_t>(End - Ctx.Decoded.begin());
       std::optional<size_t> PreviousIndex;
@@ -8838,19 +8780,16 @@ assignLongBranchGateways(PatchContext &Ctx,
 
         std::optional<ElfView::FunctionTextRange> Function =
             Ctx.Elf.findFunctionTextRangeAtOffset(Start);
-        if (!Function ||
-            PromotionIndirectFunctions.contains(Function->Begin)) {
+        if (!Function || PromotionIndirectFunctions.contains(Function->Begin)) {
           PromotionStillPossible.reset(Index);
           continue;
         }
 
         uint64_t DemandBytes =
             RemainingRelayDemand >
-                    (std::numeric_limits<uint32_t>::max() -
-                     *ProbeDirectSize) /
+                    (std::numeric_limits<uint32_t>::max() - *ProbeDirectSize) /
                         MinInstSize
-                ? std::numeric_limits<uint32_t>::max() -
-                      *ProbeDirectSize
+                ? std::numeric_limits<uint32_t>::max() - *ProbeDirectSize
                 : RemainingRelayDemand * MinInstSize;
         uint64_t DesiredSourceBytes = *ProbeDirectSize + DemandBytes;
         DesiredSourceBytes =
@@ -8879,17 +8818,16 @@ assignLongBranchGateways(PatchContext &Ctx,
                                             PromotionProtectedOffsets) ||
               Current->Inst.getOpcode() == Ctx.LS.SNopOpcode)
             break;
-          std::optional<uint64_t> MemberEnd = checkedAddUint64(
-              Member->Offset, Member->Size,
-              "promoted branch-capacity member end");
+          std::optional<uint64_t> MemberEnd =
+              checkedAddUint64(Member->Offset, Member->Size,
+                               "promoted branch-capacity member end");
           if (!MemberEnd || *MemberEnd > Function->End ||
               Replacement.size() + Member->Size > DesiredSourceBytes ||
               OverlapsPromotionRange(Member->Offset, *MemberEnd))
             break;
 
           if (!FullyWritesVcc &&
-              instructionReadsRegister(*Current, Ctx.LS,
-                                       Ctx.LS.VCCRegister))
+              instructionReadsRegister(*Current, Ctx.LS, Ctx.LS.VCCRegister))
             NeedsIncomingVcc = true;
           if (instructionFullyWritesRegister(*Current, Ctx.LS,
                                              Ctx.LS.VCCRegister))
@@ -8904,8 +8842,7 @@ assignLongBranchGateways(PatchContext &Ctx,
             MinimumReplacementSize = Replacement.size();
           if (Replacement.size() >= MinBranchCapacitySourceBytes &&
               !NeedsIncomingVcc && Ctx.LS.VCCRegister.isValid() &&
-              IsVccDeadAtContinuation(*Function, Start,
-                                      Replacement.size()))
+              IsVccDeadAtContinuation(*Function, Start, Replacement.size()))
             BestVccReplacementSize = Replacement.size();
         }
         if (!MinimumReplacementSize ||
@@ -8965,18 +8902,17 @@ assignLongBranchGateways(PatchContext &Ctx,
         Promoted.DirectSetPCForwardBytes = std::move(*Direct);
         Promoted.HasPoolBranchIsland = true;
 
-        std::optional<uint64_t> NewPoolEnd = checkedAddUint64(
-            PoolEndOffset, Promoted.Bytes.size(),
-            "promoted branch-capacity trampoline layout");
+        std::optional<uint64_t> NewPoolEnd =
+            checkedAddUint64(PoolEndOffset, Promoted.Bytes.size(),
+                             "promoted branch-capacity trampoline layout");
         if (!NewPoolEnd)
           return false;
-        Promoted.PoolBranchIslandOffset =
-            *NewPoolEnd - PoolBranchIslandBytes;
+        Promoted.PoolBranchIslandOffset = *NewPoolEnd - PoolBranchIslandBytes;
         size_t NewIndex = Ctx.OutTrampolines.size();
         Ctx.OutTrampolines.emplace_back(std::move(Promoted));
         PoolIslandOwners[*NewPoolEnd - PoolBranchIslandBytes] = {
-            NewIndex, Ctx.OutTrampolines.back().Bytes.size() -
-                          PoolBranchIslandBytes};
+            NewIndex,
+            Ctx.OutTrampolines.back().Bytes.size() - PoolBranchIslandBytes};
         size_t PoolGatewayIndex = Gateways.size();
         Gateways.push_back({*NewPoolEnd - PoolBranchIslandBytes, *NewPoolEnd,
                             *NewPoolEnd - PoolBranchIslandBytes, 0,
@@ -8988,12 +8924,11 @@ assignLongBranchGateways(PatchContext &Ctx,
              Relay += MinInstSize)
           SourceTailIslandOwners[Relay] = NewIndex;
         size_t SourceGatewayIndex = Gateways.size();
-        Gateways.push_back({Tail, End, Tail, 0,
-                            std::numeric_limits<uint64_t>::max()});
+        Gateways.push_back(
+            {Tail, End, Tail, 0, std::numeric_limits<uint64_t>::max()});
         BranchGatewayHeads.insert({Tail, SourceGatewayIndex});
         if (PlanningRegisterlessReturns)
-          ReturnPromotionBranchOnlyRanges.push_back(
-              {SourceGatewayIndex, End});
+          ReturnPromotionBranchOnlyRanges.push_back({SourceGatewayIndex, End});
         ReservePromotionRange(Start, End);
 
         PromotionStillPossible.reset(Index);
@@ -9007,12 +8942,10 @@ assignLongBranchGateways(PatchContext &Ctx,
             isPowerOf2_64(PromotedBranchCapacityRelays))
           log() << "hotswap: promoted safe straight-line source at 0x"
                 << utohexstr(Start) << " (size=" << Replacement.size()
-                << ") to provide "
-                << (Failure.Forward ? "forward" : "return")
+                << ") to provide " << (Failure.Forward ? "forward" : "return")
                 << "-capacity relay window [0x" << utohexstr(Tail) << ",0x"
-                << utohexstr(End) << ") with "
-                << (End - Tail) / MinInstSize << " slot(s) using "
-                << (UseVcc ? "VCC" : "a local SGPR pair")
+                << utohexstr(End) << ") with " << (End - Tail) / MinInstSize
+                << " slot(s) using " << (UseVcc ? "VCC" : "a local SGPR pair")
                 << " (promotion " << PromotedBranchCapacityRelays << ")\n";
         return true;
       }
@@ -9056,19 +8989,18 @@ assignLongBranchGateways(PatchContext &Ctx,
     uint64_t ChainTarget = ReservedReturnTails.lookup(I);
     BranchIslandFailure Failure;
     std::optional<SmallVector<uint64_t, 4>> ReturnIslands =
-        allocateBackwardBranchIslands(
-            Gateways, OwnerOffset, BackSlot,
-            ChainTarget ? ChainTarget : *ReturnTo, &Failure,
-            &BranchGatewayHeads, &OccupiedBranchGatewaySlots,
-            PromoteBranchCapacityRelay);
+        allocateBackwardBranchIslands(Gateways, OwnerOffset, BackSlot,
+                                      ChainTarget ? ChainTarget : *ReturnTo,
+                                      &Failure, &BranchGatewayHeads,
+                                      &OccupiedBranchGatewaySlots,
+                                      PromoteBranchCapacityRelay);
     if (!ReturnIslands) {
       log() << "hotswap: error: no safe return s_branch island chain for far "
                "site 0x"
             << utohexstr(OwnerOffset) << " (size=" << OwnerSize
-            << ", pool-back-slot=0x" << utohexstr(BackSlot)
-            << ", return-to=0x" << utohexstr(*ReturnTo)
-            << ", reserved-tail=0x" << utohexstr(ChainTarget)
-            << ", preserve-vcc=" << OwnerPreservesVcc
+            << ", pool-back-slot=0x" << utohexstr(BackSlot) << ", return-to=0x"
+            << utohexstr(*ReturnTo) << ", reserved-tail=0x"
+            << utohexstr(ChainTarget) << ", preserve-vcc=" << OwnerPreservesVcc
             << ", shared=" << OwnerUsesShared
             << ", mirrored=" << OwnerUsesMirrored << ")\n";
       return false;
@@ -9092,8 +9024,7 @@ assignLongBranchGateways(PatchContext &Ctx,
   // registerless branch relays. Hide its remaining slots from the ordinary
   // set-PC planners, which do not record source-tail gateway ownership and
   // would otherwise have their bytes overwritten by final source padding.
-  SmallVector<std::pair<uint64_t, uint64_t>, 8>
-      HiddenReturnPromotionRanges;
+  SmallVector<std::pair<uint64_t, uint64_t>, 8> HiddenReturnPromotionRanges;
   for (const auto &[GatewayIndex, OriginalEnd] :
        ReturnPromotionBranchOnlyRanges) {
     if (Gateways[GatewayIndex].WritePos < OriginalEnd)
@@ -9105,8 +9036,7 @@ assignLongBranchGateways(PatchContext &Ctx,
   // variable-width ordinary gateway can cross and overwrite it. Splitting a
   // range preserves the free prefix and suffix while making the occupied
   // dword a hard layout boundary.
-  subtractOccupiedBranchGatewaySlots(Gateways,
-                                     OccupiedBranchGatewaySlots);
+  subtractOccupiedBranchGatewaySlots(Gateways, OccupiedBranchGatewaySlots);
   const auto CandidateCountStart = std::chrono::steady_clock::now();
   for (PendingGateway &P : Pending) {
     const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
@@ -9164,10 +9094,9 @@ assignLongBranchGateways(PatchContext &Ctx,
     std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
     if (!Gateway) {
       if (T.LongBranchPreservesVcc) {
-        std::optional<EncodedSplitVccGateway> Split =
-            findSplitVccGateway(Gateways, Ctx.LS, T.OriginalOffset,
-                                P.TargetOffset, T.LongBranchSgprBase,
-                                &OccupiedBranchGatewaySlots);
+        std::optional<EncodedSplitVccGateway> Split = findSplitVccGateway(
+            Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
+            T.LongBranchSgprBase, &OccupiedBranchGatewaySlots);
         if (Split) {
           NopSled &Primary = Gateways[Split->PrimaryIndex];
           NopSled &Secondary = Gateways[Split->SecondaryIndex];
@@ -9229,8 +9158,7 @@ assignLongBranchGateways(PatchContext &Ctx,
       OwnerT.SourceTailGatewayBytes = T.ForwardGatewayBytes.size();
     }
     Gateway->Sled->WritePos += T.ForwardGatewayBytes.size();
-    OccupyOrdinaryGateway(T.ForwardGatewayOffset,
-                          T.ForwardGatewayBytes.size());
+    OccupyOrdinaryGateway(T.ForwardGatewayOffset, T.ForwardGatewayBytes.size());
     ++AssignedGateways;
     if (RemainingRelayDemand)
       --RemainingRelayDemand;
@@ -9238,10 +9166,9 @@ assignLongBranchGateways(PatchContext &Ctx,
   Pending = std::move(StillPending);
 
   for (const auto &[Begin, End] : HiddenReturnPromotionRanges)
-    Gateways.push_back({Begin, End, Begin, 0,
-                        std::numeric_limits<uint64_t>::max()});
-  subtractOccupiedBranchGatewaySlots(Gateways,
-                                     OccupiedBranchGatewaySlots);
+    Gateways.push_back(
+        {Begin, End, Begin, 0, std::numeric_limits<uint64_t>::max()});
+  subtractOccupiedBranchGatewaySlots(Gateways, OccupiedBranchGatewaySlots);
   BranchGatewayHeads =
       buildBranchGatewayHeads(Gateways, OccupiedBranchGatewaySlots);
   uint64_t BranchIslandChains = 0;
@@ -9249,14 +9176,13 @@ assignLongBranchGateways(PatchContext &Ctx,
   StillPending.reserve(Pending.size());
   const auto ForwardBranchPlanStart = std::chrono::steady_clock::now();
   for (const PendingGateway &P : Pending) {
-    uint64_t OwnerOffset =
-        Ctx.OutTrampolines[P.TrampolineIndex].OriginalOffset;
+    uint64_t OwnerOffset = Ctx.OutTrampolines[P.TrampolineIndex].OriginalOffset;
     BranchIslandFailure Failure;
     std::optional<SmallVector<uint64_t, 4>> Islands =
-        allocateForwardBranchIslands(
-            Gateways, OwnerOffset, P.TargetOffset, &Failure,
-            &BranchGatewayHeads, &OccupiedBranchGatewaySlots,
-            PromoteBranchCapacityRelay);
+        allocateForwardBranchIslands(Gateways, OwnerOffset, P.TargetOffset,
+                                     &Failure, &BranchGatewayHeads,
+                                     &OccupiedBranchGatewaySlots,
+                                     PromoteBranchCapacityRelay);
     if (!Islands || Islands->empty()) {
       StillPending.push_back(P);
       continue;
@@ -9359,8 +9285,7 @@ assignLongBranchGateways(PatchContext &Ctx,
           return false;
         }
       } else if (Owner != PoolIslandOwners.end()) {
-        Trampoline &OwnerT =
-            Ctx.OutTrampolines[Owner->second.TrampolineIndex];
+        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second.TrampolineIndex];
         std::memcpy(OwnerT.Bytes.data() + Owner->second.RelativeOffset,
                     Branch.data(), Branch.size());
       } else {
@@ -9395,8 +9320,7 @@ assignLongBranchGateways(PatchContext &Ctx,
           return false;
         }
       } else if (Owner != PoolIslandOwners.end()) {
-        Trampoline &OwnerT =
-            Ctx.OutTrampolines[Owner->second.TrampolineIndex];
+        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second.TrampolineIndex];
         std::memcpy(OwnerT.Bytes.data() + Owner->second.RelativeOffset,
                     Branch.data(), Branch.size());
       } else {
@@ -9941,13 +9865,11 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
       std::memcpy(Text + T.OriginalOffset + I, LS.SNopBytes.data(),
                   MinInstSize);
     }
-    for (const auto &[RelayOffset, RelayTarget] :
-         T.SourceTailBranchIslands) {
+    for (const auto &[RelayOffset, RelayTarget] : T.SourceTailBranchIslands) {
       if (RelayOffset < T.OriginalOffset ||
           RelayOffset - T.OriginalOffset < PadStart ||
           RelayOffset - T.OriginalOffset > T.OriginalSize - MinInstSize ||
-          (T.HasSourceTailGateway &&
-           RelayOffset >= T.SourceTailGatewayOffset &&
+          (T.HasSourceTailGateway && RelayOffset >= T.SourceTailGatewayOffset &&
            RelayOffset - T.SourceTailGatewayOffset <
                T.SourceTailGatewayBytes)) {
         log() << "hotswap: error: source-tail branch island overlaps the "
@@ -9955,8 +9877,7 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
               << utohexstr(T.OriginalOffset) << "\n";
         return false;
       }
-      SmallVector<uint8_t> Relay =
-          LS.encodeSBranch(RelayOffset, RelayTarget);
+      SmallVector<uint8_t> Relay = LS.encodeSBranch(RelayOffset, RelayTarget);
       if (Relay.size() != MinInstSize) {
         log() << "hotswap: error: source-tail branch island encoding failed "
                  "at 0x"

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -5631,7 +5631,7 @@ static std::optional<WellFormedAbiEntrySet> validateWellFormedAbiEntrySet(
     return std::nullopt;
   }
 
-  if (!SawAbiCall) {
+  {
     auto HasMaterializationEntry =
         [&](const PcMaterializedCallInfo &Materialized) {
           auto IsInterior = [&](uint64_t Offset) {

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -30,18 +30,24 @@
 #include "comgr-env.h"
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/MC/MCExpr.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/Endian.h"
 #include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <cstdio>
+#include <functional>
 #include <limits>
 #include <mutex>
+#include <set>
+#include <tuple>
 
 using namespace llvm;
 
@@ -406,19 +412,19 @@ truncateNopSledsAtDirectTargets(std::vector<NopSled> &Sleds,
   return true;
 }
 
-std::optional<SmallVector<uint8_t>> encodeSetPCLongBranch(const LLVMState &LS,
-                                                          uint64_t FromOffset,
-                                                          uint64_t TargetOffset,
-                                                          unsigned SgprBase) {
-  if ((SgprBase & 1u) != 0) {
+std::optional<SmallVector<uint8_t>>
+encodeSetPCLongBranch(const LLVMState &LS, uint64_t FromOffset,
+                      uint64_t TargetOffset, unsigned SgprBase, bool UseVcc) {
+  if (!UseVcc && (SgprBase & 1u) != 0) {
     log() << "hotswap: error: set-PC long branch requires an aligned "
              "SGPR pair, got s"
           << SgprBase << "\n";
     return std::nullopt;
   }
 
-  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
-                           std::to_string(SgprBase + 1) + "]";
+  const std::string Pair = UseVcc ? "vcc"
+                                  : "s[" + std::to_string(SgprBase) + ":" +
+                                        std::to_string(SgprBase + 1) + "]";
   SmallVector<uint8_t> GetPc = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
   if (GetPc.empty())
     return std::nullopt;
@@ -489,10 +495,79 @@ getSetPcLongBranchLayoutSize(uint64_t FromOffset, uint64_t TargetOffset) {
   return SetPcReturnReserveBytes;
 }
 
+static std::optional<SmallVector<uint8_t>>
+encodeSetPcGateway(const LLVMState &LS, uint64_t FromOffset,
+                   uint64_t TargetOffset, unsigned SgprBase, bool UseVcc,
+                   bool PreserveVcc) {
+  SmallVector<uint8_t> Bytes;
+  uint64_t SetPcOffset = FromOffset;
+  if (PreserveVcc) {
+    if (!UseVcc) {
+      log() << "hotswap: error: VCC-preserving gateway does not use VCC\n";
+      return std::nullopt;
+    }
+    Bytes = assembleSingleInst(
+        "s_mov_b32 s" + std::to_string(SgprBase) + ", vcc_lo", LS);
+    if (Bytes.size() != VccMoveBytes)
+      return std::nullopt;
+    std::optional<uint64_t> Offset = checkedAddUint64(
+        FromOffset, Bytes.size(), "VCC-preserving set-PC gateway offset");
+    if (!Offset)
+      return std::nullopt;
+    SetPcOffset = *Offset;
+  }
+
+  std::optional<SmallVector<uint8_t>> SetPc =
+      encodeSetPCLongBranch(LS, SetPcOffset, TargetOffset, SgprBase, UseVcc);
+  if (!SetPc)
+    return std::nullopt;
+  Bytes.append(SetPc->begin(), SetPc->end());
+  return Bytes;
+}
+
+static std::optional<uint32_t>
+getSetPcGatewayLayoutSize(uint64_t FromOffset, uint64_t TargetOffset,
+                          unsigned SgprBase, bool UseVcc, bool PreserveVcc) {
+  if (PreserveVcc && !UseVcc)
+    return std::nullopt;
+  if (!UseVcc && (SgprBase & 1u) != 0)
+    return std::nullopt;
+
+  uint64_t SetPcOffset = FromOffset;
+  uint32_t PrefixBytes = 0;
+  if (PreserveVcc) {
+    std::optional<uint64_t> Offset =
+        checkedAddUint64(FromOffset, VccMoveBytes,
+                         "VCC-preserving set-PC gateway layout offset");
+    if (!Offset)
+      return std::nullopt;
+    SetPcOffset = *Offset;
+    PrefixBytes = VccMoveBytes;
+  }
+
+  std::optional<uint32_t> SetPcBytes =
+      getSetPcLongBranchLayoutSize(SetPcOffset, TargetOffset);
+  if (!SetPcBytes)
+    return std::nullopt;
+  return PrefixBytes + *SetPcBytes;
+}
+
+static bool gatewayRangeIsOccupied(
+    uint64_t Begin, uint64_t Size,
+    const DenseSet<uint64_t> *Occupied) {
+  if (!Occupied)
+    return false;
+  for (uint64_t Offset = 0; Offset < Size; Offset += MinInstSize)
+    if (Occupied->contains(Begin + Offset))
+      return true;
+  return false;
+}
+
 Expected<std::optional<EncodedSetPcGateway>>
 findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                         uint64_t FromOffset, uint64_t TargetOffset,
-                        unsigned SgprBase) {
+                        unsigned SgprBase, bool UseVcc, bool PreserveVcc,
+                        const DenseSet<uint64_t> *Occupied) {
   NopSled *Best = nullptr;
   uint32_t BestLayoutSize = 0;
   uint64_t BestUsableEnd = 0;
@@ -508,14 +583,14 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
     if (Distance >= MaxSledDistance || Distance >= BestDistance ||
         LS.encodeSBranch(FromOffset, Sled.WritePos).empty())
       continue;
-
-    std::optional<uint32_t> LayoutSize =
-        getSetPcLongBranchLayoutSize(Sled.WritePos, TargetOffset);
-    if ((SgprBase & 1u) != 0 || !LayoutSize)
+    std::optional<uint32_t> LayoutSize = getSetPcGatewayLayoutSize(
+        Sled.WritePos, TargetOffset, SgprBase, UseVcc, PreserveVcc);
+    if (!LayoutSize)
       return createStringError(
           Twine("failed to encode set-PC gateway at candidate offset 0x") +
           utohexstr(Sled.WritePos));
-    if (*LayoutSize > UsableEnd - Sled.WritePos)
+    if (*LayoutSize > UsableEnd - Sled.WritePos ||
+        gatewayRangeIsOccupied(Sled.WritePos, *LayoutSize, Occupied))
       continue;
 
     Best = &Sled;
@@ -525,8 +600,8 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
   }
   if (!Best)
     return std::nullopt;
-  std::optional<SmallVector<uint8_t>> BestBytes =
-      encodeSetPCLongBranch(LS, Best->WritePos, TargetOffset, SgprBase);
+  std::optional<SmallVector<uint8_t>> BestBytes = encodeSetPcGateway(
+      LS, Best->WritePos, TargetOffset, SgprBase, UseVcc, PreserveVcc);
   if (!BestBytes)
     return createStringError(
         Twine("failed to encode set-PC gateway at candidate offset 0x") +
@@ -539,6 +614,75 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
         " bytes, encoded " + Twine(BestBytes->size()) + " bytes");
   return std::optional<EncodedSetPcGateway>(
       EncodedSetPcGateway{Best, std::move(*BestBytes)});
+}
+
+/// Split a live-VCC gateway across an eight-byte nearby save/branch segment
+/// and a 16-byte get-PC/add/set-PC segment. This serves functions whose safe
+/// padding is fragmented too finely for the ordinary contiguous 20-byte
+/// sequence, while preserving SCC and saving VCC before it is used as the
+/// target pair.
+std::optional<EncodedSplitVccGateway>
+findSplitVccGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
+                    uint64_t FromOffset, uint64_t TargetOffset,
+                    unsigned SaveSgpr,
+                    const DenseSet<uint64_t> *Occupied) {
+  constexpr uint64_t PrimaryBytes = 2 * MinInstSize;
+  constexpr uint64_t SecondaryBytes = SetPcForwardSequenceBytes - MinInstSize;
+  SmallVector<size_t, 32> PrimaryCandidates;
+  for (size_t I = 0; I != Gateways.size(); ++I) {
+    const NopSled &Sled = Gateways[I];
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    if (Sled.GatewayOnly || FromOffset < Sled.FunctionStart ||
+        FromOffset >= Sled.FunctionEnd || Sled.WritePos > UsableEnd ||
+        PrimaryBytes > UsableEnd - Sled.WritePos ||
+        gatewayRangeIsOccupied(Sled.WritePos, PrimaryBytes, Occupied) ||
+        !isSBranchReachable(FromOffset, Sled.WritePos))
+      continue;
+    PrimaryCandidates.push_back(I);
+  }
+  llvm::sort(PrimaryCandidates, [&](size_t LHS, size_t RHS) {
+    uint64_t L = Gateways[LHS].WritePos;
+    uint64_t R = Gateways[RHS].WritePos;
+    uint64_t LDistance = FromOffset > L ? FromOffset - L : L - FromOffset;
+    uint64_t RDistance = FromOffset > R ? FromOffset - R : R - FromOffset;
+    return LDistance < RDistance;
+  });
+
+  for (size_t PrimaryIndex : PrimaryCandidates) {
+    const NopSled &Primary = Gateways[PrimaryIndex];
+    uint64_t PrimaryOffset = Primary.WritePos;
+    for (size_t SecondaryIndex = 0; SecondaryIndex != Gateways.size();
+         ++SecondaryIndex) {
+      if (SecondaryIndex == PrimaryIndex)
+        continue;
+      const NopSled &Secondary = Gateways[SecondaryIndex];
+      uint64_t UsableEnd = std::min(Secondary.End, Secondary.FunctionEnd);
+      if (FromOffset < Secondary.FunctionStart ||
+          FromOffset >= Secondary.FunctionEnd ||
+          Secondary.WritePos > UsableEnd ||
+          SecondaryBytes > UsableEnd - Secondary.WritePos ||
+          gatewayRangeIsOccupied(Secondary.WritePos, SecondaryBytes,
+                                 Occupied) ||
+          (PrimaryOffset < Secondary.WritePos + SecondaryBytes &&
+           Secondary.WritePos < PrimaryOffset + PrimaryBytes) ||
+          !isSBranchReachable(PrimaryOffset + MinInstSize, Secondary.WritePos))
+        continue;
+      std::optional<SmallVector<uint8_t>> SetPc = encodeSetPCLongBranch(
+          LS, Secondary.WritePos, TargetOffset, SaveSgpr, /*UseVcc=*/true);
+      if (!SetPc || SetPc->size() > SecondaryBytes)
+        continue;
+      SmallVector<uint8_t> Save = assembleSingleInst(
+          "s_mov_b32 s" + std::to_string(SaveSgpr) + ", vcc_lo", LS);
+      SmallVector<uint8_t> Branch =
+          LS.encodeSBranch(PrimaryOffset + MinInstSize, Secondary.WritePos);
+      if (Save.size() != MinInstSize || Branch.size() != MinInstSize)
+        continue;
+      Save.append(Branch);
+      return EncodedSplitVccGateway{PrimaryIndex, SecondaryIndex,
+                                    std::move(Save), std::move(*SetPc)};
+    }
+  }
+  return std::nullopt;
 }
 
 static std::optional<unsigned> numberedSgprIndex(const MCRegisterInfo &MRI,
@@ -554,6 +698,23 @@ static std::optional<unsigned> numberedSgprIndex(const MCRegisterInfo &MRI,
   if (Name.getAsInteger(10, Index))
     return std::nullopt;
   return Index;
+}
+
+static std::optional<unsigned>
+numberedSgprPairLowIndex(const MCRegisterInfo &MRI, MCRegister Reg) {
+  SmallVector<unsigned, 2> Indices;
+  auto Add = [&](MCRegister Candidate) {
+    std::optional<unsigned> Index = numberedSgprIndex(MRI, Candidate);
+    if (Index && !llvm::is_contained(Indices, *Index))
+      Indices.push_back(*Index);
+  };
+  Add(Reg);
+  for (MCPhysReg Sub : MRI.subregs(Reg))
+    Add(MCRegister(Sub));
+  llvm::sort(Indices);
+  if (Indices.size() != 2 || Indices[1] != Indices[0] + 1)
+    return std::nullopt;
+  return Indices[0];
 }
 
 static bool updateNumberedSgprHighWatermark(const MCRegisterInfo &MRI,
@@ -640,7 +801,8 @@ summarizeSafeSgprUsage(PatchContext &Ctx,
 
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
-                         unsigned Alignment, StringRef Context) {
+                         unsigned Alignment, StringRef Context,
+                         bool ReportNoSpace) {
   if (Count == 0 || Alignment == 0 || (Alignment & (Alignment - 1)) != 0) {
     log() << "hotswap: error: " << Context
           << ": invalid global SGPR block request (count=" << Count
@@ -737,8 +899,10 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
   }
   unsigned Base = (HighWatermark + Alignment - 1) & ~(Alignment - 1);
   if (Base > Ctx.Config.MaxSgprs || Count > Ctx.Config.MaxSgprs - Base) {
-    log() << "hotswap: error: " << Context << ": no aligned block of " << Count
-          << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs << "\n";
+    if (ReportNoSpace)
+      log() << "hotswap: error: " << Context << ": no aligned block of "
+            << Count << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs
+            << "\n";
     return std::nullopt;
   }
   return SafeSgprScratchBlock{Base, Count};
@@ -791,15 +955,844 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
   return true;
 }
 
-static std::optional<SafeSgprScratchBlock>
-reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset) {
+bool instructionReadsRegister(const InternalDecodedInst &DI,
+                              const LLVMState &LS, MCRegister Register) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  // A tied use makes its corresponding explicit def a read/modify/write
+  // operand. Some MCInst producers materialize a duplicate use operand while
+  // others only retain the destination operand, so consult the descriptor
+  // instead of relying on the decoded operand list to contain that duplicate.
+  for (unsigned Def = 0; Def != DefCount; ++Def) {
+    bool HasTiedUse = false;
+    for (unsigned Use = Desc.getNumDefs(); Use != Desc.getNumOperands();
+         ++Use) {
+      if (Desc.getOperandConstraint(Use, MCOI::TIED_TO) ==
+          static_cast<int>(Def)) {
+        HasTiedUse = true;
+        break;
+      }
+    }
+    if (!HasTiedUse)
+      continue;
+    const MCOperand &Operand = DI.Inst.getOperand(Def);
+    if (Operand.isReg() && Operand.getReg() &&
+        LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+      return true;
+  }
+  for (unsigned I = DefCount; I != DI.Inst.getNumOperands(); ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (Operand.isReg() && Operand.getReg() &&
+        LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+      return true;
+  }
+  for (MCPhysReg ImplicitUse : Desc.implicit_uses())
+    if (LS.MRI->regsOverlap(MCRegister(ImplicitUse), Register))
+      return true;
+  return false;
+}
+
+static bool instructionWritesRegister(const InternalDecodedInst &DI,
+                                      const LLVMState &LS,
+                                      MCRegister Register) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != DefCount; ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (Operand.isReg() && Operand.getReg() &&
+        LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+      return true;
+  }
+  if (Desc.variadicOpsAreDefs()) {
+    unsigned VariadicBegin =
+        std::min(Desc.getNumOperands(), DI.Inst.getNumOperands());
+    for (unsigned I = VariadicBegin; I != DI.Inst.getNumOperands(); ++I) {
+      const MCOperand &Operand = DI.Inst.getOperand(I);
+      if (Operand.isReg() && Operand.getReg() &&
+          LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+        return true;
+    }
+  }
+  for (MCPhysReg ImplicitDef : Desc.implicit_defs())
+    if (LS.MRI->regsOverlap(MCRegister(ImplicitDef), Register))
+      return true;
+  return false;
+}
+
+bool instructionFullyWritesRegister(const InternalDecodedInst &DI,
+                                    const LLVMState &LS,
+                                    MCRegister Register) {
+  auto DefinitionCoversRegister = [&](MCRegister Def) {
+    return Def.isValid() && LS.MRI->isSubRegisterEq(Def, Register);
+  };
+
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != DefCount; ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (Operand.isReg() &&
+        DefinitionCoversRegister(MCRegister(Operand.getReg())))
+      return true;
+  }
+  if (Desc.variadicOpsAreDefs()) {
+    unsigned VariadicBegin =
+        std::min(Desc.getNumOperands(), DI.Inst.getNumOperands());
+    for (unsigned I = VariadicBegin; I != DI.Inst.getNumOperands(); ++I) {
+      const MCOperand &Operand = DI.Inst.getOperand(I);
+      if (Operand.isReg() &&
+          DefinitionCoversRegister(MCRegister(Operand.getReg())))
+        return true;
+    }
+  }
+  for (MCPhysReg ImplicitDef : Desc.implicit_defs())
+    if (DefinitionCoversRegister(MCRegister(ImplicitDef)))
+      return true;
+  return false;
+}
+
+bool replacementNeedsIncomingRegister(ArrayRef<uint8_t> Replacement,
+                                      const LLVMState &LS,
+                                      MCRegister Register) {
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Replacement.data(), Replacement.size(), LS, Decoded))
+    return true;
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (!DI.DecodeSucceeded || !LS.MIA ||
+        LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
+      return true;
+    if (instructionReadsRegister(DI, LS, Register))
+      return true;
+    if (instructionFullyWritesRegister(DI, LS, Register))
+      return false;
+  }
+  return false;
+}
+
+static bool isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx,
+                                                   uint64_t InstOffset,
+                                                   uint32_t InstSize,
+                                                   MCRegister Register) {
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!FunctionRange)
+    return false;
+
+  std::optional<uint64_t> Continuation = checkedAddUint64(
+      InstOffset, InstSize, "far-return register liveness continuation");
+  if (!Continuation)
+    return false;
+  std::vector<InternalDecodedInst>::const_iterator It =
+      std::lower_bound(Ctx.Decoded.cbegin(), Ctx.Decoded.cend(), *Continuation,
+                       [](const InternalDecodedInst &DI, uint64_t Offset) {
+                         return DI.Offset < Offset;
+                       });
+  if (It == Ctx.Decoded.cend() || It->Offset != *Continuation)
+    return false;
+
+  SmallVector<size_t, 8> Worklist;
+  DenseSet<size_t> Visited;
+  Worklist.push_back(It - Ctx.Decoded.cbegin());
+  while (!Worklist.empty()) {
+    size_t Index = Worklist.pop_back_val();
+    if (!Visited.insert(Index).second)
+      continue;
+    const InternalDecodedInst &DI = Ctx.Decoded[Index];
+    if (!DI.DecodeSucceeded || !Ctx.LS.MIA ||
+        DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End)
+      return false;
+    if (instructionReadsRegister(DI, Ctx.LS, Register))
+      return false;
+    if (instructionFullyWritesRegister(DI, Ctx.LS, Register) ||
+        DI.Inst.getOpcode() == Ctx.LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == Ctx.LS.SEndPgmSavedOpcode)
+      continue;
+
+    auto AddSuccessor = [&](uint64_t Offset) {
+      if (Offset < FunctionRange->Begin || Offset >= FunctionRange->End)
+        return false;
+      std::vector<InternalDecodedInst>::const_iterator Successor =
+          std::lower_bound(
+              Ctx.Decoded.cbegin(), Ctx.Decoded.cend(), Offset,
+              [](const InternalDecodedInst &Candidate, uint64_t Target) {
+                return Candidate.Offset < Target;
+              });
+      if (Successor == Ctx.Decoded.cend() || Successor->Offset != Offset)
+        return false;
+      Worklist.push_back(Successor - Ctx.Decoded.cbegin());
+      return true;
+    };
+
+    if (Ctx.LS.MIA->isCall(DI.Inst) || Ctx.LS.MIA->isIndirectBranch(DI.Inst) ||
+        Ctx.LS.MIA->isReturn(DI.Inst))
+      return false;
+    if (Ctx.LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target =
+          evaluateDirectControlFlowTarget(DI, Ctx.LS);
+      if (!Target || !AddSuccessor(*Target))
+        return false;
+      if (Ctx.LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI) &&
+               !Ctx.LS.MIA->isBarrier(DI.Inst)) {
+      return false;
+    }
+
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "far-return register liveness fallthrough");
+    if (!Fallthrough || !AddSuccessor(*Fallthrough))
+      return false;
+  }
+  return true;
+}
+
+std::optional<DenseSet<uint64_t>> computeIncomingRegisterNeeds(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t FunctionBegin, uint64_t FunctionEnd, MCRegister Register) {
+  if (!LS.MIA || FunctionBegin >= FunctionEnd)
+    return std::nullopt;
+
+  auto Begin = llvm::lower_bound(
+      Decoded, FunctionBegin,
+      [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  auto End = llvm::lower_bound(
+      Decoded, FunctionEnd,
+      [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  if (Begin == End)
+    return std::nullopt;
+
+  const size_t Count = End - Begin;
+  std::vector<SmallVector<size_t, 2>> Predecessors(Count);
+  BitVector NeedsIncoming(Count);
+  BitVector FullDefinitions(Count);
+
+  auto FindLocalIndex = [&](uint64_t Offset) -> std::optional<size_t> {
+    if (Offset < FunctionBegin || Offset >= FunctionEnd)
+      return std::nullopt;
+    auto It = std::lower_bound(
+        Begin, End, Offset,
+        [](const InternalDecodedInst &DI, uint64_t Target) {
+          return DI.Offset < Target;
+        });
+    if (It == End || It->Offset != Offset)
+      return std::nullopt;
+    return It - Begin;
+  };
+
+  for (size_t I = 0; I != Count; ++I) {
+    const InternalDecodedInst &DI = Begin[I];
+    if (!DI.DecodeSucceeded) {
+      NeedsIncoming.set(I);
+      continue;
+    }
+    if (instructionReadsRegister(DI, LS, Register)) {
+      NeedsIncoming.set(I);
+      continue;
+    }
+    if (instructionFullyWritesRegister(DI, LS, Register)) {
+      FullDefinitions.set(I);
+      continue;
+    }
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode)
+      continue;
+    if (LS.MIA->isCall(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
+        LS.MIA->isReturn(DI.Inst)) {
+      NeedsIncoming.set(I);
+      continue;
+    }
+
+    auto AddSuccessor = [&](uint64_t Offset) {
+      std::optional<size_t> Successor = FindLocalIndex(Offset);
+      if (!Successor) {
+        NeedsIncoming.set(I);
+        return;
+      }
+      Predecessors[*Successor].push_back(I);
+    };
+
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target =
+          evaluateDirectControlFlowTarget(DI, LS);
+      if (Target)
+        AddSuccessor(*Target);
+      else
+        NeedsIncoming.set(I);
+      if (LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
+               !LS.MIA->isBarrier(DI.Inst)) {
+      NeedsIncoming.set(I);
+      continue;
+    }
+
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "batched register liveness fallthrough");
+    if (Fallthrough)
+      AddSuccessor(*Fallthrough);
+    else
+      NeedsIncoming.set(I);
+  }
+
+  SmallVector<size_t, 32> Worklist;
+  for (int I = NeedsIncoming.find_first(); I >= 0;
+       I = NeedsIncoming.find_next(I))
+    Worklist.push_back(static_cast<size_t>(I));
+  while (!Worklist.empty()) {
+    size_t Successor = Worklist.pop_back_val();
+    for (size_t Predecessor : Predecessors[Successor]) {
+      if (NeedsIncoming.test(Predecessor) ||
+          FullDefinitions.test(Predecessor))
+        continue;
+      NeedsIncoming.set(Predecessor);
+      Worklist.push_back(Predecessor);
+    }
+  }
+
+  DenseSet<uint64_t> Result;
+  for (int I = NeedsIncoming.find_first(); I >= 0;
+       I = NeedsIncoming.find_next(I))
+    Result.insert(Begin[static_cast<size_t>(I)].Offset);
+  return Result;
+}
+
+std::optional<SmallVector<MCRegister, 128>>
+resolveNumberedSgprRegisters(const MCRegisterInfo &MRI, unsigned MaxSgprs) {
+  SmallVector<MCRegister, 128> Registers(MaxSgprs);
+  for (unsigned I = 1; I != MRI.getNumRegs(); ++I) {
+    MCRegister Register(I);
+    std::optional<unsigned> Index = numberedSgprIndex(MRI, Register);
+    if (Index && *Index < MaxSgprs)
+      Registers[*Index] = Register;
+  }
+  if (llvm::any_of(Registers,
+                   [](MCRegister Register) { return !Register.isValid(); }))
+    return std::nullopt;
+  return Registers;
+}
+
+void getNumberedSgprUsesAndDefs(const InternalDecodedInst &DI,
+                                const LLVMState &LS,
+                                ArrayRef<MCRegister> NumberedSgprs,
+                                BitVector &Uses, BitVector &Defs) {
+  assert(Uses.size() == NumberedSgprs.size() &&
+         Defs.size() == NumberedSgprs.size());
+  for (unsigned I = 0; I != NumberedSgprs.size(); ++I) {
+    if (instructionReadsRegister(DI, LS, NumberedSgprs[I]))
+      Uses.set(I);
+    if (instructionWritesRegister(DI, LS, NumberedSgprs[I]))
+      Defs.set(I);
+  }
+}
+
+/// Return the numbered SGPRs whose incoming values can be observed by the
+/// replacement. A malformed or control-flow-bearing replacement conservatively
+/// keeps every value that has not already been overwritten.
+BitVector
+unsafeIncomingNumberedSgprsInReplacement(ArrayRef<uint8_t> Replacement,
+                                         const LLVMState &LS,
+                                         ArrayRef<MCRegister> NumberedSgprs) {
+  const unsigned MaxSgprs = NumberedSgprs.size();
+  BitVector Unsafe(MaxSgprs);
+  BitVector Incoming(MaxSgprs, true);
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Replacement.data(), Replacement.size(), LS, Decoded)) {
+    Unsafe.set();
+    return Unsafe;
+  }
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (!DI.DecodeSucceeded || !LS.MIA) {
+      Unsafe |= Incoming;
+      break;
+    }
+    BitVector Uses(MaxSgprs);
+    BitVector Defs(MaxSgprs);
+    getNumberedSgprUsesAndDefs(DI, LS, NumberedSgprs, Uses, Defs);
+    Uses &= Incoming;
+    Unsafe |= Uses;
+    Incoming.reset(Defs);
+    if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+      Unsafe |= Incoming;
+      break;
+    }
+  }
+  return Unsafe;
+}
+
+/// Analyze all numbered SGPR incoming values in one monotone CFG walk.
+/// Unsafe contains a register when some path reads its incoming value before
+/// overwriting it, or reaches control flow that cannot be bounded precisely.
+std::optional<BitVector>
+unsafeIncomingNumberedSgprsInRange(ArrayRef<InternalDecodedInst> Decoded,
+                                   const LLVMState &LS, uint64_t FunctionBegin,
+                                   uint64_t FunctionEnd, uint64_t Continuation,
+                                   ArrayRef<MCRegister> NumberedSgprs) {
+  const unsigned MaxSgprs = NumberedSgprs.size();
+  if (!LS.MIA)
+    return std::nullopt;
+
+  auto FindInstruction = [&](uint64_t Offset) -> std::optional<size_t> {
+    if (Offset < FunctionBegin || Offset >= FunctionEnd)
+      return std::nullopt;
+    auto It =
+        std::lower_bound(Decoded.begin(), Decoded.end(), Offset,
+                         [](const InternalDecodedInst &DI, uint64_t Target) {
+                           return DI.Offset < Target;
+                         });
+    if (It == Decoded.end() || It->Offset != Offset)
+      return std::nullopt;
+    return It - Decoded.begin();
+  };
+  std::optional<size_t> ContinuationIndex = FindInstruction(Continuation);
+  if (!ContinuationIndex)
+    return std::nullopt;
+
+  DenseMap<size_t, BitVector> IncomingAt;
+  IncomingAt.try_emplace(*ContinuationIndex, MaxSgprs, true);
+  SmallVector<size_t, 16> Worklist(1, *ContinuationIndex);
+  BitVector Queued(Decoded.size());
+  Queued.set(*ContinuationIndex);
+  BitVector Unsafe(MaxSgprs);
+
+  auto Propagate = [&](uint64_t Offset, const BitVector &Incoming) {
+    std::optional<size_t> Successor = FindInstruction(Offset);
+    if (!Successor) {
+      Unsafe |= Incoming;
+      return;
+    }
+    auto It = IncomingAt.try_emplace(*Successor, MaxSgprs).first;
+    BitVector NewValues = Incoming;
+    NewValues.reset(It->second);
+    if (NewValues.none())
+      return;
+    It->second |= Incoming;
+    if (!Queued.test(*Successor)) {
+      Queued.set(*Successor);
+      Worklist.push_back(*Successor);
+    }
+  };
+
+  while (!Worklist.empty()) {
+    size_t Index = Worklist.pop_back_val();
+    Queued.reset(Index);
+    const InternalDecodedInst &DI = Decoded[Index];
+    BitVector Incoming = IncomingAt.find(Index)->second;
+    if (!DI.DecodeSucceeded || DI.Offset < FunctionBegin ||
+        DI.Offset >= FunctionEnd) {
+      Unsafe |= Incoming;
+      continue;
+    }
+
+    BitVector Uses(MaxSgprs);
+    BitVector Defs(MaxSgprs);
+    getNumberedSgprUsesAndDefs(DI, LS, NumberedSgprs, Uses, Defs);
+    Uses &= Incoming;
+    Unsafe |= Uses;
+    Incoming.reset(Defs);
+    if (Incoming.none())
+      continue;
+
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode)
+      continue;
+    if (LS.MIA->isCall(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
+        LS.MIA->isReturn(DI.Inst)) {
+      Unsafe |= Incoming;
+      continue;
+    }
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (Target)
+        Propagate(*Target, Incoming);
+      else
+        Unsafe |= Incoming;
+      if (LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
+               !LS.MIA->isBarrier(DI.Inst)) {
+      Unsafe |= Incoming;
+      continue;
+    }
+
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "far-return SGPR liveness fallthrough");
+    if (Fallthrough)
+      Propagate(*Fallthrough, Incoming);
+    else
+      Unsafe |= Incoming;
+  }
+  return Unsafe;
+}
+
+struct BatchedSgprContinuationAnalysis {
+  uint64_t FunctionBegin = 0;
+  uint64_t FunctionEnd = 0;
+  size_t BeginIndex = 0;
+  size_t InstructionCount = 0;
+  unsigned RegisterCount = 0;
+  unsigned WordsPerRow = 0;
+  std::vector<uint64_t> UnsafeRows;
+
+  std::optional<BitVector>
+  query(ArrayRef<InternalDecodedInst> Decoded, uint64_t Continuation) const {
+    if (Continuation < FunctionBegin || Continuation >= FunctionEnd)
+      return std::nullopt;
+    auto Begin = Decoded.begin() + BeginIndex;
+    auto End = Begin + InstructionCount;
+    auto It = llvm::lower_bound(
+        ArrayRef<InternalDecodedInst>(Begin, End), Continuation,
+        [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
+    if (It == ArrayRef<InternalDecodedInst>(Begin, End).end() ||
+        It->Offset != Continuation)
+      return std::nullopt;
+    size_t LocalIndex = It - Begin;
+    const uint64_t *Row =
+        UnsafeRows.data() + LocalIndex * WordsPerRow;
+    BitVector Result(RegisterCount);
+    for (unsigned Register = 0; Register != RegisterCount; ++Register)
+      if ((Row[Register / 64] >> (Register % 64)) & 1)
+        Result.set(Register);
+    return Result;
+  }
+};
+
+static std::optional<BatchedSgprContinuationAnalysis>
+computeBatchedSgprContinuationAnalysis(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t FunctionBegin, uint64_t FunctionEnd,
+    ArrayRef<MCRegister> NumberedSgprs) {
+  if (!LS.MIA || FunctionBegin >= FunctionEnd)
+    return std::nullopt;
+  auto Begin = llvm::lower_bound(
+      Decoded, FunctionBegin,
+      [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  auto End = llvm::lower_bound(
+      Decoded, FunctionEnd,
+      [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  if (Begin == End)
+    return std::nullopt;
+
+  BatchedSgprContinuationAnalysis Result;
+  Result.FunctionBegin = FunctionBegin;
+  Result.FunctionEnd = FunctionEnd;
+  Result.BeginIndex = Begin - Decoded.begin();
+  Result.InstructionCount = End - Begin;
+  Result.RegisterCount = NumberedSgprs.size();
+  Result.WordsPerRow = (Result.RegisterCount + 63) / 64;
+  if (Result.WordsPerRow == 0)
+    return Result;
+  if (Result.InstructionCount >
+      std::numeric_limits<size_t>::max() / Result.WordsPerRow)
+    return std::nullopt;
+  size_t WordCount = Result.InstructionCount * Result.WordsPerRow;
+
+  std::vector<uint64_t> UsesRows(WordCount);
+  std::vector<uint64_t> DefsRows(WordCount);
+  Result.UnsafeRows.assign(WordCount, 0);
+  std::vector<SmallVector<size_t, 2>> Successors(Result.InstructionCount);
+  std::vector<SmallVector<size_t, 2>> Predecessors(Result.InstructionCount);
+  BitVector OpaqueSuccessor(Result.InstructionCount);
+
+  auto FindLocalIndex = [&](uint64_t Offset) -> std::optional<size_t> {
+    if (Offset < FunctionBegin || Offset >= FunctionEnd)
+      return std::nullopt;
+    auto It = llvm::lower_bound(
+        ArrayRef<InternalDecodedInst>(Begin, End), Offset,
+        [](const InternalDecodedInst &DI, uint64_t Target) {
+          return DI.Offset < Target;
+        });
+    if (It == ArrayRef<InternalDecodedInst>(Begin, End).end() ||
+        It->Offset != Offset)
+      return std::nullopt;
+    return It - Begin;
+  };
+  auto AddSuccessor = [&](size_t From, uint64_t Offset) {
+    std::optional<size_t> To = FindLocalIndex(Offset);
+    if (!To) {
+      OpaqueSuccessor.set(From);
+      return;
+    }
+    if (!llvm::is_contained(Successors[From], *To)) {
+      Successors[From].push_back(*To);
+      Predecessors[*To].push_back(From);
+    }
+  };
+  auto StoreBits = [&](uint64_t *Row, const BitVector &Bits) {
+    for (int Bit = Bits.find_first(); Bit >= 0; Bit = Bits.find_next(Bit))
+      Row[static_cast<unsigned>(Bit) / 64] |=
+          uint64_t{1} << (static_cast<unsigned>(Bit) % 64);
+  };
+
+  for (size_t I = 0; I != Result.InstructionCount; ++I) {
+    const InternalDecodedInst &DI = Begin[I];
+    uint64_t *Uses = UsesRows.data() + I * Result.WordsPerRow;
+    uint64_t *Defs = DefsRows.data() + I * Result.WordsPerRow;
+    if (!DI.DecodeSucceeded || DI.Offset < FunctionBegin ||
+        DI.Offset >= FunctionEnd) {
+      OpaqueSuccessor.set(I);
+      continue;
+    }
+
+    BitVector UsesBits(Result.RegisterCount);
+    BitVector DefsBits(Result.RegisterCount);
+    getNumberedSgprUsesAndDefs(DI, LS, NumberedSgprs, UsesBits, DefsBits);
+    StoreBits(Uses, UsesBits);
+    StoreBits(Defs, DefsBits);
+
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode)
+      continue;
+    if (LS.MIA->isCall(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
+        LS.MIA->isReturn(DI.Inst)) {
+      OpaqueSuccessor.set(I);
+      continue;
+    }
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (Target)
+        AddSuccessor(I, *Target);
+      else
+        OpaqueSuccessor.set(I);
+      if (LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
+               !LS.MIA->isBarrier(DI.Inst)) {
+      OpaqueSuccessor.set(I);
+      continue;
+    }
+
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "batched SGPR liveness fallthrough");
+    if (Fallthrough)
+      AddSuccessor(I, *Fallthrough);
+    else
+      OpaqueSuccessor.set(I);
+  }
+
+  SmallVector<size_t, 32> Worklist;
+  Worklist.reserve(Result.InstructionCount);
+  BitVector Queued(Result.InstructionCount, true);
+  for (size_t I = 0; I != Result.InstructionCount; ++I)
+    Worklist.push_back(I);
+  while (!Worklist.empty()) {
+    size_t I = Worklist.pop_back_val();
+    Queued.reset(I);
+    const uint64_t *Uses = UsesRows.data() + I * Result.WordsPerRow;
+    const uint64_t *Defs = DefsRows.data() + I * Result.WordsPerRow;
+    uint64_t *Unsafe =
+        Result.UnsafeRows.data() + I * Result.WordsPerRow;
+    bool Changed = false;
+    for (unsigned Word = 0; Word != Result.WordsPerRow; ++Word) {
+      uint64_t SuccessorUnsafe =
+          OpaqueSuccessor.test(I) ? std::numeric_limits<uint64_t>::max() : 0;
+      for (size_t Successor : Successors[I])
+        SuccessorUnsafe |=
+            Result.UnsafeRows[Successor * Result.WordsPerRow + Word];
+      uint64_t NewUnsafe =
+          Uses[Word] | (SuccessorUnsafe & ~Defs[Word]);
+      if (Word + 1 == Result.WordsPerRow &&
+          Result.RegisterCount % 64 != 0)
+        NewUnsafe &= (uint64_t{1} << (Result.RegisterCount % 64)) - 1;
+      uint64_t Added = NewUnsafe & ~Unsafe[Word];
+      if (Added != 0) {
+        Unsafe[Word] |= Added;
+        Changed = true;
+      }
+    }
+    if (!Changed)
+      continue;
+    for (size_t Predecessor : Predecessors[I])
+      if (!Queued.test(Predecessor)) {
+        Queued.set(Predecessor);
+        Worklist.push_back(Predecessor);
+      }
+  }
+  return Result;
+}
+
+BatchedSgprContinuationTestResult
+runBatchedSgprContinuationAnalysisForTest(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t FunctionBegin, uint64_t FunctionEnd,
+    ArrayRef<uint64_t> Continuations,
+    ArrayRef<MCRegister> NumberedSgprs) {
+  BatchedSgprContinuationTestResult Result;
+  std::optional<BatchedSgprContinuationAnalysis> Analysis =
+      computeBatchedSgprContinuationAnalysis(
+          Decoded, LS, FunctionBegin, FunctionEnd, NumberedSgprs);
+  Result.Analyses = 1;
+  for (uint64_t Continuation : Continuations)
+    Result.Queries.push_back(
+        Analysis ? Analysis->query(Decoded, Continuation) : std::nullopt);
+  return Result;
+}
+
+static std::optional<BitVector> unsafeIncomingNumberedSgprsAtContinuation(
+    PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+    ArrayRef<MCRegister> NumberedSgprs) {
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!FunctionRange)
+    return std::nullopt;
+  std::optional<uint64_t> Continuation = checkedAddUint64(
+      InstOffset, InstSize, "far-return SGPR liveness continuation");
+  if (!Continuation)
+    return std::nullopt;
+  return unsafeIncomingNumberedSgprsInRange(
+      Ctx.Decoded, Ctx.LS, FunctionRange->Begin, FunctionRange->End,
+      *Continuation, NumberedSgprs);
+}
+
+static std::optional<unsigned>
+selectLocallyDeadSgprPair(unsigned MaxSgprs, const BitVector &Unsafe) {
+  if (MaxSgprs < 2 || Unsafe.size() < MaxSgprs)
+    return std::nullopt;
+  unsigned Base = (MaxSgprs - 2) & ~1u;
+  for (;;) {
+    if (!Unsafe.test(Base) && !Unsafe.test(Base + 1))
+      return Base;
+    if (Base == 0)
+      break;
+    Base -= 2;
+  }
+  return std::nullopt;
+}
+
+static std::optional<unsigned>
+findLocallyDeadSgprPair(PatchContext &Ctx, uint64_t InstOffset,
+                        uint32_t InstSize, ArrayRef<uint8_t> Replacement) {
+  if (Ctx.Config.MaxSgprs < 2)
+    return std::nullopt;
+  std::optional<SmallVector<MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*Ctx.LS.MRI, Ctx.Config.MaxSgprs);
+  if (!NumberedSgprs)
+    return std::nullopt;
+  std::optional<BitVector> ContinuationUnsafe =
+      unsafeIncomingNumberedSgprsAtContinuation(Ctx, InstOffset, InstSize,
+                                                *NumberedSgprs);
+  if (!ContinuationUnsafe)
+    return std::nullopt;
+  BitVector Unsafe = unsafeIncomingNumberedSgprsInReplacement(
+      Replacement, Ctx.LS, *NumberedSgprs);
+  Unsafe |= *ContinuationUnsafe;
+  return selectLocallyDeadSgprPair(Ctx.Config.MaxSgprs, Unsafe);
+}
+
+using BatchedSgprContinuationCache =
+    DenseMap<std::pair<uint64_t, uint64_t>,
+             std::optional<BatchedSgprContinuationAnalysis>>;
+
+static std::optional<unsigned> findLocallyDeadSgprPairWithCache(
+    PatchContext &Ctx, const ElfView::FunctionTextRange &FunctionRange,
+    uint64_t InstOffset, uint32_t InstSize, ArrayRef<uint8_t> Replacement,
+    ArrayRef<MCRegister> NumberedSgprs,
+    BatchedSgprContinuationCache &Cache, uint64_t &AnalysisCount) {
+  std::optional<uint64_t> Continuation = checkedAddUint64(
+      InstOffset, InstSize, "cached far-return SGPR liveness continuation");
+  if (!Continuation)
+    return std::nullopt;
+
+  std::pair<uint64_t, uint64_t> Key{FunctionRange.Begin, FunctionRange.End};
+  auto It = Cache.find(Key);
+  if (It == Cache.end()) {
+    std::optional<BatchedSgprContinuationAnalysis> Analysis =
+        computeBatchedSgprContinuationAnalysis(
+            Ctx.Decoded, Ctx.LS, FunctionRange.Begin, FunctionRange.End,
+            NumberedSgprs);
+    It = Cache.try_emplace(Key, std::move(Analysis)).first;
+    ++AnalysisCount;
+  }
+  if (!It->second)
+    return std::nullopt;
+  std::optional<BitVector> ContinuationUnsafe =
+      It->second->query(Ctx.Decoded, *Continuation);
+  if (!ContinuationUnsafe)
+    return std::nullopt;
+
+  BitVector Unsafe = unsafeIncomingNumberedSgprsInReplacement(
+      Replacement, Ctx.LS, NumberedSgprs);
+  Unsafe |= *ContinuationUnsafe;
+  return selectLocallyDeadSgprPair(Ctx.Config.MaxSgprs, Unsafe);
+}
+
+struct FarReturnScratch {
+  bool Available = false;
+  unsigned SgprBase = 0;
+  bool UseVcc = false;
+  bool PreserveVcc = false;
+};
+
+static FarReturnScratch reserveSafeFarReturn(PatchContext &Ctx,
+                                             uint64_t InstOffset,
+                                             uint32_t InstSize,
+                                             ArrayRef<uint8_t> Replacement) {
   std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
-      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return");
-  if (!Scratch)
-    return std::nullopt;
-  if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch, "safe far return"))
-    return std::nullopt;
-  return Scratch;
+      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return",
+      /*ReportNoSpace=*/false);
+  if (Scratch) {
+    if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch,
+                                    "safe far return"))
+      return {};
+    return FarReturnScratch{/*Available=*/true, Scratch->Base,
+                            /*UseVcc=*/false, /*PreserveVcc=*/false};
+  }
+
+  if (Ctx.LS.VCCRegister.isValid() &&
+      !replacementNeedsIncomingRegister(Replacement, Ctx.LS,
+                                        Ctx.LS.VCCRegister) &&
+      isRegisterDefinitelyDeadAtContinuation(Ctx, InstOffset, InstSize,
+                                             Ctx.LS.VCCRegister)) {
+    log() << "hotswap: safe far return: reusing dead VCC at 0x"
+          << utohexstr(InstOffset) << "\n";
+    return FarReturnScratch{/*Available=*/true, /*SgprBase=*/0,
+                            /*UseVcc=*/true, /*PreserveVcc=*/false};
+  }
+
+  if (std::optional<unsigned> LocalPair =
+          findLocallyDeadSgprPair(Ctx, InstOffset, InstSize, Replacement)) {
+    SafeSgprScratchBlock Scratch{*LocalPair, 2};
+    if (!commitSafeSgprScratchBlock(Ctx, InstOffset, Scratch,
+                                    "locally dead far-return SGPR pair"))
+      return {};
+    log() << "hotswap: safe far return: reusing locally dead s[" << *LocalPair
+          << ":" << *LocalPair + 1 << "] at 0x" << utohexstr(InstOffset)
+          << "\n";
+    return FarReturnScratch{/*Available=*/true, *LocalPair,
+                            /*UseVcc=*/false, /*PreserveVcc=*/false};
+  }
+
+  std::string Owner =
+      Ctx.Elf.findKernelAtAddress(InstOffset + Ctx.Elf.textAddr());
+  std::optional<unsigned> WavefrontSize =
+      Owner.empty() ? std::nullopt : Ctx.Elf.getKernelWavefrontSize(Owner);
+  if (WavefrontSize == 32 && InstSize >= 2 * MinInstSize) {
+    std::optional<SafeSgprScratchBlock> Save = findSafeSgprScratchBlock(
+        Ctx, InstOffset, /*Count=*/1, /*Alignment=*/1,
+        "VCC-preserving far return", /*ReportNoSpace=*/false);
+    if (Save) {
+      log() << "hotswap: safe far return: deferring live wave32 VCC_LO "
+               "preservation in s"
+            << Save->Base << " at 0x" << utohexstr(InstOffset) << "\n";
+      return FarReturnScratch{/*Available=*/true, Save->Base,
+                              /*UseVcc=*/true, /*PreserveVcc=*/true};
+    }
+  }
+
+  log() << "hotswap: safe far return: no register pair at 0x"
+        << utohexstr(InstOffset)
+        << "; deferring to the s_branch island planner\n";
+  return {};
 }
 
 bool isSBranchReachable(uint64_t From, uint64_t To) {
@@ -819,11 +1812,13 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
 /// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
 /// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
 /// the pool layout is known. A site beyond s_branch reach of the appended pool
-/// uses an SCC-neutral get-PC/add/set-PC sequence on the backward edge.
+/// uses either an SCC-neutral get-PC/add/set-PC sequence or a chain of
+/// registerless s_branch islands on the backward edge.
 /// Adjacent far sites are coalesced after patching to reduce gateway pressure.
-/// Every far source edge then uses a short branch to nearby safe NOP padding;
-/// that gateway uses the gfx12 SGPR-backed set-PC sequence. No source or return
-/// edge executes gfx1250's broken s_add_pc_i64 instruction.
+/// Every far source edge uses a short branch to nearby safe padding; that
+/// gateway either continues through s_branch islands or uses the gfx12
+/// SGPR-backed set-PC sequence. No source or return edge executes gfx1250's
+/// broken s_add_pc_i64 instruction.
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
                                     ArrayRef<uint8_t> Replacement) {
@@ -850,9 +1845,21 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   const bool Far = !(isSBranchReachable(InstOffset, *PoolStart) &&
                      isSBranchReachable(*ShortBackFrom, *ReturnTo));
 
-  uint64_t ReturnReserve = Far ? SetPcReturnReserveBytes : MinInstSize;
+  FarReturnScratch Scratch;
+  if (Far)
+    Scratch = reserveSafeFarReturn(Ctx, InstOffset, InstSize, Replacement);
+  uint64_t ReturnReserve = MinInstSize;
+  uint64_t BodyPrefix = 0;
+  if (Far && Scratch.Available) {
+    ReturnReserve = Scratch.PreserveVcc ? VccPreservingReturnReserveBytes
+                                        : SetPcReturnReserveBytes;
+    BodyPrefix = Scratch.PreserveVcc ? VccRestoreSequenceBytes : 0;
+  }
   std::optional<uint64_t> TrampolineSize = checkedAddUint64(
-      Replacement.size(), ReturnReserve, "queued trampoline size");
+      Replacement.size(), BodyPrefix, "queued trampoline body size");
+  if (TrampolineSize)
+    TrampolineSize = checkedAddUint64(*TrampolineSize, ReturnReserve,
+                                      "queued trampoline size");
   if (!TrampolineSize)
     return false;
   std::optional<uint64_t> QueuedBytes =
@@ -864,6 +1871,17 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   Trampoline T;
   T.OriginalOffset = InstOffset;
   T.OriginalSize = InstSize;
+  if (Scratch.PreserveVcc) {
+    SmallVector<std::string, 2> RestoreLines;
+    RestoreLines.push_back("s_mov_b32 vcc_lo, s" +
+                           std::to_string(Scratch.SgprBase));
+    RestoreLines.push_back("s_delay_alu instid0(SALU_CYCLE_1)");
+    SmallVector<uint8_t> Restore =
+        assembleInstructions(joinAsmLines(RestoreLines), Ctx.LS);
+    if (Restore.size() != VccRestoreSequenceBytes)
+      return false;
+    T.Bytes.append(Restore.begin(), Restore.end());
+  }
   T.Bytes.insert(T.Bytes.end(), Replacement.begin(), Replacement.end());
   if (std::optional<ElfView::FunctionTextRange> Range =
           Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset)) {
@@ -885,14 +1903,12 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
     if (InstSize < MinInstSize)
       return declineFar(Twine(InstSize) + " B, smaller than " +
                         Twine(MinInstSize) + " B forward branch");
-    std::optional<SafeSgprScratchBlock> Scratch =
-        reserveSafeFarReturn(Ctx, InstOffset);
-    if (!Scratch)
-      return declineFar("no safe SGPR triple for set-PC return");
-    T.Bytes.insert(T.Bytes.end(), SetPcReturnReserveBytes, uint8_t{0});
+    T.Bytes.insert(T.Bytes.end(), ReturnReserve, uint8_t{0});
     T.Long = true;
-    T.UsesSetPCBack = true;
-    T.LongBranchSgprBase = Scratch->Base;
+    T.UsesSetPCBack = Scratch.Available;
+    T.LongBranchSgprBase = Scratch.SgprBase;
+    T.LongBranchUsesVcc = Scratch.UseVcc;
+    T.LongBranchPreservesVcc = Scratch.PreserveVcc;
     Ctx.Profile.count(HotswapMetric::JumpLong);
     Ctx.OutTrampolines.emplace_back(std::move(T));
     Ctx.QueuedTrampolineBytes = *QueuedBytes;
@@ -984,6 +2000,7 @@ static bool isControlFlowBoundary(const InternalDecodedInst &DI,
 struct DeclaredTextEntryInfo {
   SmallVector<uint64_t, 16> Entries;
   SmallVector<uint64_t, 16> ExternalEntries;
+  SmallVector<uint64_t, 16> NonCallEntries;
 };
 
 static std::optional<DeclaredTextEntryInfo>
@@ -1022,6 +2039,7 @@ collectDeclaredTextEntries(const ElfView &Elf) {
       uint64_t Entry = *EntryAddress - Elf.textAddr();
       Info.Entries.push_back(Entry);
       Info.ExternalEntries.push_back(Entry);
+      Info.NonCallEntries.push_back(Entry);
     }
   }
   return Info;
@@ -1033,6 +2051,18 @@ struct PcMaterializedCallInfo {
   uint64_t SequenceEnd = 0;
   MCRegister ReturnRegister;
 };
+
+static std::optional<uint64_t>
+evaluateAbsoluteUint64Operand(const MCOperand &Operand) {
+  if (Operand.isImm())
+    return static_cast<uint64_t>(Operand.getImm());
+  if (!Operand.isExpr())
+    return std::nullopt;
+  int64_t Value = 0;
+  if (!Operand.getExpr()->evaluateAsAbsolute(Value))
+    return std::nullopt;
+  return static_cast<uint64_t>(Value);
+}
 
 /// Resolve the compiler-emitted PC materialization used by the production
 /// reproducer:
@@ -1057,7 +2087,7 @@ resolveMaterializedPcTarget(ArrayRef<InternalDecodedInst> Decoded,
                             size_t TransferIndex, MCRegister TargetRegister,
                             const LLVMState &LS, uint64_t TextAddr) {
   std::optional<size_t> AddIndex;
-  int64_t AddImmediate = 0;
+  uint64_t AddImmediate = 0;
   for (size_t I = TransferIndex; I != 0;) {
     --I;
     const InternalDecodedInst &Candidate = Decoded[I];
@@ -1070,11 +2100,14 @@ resolveMaterializedPcTarget(ArrayRef<InternalDecodedInst> Decoded,
         !Candidate.Inst.getOperand(0).isReg() ||
         Candidate.Inst.getOperand(0).getReg() != TargetRegister ||
         !Candidate.Inst.getOperand(1).isReg() ||
-        Candidate.Inst.getOperand(1).getReg() != TargetRegister ||
-        !Candidate.Inst.getOperand(2).isImm())
+        Candidate.Inst.getOperand(1).getReg() != TargetRegister)
       return std::nullopt;
     AddIndex = I;
-    AddImmediate = Candidate.Inst.getOperand(2).getImm();
+    std::optional<uint64_t> Immediate =
+        evaluateAbsoluteUint64Operand(Candidate.Inst.getOperand(2));
+    if (!Immediate)
+      return std::nullopt;
+    AddImmediate = *Immediate;
     break;
   }
   if (!AddIndex)
@@ -1104,8 +2137,7 @@ resolveMaterializedPcTarget(ArrayRef<InternalDecodedInst> Decoded,
     // s_add_nc_u64 uses modulo-2^64 arithmetic. Casting the signed MC
     // immediate to uint64_t and adding it reproduces both positive and
     // negative literals, including INT64_MIN, without signed overflow.
-    return MaterializedPcSequence{
-        *PcValue + static_cast<uint64_t>(AddImmediate), Candidate.Offset};
+    return MaterializedPcSequence{*PcValue + AddImmediate, Candidate.Offset};
   }
   return std::nullopt;
 }
@@ -1131,6 +2163,836 @@ matchPcMaterializedCall(ArrayRef<InternalDecodedInst> Decoded, size_t CallIndex,
                                 MCRegister(Call.Inst.getOperand(0).getReg())};
 }
 
+using ReachingCallTargets = SmallVector<uint64_t, 8>;
+
+struct ReachingPcState {
+  bool Reached = false;
+  bool HasUnknown = false;
+  ReachingCallTargets Targets;
+  SmallVector<size_t, 4> ActiveMaterializations;
+};
+
+static bool mergeReachingPcState(ReachingPcState &Into,
+                                 const ReachingPcState &From) {
+  if (!From.Reached)
+    return false;
+  ReachingPcState Before = Into;
+  Into.Reached = true;
+  Into.HasUnknown |= From.HasUnknown;
+  for (uint64_t Target : From.Targets)
+    if (!llvm::is_contained(Into.Targets, Target))
+      Into.Targets.push_back(Target);
+  for (size_t Completion : From.ActiveMaterializations)
+    if (!llvm::is_contained(Into.ActiveMaterializations, Completion))
+      Into.ActiveMaterializations.push_back(Completion);
+  llvm::sort(Into.Targets);
+  llvm::sort(Into.ActiveMaterializations);
+  return Before.Reached != Into.Reached ||
+         Before.HasUnknown != Into.HasUnknown ||
+         Before.Targets != Into.Targets ||
+         Before.ActiveMaterializations != Into.ActiveMaterializations;
+}
+
+static bool isExactRegisterOperand(const MCInst &Inst, unsigned Index,
+                                   MCRegister Reg) {
+  return Index < Inst.getNumOperands() && Inst.getOperand(Index).isReg() &&
+         Inst.getOperand(Index).getReg() == Reg;
+}
+
+static std::optional<uint32_t>
+evaluateAbsoluteUint32Operand(const MCOperand &Operand) {
+  if (Operand.isImm())
+    return static_cast<uint32_t>(Operand.getImm());
+  if (!Operand.isExpr())
+    return std::nullopt;
+  int64_t Value = 0;
+  if (!Operand.getExpr()->evaluateAsAbsolute(Value))
+    return std::nullopt;
+  return static_cast<uint32_t>(Value);
+}
+
+/// Recognize the two compiler-emitted ways a reusable register-call target is
+/// materialized. The first is the canonical get-PC/add-nc pair. Tensile also
+/// computes a 32-bit displacement in a temporary and propagates carry into the
+/// high half:
+///
+///   s_get_pc_i64 Pair
+///   s_add_co_i32 Tmp, Imm0, Imm1
+///   s_add_co_u32 Pair.lo, Pair.lo, Tmp
+///   s_add_co_ci_u32 Pair.hi, Pair.hi, 0
+///
+/// Return the completion instruction and absolute target. Intermediate
+/// definitions deliberately remain "unknown" in the reaching-value solver.
+static std::optional<std::pair<size_t, uint64_t>>
+matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
+                               size_t GetPcIndex, size_t FunctionEndIndex,
+                               MCRegister Pair, const LLVMState &LS,
+                               uint64_t TextAddr) {
+  const InternalDecodedInst &GetPc = Decoded[GetPcIndex];
+  if (!GetPc.DecodeSucceeded || GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
+      !isExactRegisterOperand(GetPc.Inst, 0, Pair))
+    return std::nullopt;
+  std::optional<uint64_t> Pc =
+      checkedAddUint64(TextAddr, GetPc.Offset, "reusable get-PC address");
+  if (!Pc)
+    return std::nullopt;
+  Pc = checkedAddUint64(*Pc, GetPc.Size, "reusable get-PC value");
+  if (!Pc)
+    return std::nullopt;
+
+  for (size_t I = GetPcIndex + 1; I < FunctionEndIndex; ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!DI.DecodeSucceeded || isControlFlowBoundary(DI, LS))
+      break;
+    if (!definesOverlappingRegister(DI, LS, Pair))
+      continue;
+    if (DI.Inst.getOpcode() != LS.SAddNcU64Opcode ||
+        DI.Inst.getNumOperands() != 3 ||
+        !isExactRegisterOperand(DI.Inst, 0, Pair) ||
+        !isExactRegisterOperand(DI.Inst, 1, Pair))
+      break;
+    std::optional<uint64_t> Delta =
+        evaluateAbsoluteUint64Operand(DI.Inst.getOperand(2));
+    if (!Delta)
+      break;
+    return std::make_pair(I, *Pc + *Delta);
+  }
+
+  if (GetPcIndex + 3 >= FunctionEndIndex)
+    return std::nullopt;
+  const InternalDecodedInst &MakeDelta = Decoded[GetPcIndex + 1];
+  const InternalDecodedInst &AddLow = Decoded[GetPcIndex + 2];
+  const InternalDecodedInst &AddHigh = Decoded[GetPcIndex + 3];
+  if (MakeDelta.Mnemonic != "s_add_co_i32" ||
+      AddLow.Mnemonic != "s_add_co_u32" ||
+      AddHigh.Mnemonic != "s_add_co_ci_u32" ||
+      MakeDelta.Inst.getNumOperands() != 3 ||
+      !MakeDelta.Inst.getOperand(0).isReg() ||
+      !MakeDelta.Inst.getOperand(0).getReg() ||
+      !MakeDelta.Inst.getOperand(2).isImm())
+    return std::nullopt;
+  MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
+  if (LS.MRI->regsOverlap(DeltaReg, Pair))
+    return std::nullopt;
+  if (AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
+      !AddLow.Inst.getOperand(1).isReg() ||
+      !AddLow.Inst.getOperand(0).getReg() ||
+      AddLow.Inst.getOperand(0).getReg() !=
+          AddLow.Inst.getOperand(1).getReg() ||
+      !isExactRegisterOperand(AddLow.Inst, 2, DeltaReg) ||
+      AddHigh.Inst.getNumOperands() != 3 ||
+      !AddHigh.Inst.getOperand(0).isReg() ||
+      !AddHigh.Inst.getOperand(1).isReg() ||
+      !AddHigh.Inst.getOperand(0).getReg() ||
+      AddHigh.Inst.getOperand(0).getReg() !=
+          AddHigh.Inst.getOperand(1).getReg() ||
+      !AddHigh.Inst.getOperand(2).isImm() ||
+      AddHigh.Inst.getOperand(2).getImm() != 0)
+    return std::nullopt;
+  MCRegister Low(AddLow.Inst.getOperand(0).getReg());
+  MCRegister High(AddHigh.Inst.getOperand(0).getReg());
+  std::optional<unsigned> LowIndex = numberedSgprIndex(*LS.MRI, Low);
+  std::optional<unsigned> HighIndex = numberedSgprIndex(*LS.MRI, High);
+  if (!LowIndex || !HighIndex || *HighIndex != *LowIndex + 1 ||
+      !LS.MRI->regsOverlap(Low, Pair) || !LS.MRI->regsOverlap(High, Pair))
+    return std::nullopt;
+
+  std::optional<uint32_t> FirstAddend =
+      evaluateAbsoluteUint32Operand(MakeDelta.Inst.getOperand(1));
+  if (!FirstAddend)
+    return std::nullopt;
+  uint32_t Delta = *FirstAddend +
+                   static_cast<uint32_t>(MakeDelta.Inst.getOperand(2).getImm());
+  return std::make_pair(GetPcIndex + 3, *Pc + Delta);
+}
+
+struct ReachingCallGroup {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  MCRegister TargetRegister;
+  SmallVector<size_t, 8> Calls;
+};
+
+struct ReachingPcUse {
+  size_t InstIndex = 0;
+  MCRegister Register;
+};
+
+struct FiniteSetPcTransfer {
+  size_t InstIndex = 0;
+  size_t SequenceBeginIndex = 0;
+  size_t SequenceEndIndex = 0;
+  uint64_t Target = 0;
+  std::optional<size_t> LocalTargetIndex;
+  uint64_t FunctionBegin = 0;
+  uint64_t FunctionEnd = 0;
+};
+
+static const ElfView::FunctionTextRange *
+findInnermostFunctionRange(uint64_t Address,
+                           ArrayRef<ElfView::FunctionTextRange> Ranges) {
+  const ElfView::FunctionTextRange *Best = nullptr;
+  for (const ElfView::FunctionTextRange &Range : Ranges)
+    if (Range.Begin <= Address && Address < Range.End &&
+        (!Best || Range.Begin > Best->Begin ||
+         (Range.Begin == Best->Begin && Range.End < Best->End)))
+      Best = &Range;
+  return Best;
+}
+
+/// Collect exact materialized s_set_pc_i64 transfers. These are candidates,
+/// not proofs: a later closed-world audit must still rule out an alternate
+/// entry into the materialization before the edge can authorize mutation.
+static SmallVector<FiniteSetPcTransfer, 8> collectFiniteSetPcCandidates(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextEnd,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
+  SmallVector<FiniteSetPcTransfer, 8> Candidates;
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+  std::optional<SmallVector<MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*LS.MRI, Gfx1250MaxSgprs);
+
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &GetPc = Decoded[I];
+    if (!GetPc.DecodeSucceeded ||
+        GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
+        GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+        !GetPc.Inst.getOperand(0).getReg())
+      continue;
+    MCRegister Pair(GetPc.Inst.getOperand(0).getReg());
+    std::optional<uint64_t> GetPcAddress = checkedAddUint64(
+        TextAddr, GetPc.Offset, "finite set-PC get-PC address");
+    if (!GetPcAddress)
+      continue;
+    const ElfView::FunctionTextRange *Range =
+        findInnermostFunctionRange(*GetPcAddress, FunctionRanges);
+    if (!Range || Range->Begin < TextAddr || Range->End > TextEnd)
+      continue;
+    ArrayRef<InternalDecodedInst>::const_iterator FunctionEnd =
+        llvm::lower_bound(Decoded, Range->End - TextAddr,
+                          [](const InternalDecodedInst &DI, uint64_t Offset) {
+                            return DI.Offset < Offset;
+                          });
+    size_t FunctionEndIndex =
+        static_cast<size_t>(FunctionEnd - Decoded.begin());
+    auto appendCandidate = [&](size_t SetPcIndex, size_t SequenceEndIndex,
+                               uint64_t Target) {
+      for (size_t J = I; J <= SequenceEndIndex; ++J) {
+        if (!Decoded[J].DecodeSucceeded)
+          return;
+        if (J == SequenceEndIndex)
+          break;
+        std::optional<uint64_t> End =
+            checkedAddUint64(Decoded[J].Offset, Decoded[J].Size,
+                             "finite set-PC materialization instruction end");
+        if (!End || *End != Decoded[J + 1].Offset)
+          return;
+      }
+      std::optional<size_t> LocalTargetIndex;
+      if (Target >= TextAddr && Target < TextEnd) {
+        DenseMap<uint64_t, size_t>::const_iterator LocalTarget =
+            OffsetToIndex.find(Target - TextAddr);
+        // A local transfer to the middle of an instruction is not finite for
+        // purposes of safe rewriting.
+        if (LocalTarget == OffsetToIndex.end())
+          return;
+        LocalTargetIndex = LocalTarget->second;
+      }
+      Candidates.push_back({SetPcIndex, I, SequenceEndIndex, Target,
+                            LocalTargetIndex, Range->Begin - TextAddr,
+                            Range->End - TextAddr});
+    };
+
+    std::optional<std::pair<size_t, uint64_t>> Match =
+        matchReusablePcMaterialization(Decoded, I, FunctionEndIndex, Pair, LS,
+                                       TextAddr);
+    if (Match && Match->first + 1 < FunctionEndIndex) {
+      size_t SetPcIndex = Match->first + 1;
+      const InternalDecodedInst &SetPc = Decoded[SetPcIndex];
+      if (SetPc.DecodeSucceeded &&
+          SetPc.Inst.getOpcode() == LS.SSetPcI64Opcode &&
+          SetPc.Inst.getNumOperands() == 1 &&
+          isExactRegisterOperand(SetPc.Inst, 0, Pair))
+        appendCandidate(SetPcIndex, SetPcIndex, Match->second);
+    }
+
+    // gfx1250 also materializes a local 64-bit PC delta directly into the
+    // low/high halves of the get-PC pair:
+    //
+    //   s_get_pc_i64 Pair
+    //   s_add_co_u32 Pair.lo, Pair.lo, Delta.lo
+    //   s_add_co_ci_u32 Pair.hi, Pair.hi, Delta.hi
+    //   s_set_pc_i64 Pair
+    //
+    // The two immediate halves are linker constants. Treat the four-op shape
+    // as one candidate; appendCandidate and the later closed-world audit still
+    // reject gaps, instruction-interior targets, and alternate entries.
+    if (I + 3 < FunctionEndIndex) {
+      const InternalDecodedInst &AddLow = Decoded[I + 1];
+      const InternalDecodedInst &AddHigh = Decoded[I + 2];
+      const InternalDecodedInst &SetPc = Decoded[I + 3];
+      if (AddLow.Mnemonic == "s_add_co_u32" &&
+          AddHigh.Mnemonic == "s_add_co_ci_u32" &&
+          AddLow.Inst.getNumOperands() == 3 &&
+          AddHigh.Inst.getNumOperands() == 3 &&
+          SetPc.Inst.getOpcode() == LS.SSetPcI64Opcode &&
+          SetPc.Inst.getNumOperands() == 1 &&
+          isExactRegisterOperand(SetPc.Inst, 0, Pair)) {
+        std::optional<unsigned> PairIndex =
+            numberedSgprPairLowIndex(*LS.MRI, Pair);
+        std::optional<uint32_t> LowDelta =
+            evaluateAbsoluteUint32Operand(AddLow.Inst.getOperand(2));
+        std::optional<uint32_t> HighDelta =
+            evaluateAbsoluteUint32Operand(AddHigh.Inst.getOperand(2));
+        if (PairIndex && LowDelta && HighDelta && NumberedSgprs &&
+            *PairIndex + 1 < NumberedSgprs->size() &&
+            isExactRegisterOperand(AddLow.Inst, 0,
+                                   (*NumberedSgprs)[*PairIndex]) &&
+            isExactRegisterOperand(AddLow.Inst, 1,
+                                   AddLow.Inst.getOperand(0).getReg()) &&
+            isExactRegisterOperand(AddHigh.Inst, 0,
+                                   (*NumberedSgprs)[*PairIndex + 1]) &&
+            isExactRegisterOperand(AddHigh.Inst, 1,
+                                   AddHigh.Inst.getOperand(0).getReg())) {
+          std::optional<uint64_t> PcValue = checkedAddUint64(
+              *GetPcAddress, GetPc.Size, "split-immediate set-PC value");
+          if (PcValue) {
+            uint64_t Delta = static_cast<uint64_t>(*LowDelta) |
+                             (static_cast<uint64_t>(*HighDelta) << 32);
+            // s_add_co_u32 / s_add_co_ci_u32 form one modulo-2^64 add.
+            // A negative linker delta therefore wraps in unsigned arithmetic;
+            // appendCandidate still requires every local result to be an
+            // exact decoded instruction boundary.
+            appendCandidate(I + 3, I + 3, *PcValue + Delta);
+          }
+        }
+      }
+    }
+
+    // Tensile also emits a signed-direction materialized jump. The signed
+    // displacement is a link-time constant, but the sequence uses a generic
+    // compare/abs/add-or-sub shape:
+    //
+    //   get_pc Pair
+    //   add_co_i32 Delta, Literal, Imm
+    //   cmp_ge_i32 Delta, 0
+    //   cbranch_scc1 Positive
+    //   abs_i32 Delta, Delta
+    //   sub_co_u32/sub_co_ci_u32 Pair, Pair, Delta
+    //   set_pc Pair
+    // Positive:
+    //   add_co_u32/add_co_ci_u32 Pair, Pair, Delta
+    //   set_pc Pair
+    //
+    // Both set-PC instructions have the same finite target. Keep the entire
+    // shape in one audited materialization interval so an alternate entry
+    // into either arm invalidates both candidates.
+    if (I + 10 >= FunctionEndIndex)
+      continue;
+    const InternalDecodedInst &MakeDelta = Decoded[I + 1];
+    const InternalDecodedInst &Compare = Decoded[I + 2];
+    const InternalDecodedInst &Branch = Decoded[I + 3];
+    const InternalDecodedInst &Abs = Decoded[I + 4];
+    const InternalDecodedInst &SubLow = Decoded[I + 5];
+    const InternalDecodedInst &SubHigh = Decoded[I + 6];
+    const InternalDecodedInst &NegativeSetPc = Decoded[I + 7];
+    const InternalDecodedInst &AddLow = Decoded[I + 8];
+    const InternalDecodedInst &AddHigh = Decoded[I + 9];
+    const InternalDecodedInst &PositiveSetPc = Decoded[I + 10];
+    if (!MakeDelta.DecodeSucceeded || !Compare.DecodeSucceeded ||
+        !Branch.DecodeSucceeded || !Abs.DecodeSucceeded ||
+        !SubLow.DecodeSucceeded || !SubHigh.DecodeSucceeded ||
+        !NegativeSetPc.DecodeSucceeded || !AddLow.DecodeSucceeded ||
+        !AddHigh.DecodeSucceeded || !PositiveSetPc.DecodeSucceeded ||
+        MakeDelta.Mnemonic != "s_add_co_i32" ||
+        MakeDelta.Inst.getNumOperands() != 3 ||
+        !MakeDelta.Inst.getOperand(0).isReg() ||
+        !MakeDelta.Inst.getOperand(0).getReg() ||
+        !MakeDelta.Inst.getOperand(2).isImm())
+      continue;
+    MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
+    if (LS.MRI->regsOverlap(DeltaReg, Pair))
+      continue;
+    if (Compare.Mnemonic != "s_cmp_ge_i32" ||
+        Compare.Inst.getNumOperands() != 2 ||
+        !isExactRegisterOperand(Compare.Inst, 0, DeltaReg) ||
+        !Compare.Inst.getOperand(1).isImm() ||
+        Compare.Inst.getOperand(1).getImm() != 0 ||
+        Branch.Mnemonic != "s_cbranch_scc1" || Abs.Mnemonic != "s_abs_i32" ||
+        Abs.Inst.getNumOperands() != 2 ||
+        !isExactRegisterOperand(Abs.Inst, 0, DeltaReg) ||
+        !isExactRegisterOperand(Abs.Inst, 1, DeltaReg) ||
+        NegativeSetPc.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        NegativeSetPc.Inst.getNumOperands() != 1 ||
+        !isExactRegisterOperand(NegativeSetPc.Inst, 0, Pair) ||
+        PositiveSetPc.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        PositiveSetPc.Inst.getNumOperands() != 1 ||
+        !isExactRegisterOperand(PositiveSetPc.Inst, 0, Pair))
+      continue;
+    std::optional<uint64_t> PositiveLabel =
+        evaluateDirectControlFlowTarget(Branch, LS);
+    if (!PositiveLabel || *PositiveLabel != AddLow.Offset)
+      continue;
+
+    auto matchesPairArithmetic = [&](const InternalDecodedInst &Low,
+                                     const InternalDecodedInst &High,
+                                     StringRef LowMnemonic,
+                                     StringRef HighMnemonic) {
+      if (Low.Mnemonic != LowMnemonic || High.Mnemonic != HighMnemonic ||
+          Low.Inst.getNumOperands() != 3 || !Low.Inst.getOperand(0).isReg() ||
+          !Low.Inst.getOperand(1).isReg() || !Low.Inst.getOperand(0).getReg() ||
+          Low.Inst.getOperand(0).getReg() != Low.Inst.getOperand(1).getReg() ||
+          !isExactRegisterOperand(Low.Inst, 2, DeltaReg) ||
+          High.Inst.getNumOperands() != 3 || !High.Inst.getOperand(0).isReg() ||
+          !High.Inst.getOperand(1).isReg() ||
+          !High.Inst.getOperand(0).getReg() ||
+          High.Inst.getOperand(0).getReg() !=
+              High.Inst.getOperand(1).getReg() ||
+          !High.Inst.getOperand(2).isImm() ||
+          High.Inst.getOperand(2).getImm() != 0)
+        return false;
+      MCRegister LowReg(Low.Inst.getOperand(0).getReg());
+      MCRegister HighReg(High.Inst.getOperand(0).getReg());
+      std::optional<unsigned> LowIndex = numberedSgprIndex(*LS.MRI, LowReg);
+      std::optional<unsigned> HighIndex = numberedSgprIndex(*LS.MRI, HighReg);
+      return LowIndex && HighIndex && *HighIndex == *LowIndex + 1 &&
+             LS.MRI->regsOverlap(LowReg, Pair) &&
+             LS.MRI->regsOverlap(HighReg, Pair);
+    };
+    if (!matchesPairArithmetic(SubLow, SubHigh, "s_sub_co_u32",
+                               "s_sub_co_ci_u32") ||
+        !matchesPairArithmetic(AddLow, AddHigh, "s_add_co_u32",
+                               "s_add_co_ci_u32"))
+      continue;
+
+    std::optional<uint32_t> FirstAddend =
+        evaluateAbsoluteUint32Operand(MakeDelta.Inst.getOperand(1));
+    if (!FirstAddend)
+      continue;
+    uint32_t DeltaBits =
+        *FirstAddend +
+        static_cast<uint32_t>(MakeDelta.Inst.getOperand(2).getImm());
+    int64_t SignedDelta = static_cast<int32_t>(DeltaBits);
+    std::optional<uint64_t> PcValue = checkedAddUint64(
+        *GetPcAddress, GetPc.Size, "signed finite set-PC get-PC value");
+    if (!PcValue)
+      continue;
+    uint64_t Target = *PcValue + static_cast<uint64_t>(SignedDelta);
+    appendCandidate(I + 7, I + 10, Target);
+    appendCandidate(I + 10, I + 10, Target);
+  }
+
+  // The one-shot get-PC/add-nc resolver permits unrelated register restores
+  // between the add and transfer while stopping at any target-pair clobber or
+  // control-flow boundary. Reuse it for set-PC as well as swap-PC so compiler
+  // epilogues with delayed transfers remain finite candidates.
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &SetPc = Decoded[I];
+    if (!SetPc.DecodeSucceeded ||
+        SetPc.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        SetPc.Inst.getNumOperands() != 1 || !SetPc.Inst.getOperand(0).isReg() ||
+        !SetPc.Inst.getOperand(0).getReg())
+      continue;
+    MCRegister Pair(SetPc.Inst.getOperand(0).getReg());
+    std::optional<MaterializedPcSequence> Sequence =
+        resolveMaterializedPcTarget(Decoded, I, Pair, LS, TextAddr);
+    if (!Sequence)
+      continue;
+    DenseMap<uint64_t, size_t>::const_iterator Begin =
+        OffsetToIndex.find(Sequence->SequenceStart);
+    if (Begin == OffsetToIndex.end() || Begin->second > I)
+      continue;
+    std::optional<uint64_t> SetPcAddress = checkedAddUint64(
+        TextAddr, SetPc.Offset, "delayed finite set-PC address");
+    if (!SetPcAddress)
+      continue;
+    const ElfView::FunctionTextRange *Range =
+        findInnermostFunctionRange(*SetPcAddress, FunctionRanges);
+    if (!Range || Range->Begin < TextAddr || Range->End > TextEnd ||
+        Decoded[Begin->second].Offset < Range->Begin - TextAddr)
+      continue;
+    bool Contiguous = true;
+    for (size_t J = Begin->second; J < I; ++J) {
+      std::optional<uint64_t> End =
+          checkedAddUint64(Decoded[J].Offset, Decoded[J].Size,
+                           "delayed finite set-PC instruction end");
+      if (!Decoded[J].DecodeSucceeded || !End ||
+          *End != Decoded[J + 1].Offset) {
+        Contiguous = false;
+        break;
+      }
+    }
+    if (!Contiguous)
+      continue;
+    std::optional<size_t> LocalTargetIndex;
+    if (Sequence->Target >= TextAddr && Sequence->Target < TextEnd) {
+      DenseMap<uint64_t, size_t>::const_iterator Target =
+          OffsetToIndex.find(Sequence->Target - TextAddr);
+      if (Target == OffsetToIndex.end())
+        continue;
+      LocalTargetIndex = Target->second;
+    }
+    Candidates.push_back({I, Begin->second, I, Sequence->Target,
+                          LocalTargetIndex, Range->Begin - TextAddr,
+                          Range->End - TextAddr});
+  }
+  llvm::sort(Candidates, [](const FiniteSetPcTransfer &LHS,
+                            const FiniteSetPcTransfer &RHS) {
+    return std::tie(LHS.InstIndex, LHS.Target, LHS.SequenceBeginIndex,
+                    LHS.SequenceEndIndex) < std::tie(RHS.InstIndex, RHS.Target,
+                                                     RHS.SequenceBeginIndex,
+                                                     RHS.SequenceEndIndex);
+  });
+  SmallVector<FiniteSetPcTransfer, 8> Unambiguous;
+  for (size_t I = 0; I != Candidates.size();) {
+    size_t After = I + 1;
+    while (After != Candidates.size() &&
+           Candidates[After].InstIndex == Candidates[I].InstIndex)
+      ++After;
+    bool Same = llvm::all_of(
+        ArrayRef<FiniteSetPcTransfer>(Candidates).slice(I, After - I),
+        [&](const FiniteSetPcTransfer &Candidate) {
+          return Candidate.Target == Candidates[I].Target &&
+                 Candidate.SequenceBeginIndex ==
+                     Candidates[I].SequenceBeginIndex &&
+                 Candidate.SequenceEndIndex == Candidates[I].SequenceEndIndex;
+        });
+    if (Same)
+      Unambiguous.push_back(Candidates[I]);
+    else
+      log() << "hotswap: rejected ambiguous exact set-PC materialization at "
+               "0x"
+            << utohexstr(Decoded[Candidates[I].InstIndex].Offset) << "\n";
+    I = After;
+  }
+  return Unambiguous;
+}
+
+static BitVector computeStaticallyReachableInstructions(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers) {
+  BitVector Reachable(Decoded.size());
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+  DenseMap<size_t, const FiniteSetPcTransfer *> TransferByInst;
+  for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
+    TransferByInst.try_emplace(Transfer.InstIndex, &Transfer);
+
+  SmallVector<size_t, 32> Worklist;
+  auto addRoot = [&](uint64_t Offset) {
+    DenseMap<uint64_t, size_t>::const_iterator It = OffsetToIndex.find(Offset);
+    if (It != OffsetToIndex.end())
+      Worklist.push_back(It->second);
+  };
+  for (uint64_t Entry : DeclaredEntries)
+    addRoot(Entry);
+  for (uint64_t Entry : ExternalEntries)
+    addRoot(Entry);
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin >= TextAddr)
+      addRoot(Range.Begin - TextAddr);
+  if (Worklist.empty() && !Decoded.empty())
+    Worklist.push_back(0);
+
+  while (!Worklist.empty()) {
+    size_t I = Worklist.pop_back_val();
+    if (Reachable.test(I))
+      continue;
+    Reachable.set(I);
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!DI.DecodeSucceeded)
+      continue;
+    auto addOffset = [&](uint64_t Offset) {
+      DenseMap<uint64_t, size_t>::const_iterator It =
+          OffsetToIndex.find(Offset);
+      if (It != OffsetToIndex.end())
+        Worklist.push_back(It->second);
+    };
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+    if (LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Fallthrough = checkedAddUint64(
+          DI.Offset, DI.Size, "finite set-PC call continuation");
+      if (Fallthrough)
+        addOffset(*Fallthrough);
+      continue;
+    }
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
+        LS.MIA->isIndirectBranch(DI.Inst)) {
+      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator Transfer =
+          TransferByInst.find(I);
+      if (Transfer != TransferByInst.end() &&
+          Transfer->second->LocalTargetIndex)
+        Worklist.push_back(*Transfer->second->LocalTargetIndex);
+      continue;
+    }
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (Target)
+        addOffset(*Target);
+      if (LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    }
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "finite set-PC reachability fallthrough");
+    if (Fallthrough)
+      addOffset(*Fallthrough);
+  }
+  return Reachable;
+}
+
+static SmallVector<FiniteSetPcTransfer, 8> selectLeastReachableSetPcCandidates(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr,
+    ArrayRef<FiniteSetPcTransfer> AllCandidates,
+    const BitVector &ProvenCandidates, const BitVector &RejectedCandidates) {
+  SmallVector<FiniteSetPcTransfer, 8> Selected;
+  BitVector SelectedBits(AllCandidates.size());
+  for (size_t I = 0; I != AllCandidates.size(); ++I)
+    if (ProvenCandidates.test(I) && !RejectedCandidates.test(I)) {
+      SelectedBits.set(I);
+      Selected.push_back(AllCandidates[I]);
+    }
+  for (;;) {
+    BitVector Reachable = computeStaticallyReachableInstructions(
+        Decoded, LS, DeclaredEntries, ExternalEntries, FunctionRanges, TextAddr,
+        Selected);
+    bool Changed = false;
+    for (size_t I = 0; I != AllCandidates.size(); ++I) {
+      if (RejectedCandidates.test(I) || SelectedBits.test(I) ||
+          !Reachable.test(AllCandidates[I].InstIndex))
+        continue;
+      SelectedBits.set(I);
+      Selected.push_back(AllCandidates[I]);
+      Changed = true;
+    }
+    if (!Changed)
+      return Selected;
+  }
+}
+
+/// Resolve uses of an SGPR pair whose value is selected once and reused across
+/// control flow. A monotone intraprocedural solver propagates finite values
+/// from proven get-PC materializations. Any unrecognized pair definition
+/// introduces Unknown, so a bypass around the selector remains fail-closed.
+static std::vector<ReachingCallTargets> resolveReusablePcValuesAtUses(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextEnd,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<ReachingPcUse> Uses,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
+  std::vector<ReachingCallTargets> Resolved(Decoded.size());
+  SmallVector<ReachingCallGroup, 8> Groups;
+  DenseMap<size_t, const FiniteSetPcTransfer *> FiniteSetPcByInst;
+  for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
+    FiniteSetPcByInst.try_emplace(Transfer.InstIndex, &Transfer);
+
+  for (const ReachingPcUse &Use : Uses) {
+    size_t I = Use.InstIndex;
+    if (I >= Decoded.size() || !Decoded[I].DecodeSucceeded || !Use.Register)
+      continue;
+    MCRegister TargetRegister = Use.Register;
+
+    const ElfView::FunctionTextRange *Best = nullptr;
+    uint64_t Address = TextAddr + Decoded[I].Offset;
+    for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+      if (Range.Begin <= Address && Address < Range.End &&
+          (!Best || Range.Begin > Best->Begin))
+        Best = &Range;
+    if (!Best || Best->Begin < TextAddr || Best->End > TextEnd)
+      continue;
+    uint64_t Begin = Best->Begin - TextAddr;
+    uint64_t End = Best->End - TextAddr;
+    ReachingCallGroup *Group = nullptr;
+    for (ReachingCallGroup &Candidate : Groups)
+      if (Candidate.Begin == Begin && Candidate.End == End &&
+          Candidate.TargetRegister == TargetRegister) {
+        Group = &Candidate;
+        break;
+      }
+    if (!Group) {
+      Groups.push_back({Begin, End, TargetRegister, {}});
+      Group = &Groups.back();
+    }
+    Group->Calls.push_back(I);
+  }
+
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex[Decoded[I].Offset] = I;
+
+  for (const ReachingCallGroup &Group : Groups) {
+    ArrayRef<InternalDecodedInst>::const_iterator Begin =
+        llvm::lower_bound(Decoded, Group.Begin,
+                          [](const InternalDecodedInst &DI, uint64_t Offset) {
+                            return DI.Offset < Offset;
+                          });
+    ArrayRef<InternalDecodedInst>::const_iterator End =
+        std::lower_bound(Begin, Decoded.end(), Group.End,
+                         [](const InternalDecodedInst &DI, uint64_t Offset) {
+                           return DI.Offset < Offset;
+                         });
+    size_t BeginIndex = static_cast<size_t>(Begin - Decoded.begin());
+    size_t EndIndex = static_cast<size_t>(End - Decoded.begin());
+    if (BeginIndex == EndIndex)
+      continue;
+
+    DenseMap<size_t, size_t> Starters;
+    DenseMap<size_t, uint64_t> Completions;
+    DenseMap<size_t, SmallVector<size_t, 2>> Intermediates;
+    for (size_t I = BeginIndex; I != EndIndex; ++I) {
+      std::optional<std::pair<size_t, uint64_t>> Match =
+          matchReusablePcMaterialization(Decoded, I, EndIndex,
+                                         Group.TargetRegister, LS, TextAddr);
+      if (Match) {
+        Starters[I] = Match->first;
+        Completions[Match->first] = Match->second;
+        for (size_t J = I + 1; J != Match->first; ++J)
+          if (definesOverlappingRegister(Decoded[J], LS, Group.TargetRegister))
+            Intermediates[J].push_back(Match->first);
+      }
+    }
+    if (Completions.empty())
+      continue;
+
+    std::vector<ReachingPcState> Before(EndIndex - BeginIndex);
+    Before.front().Reached = true;
+    Before.front().HasUnknown = true;
+    SmallVector<size_t, 32> Worklist;
+    BitVector Queued(EndIndex - BeginIndex);
+    Worklist.push_back(BeginIndex);
+    Queued.set(0);
+
+    while (!Worklist.empty()) {
+      size_t I = Worklist.pop_back_val();
+      Queued.reset(I - BeginIndex);
+      ReachingPcState State = Before[I - BeginIndex];
+      const InternalDecodedInst &DI = Decoded[I];
+
+      DenseMap<size_t, size_t>::const_iterator Starter = Starters.find(I);
+      DenseMap<size_t, uint64_t>::const_iterator Completion =
+          Completions.find(I);
+      if (Starter != Starters.end()) {
+        // The get-PC instruction overwrites the complete target pair. Record a
+        // token proving that this path entered the exact materialization; the
+        // completion may only produce a known target from that token.
+        State.HasUnknown = false;
+        State.Targets.clear();
+        State.ActiveMaterializations.assign(1, Starter->second);
+      } else if (Completion != Completions.end()) {
+        bool HasMatchingToken =
+            llvm::is_contained(State.ActiveMaterializations, I);
+        bool HasBypassPath =
+            State.HasUnknown || !State.Targets.empty() ||
+            llvm::any_of(State.ActiveMaterializations,
+                         [I](size_t Active) { return Active != I; });
+        State.HasUnknown = HasBypassPath || !HasMatchingToken;
+        State.Targets.clear();
+        State.ActiveMaterializations.clear();
+        if (HasMatchingToken)
+          State.Targets.push_back(Completion->second);
+      } else if (definesOverlappingRegister(DI, LS, Group.TargetRegister)) {
+        // Preserve only tokens for which this is a proven instruction inside
+        // the exact matched sequence. All other reaching values are clobbered.
+        SmallVector<size_t, 4> Preserved;
+        DenseMap<size_t, SmallVector<size_t, 2>>::const_iterator Intermediate =
+            Intermediates.find(I);
+        if (Intermediate != Intermediates.end())
+          for (size_t Active : State.ActiveMaterializations)
+            if (llvm::is_contained(Intermediate->second, Active))
+              Preserved.push_back(Active);
+        if (State.HasUnknown || !State.Targets.empty() ||
+            Preserved.size() != State.ActiveMaterializations.size())
+          State.HasUnknown = true;
+        State.Targets.clear();
+        State.ActiveMaterializations = std::move(Preserved);
+      }
+
+      if (llvm::is_contained(Group.Calls, I) && !State.HasUnknown &&
+          State.ActiveMaterializations.empty() && !State.Targets.empty())
+        Resolved[I] = State.Targets;
+
+      SmallVector<size_t, 2> Successors;
+      auto appendFallthrough = [&]() {
+        if (I + 1 < EndIndex)
+          Successors.push_back(I + 1);
+      };
+      if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+          DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+          LS.MIA->isReturn(DI.Inst)) {
+        // No successor.
+      } else if (LS.MIA->isCall(DI.Inst)) {
+        appendFallthrough();
+      } else if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
+                 LS.MIA->isIndirectBranch(DI.Inst)) {
+        DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator
+            FiniteSetPc = FiniteSetPcByInst.find(I);
+        if (FiniteSetPc != FiniteSetPcByInst.end() &&
+            FiniteSetPc->second->LocalTargetIndex &&
+            *FiniteSetPc->second->LocalTargetIndex >= BeginIndex &&
+            *FiniteSetPc->second->LocalTargetIndex < EndIndex)
+          Successors.push_back(*FiniteSetPc->second->LocalTargetIndex);
+        // All other indirect jumps or bounded returns leave this
+        // intraprocedural path.
+      } else if (LS.MIA->isBranch(DI.Inst)) {
+        std::optional<uint64_t> Target =
+            evaluateDirectControlFlowTarget(DI, LS);
+        if (Target) {
+          DenseMap<uint64_t, size_t>::const_iterator TargetIndex =
+              OffsetToIndex.find(*Target);
+          if (TargetIndex != OffsetToIndex.end() &&
+              TargetIndex->second >= BeginIndex &&
+              TargetIndex->second < EndIndex)
+            Successors.push_back(TargetIndex->second);
+        }
+        if (!LS.MIA->isUnconditionalBranch(DI.Inst))
+          appendFallthrough();
+      } else {
+        appendFallthrough();
+      }
+
+      for (size_t Successor : Successors) {
+        if (mergeReachingPcState(Before[Successor - BeginIndex], State) &&
+            !Queued.test(Successor - BeginIndex)) {
+          Worklist.push_back(Successor);
+          Queued.set(Successor - BeginIndex);
+        }
+      }
+    }
+  }
+  return Resolved;
+}
+
+/// Call-specific wrapper for the generic reusable-PC value solver.
+static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextEnd,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
+  SmallVector<ReachingPcUse, 8> Uses;
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &Call = Decoded[I];
+    if (!Call.DecodeSucceeded || Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+        Call.Inst.getNumOperands() < 2)
+      continue;
+    const MCOperand &TargetOp =
+        Call.Inst.getOperand(Call.Inst.getNumOperands() - 1);
+    if (TargetOp.isReg() && TargetOp.getReg())
+      Uses.push_back({I, MCRegister(TargetOp.getReg())});
+  }
+  return resolveReusablePcValuesAtUses(Decoded, LS, TextAddr, TextEnd,
+                                       FunctionRanges, Uses,
+                                       FiniteSetPcTransfers);
+}
+
 struct KnownCallSite {
   size_t InstIndex = 0;
   uint64_t Target = 0;
@@ -1143,9 +3005,9 @@ struct BoundedSetPcReturn {
   SmallVector<uint64_t, 2> Targets;
 };
 
-struct DirectTextEntry {
+struct DirectTargetSource {
+  size_t InstIndex = 0;
   uint64_t Target = 0;
-  size_t SourceIndex = 0;
 };
 
 struct KnownCallEntry {
@@ -1153,18 +3015,59 @@ struct KnownCallEntry {
   size_t CallIndex = 0;
 };
 
-static bool compareDirectTextEntries(const DirectTextEntry &LHS,
-                                     const DirectTextEntry &RHS) {
-  if (LHS.Target != RHS.Target)
-    return LHS.Target < RHS.Target;
-  return LHS.SourceIndex < RHS.SourceIndex;
-}
-
 static bool compareKnownCallEntries(const KnownCallEntry &LHS,
                                     const KnownCallEntry &RHS) {
-  if (LHS.Entry != RHS.Entry)
-    return LHS.Entry < RHS.Entry;
-  return LHS.CallIndex < RHS.CallIndex;
+  return std::tie(LHS.Entry, LHS.CallIndex) <
+         std::tie(RHS.Entry, RHS.CallIndex);
+}
+
+struct ExternalCallContinuation {
+  size_t InstIndex = 0;
+  uint64_t Continuation = 0;
+};
+
+struct CallContinuationSource {
+  size_t InstIndex = 0;
+  uint64_t Continuation = 0;
+};
+
+struct FallthroughEntryInfo {
+  bool Proven = false;
+  uint64_t ChainBegin = 0;
+};
+
+struct ControlFlowScanIndex {
+  DenseMap<size_t, PcMaterializedCallInfo> MaterializedCalls;
+  DenseMap<uint64_t, FallthroughEntryInfo> FallthroughEntries;
+  SmallVector<KnownCallSite, 4> Calls;
+  SmallVector<KnownCallEntry, 8> CallsByTarget;
+  SmallVector<KnownCallEntry, 16> CallEntries;
+  DenseMap<size_t, MCRegister> CallReturnRegistersBySource;
+  SmallVector<CallContinuationSource, 4> CallContinuationsByOffset;
+  SmallVector<ExternalCallContinuation, 4> ExternalCallContinuations;
+  SmallVector<size_t, 16> SetPcIndices;
+  SmallVector<size_t, 4> UnboundedIndirectIndices;
+  SmallVector<size_t, 16> BranchOrCallIndices;
+  SmallVector<DirectTargetSource, 16> DirectTargetsByTarget;
+  bool HasUnboundedIndirectEntry = false;
+};
+
+static void indexKnownCalls(ControlFlowScanIndex &Index) {
+  Index.CallsByTarget.clear();
+  Index.CallEntries.clear();
+  Index.CallReturnRegistersBySource.clear();
+  Index.CallsByTarget.reserve(Index.Calls.size());
+  Index.CallEntries.reserve(Index.Calls.size() * 2);
+  for (size_t CallIndex = 0; CallIndex != Index.Calls.size(); ++CallIndex) {
+    const KnownCallSite &Call = Index.Calls[CallIndex];
+    Index.CallsByTarget.push_back({Call.Target, CallIndex});
+    Index.CallEntries.push_back({Call.Target, CallIndex});
+    Index.CallEntries.push_back({Call.Continuation, CallIndex});
+    Index.CallReturnRegistersBySource.try_emplace(Call.InstIndex,
+                                                  Call.ReturnRegister);
+  }
+  llvm::sort(Index.CallsByTarget, compareKnownCallEntries);
+  llvm::sort(Index.CallEntries, compareKnownCallEntries);
 }
 
 static bool hasPcRelativeOperand(const InternalDecodedInst &DI,
@@ -1207,93 +3110,149 @@ getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
   return AbsoluteTarget - TextAddr;
 }
 
-static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
-    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-    uint64_t TextAddr, uint64_t TextEnd,
-    ArrayRef<std::optional<PcMaterializedCallInfo>> MaterializedCalls) {
-  SmallVector<KnownCallSite, 4> Calls;
+static std::optional<ControlFlowScanIndex>
+buildControlFlowScanIndex(ArrayRef<InternalDecodedInst> Decoded,
+                          const LLVMState &LS, uint64_t TextAddr,
+                          uint64_t TextEnd,
+                          ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
+  ControlFlowScanIndex Index;
+  DenseSet<uint64_t> FunctionBegins;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin >= TextAddr && Range.Begin < TextEnd)
+      FunctionBegins.insert(Range.Begin - TextAddr);
+
+  bool FallthroughProven = true;
+  uint64_t FallthroughChainBegin = 0;
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &DI = Decoded[I];
-    std::optional<MCRegister> ReturnRegister = getCallReturnRegister(DI, LS);
-    if (!ReturnRegister)
-      continue;
-
-    std::optional<uint64_t> Target;
-    if (MaterializedCalls[I]) {
-      uint64_t AbsoluteTarget = MaterializedCalls[I]->Target;
-      if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
-        Target = AbsoluteTarget - TextAddr;
+    if (I == 0) {
+      FallthroughChainBegin = DI.Offset;
     } else {
-      Target = getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+      const InternalDecodedInst &Predecessor = Decoded[I - 1];
+      bool EndOverflows =
+          Predecessor.Offset >
+          std::numeric_limits<uint64_t>::max() - Predecessor.Size;
+      if (EndOverflows || Predecessor.Offset + Predecessor.Size != DI.Offset ||
+          !Predecessor.DecodeSucceeded) {
+        FallthroughProven = false;
+        FallthroughChainBegin = DI.Offset;
+      } else if (LS.MIA->isBarrier(Predecessor.Inst)) {
+        FallthroughProven = true;
+        FallthroughChainBegin = DI.Offset;
+      }
     }
-    if (!Target)
+    if (FunctionBegins.contains(DI.Offset))
+      Index.FallthroughEntries.try_emplace(
+          DI.Offset,
+          FallthroughEntryInfo{FallthroughProven, FallthroughChainBegin});
+
+    std::optional<PcMaterializedCallInfo> Materialized =
+        matchPcMaterializedCall(Decoded, I, LS, TextAddr);
+    if (Materialized)
+      Index.MaterializedCalls.try_emplace(I, *Materialized);
+
+    std::optional<MCRegister> ReturnRegister = getCallReturnRegister(DI, LS);
+    if (ReturnRegister) {
+      std::optional<uint64_t> Target;
+      bool HasFiniteExternalTarget = false;
+      if (Materialized) {
+        uint64_t AbsoluteTarget = Materialized->Target;
+        if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
+          Target = AbsoluteTarget - TextAddr;
+        else
+          HasFiniteExternalTarget = true;
+      } else if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
+                 DI.Inst.getNumOperands() != 0 &&
+                 DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
+        uint64_t AbsoluteTarget = static_cast<uint64_t>(
+            DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
+        if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
+          Target = AbsoluteTarget - TextAddr;
+        else
+          HasFiniteExternalTarget = true;
+      } else if (hasPcRelativeOperand(DI, LS)) {
+        std::optional<uint64_t> RelativeTarget =
+            evaluateDirectControlFlowTarget(DI, LS);
+        if (RelativeTarget) {
+          uint64_t TextSize = TextEnd - TextAddr;
+          if (*RelativeTarget < TextSize)
+            Target = *RelativeTarget;
+          else
+            HasFiniteExternalTarget = true;
+        }
+      } else {
+        Target = getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+      }
+      if (Target || HasFiniteExternalTarget) {
+        std::optional<uint64_t> Continuation = checkedAddUint64(
+            DI.Offset, DI.Size, "known call continuation address");
+        if (!Continuation)
+          return std::nullopt;
+        if (Target)
+          Index.Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
+        if (HasFiniteExternalTarget)
+          Index.ExternalCallContinuations.push_back({I, *Continuation});
+      }
+    }
+
+    if (DI.DecodeSucceeded && DI.Inst.getOpcode() == LS.SSetPcI64Opcode)
+      Index.SetPcIndices.push_back(I);
+
+    // Set-PC returns are checked separately against BoundedReturnPositions.
+    // MC lowering erases their return pseudo identity, so including them in
+    // this generic bucket would make even a proven bounded return look like
+    // an arbitrary object-wide entry.
+    if (DI.DecodeSucceeded && DI.Inst.getOpcode() != LS.SSetPcI64Opcode &&
+        !LS.MIA->isReturn(DI.Inst) &&
+        (LS.MIA->isIndirectBranch(DI.Inst) ||
+         DI.Inst.getOpcode() == LS.SAddPcI64Opcode)) {
+      Index.HasUnboundedIndirectEntry = true;
+      Index.UnboundedIndirectIndices.push_back(I);
+    }
+
+    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+        LS.MIA->isReturn(DI.Inst))
       continue;
+    Index.BranchOrCallIndices.push_back(I);
 
-    std::optional<uint64_t> Continuation =
-        checkedAddUint64(DI.Offset, DI.Size, "known call continuation address");
-    if (!Continuation)
-      return std::nullopt;
-    Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
+    std::optional<uint64_t> DirectTarget =
+        getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+    if (DirectTarget)
+      Index.DirectTargetsByTarget.push_back({I, *DirectTarget});
   }
-  return Calls;
+  llvm::sort(Index.DirectTargetsByTarget,
+             [](const DirectTargetSource &LHS, const DirectTargetSource &RHS) {
+               return std::tie(LHS.Target, LHS.InstIndex) <
+                      std::tie(RHS.Target, RHS.InstIndex);
+             });
+  return Index;
 }
 
-static size_t findDecodedIndexAtOrAfter(ArrayRef<InternalDecodedInst> Decoded,
-                                        uint64_t Offset) {
-  return std::lower_bound(Decoded.begin(), Decoded.end(), Offset,
-                          [](const InternalDecodedInst &DI, uint64_t Value) {
-                            return DI.Offset < Value;
-                          }) -
-         Decoded.begin();
-}
-
-static bool isSetPcReturnCandidate(const InternalDecodedInst &DI,
-                                   const LLVMState &LS) {
-  // AMDGPUMCInstLower lowers S_SETPC_B64_return to S_SETPC_B64, so the
-  // decoded instruction no longer carries MIA::isReturn identity. Recover
-  // only the bounded local-function form from its call/link dataflow.
-  return DI.DecodeSucceeded && DI.Inst.getOpcode() == LS.SSetPcI64Opcode &&
-         DI.Inst.getNumOperands() == 1 && DI.Inst.getOperand(0).isReg() &&
-         DI.Inst.getOperand(0).getReg();
-}
-
-static bool hasUnprovenFallthroughEntry(
-    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-    uint64_t FunctionBegin, uint64_t ReturnOffset,
-    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<KnownCallSite> Calls,
-    ArrayRef<KnownCallEntry> CallEntries,
-    ArrayRef<DirectTextEntry> DirectEntries) {
+static bool hasUnprovenFallthroughEntry(ArrayRef<InternalDecodedInst> Decoded,
+                                        uint64_t FunctionBegin,
+                                        uint64_t ReturnOffset,
+                                        ArrayRef<uint64_t> DeclaredEntries,
+                                        const ControlFlowScanIndex &Index) {
   if (FunctionBegin == 0)
     return false;
 
-  size_t BeginIndex = findDecodedIndexAtOrAfter(Decoded, FunctionBegin);
-  if (BeginIndex == Decoded.size() ||
-      Decoded[BeginIndex].Offset != FunctionBegin) {
+  DenseMap<uint64_t, FallthroughEntryInfo>::const_iterator Fallthrough =
+      Index.FallthroughEntries.find(FunctionBegin);
+  if (Fallthrough == Index.FallthroughEntries.end()) {
     log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
           << " is not a bounded return: function entry at 0x"
           << utohexstr(FunctionBegin) << " is not an instruction boundary\n";
     return true;
   }
 
-  uint64_t ChainBegin = FunctionBegin;
-  size_t PredecessorIndex = BeginIndex;
-  while (PredecessorIndex != 0) {
-    const InternalDecodedInst &Predecessor = Decoded[PredecessorIndex - 1];
-    std::optional<uint64_t> PredecessorEnd = checkedAddUint64(
-        Predecessor.Offset, Predecessor.Size, "fallthrough predecessor end");
-    if (!PredecessorEnd || *PredecessorEnd != ChainBegin ||
-        !Predecessor.DecodeSucceeded) {
-      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
-            << " is not a bounded return: fallthrough into function entry "
-               "at 0x"
-            << utohexstr(FunctionBegin) << " is unprovable\n";
-      return true;
-    }
-    if (LS.MIA->isBarrier(Predecessor.Inst))
-      break;
-    ChainBegin = Predecessor.Offset;
-    --PredecessorIndex;
+  if (!Fallthrough->second.Proven) {
+    log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+          << " is not a bounded return: fallthrough into function entry "
+             "at 0x"
+          << utohexstr(FunctionBegin) << " is unprovable\n";
+    return true;
   }
+  uint64_t ChainBegin = Fallthrough->second.ChainBegin;
 
   if (ChainBegin == FunctionBegin)
     return false;
@@ -1309,14 +3268,15 @@ static bool hasUnprovenFallthroughEntry(
     return true;
   }
 
-  ArrayRef<KnownCallEntry>::iterator CallEntry =
-      std::lower_bound(CallEntries.begin(), CallEntries.end(), ChainBegin,
-                       [](const KnownCallEntry &Indexed, uint64_t Offset) {
-                         return Indexed.Entry < Offset;
-                       });
-  for (; CallEntry != CallEntries.end() && CallEntry->Entry < FunctionBegin;
+  SmallVector<KnownCallEntry, 16>::const_iterator CallEntry =
+      llvm::lower_bound(Index.CallEntries, ChainBegin,
+                        [](const KnownCallEntry &Indexed, uint64_t Offset) {
+                          return Indexed.Entry < Offset;
+                        });
+  for (;
+       CallEntry != Index.CallEntries.end() && CallEntry->Entry < FunctionBegin;
        ++CallEntry) {
-    const KnownCallSite &Call = Calls[CallEntry->CallIndex];
+    const KnownCallSite &Call = Index.Calls[CallEntry->CallIndex];
     uint64_t Source = Decoded[Call.InstIndex].Offset;
     if (Source >= ChainBegin && Source < FunctionBegin)
       continue;
@@ -1327,21 +3287,41 @@ static bool hasUnprovenFallthroughEntry(
     return true;
   }
 
-  ArrayRef<DirectTextEntry>::iterator DirectEntry =
-      std::lower_bound(DirectEntries.begin(), DirectEntries.end(), ChainBegin,
-                       [](const DirectTextEntry &Indexed, uint64_t Offset) {
-                         return Indexed.Target < Offset;
-                       });
-  for (; DirectEntry != DirectEntries.end() &&
-         DirectEntry->Target < FunctionBegin;
-       ++DirectEntry) {
-    const InternalDecodedInst &Source = Decoded[DirectEntry->SourceIndex];
+  for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations) {
+    uint64_t Source = Decoded[Call.InstIndex].Offset;
+    if (Call.Continuation >= ChainBegin && Call.Continuation < FunctionBegin) {
+      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+            << " is not a bounded return: external call at 0x"
+            << utohexstr(Source) << " returns into the fallthrough chain at 0x"
+            << utohexstr(Call.Continuation) << "\n";
+      return true;
+    }
+  }
+
+  SmallVector<DirectTargetSource, 16>::const_iterator FirstTarget =
+      llvm::lower_bound(Index.DirectTargetsByTarget, ChainBegin,
+                        [](const DirectTargetSource &Source, uint64_t Target) {
+                          return Source.Target < Target;
+                        });
+  size_t FirstSourceIndex = Decoded.size();
+  uint64_t FirstSourceTarget = 0;
+  for (SmallVector<DirectTargetSource, 16>::const_iterator It = FirstTarget;
+       It != Index.DirectTargetsByTarget.end() && It->Target < FunctionBegin;
+       ++It) {
+    const InternalDecodedInst &Source = Decoded[It->InstIndex];
     if (Source.Offset >= ChainBegin && Source.Offset < FunctionBegin)
       continue;
+    if (It->InstIndex < FirstSourceIndex) {
+      FirstSourceIndex = It->InstIndex;
+      FirstSourceTarget = It->Target;
+    }
+  }
+  if (FirstSourceIndex != Decoded.size()) {
     log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
           << " is not a bounded return: control flow at 0x"
-          << utohexstr(Source.Offset) << " enters the fallthrough chain at 0x"
-          << utohexstr(DirectEntry->Target) << "\n";
+          << utohexstr(Decoded[FirstSourceIndex].Offset)
+          << " enters the fallthrough chain at 0x"
+          << utohexstr(FirstSourceTarget) << "\n";
     return true;
   }
   return false;
@@ -1352,17 +3332,9 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
                            const LLVMState &LS, uint64_t TextAddr,
                            uint64_t TextEnd, ArrayRef<uint64_t> DeclaredEntries,
                            ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-                           ArrayRef<KnownCallSite> Calls,
-                           ArrayRef<uint64_t> ExternalEntries) {
-  SmallVector<size_t, 2> ReturnIndices;
-  for (size_t ReturnIndex = 0; ReturnIndex != Decoded.size(); ++ReturnIndex)
-    if (isSetPcReturnCandidate(Decoded[ReturnIndex], LS))
-      ReturnIndices.push_back(ReturnIndex);
-
+                           ArrayRef<uint64_t> ExternalEntries,
+                           const ControlFlowScanIndex &Index) {
   SmallVector<BoundedSetPcReturn, 2> Returns;
-  if (ReturnIndices.empty())
-    return Returns;
-
   SmallVector<uint64_t, 16> SortedDeclaredEntries(DeclaredEntries);
   llvm::sort(SortedDeclaredEntries);
   SortedDeclaredEntries.erase(
@@ -1375,30 +3347,47 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
       std::unique(SortedExternalEntries.begin(), SortedExternalEntries.end()),
       SortedExternalEntries.end());
 
-  SmallVector<DirectTextEntry, 16> DirectEntries;
-  for (size_t SourceIndex = 0; SourceIndex != Decoded.size(); ++SourceIndex)
-    if (std::optional<uint64_t> Target =
-            getDirectTextTarget(Decoded[SourceIndex], LS, TextAddr, TextEnd))
-      DirectEntries.push_back({*Target, SourceIndex});
-  llvm::sort(DirectEntries, compareDirectTextEntries);
-
-  SmallVector<KnownCallEntry, 8> CallsByTarget;
-  SmallVector<KnownCallEntry, 16> CallEntries;
-  for (size_t CallIndex = 0; CallIndex != Calls.size(); ++CallIndex) {
-    const KnownCallSite &Call = Calls[CallIndex];
-    CallsByTarget.push_back({Call.Target, CallIndex});
-    CallEntries.push_back({Call.Target, CallIndex});
-    CallEntries.push_back({Call.Continuation, CallIndex});
+  SmallVector<SmallVector<size_t, 2>, 16> CandidateRanges(
+      Index.SetPcIndices.size());
+  for (size_t RangeIndex = 0; RangeIndex != FunctionRanges.size();
+       ++RangeIndex) {
+    const ElfView::FunctionTextRange &Range = FunctionRanges[RangeIndex];
+    if (Range.End <= Range.Begin)
+      continue;
+    SmallVector<size_t, 16>::const_iterator First = llvm::lower_bound(
+        Index.SetPcIndices, Range.Begin,
+        [&](size_t InstIndex, uint64_t Address) {
+          return TextAddr + Decoded[InstIndex].Offset < Address;
+        });
+    SmallVector<size_t, 16>::const_iterator After = std::lower_bound(
+        First, Index.SetPcIndices.end(), Range.End,
+        [&](size_t InstIndex, uint64_t Address) {
+          return TextAddr + Decoded[InstIndex].Offset < Address;
+        });
+    for (SmallVector<size_t, 16>::const_iterator It = First; It != After;
+         ++It) {
+      size_t Position = static_cast<size_t>(It - Index.SetPcIndices.begin());
+      CandidateRanges[Position].push_back(RangeIndex);
+    }
   }
-  llvm::sort(CallsByTarget, compareKnownCallEntries);
-  llvm::sort(CallEntries, compareKnownCallEntries);
 
-  for (size_t ReturnIndex : ReturnIndices) {
+  for (size_t ReturnPosition = 0; ReturnPosition != Index.SetPcIndices.size();
+       ++ReturnPosition) {
+    size_t ReturnIndex = Index.SetPcIndices[ReturnPosition];
     const InternalDecodedInst &Return = Decoded[ReturnIndex];
+    // AMDGPUMCInstLower lowers S_SETPC_B64_return to S_SETPC_B64, so the
+    // decoded instruction no longer carries MIA::isReturn identity. Recover
+    // only the bounded local-function form from its call/link dataflow.
+    if (!Return.DecodeSucceeded ||
+        Return.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        Return.Inst.getNumOperands() != 1 ||
+        !Return.Inst.getOperand(0).isReg() ||
+        !Return.Inst.getOperand(0).getReg())
+      continue;
     MCRegister ReturnRegister(Return.Inst.getOperand(0).getReg());
 
-    bool IsBounded = false;
-    for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+    for (size_t RangeIndex : CandidateRanges[ReturnPosition]) {
+      const ElfView::FunctionTextRange &Range = FunctionRanges[RangeIndex];
       if (Range.Begin < TextAddr || Range.Begin >= TextEnd ||
           Range.End <= Range.Begin || Range.End > TextEnd ||
           (Range.Symbol && Range.Symbol->getBinding() != ELF::STB_LOCAL))
@@ -1420,9 +3409,9 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
         continue;
       }
 
-      for (const ElfView::FunctionTextRange &Alias : FunctionRanges) {
-        if (Return.Offset + TextAddr < Alias.Begin ||
-            Return.Offset + TextAddr >= Alias.End || Alias.Begin == Range.Begin)
+      for (size_t AliasIndex : CandidateRanges[ReturnPosition]) {
+        const ElfView::FunctionTextRange &Alias = FunctionRanges[AliasIndex];
+        if (Alias.Begin == Range.Begin)
           continue;
         log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
               << " is not a bounded return: overlapping function entry at "
@@ -1446,20 +3435,26 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
         continue;
       }
 
-      if (hasUnprovenFallthroughEntry(Decoded, LS, FunctionBegin, Return.Offset,
-                                      SortedDeclaredEntries, Calls, CallEntries,
-                                      DirectEntries))
+      if (hasUnprovenFallthroughEntry(Decoded, FunctionBegin, Return.Offset,
+                                      SortedDeclaredEntries, Index))
         continue;
 
       // The link pair must retain the value written by the incoming call
       // throughout the function. This includes blocks laid out after the
       // return that may branch back into its epilogue.
-      size_t FunctionInstBegin =
-          findDecodedIndexAtOrAfter(Decoded, FunctionBegin);
-      size_t FunctionInstEnd = findDecodedIndexAtOrAfter(Decoded, FunctionEnd);
-      for (size_t InstIndex = FunctionInstBegin; InstIndex != FunctionInstEnd;
-           ++InstIndex) {
-        const InternalDecodedInst &DI = Decoded[InstIndex];
+      ArrayRef<InternalDecodedInst>::const_iterator FunctionFirst =
+          llvm::lower_bound(Decoded, FunctionBegin,
+                            [](const InternalDecodedInst &DI, uint64_t Offset) {
+                              return DI.Offset < Offset;
+                            });
+      ArrayRef<InternalDecodedInst>::const_iterator FunctionAfter =
+          std::lower_bound(FunctionFirst, Decoded.end(), FunctionEnd,
+                           [](const InternalDecodedInst &DI, uint64_t Offset) {
+                             return DI.Offset < Offset;
+                           });
+      for (ArrayRef<InternalDecodedInst>::const_iterator It = FunctionFirst;
+           It != FunctionAfter; ++It) {
+        const InternalDecodedInst &DI = *It;
         // MC call instructions carry no transitive callee-clobber information.
         // Without interprocedural proof, a nested callee may overwrite the
         // outer link pair even when the call defines a different return pair.
@@ -1483,14 +3478,55 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
       if (!Safe)
         continue;
 
+      // A call that returns into this function does not supply its link pair
+      // at the function entry. Reject continuations at the exact entry as
+      // well as in the interior; the earlier fallthrough-chain check only
+      // covers bytes laid out before FunctionBegin.
+      SmallVector<CallContinuationSource, 4>::const_iterator Continuation =
+          llvm::lower_bound(
+              Index.CallContinuationsByOffset, FunctionBegin,
+              [](const CallContinuationSource &Source, uint64_t Offset) {
+                return Source.Continuation < Offset;
+              });
+      if (Continuation != Index.CallContinuationsByOffset.end() &&
+          Continuation->Continuation < FunctionEnd) {
+        log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+              << " is not a bounded return: call at 0x"
+              << utohexstr(Decoded[Continuation->InstIndex].Offset)
+              << " returns into the function at 0x"
+              << utohexstr(Continuation->Continuation) << "\n";
+        Safe = false;
+      }
+      if (!Safe)
+        continue;
+      SmallVector<ExternalCallContinuation, 4>::const_iterator
+          ExternalContinuation = llvm::lower_bound(
+              Index.ExternalCallContinuations, FunctionBegin,
+              [](const ExternalCallContinuation &Source, uint64_t Offset) {
+                return Source.Continuation < Offset;
+              });
+      if (ExternalContinuation != Index.ExternalCallContinuations.end() &&
+          ExternalContinuation->Continuation < FunctionEnd) {
+        log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+              << " is not a bounded return: external call at 0x"
+              << utohexstr(Decoded[ExternalContinuation->InstIndex].Offset)
+              << " returns into the function at 0x"
+              << utohexstr(ExternalContinuation->Continuation) << "\n";
+        Safe = false;
+      }
+      if (!Safe)
+        continue;
+
       SmallVector<uint64_t, 2> Targets;
-      SmallVector<KnownCallEntry, 8>::iterator CallAtTarget = std::lower_bound(
-          CallsByTarget.begin(), CallsByTarget.end(),
-          KnownCallEntry{FunctionBegin, 0}, compareKnownCallEntries);
-      for (; CallAtTarget != CallsByTarget.end() &&
+      SmallVector<KnownCallEntry, 8>::const_iterator CallAtTarget =
+          llvm::lower_bound(Index.CallsByTarget, FunctionBegin,
+                            [](const KnownCallEntry &Indexed, uint64_t Offset) {
+                              return Indexed.Entry < Offset;
+                            });
+      for (; CallAtTarget != Index.CallsByTarget.end() &&
              CallAtTarget->Entry < FunctionEnd;
            ++CallAtTarget) {
-        const KnownCallSite &Call = Calls[CallAtTarget->CallIndex];
+        const KnownCallSite &Call = Index.Calls[CallAtTarget->CallIndex];
         if (Call.Target != FunctionBegin) {
           log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
                 << " is not a bounded return: call at 0x"
@@ -1516,37 +3552,41 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
       // A branch from outside the function would bypass the call link
       // definition. Direct calls to the function entry are allowed only when
       // they were collected above with this exact return register.
-      SmallVector<DirectTextEntry, 16>::iterator DirectEntry = std::lower_bound(
-          DirectEntries.begin(), DirectEntries.end(),
-          DirectTextEntry{FunctionBegin, 0}, compareDirectTextEntries);
-      for (; DirectEntry != DirectEntries.end() &&
-             DirectEntry->Target < FunctionEnd;
-           ++DirectEntry) {
-        size_t SourceIndex = DirectEntry->SourceIndex;
+      SmallVector<DirectTargetSource, 16>::const_iterator FirstTarget =
+          llvm::lower_bound(
+              Index.DirectTargetsByTarget, FunctionBegin,
+              [](const DirectTargetSource &Source, uint64_t Target) {
+                return Source.Target < Target;
+              });
+      size_t FirstUnsafeSourceIndex = Decoded.size();
+      uint64_t FirstUnsafeTarget = 0;
+      for (SmallVector<DirectTargetSource, 16>::const_iterator It = FirstTarget;
+           It != Index.DirectTargetsByTarget.end() && It->Target < FunctionEnd;
+           ++It) {
+        size_t SourceIndex = It->InstIndex;
         const InternalDecodedInst &Source = Decoded[SourceIndex];
         if (Source.Offset >= FunctionBegin && Source.Offset < FunctionEnd)
           continue;
 
         bool IsKnownEntryCall = false;
-        if (LS.MIA->isCall(Source.Inst) &&
-            DirectEntry->Target == FunctionBegin) {
-          ArrayRef<KnownCallSite>::iterator KnownCall =
-              std::lower_bound(Calls.begin(), Calls.end(), SourceIndex,
-                               [](const KnownCallSite &Call, size_t Index) {
-                                 return Call.InstIndex < Index;
-                               });
-          IsKnownEntryCall = KnownCall != Calls.end() &&
-                             KnownCall->InstIndex == SourceIndex &&
-                             KnownCall->ReturnRegister == ReturnRegister;
+        if (LS.MIA->isCall(Source.Inst) && It->Target == FunctionBegin) {
+          DenseMap<size_t, MCRegister>::const_iterator KnownCall =
+              Index.CallReturnRegistersBySource.find(SourceIndex);
+          IsKnownEntryCall =
+              KnownCall != Index.CallReturnRegistersBySource.end() &&
+              KnownCall->second == ReturnRegister;
         }
-        if (!IsKnownEntryCall) {
-          log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
-                << " is not a bounded return: control flow at 0x"
-                << utohexstr(Source.Offset) << " enters at 0x"
-                << utohexstr(DirectEntry->Target) << "\n";
-          Safe = false;
-          break;
+        if (!IsKnownEntryCall && SourceIndex < FirstUnsafeSourceIndex) {
+          FirstUnsafeSourceIndex = SourceIndex;
+          FirstUnsafeTarget = It->Target;
         }
+      }
+      if (FirstUnsafeSourceIndex != Decoded.size()) {
+        log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+              << " is not a bounded return: control flow at 0x"
+              << utohexstr(Decoded[FirstUnsafeSourceIndex].Offset)
+              << " enters at 0x" << utohexstr(FirstUnsafeTarget) << "\n";
+        Safe = false;
       }
       if (!Safe)
         continue;
@@ -1554,65 +3594,2206 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
       llvm::sort(Targets);
       Targets.erase(std::unique(Targets.begin(), Targets.end()), Targets.end());
       Returns.push_back({ReturnIndex, std::move(Targets)});
-      IsBounded = true;
       break;
     }
-    if (!IsBounded)
-      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
-            << " remains an unbounded indirect transfer\n";
   }
   return Returns;
 }
 
-static const BoundedSetPcReturn *
-findBoundedSetPcReturn(ArrayRef<BoundedSetPcReturn> Returns, size_t InstIndex) {
-  for (const BoundedSetPcReturn &Return : Returns)
-    if (Return.InstIndex == InstIndex)
-      return &Return;
-  return nullptr;
+static BitVector computeFiniteControlFlowReachability(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries,
+    ArrayRef<uint64_t> ExternalEntries,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    const ControlFlowScanIndex &Index,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers,
+    ArrayRef<BoundedSetPcReturn> BoundedReturns) {
+  BitVector Reachable(Decoded.size());
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+  DenseMap<size_t, const FiniteSetPcTransfer *> TransferByInst;
+  for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
+    TransferByInst.try_emplace(Transfer.InstIndex, &Transfer);
+  DenseMap<size_t, const BoundedSetPcReturn *> ReturnByInst;
+  for (const BoundedSetPcReturn &Return : BoundedReturns)
+    ReturnByInst.try_emplace(Return.InstIndex, &Return);
+  DenseMap<size_t, SmallVector<uint64_t, 2>> CallTargetsByInst;
+  for (const KnownCallSite &Call : Index.Calls) {
+    SmallVector<uint64_t, 2> &Targets = CallTargetsByInst[Call.InstIndex];
+    if (!llvm::is_contained(Targets, Call.Target))
+      Targets.push_back(Call.Target);
+  }
+
+  SmallVector<size_t, 32> Worklist;
+  auto addOffset = [&](uint64_t Offset) {
+    DenseMap<uint64_t, size_t>::const_iterator It = OffsetToIndex.find(Offset);
+    if (It != OffsetToIndex.end())
+      Worklist.push_back(It->second);
+  };
+  for (uint64_t Entry : DeclaredEntries)
+    addOffset(Entry);
+  for (uint64_t Entry : ExternalEntries)
+    addOffset(Entry);
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin >= TextAddr)
+      addOffset(Range.Begin - TextAddr);
+  if (Worklist.empty() && !Decoded.empty())
+    Worklist.push_back(0);
+
+  while (!Worklist.empty()) {
+    size_t I = Worklist.pop_back_val();
+    if (Reachable.test(I))
+      continue;
+    Reachable.set(I);
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!DI.DecodeSucceeded)
+      continue;
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator Transfer =
+          TransferByInst.find(I);
+      if (Transfer != TransferByInst.end() &&
+          Transfer->second->LocalTargetIndex)
+        Worklist.push_back(*Transfer->second->LocalTargetIndex);
+      DenseMap<size_t, const BoundedSetPcReturn *>::const_iterator Return =
+          ReturnByInst.find(I);
+      if (Return != ReturnByInst.end())
+        for (uint64_t Target : Return->second->Targets)
+          if (Target < TextSize)
+            addOffset(Target);
+      continue;
+    }
+    if (LS.MIA->isCall(DI.Inst)) {
+      DenseMap<size_t, SmallVector<uint64_t, 2>>::const_iterator Targets =
+          CallTargetsByInst.find(I);
+      if (Targets != CallTargetsByInst.end())
+        for (uint64_t Target : Targets->second)
+          addOffset(Target);
+      std::optional<uint64_t> Fallthrough = checkedAddUint64(
+          DI.Offset, DI.Size, "finite call continuation reachability");
+      if (Fallthrough && *Fallthrough < TextSize)
+        addOffset(*Fallthrough);
+      continue;
+    }
+    if (LS.MIA->isIndirectBranch(DI.Inst) ||
+        DI.Inst.getOpcode() == LS.SAddPcI64Opcode)
+      continue;
+    if (LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (Target)
+        addOffset(*Target);
+      if (LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    }
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "finite control-flow reachability fallthrough");
+    if (Fallthrough && *Fallthrough < TextSize)
+      addOffset(*Fallthrough);
+  }
+  return Reachable;
+}
+
+struct SymbolLessReturnRegion {
+  uint64_t Entry = 0;
+  MCRegister LinkRegister;
+  SmallVector<size_t, 16> Instructions;
+  SmallVector<size_t, 2> Returns;
+  SmallVector<uint64_t, 8> Continuations;
+};
+
+static bool instructionMayFallThrough(const InternalDecodedInst &DI,
+                                      const LLVMState &LS) {
+  if (!DI.DecodeSucceeded)
+    return true;
+  if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+      DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+      LS.MIA->isReturn(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst))
+    return false;
+  return !LS.MIA->isBranch(DI.Inst) || !LS.MIA->isUnconditionalBranch(DI.Inst);
+}
+
+/// Prove symbol-less callable regions from finite call targets. This is
+/// intentionally based on forward CFG reachability from a concrete call
+/// target, rather than layout labels or source tails. Every entry into the
+/// resulting region must be one of the calls that supplies the exact link
+/// pair, and the pair must remain untouched until each s_set_pc_i64 return.
+static SmallVector<SymbolLessReturnRegion, 8> collectSymbolLessReturnRegions(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextSize,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    const ControlFlowScanIndex &Index,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers,
+    ArrayRef<BoundedSetPcReturn> PreviouslyBoundedReturns,
+    const BitVector &ReachableCallSources) {
+  struct CallGroup {
+    uint64_t Entry = 0;
+    MCRegister LinkRegister;
+    SmallVector<uint64_t, 8> Continuations;
+  };
+  SmallVector<CallGroup, 8> Groups;
+  DenseMap<std::pair<uint64_t, unsigned>, size_t> GroupPositions;
+  for (const KnownCallSite &Call : Index.Calls) {
+    if (!ReachableCallSources.test(Call.InstIndex))
+      continue;
+    std::pair<uint64_t, unsigned> Key{Call.Target, Call.ReturnRegister.id()};
+    auto Inserted = GroupPositions.try_emplace(Key, Groups.size());
+    if (Inserted.second) {
+      Groups.push_back({Call.Target, Call.ReturnRegister, {}});
+    }
+    Groups[Inserted.first->second].Continuations.push_back(Call.Continuation);
+  }
+
+  DenseSet<uint64_t> RejectedRegionEntries;
+  RejectedRegionEntries.insert(DeclaredEntries.begin(), DeclaredEntries.end());
+  RejectedRegionEntries.insert(ExternalEntries.begin(), ExternalEntries.end());
+  size_t RetainedGroups = 0;
+  for (size_t I = 0; I != Groups.size(); ++I) {
+    if (RejectedRegionEntries.contains(Groups[I].Entry))
+      continue;
+    if (RetainedGroups != I)
+      Groups[RetainedGroups] = std::move(Groups[I]);
+    ++RetainedGroups;
+  }
+  Groups.resize(RetainedGroups);
+  if (Groups.empty())
+    return {};
+
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+
+  SmallVector<SymbolLessReturnRegion, 8> Regions;
+  // Track overlap components as regions are proven instead of retaining every
+  // overlapping instruction vector until a final quadratic pass. A value of
+  // -1 is unclaimed, -2 belongs to an already-invalid overlap component, and
+  // every nonnegative value names the sole still-valid owning region.
+  std::vector<int64_t> RegionOwner;
+  for (CallGroup &Group : Groups) {
+    DenseMap<uint64_t, size_t>::const_iterator Entry =
+        OffsetToIndex.find(Group.Entry);
+    if (Entry == OffsetToIndex.end())
+      continue;
+
+    SymbolLessReturnRegion Region;
+    Region.Entry = Group.Entry;
+    Region.LinkRegister = Group.LinkRegister;
+    llvm::sort(Group.Continuations);
+    Group.Continuations.erase(
+        std::unique(Group.Continuations.begin(), Group.Continuations.end()),
+        Group.Continuations.end());
+    Region.Continuations = Group.Continuations;
+
+    SmallVector<size_t, 32> Worklist{Entry->second};
+    BitVector Visited(Decoded.size());
+    bool Safe = true;
+    while (!Worklist.empty() && Safe) {
+      size_t I = Worklist.pop_back_val();
+      if (Visited.test(I))
+        continue;
+      Visited.set(I);
+      Region.Instructions.push_back(I);
+      const InternalDecodedInst &DI = Decoded[I];
+      if (!DI.DecodeSucceeded) {
+        Safe = false;
+        break;
+      }
+      if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+        if (DI.Inst.getNumOperands() != 1 ||
+            !isExactRegisterOperand(DI.Inst, 0, Group.LinkRegister)) {
+          Safe = false;
+          break;
+        }
+        Region.Returns.push_back(I);
+        continue;
+      }
+      if (LS.MIA->isCall(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
+          DI.Inst.getOpcode() == LS.SAddPcI64Opcode ||
+          LS.MIA->isReturn(DI.Inst) ||
+          definesOverlappingRegister(DI, LS, Group.LinkRegister)) {
+        Safe = false;
+        break;
+      }
+      if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+          DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode)
+        continue;
+
+      auto addSuccessor = [&](uint64_t Offset) {
+        DenseMap<uint64_t, size_t>::const_iterator It =
+            OffsetToIndex.find(Offset);
+        if (It == OffsetToIndex.end()) {
+          Safe = false;
+          return;
+        }
+        Worklist.push_back(It->second);
+      };
+      if (LS.MIA->isBranch(DI.Inst)) {
+        std::optional<uint64_t> Target =
+            evaluateDirectControlFlowTarget(DI, LS);
+        if (!Target || *Target >= TextSize) {
+          Safe = false;
+          break;
+        }
+        addSuccessor(*Target);
+        if (!Safe)
+          break;
+        if (LS.MIA->isUnconditionalBranch(DI.Inst))
+          continue;
+      }
+      std::optional<uint64_t> Fallthrough = checkedAddUint64(
+          DI.Offset, DI.Size, "symbol-less return fallthrough");
+      if (!Fallthrough || *Fallthrough >= TextSize) {
+        Safe = false;
+        break;
+      }
+      addSuccessor(*Fallthrough);
+    }
+    if (!Safe || Region.Returns.empty())
+      continue;
+    llvm::sort(Region.Instructions);
+    llvm::sort(Region.Returns);
+
+    auto containsInstructionByte = [&](uint64_t Offset) {
+      for (size_t InstIndex : Region.Instructions) {
+        const InternalDecodedInst &DI = Decoded[InstIndex];
+        std::optional<uint64_t> End = checkedAddUint64(
+            DI.Offset, DI.Size, "symbol-less return instruction end");
+        // Overflow is itself unprovable; conservatively treat the queried
+        // byte as overlapping the claimed region.
+        if (!End || (Offset >= DI.Offset && Offset < *End))
+          return true;
+      }
+      return false;
+    };
+    auto sourceIsInside = [&](size_t InstIndex) {
+      return llvm::is_contained(Region.Instructions, InstIndex);
+    };
+
+    for (uint64_t EntryOffset : DeclaredEntries)
+      if (containsInstructionByte(EntryOffset)) {
+        Safe = false;
+        break;
+      }
+    if (!Safe)
+      continue;
+    for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+      if (Range.Begin < TextAddr || Range.Begin - TextAddr >= TextSize)
+        continue;
+      uint64_t EntryOffset = Range.Begin - TextAddr;
+      if (EntryOffset != Region.Entry && containsInstructionByte(EntryOffset)) {
+        Safe = false;
+        break;
+      }
+    }
+    if (!Safe)
+      continue;
+    for (uint64_t EntryOffset : ExternalEntries)
+      if (containsInstructionByte(EntryOffset)) {
+        Safe = false;
+        break;
+      }
+    if (!Safe)
+      continue;
+
+    // Reject layout fallthrough from outside the reachable region.
+    for (size_t InstIndex : Region.Instructions) {
+      if (InstIndex == 0)
+        continue;
+      const InternalDecodedInst &DI = Decoded[InstIndex];
+      const InternalDecodedInst &Predecessor = Decoded[InstIndex - 1];
+      std::optional<uint64_t> PredecessorEnd =
+          checkedAddUint64(Predecessor.Offset, Predecessor.Size,
+                           "symbol-less return predecessor end");
+      if (sourceIsInside(InstIndex - 1))
+        continue;
+      if (!Predecessor.DecodeSucceeded || !PredecessorEnd ||
+          *PredecessorEnd != DI.Offset ||
+          instructionMayFallThrough(Predecessor, LS)) {
+        Safe = false;
+        break;
+      }
+    }
+    if (!Safe)
+      continue;
+
+    for (const KnownCallSite &Call : Index.Calls) {
+      bool TargetInside = containsInstructionByte(Call.Target);
+      bool ContinuationInside = containsInstructionByte(Call.Continuation);
+      if (!TargetInside && !ContinuationInside)
+        continue;
+      if (sourceIsInside(Call.InstIndex)) {
+        Safe = false;
+        break;
+      }
+      if (ContinuationInside || Call.Target != Region.Entry ||
+          Call.ReturnRegister != Region.LinkRegister) {
+        Safe = false;
+        break;
+      }
+    }
+    if (!Safe)
+      continue;
+    for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
+      if (containsInstructionByte(Call.Continuation)) {
+        Safe = false;
+        break;
+      }
+    if (!Safe)
+      continue;
+
+    for (const DirectTargetSource &Source : Index.DirectTargetsByTarget) {
+      if (!containsInstructionByte(Source.Target) ||
+          sourceIsInside(Source.InstIndex))
+        continue;
+      bool IsEntryCall = false;
+      for (const KnownCallSite &Call : Index.Calls)
+        IsEntryCall |= Call.InstIndex == Source.InstIndex &&
+                       Call.Target == Region.Entry &&
+                       Call.ReturnRegister == Region.LinkRegister;
+      if (!IsEntryCall) {
+        Safe = false;
+        break;
+      }
+    }
+    if (!Safe)
+      continue;
+
+    for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers) {
+      if (!Transfer.LocalTargetIndex ||
+          !llvm::is_contained(Region.Instructions,
+                              *Transfer.LocalTargetIndex) ||
+          sourceIsInside(Transfer.InstIndex))
+        continue;
+      Safe = false;
+      break;
+    }
+    if (!Safe)
+      continue;
+    for (const BoundedSetPcReturn &Return : PreviouslyBoundedReturns) {
+      if (sourceIsInside(Return.InstIndex))
+        continue;
+      for (uint64_t Target : Return.Targets)
+        if (containsInstructionByte(Target)) {
+          Safe = false;
+          break;
+        }
+      if (!Safe)
+        break;
+    }
+    if (!Safe)
+      continue;
+
+    if (RegionOwner.empty())
+      RegionOwner.assign(Decoded.size(), -1);
+    bool Overlaps = false;
+    SmallVector<size_t, 4> OverlappingOwners;
+    for (size_t InstIndex : Region.Instructions) {
+      int64_t Owner = RegionOwner[InstIndex];
+      if (Owner == -1)
+        continue;
+      Overlaps = true;
+      if (Owner >= 0 &&
+          !llvm::is_contained(OverlappingOwners, static_cast<size_t>(Owner)))
+        OverlappingOwners.push_back(static_cast<size_t>(Owner));
+    }
+    if (Overlaps) {
+      // Preserve the transitive overlap component as a compact tombstone so a
+      // later region touching either side is rejected without retaining any
+      // of the invalid regions' instruction vectors.
+      for (size_t Owner : OverlappingOwners) {
+        for (size_t InstIndex : Regions[Owner].Instructions)
+          RegionOwner[InstIndex] = -2;
+        Regions[Owner] = SymbolLessReturnRegion{};
+      }
+      for (size_t InstIndex : Region.Instructions)
+        RegionOwner[InstIndex] = -2;
+      continue;
+    }
+
+    size_t Owner = Regions.size();
+    for (size_t InstIndex : Region.Instructions)
+      RegionOwner[InstIndex] = static_cast<int64_t>(Owner);
+    Regions.push_back(std::move(Region));
+  }
+
+  // Empty slots are regions invalidated by a later overlap.
+  SmallVector<SymbolLessReturnRegion, 8> Disjoint;
+  for (SymbolLessReturnRegion &Region : Regions)
+    if (!Region.Instructions.empty())
+      Disjoint.push_back(std::move(Region));
+  return Disjoint;
+}
+
+struct FiniteControlFlowAudit {
+  BitVector InvalidSetPcCandidates;
+  bool Closed = false;
+  bool HasUnboundedIndirectEntries = false;
+};
+
+static FiniteControlFlowAudit auditFiniteIndirectControlFlow(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextSize,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    const ControlFlowScanIndex &Index,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers,
+    ArrayRef<BoundedSetPcReturn> BoundedReturns,
+    ArrayRef<SymbolLessReturnRegion> SymbolLessRegions) {
+  FiniteControlFlowAudit Audit{BitVector(FiniteSetPcTransfers.size()), true};
+  auto markUnboundedIndirectEntry = [&]() {
+    Audit.Closed = false;
+    Audit.HasUnboundedIndirectEntries = true;
+  };
+
+  for (size_t CandidateIndex = 0; CandidateIndex != FiniteSetPcTransfers.size();
+       ++CandidateIndex) {
+    const FiniteSetPcTransfer &Candidate = FiniteSetPcTransfers[CandidateIndex];
+    uint64_t SequenceStart = Decoded[Candidate.SequenceBeginIndex].Offset;
+    std::optional<uint64_t> SequenceEnd =
+        checkedAddUint64(Decoded[Candidate.SequenceEndIndex].Offset,
+                         Decoded[Candidate.SequenceEndIndex].Size,
+                         "finite set-PC materialization end");
+    auto isInteriorByte = [&](uint64_t Offset) {
+      return !SequenceEnd || (Offset > SequenceStart && Offset < *SequenceEnd);
+    };
+    auto sourceIsSequence = [&](size_t InstIndex) {
+      return InstIndex >= Candidate.SequenceBeginIndex &&
+             InstIndex <= Candidate.SequenceEndIndex;
+    };
+    bool Safe = true;
+    for (uint64_t Entry : DeclaredEntries)
+      if (isInteriorByte(Entry)) {
+        Safe = false;
+        break;
+      }
+    if (Safe)
+      for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+        if (Range.Begin >= TextAddr && isInteriorByte(Range.Begin - TextAddr)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (uint64_t Entry : ExternalEntries)
+        if (isInteriorByte(Entry)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (const DirectTargetSource &Source : Index.DirectTargetsByTarget)
+        if (isInteriorByte(Source.Target) &&
+            !sourceIsSequence(Source.InstIndex)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (const KnownCallSite &Call : Index.Calls)
+        if ((isInteriorByte(Call.Target) ||
+             isInteriorByte(Call.Continuation)) &&
+            !sourceIsSequence(Call.InstIndex)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (const ExternalCallContinuation &Call :
+           Index.ExternalCallContinuations)
+        if (isInteriorByte(Call.Continuation) &&
+            !sourceIsSequence(Call.InstIndex)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
+        if (Transfer.LocalTargetIndex &&
+            isInteriorByte(Decoded[*Transfer.LocalTargetIndex].Offset)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (const BoundedSetPcReturn &Return : BoundedReturns) {
+        for (uint64_t TargetOffset : Return.Targets) {
+          if (isInteriorByte(TargetOffset)) {
+            Safe = false;
+            break;
+          }
+        }
+        if (!Safe)
+          break;
+      }
+    if (!Safe)
+      Audit.InvalidSetPcCandidates.set(CandidateIndex);
+  }
+
+  if (Audit.InvalidSetPcCandidates.any()) {
+    Audit.Closed = false;
+    return Audit;
+  }
+
+  BitVector BoundedSetPc(Decoded.size());
+  for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
+    BoundedSetPc.set(Transfer.InstIndex);
+  for (const BoundedSetPcReturn &Return : BoundedReturns)
+    BoundedSetPc.set(Return.InstIndex);
+  for (const SymbolLessReturnRegion &Region : SymbolLessRegions)
+    for (size_t Return : Region.Returns)
+      BoundedSetPc.set(Return);
+
+  // Symbol-less regions are inferred together so large mutually independent
+  // helper families can reach a fixed point. Validate that joint proof before
+  // treating any provisional return as bounded: each provisional source must
+  // have exactly one owning region, and a return owned by another region (or
+  // by a symbol-backed function) may not enter any byte of this region.
+  DenseMap<size_t, unsigned> ProvisionalOwners;
+  DenseMap<size_t, unsigned> PublishedProvisionalReturns;
+  for (const SymbolLessReturnRegion &Region : SymbolLessRegions)
+    for (size_t Return : Region.Returns) {
+      ++ProvisionalOwners[Return];
+      if (!llvm::is_contained(Region.Instructions, Return))
+        markUnboundedIndirectEntry();
+    }
+  for (const BoundedSetPcReturn &Return : BoundedReturns)
+    if (ProvisionalOwners.contains(Return.InstIndex))
+      ++PublishedProvisionalReturns[Return.InstIndex];
+  for (const auto &Owner : ProvisionalOwners)
+    if (Owner.second != 1 ||
+        PublishedProvisionalReturns.lookup(Owner.first) != 1)
+      markUnboundedIndirectEntry();
+
+  for (const SymbolLessReturnRegion &Region : SymbolLessRegions) {
+    auto containsInstructionByte = [&](uint64_t Offset) {
+      for (size_t InstIndex : Region.Instructions) {
+        const InternalDecodedInst &DI = Decoded[InstIndex];
+        std::optional<uint64_t> End = checkedAddUint64(
+            DI.Offset, DI.Size, "symbol-less joint audit instruction end");
+        if (!End || (Offset >= DI.Offset && Offset < *End))
+          return true;
+      }
+      return false;
+    };
+    for (const BoundedSetPcReturn &Return : BoundedReturns) {
+      if (llvm::is_contained(Region.Instructions, Return.InstIndex)) {
+        if (!llvm::is_contained(Region.Returns, Return.InstIndex))
+          markUnboundedIndirectEntry();
+        continue;
+      }
+      for (uint64_t Target : Return.Targets)
+        if (containsInstructionByte(Target)) {
+          markUnboundedIndirectEntry();
+          break;
+        }
+    }
+  }
+
+  BitVector Reachable = computeFiniteControlFlowReachability(
+      Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
+      FunctionRanges, Index, FiniteSetPcTransfers, BoundedReturns);
+  DenseSet<uint64_t> InstructionOffsets;
+  for (const InternalDecodedInst &DI : Decoded)
+    InstructionOffsets.insert(DI.Offset);
+  for (uint64_t Entry : DeclaredEntries)
+    if (Entry < TextSize && !InstructionOffsets.contains(Entry))
+      markUnboundedIndirectEntry();
+  for (uint64_t Entry : ExternalEntries)
+    if (Entry < TextSize && !InstructionOffsets.contains(Entry))
+      markUnboundedIndirectEntry();
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin >= TextAddr && Range.Begin - TextAddr < TextSize &&
+        !InstructionOffsets.contains(Range.Begin - TextAddr))
+      markUnboundedIndirectEntry();
+  for (const DirectTargetSource &Source : Index.DirectTargetsByTarget)
+    if (Reachable.test(Source.InstIndex) && Source.Target < TextSize &&
+        !InstructionOffsets.contains(Source.Target))
+      markUnboundedIndirectEntry();
+  for (const KnownCallSite &Call : Index.Calls)
+    if (Reachable.test(Call.InstIndex) &&
+        ((!InstructionOffsets.contains(Call.Target) &&
+          Call.Target < TextSize) ||
+         (!InstructionOffsets.contains(Call.Continuation) &&
+          Call.Continuation < TextSize)))
+      markUnboundedIndirectEntry();
+  for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
+    if (Reachable.test(Call.InstIndex) && Call.Continuation < TextSize &&
+        !InstructionOffsets.contains(Call.Continuation))
+      markUnboundedIndirectEntry();
+  for (size_t SetPc : Index.SetPcIndices)
+    if (Reachable.test(SetPc) && !BoundedSetPc.test(SetPc))
+      markUnboundedIndirectEntry();
+
+  // Every call is also an indirect entry source until either a finite local
+  // target or a finite external target has been recorded for it.
+  BitVector FiniteCalls(Decoded.size());
+  for (const KnownCallSite &Call : Index.Calls)
+    FiniteCalls.set(Call.InstIndex);
+  for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
+    FiniteCalls.set(Call.InstIndex);
+
+  // MC may also classify a register call as an indirect branch. Do not let
+  // that generic classification create a false unbounded self-edge after the
+  // exact call target and continuation have been admitted to this same joint
+  // audit. Unknown calls remain unbounded in the call-specific loop below.
+  for (size_t InstIndex : Index.UnboundedIndirectIndices)
+    if (Reachable.test(InstIndex) && !FiniteCalls.test(InstIndex))
+      markUnboundedIndirectEntry();
+
+  for (size_t InstIndex : Index.BranchOrCallIndices) {
+    if (!Reachable.test(InstIndex) || !LS.MIA->isCall(Decoded[InstIndex].Inst))
+      continue;
+    if (!FiniteCalls.test(InstIndex))
+      markUnboundedIndirectEntry();
+  }
+  for (const BoundedSetPcReturn &Return : BoundedReturns) {
+    if (!Reachable.test(Return.InstIndex))
+      continue;
+    for (uint64_t Target : Return.Targets)
+      if (Target < TextSize && !InstructionOffsets.contains(Target))
+        markUnboundedIndirectEntry();
+  }
+  for (int I = Reachable.find_first(); I >= 0; I = Reachable.find_next(I))
+    if (!Decoded[static_cast<size_t>(I)].DecodeSucceeded)
+      markUnboundedIndirectEntry();
+  return Audit;
 }
 
 static bool
-hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
-                         const LLVMState &LS, uint64_t TextAddr,
-                         uint64_t TextEnd, ArrayRef<uint64_t> DeclaredEntries,
+hasKnownControlFlowEntry(ArrayRef<uint64_t> DeclaredEntries,
                          ArrayRef<BoundedSetPcReturn> BoundedReturns,
+                         const DenseMap<size_t, size_t> &BoundedReturnPositions,
+                         const ControlFlowScanIndex &Index,
+                         bool HasUnboundedIndirectEntries,
                          uint64_t SequenceStart, uint64_t SequenceEnd) {
   for (uint64_t Entry : DeclaredEntries)
     if (Entry > SequenceStart && Entry <= SequenceEnd)
       return true;
 
-  for (size_t I = 0; I != Decoded.size(); ++I) {
-    const InternalDecodedInst &DI = Decoded[I];
-    if (DI.DecodeSucceeded && DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
-      const BoundedSetPcReturn *Return =
-          findBoundedSetPcReturn(BoundedReturns, I);
-      if (!Return)
-        return true;
-      for (uint64_t Target : Return->Targets)
-        if (Target > SequenceStart && Target <= SequenceEnd)
-          return true;
-      continue;
-    }
-
-    // Without bounding an indirect target, it may enter at any instruction in
-    // the materialization. Keep the call unresolved rather than relying on
-    // the indirect transfer's containing function alone.
-    if (DI.DecodeSucceeded && !LS.MIA->isReturn(DI.Inst) &&
-        (LS.MIA->isIndirectBranch(DI.Inst) ||
-         DI.Inst.getOpcode() == LS.SAddPcI64Opcode))
+  for (size_t InstIndex : Index.SetPcIndices) {
+    DenseMap<size_t, size_t>::const_iterator It =
+        BoundedReturnPositions.find(InstIndex);
+    if (It == BoundedReturnPositions.end())
       return true;
-    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+    const BoundedSetPcReturn &Return = BoundedReturns[It->second];
+    for (uint64_t Target : Return.Targets)
+      if (Target > SequenceStart && Target <= SequenceEnd)
+        return true;
+  }
+
+  // Without bounding an indirect target, it may enter at any instruction in
+  // the materialization. Keep the call unresolved rather than relying on the
+  // indirect transfer's containing function alone.
+  if (HasUnboundedIndirectEntries)
+    return true;
+
+  auto EntersSequence = [&](uint64_t Target) {
+    return Target > SequenceStart && Target <= SequenceEnd;
+  };
+  for (const KnownCallSite &Call : Index.Calls)
+    if (EntersSequence(Call.Target) || EntersSequence(Call.Continuation))
+      return true;
+  for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
+    if (EntersSequence(Call.Continuation))
+      return true;
+
+  SmallVector<DirectTargetSource, 16>::const_iterator First =
+      llvm::upper_bound(Index.DirectTargetsByTarget, SequenceStart,
+                        [](uint64_t Target, const DirectTargetSource &Source) {
+                          return Target < Source.Target;
+                        });
+  if (First != Index.DirectTargetsByTarget.end() &&
+      First->Target <= SequenceEnd)
+    return true;
+  return false;
+}
+
+struct WellFormedAbiEntrySet {
+  DenseSet<size_t> Calls;
+  DenseSet<size_t> SetPcs;
+  DenseSet<uint64_t> Targets;
+};
+
+static std::optional<unsigned> numberedVgprIndex(const MCRegisterInfo &MRI,
+                                                 MCRegister Reg) {
+  if (!Reg)
+    return std::nullopt;
+  StringRef Name(MRI.getName(Reg));
+  if (!Name.consume_front("VGPR") || Name.empty() || Name.contains('_'))
+    return std::nullopt;
+  unsigned Index = 0;
+  if (Name.getAsInteger(10, Index))
+    return std::nullopt;
+  return Index;
+}
+
+static bool isAbiCalleeSavedVgpr(unsigned Vgpr) {
+  // CSR_AMDGPU_VGPRs in AMDGPUCallingConv.td uses eight-register saved
+  // stripes alternating with eight caller-saved registers, starting at v40.
+  return Vgpr >= 40 && Vgpr <= 255 && ((Vgpr - 40) % 16) < 8;
+}
+
+static bool instructionDefinesRegisterNamed(const InternalDecodedInst &DI,
+                                            StringRef Name,
+                                            const LLVMState &LS) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I)
+    if (DI.Inst.getOperand(I).isReg() && DI.Inst.getOperand(I).getReg() &&
+        StringRef(LS.MRI->getName(DI.Inst.getOperand(I).getReg())) == Name)
+      return true;
+  return llvm::any_of(Desc.implicit_defs(), [&](MCPhysReg Reg) {
+    return StringRef(LS.MRI->getName(Reg)) == Name;
+  });
+}
+
+/// Return the exact packed VGPR-MSB mode installed by this instruction, or
+/// std::nullopt when it does not install one. The constants mirror the
+/// documented HW_REG_WAVE_MODE decode used by the WMMA mode analysis.
+static std::optional<unsigned>
+getExactAbiVgprMode(const InternalDecodedInst &DI, const LLVMState &LS) {
+  if (DI.Inst.getOpcode() == LS.SSetVgprMsbOpcode) {
+    if (DI.Inst.getNumOperands() != 1 || !DI.Inst.getOperand(0).isImm())
+      return std::nullopt;
+    return static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) & 0xff;
+  }
+  if (DI.Inst.getOpcode() != LS.SSetregImm32Opcode ||
+      DI.Inst.getNumOperands() != 2 || !DI.Inst.getOperand(0).isImm() ||
+      !DI.Inst.getOperand(1).isImm())
+    return std::nullopt;
+  constexpr unsigned HwregIdMask = 0x3f;
+  constexpr unsigned HwregIdMode = 1;
+  unsigned Simm16 = static_cast<unsigned>(DI.Inst.getOperand(1).getImm());
+  if ((Simm16 & HwregIdMask) != HwregIdMode)
+    return std::nullopt;
+  unsigned Raw =
+      (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) >> 12) & 0xff;
+  return ((Raw >> 2) | (Raw << 6)) & 0xff;
+}
+
+static bool mayWriteAbiVgprBankUnknown(const InternalDecodedInst &DI,
+                                       const LLVMState &LS) {
+  if (DI.Inst.getOpcode() == LS.SSetVgprMsbOpcode)
+    return !getExactAbiVgprMode(DI, LS);
+  if (DI.Inst.getOpcode() == LS.SSetregImm32Opcode ||
+      DI.Inst.getOpcode() == LS.SSetregB32Opcode) {
+    if (DI.Inst.getNumOperands() == 0 ||
+        !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm())
+      return true;
+    constexpr unsigned HwregIdMask = 0x3f;
+    constexpr unsigned HwregIdMode = 1;
+    unsigned Simm16 = static_cast<unsigned>(
+        DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
+    if ((Simm16 & HwregIdMask) != HwregIdMode)
+      return false;
+    return !getExactAbiVgprMode(DI, LS);
+  }
+  return instructionDefinesRegisterNamed(DI, "MODE", LS);
+}
+
+bool matchesCanonicalLaneTransfer(const InternalDecodedInst &DI,
+                                  StringRef Mnemonic, MCRegister Dst,
+                                  MCRegister Src, int64_t Lane) {
+  unsigned ExpectedOperands = Mnemonic == "v_readlane_b32"    ? 3
+                              : Mnemonic == "v_writelane_b32" ? 4
+                                                              : 0;
+  if (!ExpectedOperands || DI.Mnemonic != Mnemonic ||
+      DI.Inst.getNumOperands() != ExpectedOperands ||
+      !isExactRegisterOperand(DI.Inst, 0, Dst) ||
+      !isExactRegisterOperand(DI.Inst, 1, Src) ||
+      !DI.Inst.getOperand(2).isImm() || DI.Inst.getOperand(2).getImm() != Lane)
+    return false;
+  return Mnemonic == "v_readlane_b32" ||
+         isExactRegisterOperand(DI.Inst, 3, Dst);
+}
+
+/// MachineInstr analysis historically classifies a few EXEC-mask operations as
+/// branches even though they do not change the PC.  The canonical-frame proof
+/// needs the narrower hardware notion: an explicit PC opcode, a return or
+/// indirect branch, or a branch/call carrying a PC-relative target.
+bool isTruePcTransfer(const InternalDecodedInst &DI, const LLVMState &LS) {
+  if (!DI.DecodeSucceeded)
+    return false;
+  if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode ||
+      DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
+      DI.Inst.getOpcode() == LS.SAddPcI64Opcode || LS.MIA->isReturn(DI.Inst) ||
+      LS.MIA->isIndirectBranch(DI.Inst))
+    return true;
+  return (LS.MIA->isBranch(DI.Inst) || LS.MIA->isCall(DI.Inst)) &&
+         hasPcRelativeOperand(DI, LS);
+}
+
+struct CanonicalSavedLane {
+  MCRegister Vgpr;
+  int64_t Lane = -1;
+
+  bool operator==(const CanonicalSavedLane &Other) const {
+    return Vgpr == Other.Vgpr && Lane == Other.Lane;
+  }
+};
+
+struct CanonicalAbiReturn {
+  size_t ReturnIndex = 0;
+  size_t RestoreLowIndex = 0;
+  size_t RestoreHighIndex = 0;
+  CanonicalSavedLane SavedLow;
+  CanonicalSavedLane SavedHigh;
+};
+
+struct AbiVgprModeState {
+  int8_t Dst = -2;
+  int8_t Src0 = -2;
+  int8_t Src1 = -2;
+  int8_t Src2 = -2;
+};
+
+static AbiVgprModeState abiVgprModeState(unsigned Mode) {
+  return {static_cast<int8_t>((Mode >> 6) & 3), static_cast<int8_t>(Mode & 3),
+          static_cast<int8_t>((Mode >> 2) & 3),
+          static_cast<int8_t>((Mode >> 4) & 3)};
+}
+
+static bool isUnreachable(AbiVgprModeState State) { return State.Dst == -2; }
+
+static AbiVgprModeState mergeAbiVgprMode(AbiVgprModeState Old,
+                                         AbiVgprModeState Incoming) {
+  if (isUnreachable(Old))
+    return Incoming;
+  if (isUnreachable(Incoming))
+    return Old;
+  auto Merge = [](int8_t LHS, int8_t RHS) {
+    return LHS == RHS ? LHS : int8_t{-1};
+  };
+  return {Merge(Old.Dst, Incoming.Dst), Merge(Old.Src0, Incoming.Src0),
+          Merge(Old.Src1, Incoming.Src1), Merge(Old.Src2, Incoming.Src2)};
+}
+
+static bool sameAbiVgprMode(AbiVgprModeState LHS, AbiVgprModeState RHS) {
+  return std::tie(LHS.Dst, LHS.Src0, LHS.Src1, LHS.Src2) ==
+         std::tie(RHS.Dst, RHS.Src0, RHS.Src1, RHS.Src2);
+}
+
+static bool isAbiVgprModeZero(AbiVgprModeState State) {
+  return State.Dst == 0 && State.Src0 == 0 && State.Src1 == 0 &&
+         State.Src2 == 0;
+}
+
+/// Prove full VGPR-MSB mode zero at every call and s30 ABI return accepted by
+/// the linked-object fallback. Every defined function/declared entry is seeded
+/// with the HSA ABI entry mode; cross-function direct edges and CFG joins are
+/// then modeled explicitly so a non-ABI caller cannot be hidden by reseeding
+/// its callee.
+static bool validateAbiControlTransferModes(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextSize, ArrayRef<uint64_t> AbiRootEntries,
+    const DenseMap<size_t, const FiniteSetPcTransfer *> &ExactSetPcs,
+    MCRegister AbiLinkPair) {
+  DenseMap<uint64_t, unsigned> OffsetToIndex;
+  OffsetToIndex.reserve(Decoded.size());
+  for (unsigned I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+
+  std::vector<SmallVector<unsigned, 2>> Successors(Decoded.size());
+  auto addTarget = [&](SmallVectorImpl<unsigned> &Out, uint64_t Target) {
+    if (Target >= TextSize)
+      return true;
+    DenseMap<uint64_t, unsigned>::const_iterator It =
+        OffsetToIndex.find(Target);
+    if (It == OffsetToIndex.end())
+      return false;
+    Out.push_back(It->second);
+    return true;
+  };
+  auto addFallthrough = [&](SmallVectorImpl<unsigned> &Out, unsigned I) {
+    if (I + 1 == Decoded.size())
+      return true;
+    std::optional<uint64_t> End = checkedAddUint64(
+        Decoded[I].Offset, Decoded[I].Size, "ABI mode fallthrough");
+    return End && (*End >= TextSize || addTarget(Out, *End));
+  };
+
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    SmallVectorImpl<unsigned> &Out = Successors[I];
+    if (!DI.DecodeSucceeded)
+      return false;
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
         LS.MIA->isReturn(DI.Inst))
       continue;
-
-    std::optional<uint64_t> RelativeTarget =
-        getDirectTextTarget(DI, LS, TextAddr, TextEnd);
-    if (RelativeTarget && *RelativeTarget > SequenceStart &&
-        *RelativeTarget <= SequenceEnd)
-      return true;
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator Exact =
+          ExactSetPcs.find(I);
+      if (Exact != ExactSetPcs.end() && Exact->second->LocalTargetIndex &&
+          !addTarget(Out, Decoded[*Exact->second->LocalTargetIndex].Offset))
+        return false;
+      continue;
+    }
+    if (LS.MIA->isCall(DI.Inst) && isTruePcTransfer(DI, LS)) {
+      if (!addFallthrough(Out, I))
+        return false;
+      continue;
+    }
+    if (LS.MIA->isBranch(DI.Inst) && hasPcRelativeOperand(DI, LS)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (!Target || !addTarget(Out, *Target))
+        return false;
+      if (LS.MIA->isConditionalBranch(DI.Inst)) {
+        if (!addFallthrough(Out, I))
+          return false;
+      } else if (!LS.MIA->isUnconditionalBranch(DI.Inst)) {
+        return false;
+      }
+      continue;
+    }
+    if (isTruePcTransfer(DI, LS))
+      continue;
+    if (!addFallthrough(Out, I))
+      return false;
   }
-  return false;
+
+  SmallVector<AbiVgprModeState, 0> ModeBefore(Decoded.size());
+  SmallVector<unsigned, 64> Worklist;
+  for (uint64_t Root : AbiRootEntries) {
+    DenseMap<uint64_t, unsigned>::const_iterator It = OffsetToIndex.find(Root);
+    if (It == OffsetToIndex.end())
+      return false;
+    AbiVgprModeState Seeded =
+        mergeAbiVgprMode(ModeBefore[It->second], abiVgprModeState(0));
+    if (!sameAbiVgprMode(Seeded, ModeBefore[It->second])) {
+      ModeBefore[It->second] = Seeded;
+      Worklist.push_back(It->second);
+    }
+  }
+  for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+    unsigned I = Worklist[Next];
+    AbiVgprModeState ModeOut = ModeBefore[I];
+    if (std::optional<unsigned> Mode = getExactAbiVgprMode(Decoded[I], LS))
+      ModeOut = abiVgprModeState(*Mode);
+    else if (mayWriteAbiVgprBankUnknown(Decoded[I], LS))
+      ModeOut = {-1, -1, -1, -1};
+    for (unsigned Successor : Successors[I]) {
+      AbiVgprModeState Merged =
+          mergeAbiVgprMode(ModeBefore[Successor], ModeOut);
+      if (!sameAbiVgprMode(Merged, ModeBefore[Successor])) {
+        ModeBefore[Successor] = Merged;
+        Worklist.push_back(Successor);
+      }
+    }
+  }
+
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    bool IsCall = LS.MIA->isCall(DI.Inst) && isTruePcTransfer(DI, LS);
+    bool IsAbiReturn = DI.Inst.getOpcode() == LS.SSetPcI64Opcode &&
+                       isExactRegisterOperand(DI.Inst, 0, AbiLinkPair) &&
+                       !ExactSetPcs.contains(I);
+    if (!IsCall && !IsAbiReturn)
+      continue;
+    if (isUnreachable(ModeBefore[I])) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "control transfer at 0x"
+            << utohexstr(DI.Offset) << " is unreachable from an ABI root\n";
+      return false;
+    }
+    if (!isAbiVgprModeZero(ModeBefore[I])) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "control transfer at 0x"
+            << utohexstr(DI.Offset) << " is not in full VGPR-MSB mode 0\n";
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Prove the compiler's canonical AMDGPU nested-call frame for a group of
+/// s[30:31] returns in one local STT_FUNC:
+///
+///   v_writelane SavedLowVgpr,  s30, SavedLowLane
+///   v_writelane SavedHighVgpr, s31, SavedHighLane
+///     ... s_swap_pc_i64 s[30:31], Target ...
+///   v_readlane s30, SavedLowVgpr,  SavedLowLane
+///   v_readlane s31, SavedHighVgpr, SavedHighLane
+///   s_set_pc_i64 s[30:31]
+///
+/// Both saved VGPRs must be in CSR_AMDGPU_VGPRs, so nested C/Fast/Cold callees
+/// preserve them (SIRegisterInfo::getCallPreservedMask). The locations may
+/// straddle a VGPR boundary when the compiler packs a large SGPR spill into
+/// consecutive wave lanes. A function-local CFG fixed point additionally
+/// proves every caller write to either saved physical VGPR addresses a
+/// different persistent destination bank, writes a different lane, or is the
+/// exact prologue save. Calls are permitted only in full VGPR-MSB mode zero,
+/// the mode required at both call entry and return.
+static bool validateCanonicalAbiFrameReturns(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, const ElfView::FunctionTextRange &Range,
+    ArrayRef<size_t> ReturnIndices,
+    const DenseMap<size_t, const FiniteSetPcTransfer *> &ExactSetPcs,
+    ArrayRef<DirectTargetSource> ExactSetPcEntries,
+    ArrayRef<CallContinuationSource> AllCallContinuations,
+    const DenseSet<uint64_t> &PotentialEntries,
+    ArrayRef<uint64_t> ActualRootEntries, ArrayRef<uint64_t> AbiModeRootEntries,
+    const ControlFlowScanIndex &Index, MCRegister AbiLinkPair,
+    ArrayRef<MCRegister> NumberedSgprs,
+    const DenseSet<size_t> &CanonicalAbiTailTransfers,
+    bool ForceFullCanonicalFrame, DenseSet<size_t> &SafeReturns) {
+  if (!Range.Symbol || Range.Symbol->getType() != ELF::STT_FUNC ||
+      Range.Symbol->getBinding() != ELF::STB_LOCAL || Range.Begin < TextAddr ||
+      Range.End <= Range.Begin)
+    return false;
+  uint64_t BeginOffset = Range.Begin - TextAddr;
+  uint64_t EndOffset = Range.End - TextAddr;
+  auto reject = [&](const Twine &Reason) {
+    log() << "hotswap: canonical s30 frame at 0x" << utohexstr(BeginOffset)
+          << " rejected: " << Reason << "\n";
+    return false;
+  };
+  auto BeginIt = llvm::lower_bound(
+      Decoded, BeginOffset, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  auto EndIt =
+      std::lower_bound(BeginIt, Decoded.end(), EndOffset,
+                       [](const InternalDecodedInst &DI, uint64_t Offset) {
+                         return DI.Offset < Offset;
+                       });
+  if (BeginIt == EndIt || BeginIt->Offset != BeginOffset)
+    return reject("function start is not a decoded instruction");
+  size_t BeginIndex = static_cast<size_t>(BeginIt - Decoded.begin());
+  size_t EndIndex = static_cast<size_t>(EndIt - Decoded.begin());
+  if (hasUnprovenFallthroughEntry(Decoded, BeginOffset,
+                                  Decoded[ReturnIndices.front()].Offset,
+                                  AbiModeRootEntries, Index)) {
+    // A compiler-emitted noreturn/trap tail may be laid out immediately
+    // before the next local function. It is still a valid linked-call entry
+    // when every path through that fallthrough suffix executes one exact ABI
+    // call that defines s[30:31], and no root or transfer can bypass the call.
+    auto Fallthrough = Index.FallthroughEntries.find(BeginOffset);
+    std::optional<size_t> LinkCall;
+    if (Fallthrough != Index.FallthroughEntries.end() &&
+        Fallthrough->second.Proven) {
+      uint64_t ChainBegin = Fallthrough->second.ChainBegin;
+      for (size_t I = BeginIndex; I != 0;) {
+        --I;
+        if (Decoded[I].Offset < ChainBegin)
+          break;
+        if (!LS.MIA->isCall(Decoded[I].Inst) ||
+            !isTruePcTransfer(Decoded[I], LS))
+          continue;
+        std::optional<MCRegister> Link = getCallReturnRegister(Decoded[I], LS);
+        if (Link && *Link == AbiLinkPair)
+          LinkCall = I;
+        break;
+      }
+    }
+    if (!LinkCall)
+      return reject("function entry has an unproven layout fallthrough");
+    std::optional<uint64_t> Continuation =
+        checkedAddUint64(Decoded[*LinkCall].Offset, Decoded[*LinkCall].Size,
+                         "canonical frame prefix call continuation");
+    if (!Continuation || *Continuation >= BeginOffset)
+      return reject("function entry has an invalid link-defining prefix call");
+    ArrayRef<uint64_t>::iterator Root =
+        llvm::lower_bound(AbiModeRootEntries, *Continuation);
+    if (Root != AbiModeRootEntries.end() && *Root < BeginOffset)
+      return reject(Twine("ABI root bypasses prefix link call at 0x") +
+                    utohexstr(*Root));
+    auto Direct = llvm::lower_bound(
+        Index.DirectTargetsByTarget, *Continuation,
+        [](const DirectTargetSource &Source, uint64_t Target) {
+          return Source.Target < Target;
+        });
+    if (Direct != Index.DirectTargetsByTarget.end() &&
+        Direct->Target < BeginOffset)
+      return reject(Twine("control flow bypasses prefix link call at 0x") +
+                    utohexstr(Direct->Target));
+    auto Exact = llvm::lower_bound(
+        ExactSetPcEntries, *Continuation,
+        [](const DirectTargetSource &Source, uint64_t Target) {
+          return Source.Target < Target;
+        });
+    if (Exact != ExactSetPcEntries.end() && Exact->Target < BeginOffset)
+      return reject(Twine("exact set-PC bypasses prefix link call at 0x") +
+                    utohexstr(Exact->Target));
+    auto OtherCall = llvm::lower_bound(
+        AllCallContinuations, *Continuation,
+        [](const CallContinuationSource &Source, uint64_t Target) {
+          return Source.Continuation < Target;
+        });
+    for (; OtherCall != AllCallContinuations.end() &&
+           OtherCall->Continuation < BeginOffset;
+         ++OtherCall)
+      if (OtherCall->InstIndex != *LinkCall)
+        return reject(Twine("foreign call continuation bypasses prefix link "
+                            "call at 0x") +
+                      utohexstr(OtherCall->Continuation));
+    for (size_t I = *LinkCall + 1; I != BeginIndex; ++I)
+      if (definesOverlappingRegister(Decoded[I], LS, NumberedSgprs[30]) ||
+          definesOverlappingRegister(Decoded[I], LS, NumberedSgprs[31]) ||
+          (isTruePcTransfer(Decoded[I], LS) && LS.MIA->isCall(Decoded[I].Inst)))
+        return reject(Twine("prefix link is clobbered at 0x") +
+                      utohexstr(Decoded[I].Offset));
+  }
+  ArrayRef<uint64_t>::iterator FunctionRoot =
+      llvm::upper_bound(AbiModeRootEntries, BeginOffset);
+  if (FunctionRoot != AbiModeRootEntries.end() && *FunctionRoot < EndOffset)
+    return reject(Twine("ABI function root enters at 0x") +
+                  utohexstr(*FunctionRoot));
+  ArrayRef<uint64_t>::iterator ActualRoot =
+      llvm::lower_bound(ActualRootEntries, BeginOffset);
+  if (ActualRoot != ActualRootEntries.end() && *ActualRoot < EndOffset)
+    return reject(Twine("declared/external root enters at 0x") +
+                  utohexstr(*ActualRoot));
+  SmallVector<size_t, 4> BeginReentrySources;
+  auto Direct =
+      llvm::lower_bound(Index.DirectTargetsByTarget, BeginOffset,
+                        [](const DirectTargetSource &Source, uint64_t Target) {
+                          return Source.Target < Target;
+                        });
+  for (; Direct != Index.DirectTargetsByTarget.end() &&
+         Direct->Target < EndOffset;
+       ++Direct) {
+    const DirectTargetSource &Source = *Direct;
+    uint64_t SourceOffset = Decoded[Source.InstIndex].Offset;
+    bool SourceInside = SourceOffset >= BeginOffset && SourceOffset < EndOffset;
+    if (SourceInside) {
+      if (Source.Target == BeginOffset)
+        BeginReentrySources.push_back(Source.InstIndex);
+      continue;
+    }
+    if (Source.Target == BeginOffset) {
+      if (CanonicalAbiTailTransfers.contains(Source.InstIndex))
+        continue;
+      std::optional<MCRegister> Link =
+          getCallReturnRegister(Decoded[Source.InstIndex], LS);
+      if (!Link || *Link != AbiLinkPair)
+        return reject(Twine("non-ABI control transfer enters function at 0x") +
+                      utohexstr(SourceOffset));
+      continue;
+    }
+    return reject(Twine("external direct transfer enters at 0x") +
+                  utohexstr(Source.Target));
+  }
+  auto Exact =
+      llvm::lower_bound(ExactSetPcEntries, BeginOffset,
+                        [](const DirectTargetSource &Source, uint64_t Target) {
+                          return Source.Target < Target;
+                        });
+  for (; Exact != ExactSetPcEntries.end() && Exact->Target < EndOffset;
+       ++Exact) {
+    uint64_t Target = Exact->Target;
+    uint64_t Source = Decoded[Exact->InstIndex].Offset;
+    bool SourceInside = Source >= BeginOffset && Source < EndOffset;
+    // A separately validated canonical tail thunk may enter exactly at Begin:
+    // its source frame proves s[30:31] was restored to the incoming link
+    // before this exact set-PC. Interior entries and all other external exact
+    // transfers remain forbidden.
+    if (Target == BeginOffset && !SourceInside &&
+        CanonicalAbiTailTransfers.contains(Exact->InstIndex))
+      continue;
+    if (Target == BeginOffset || (Target > BeginOffset && !SourceInside))
+      return reject(Twine("external exact set-PC enters at 0x") +
+                    utohexstr(Target));
+  }
+  auto Continuation = llvm::lower_bound(
+      AllCallContinuations, BeginOffset,
+      [](const CallContinuationSource &Source, uint64_t Target) {
+        return Source.Continuation < Target;
+      });
+  for (; Continuation != AllCallContinuations.end() &&
+         Continuation->Continuation < EndOffset;
+       ++Continuation)
+    if (Decoded[Continuation->InstIndex].Offset < BeginOffset ||
+        Decoded[Continuation->InstIndex].Offset >= EndOffset)
+      return reject(Twine("external call continuation enters at 0x") +
+                    utohexstr(Continuation->Continuation));
+
+  bool HasNestedCall = false;
+  for (size_t I = BeginIndex; I != EndIndex; ++I)
+    HasNestedCall |=
+        LS.MIA->isCall(Decoded[I].Inst) && isTruePcTransfer(Decoded[I], LS);
+  if (!ForceFullCanonicalFrame && !HasNestedCall) {
+    bool DefinesLink = false;
+    for (size_t I = BeginIndex; I != EndIndex; ++I) {
+      const InternalDecodedInst &DI = Decoded[I];
+      DefinesLink |= definesOverlappingRegister(DI, LS, NumberedSgprs[30]) ||
+                     definesOverlappingRegister(DI, LS, NumberedSgprs[31]);
+    }
+    if (!DefinesLink) {
+      for (size_t Return : ReturnIndices)
+        SafeReturns.insert(Return);
+      return true;
+    }
+  }
+
+  SmallVector<CanonicalAbiReturn, 4> Returns;
+  std::optional<CanonicalSavedLane> SavedLow;
+  std::optional<CanonicalSavedLane> SavedHigh;
+  DenseSet<size_t> RestoreInstructions;
+  DenseSet<size_t> PostRestoreTeardownInstructions;
+  for (size_t ReturnIndex : ReturnIndices) {
+    std::optional<size_t> Low;
+    std::optional<size_t> High;
+    std::optional<CanonicalSavedLane> CandidateLow;
+    std::optional<CanonicalSavedLane> CandidateHigh;
+    for (size_t I = ReturnIndex; I != BeginIndex;) {
+      --I;
+      const InternalDecodedInst &DI = Decoded[I];
+      if (!DI.DecodeSucceeded)
+        return reject("undecoded restore instruction");
+      if (!Low && definesOverlappingRegister(DI, LS, NumberedSgprs[30])) {
+        if (DI.Mnemonic != "v_readlane_b32" || DI.Inst.getNumOperands() != 3 ||
+            !isExactRegisterOperand(DI.Inst, 0, NumberedSgprs[30]) ||
+            !DI.Inst.getOperand(1).isReg() || !DI.Inst.getOperand(1).getReg() ||
+            !DI.Inst.getOperand(2).isImm() ||
+            DI.Inst.getOperand(2).getImm() < 0 ||
+            DI.Inst.getOperand(2).getImm() >= 32)
+          return reject(Twine("invalid s30 restore before return 0x") +
+                        utohexstr(Decoded[ReturnIndex].Offset));
+        Low = I;
+        CandidateLow =
+            CanonicalSavedLane{MCRegister(DI.Inst.getOperand(1).getReg()),
+                               DI.Inst.getOperand(2).getImm()};
+      }
+      if (!High && definesOverlappingRegister(DI, LS, NumberedSgprs[31])) {
+        if (DI.Mnemonic != "v_readlane_b32" || DI.Inst.getNumOperands() != 3 ||
+            !isExactRegisterOperand(DI.Inst, 0, NumberedSgprs[31]) ||
+            !DI.Inst.getOperand(1).isReg() || !DI.Inst.getOperand(1).getReg() ||
+            !DI.Inst.getOperand(2).isImm() ||
+            DI.Inst.getOperand(2).getImm() < 0 ||
+            DI.Inst.getOperand(2).getImm() >= 32)
+          return reject(Twine("invalid s31 restore before return 0x") +
+                        utohexstr(Decoded[ReturnIndex].Offset));
+        High = I;
+        CandidateHigh =
+            CanonicalSavedLane{MCRegister(DI.Inst.getOperand(1).getReg()),
+                               DI.Inst.getOperand(2).getImm()};
+      }
+      if (Low && High)
+        break;
+      if (PotentialEntries.contains(DI.Offset))
+        return reject(Twine("entry at 0x") + utohexstr(DI.Offset) +
+                      " interrupts the restore search");
+      if (isTruePcTransfer(DI, LS))
+        return reject(Twine("control flow at 0x") + utohexstr(DI.Offset) +
+                      " interrupts the restore search (" + DI.Mnemonic + ")");
+    }
+    std::optional<unsigned> SavedLowIndex =
+        CandidateLow ? numberedVgprIndex(*LS.MRI, CandidateLow->Vgpr)
+                     : std::nullopt;
+    std::optional<unsigned> SavedHighIndex =
+        CandidateHigh ? numberedVgprIndex(*LS.MRI, CandidateHigh->Vgpr)
+                      : std::nullopt;
+    if (!Low || !High || !CandidateLow || !CandidateHigh || !SavedLowIndex ||
+        !SavedHighIndex || !isAbiCalleeSavedVgpr(*SavedLowIndex) ||
+        !isAbiCalleeSavedVgpr(*SavedHighIndex) ||
+        *CandidateLow == *CandidateHigh ||
+        (SavedLow && !(*SavedLow == *CandidateLow)) ||
+        (SavedHigh && !(*SavedHigh == *CandidateHigh)))
+      return reject(Twine("return 0x") +
+                    utohexstr(Decoded[ReturnIndex].Offset) +
+                    " has no consistent callee-saved VGPR-lane restore");
+    SavedLow = *CandidateLow;
+    SavedHigh = *CandidateHigh;
+    size_t RestoreBegin = std::min(*Low, *High);
+    size_t RestoreEnd = std::max(*Low, *High);
+    for (size_t I = RestoreBegin + 1; I <= ReturnIndex; ++I) {
+      if (PotentialEntries.contains(Decoded[I].Offset) ||
+          (I != ReturnIndex && isTruePcTransfer(Decoded[I], LS)))
+        return reject(Twine("entry or control flow interrupts epilogue at 0x") +
+                      utohexstr(Decoded[I].Offset));
+      if (I > RestoreEnd && I < ReturnIndex)
+        PostRestoreTeardownInstructions.insert(I);
+    }
+    Returns.push_back(
+        {ReturnIndex, *Low, *High, *CandidateLow, *CandidateHigh});
+    RestoreInstructions.insert(*Low);
+    RestoreInstructions.insert(*High);
+  }
+  if (!SavedLow || !SavedHigh)
+    return reject("no saved VGPR lanes recovered");
+
+  std::optional<size_t> SaveLow;
+  std::optional<size_t> SaveHigh;
+  for (size_t I = BeginIndex; I != EndIndex; ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.Offset - BeginOffset > 512)
+      break;
+    if (matchesCanonicalLaneTransfer(DI, "v_writelane_b32", SavedLow->Vgpr,
+                                     NumberedSgprs[30], SavedLow->Lane))
+      SaveLow = I;
+    if (matchesCanonicalLaneTransfer(DI, "v_writelane_b32", SavedHigh->Vgpr,
+                                     NumberedSgprs[31], SavedHigh->Lane))
+      SaveHigh = I;
+    if (SaveLow && SaveHigh)
+      break;
+    if (isTruePcTransfer(DI, LS))
+      return reject(Twine("control flow at 0x") + utohexstr(DI.Offset) +
+                    " precedes the prologue saves (" + DI.Mnemonic + ")");
+  }
+  if (!SaveLow || !SaveHigh)
+    return reject("matching prologue saves are absent");
+  size_t SaveEnd = std::max(*SaveLow, *SaveHigh);
+  for (size_t I = BeginIndex + 1; I <= SaveEnd; ++I)
+    if (PotentialEntries.contains(Decoded[I].Offset))
+      return reject(Twine("entry bypasses a prologue save at 0x") +
+                    utohexstr(Decoded[I].Offset));
+
+  const size_t Count = EndIndex - BeginIndex;
+  DenseMap<uint64_t, unsigned> OffsetToLocal;
+  OffsetToLocal.reserve(Count);
+  for (unsigned I = 0; I != Count; ++I)
+    OffsetToLocal.try_emplace(Decoded[BeginIndex + I].Offset, I);
+  std::vector<SmallVector<unsigned, 2>> Successors(Count);
+  bool Valid = true;
+  auto addTarget = [&](SmallVectorImpl<unsigned> &Out, uint64_t Target) {
+    if (Target < BeginOffset || Target >= EndOffset)
+      return;
+    DenseMap<uint64_t, unsigned>::const_iterator It =
+        OffsetToLocal.find(Target);
+    if (It == OffsetToLocal.end()) {
+      Valid = false;
+      return;
+    }
+    Out.push_back(It->second);
+  };
+  auto addFallthrough = [&](SmallVectorImpl<unsigned> &Out, unsigned I) {
+    if (I + 1 != Count)
+      Out.push_back(I + 1);
+  };
+  for (unsigned Local = 0; Local != Count && Valid; ++Local) {
+    size_t Global = BeginIndex + Local;
+    const InternalDecodedInst &DI = Decoded[Global];
+    SmallVectorImpl<unsigned> &Out = Successors[Local];
+    if (!DI.DecodeSucceeded) {
+      Valid = false;
+      break;
+    }
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode)
+      continue;
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator Exact =
+          ExactSetPcs.find(Global);
+      if (Exact != ExactSetPcs.end() && Exact->second->LocalTargetIndex)
+        addTarget(Out, Decoded[*Exact->second->LocalTargetIndex].Offset);
+      else if (!llvm::is_contained(ReturnIndices, Global))
+        Valid = false;
+      continue;
+    }
+    if (LS.MIA->isReturn(DI.Inst))
+      continue;
+    if (LS.MIA->isCall(DI.Inst) && isTruePcTransfer(DI, LS)) {
+      addFallthrough(Out, Local);
+      continue;
+    }
+    if (LS.MIA->isBranch(DI.Inst) && hasPcRelativeOperand(DI, LS)) {
+      if (LS.MIA->isIndirectBranch(DI.Inst)) {
+        Valid = false;
+        break;
+      }
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (!Target) {
+        Valid = false;
+        break;
+      }
+      addTarget(Out, *Target);
+      if (LS.MIA->isConditionalBranch(DI.Inst))
+        addFallthrough(Out, Local);
+      else if (!LS.MIA->isUnconditionalBranch(DI.Inst))
+        Valid = false;
+      continue;
+    }
+    if (isTruePcTransfer(DI, LS)) {
+      Valid = false;
+      break;
+    }
+    addFallthrough(Out, Local);
+  }
+  if (!Valid)
+    return reject("local CFG is open");
+
+  // A control-flow edge back to the function entry may execute the prologue
+  // again. It is safe only while s[30:31] still contains the function's
+  // original incoming link. Compute that as a must fact: every path reaching
+  // the edge source must be free of calls and s30/s31 definitions. Merging by
+  // AND is important for cycles where a lexically early backedge can be
+  // revisited from after a nested call.
+  SmallVector<int8_t, 0> IncomingLinkIntactBefore(Count, int8_t{-1});
+  IncomingLinkIntactBefore[0] = 1;
+  SmallVector<unsigned, 64> LinkWorklist(1, 0);
+  for (size_t Next = 0; Next != LinkWorklist.size(); ++Next) {
+    unsigned Local = LinkWorklist[Next];
+    size_t Global = BeginIndex + Local;
+    const InternalDecodedInst &DI = Decoded[Global];
+    int8_t IntactOut = IncomingLinkIntactBefore[Local];
+    if ((LS.MIA->isCall(DI.Inst) && isTruePcTransfer(DI, LS)) ||
+        definesOverlappingRegister(DI, LS, NumberedSgprs[30]) ||
+        definesOverlappingRegister(DI, LS, NumberedSgprs[31]))
+      IntactOut = 0;
+    for (unsigned Succ : Successors[Local]) {
+      int8_t Merged = IncomingLinkIntactBefore[Succ] == -1
+                          ? IntactOut
+                          : (IncomingLinkIntactBefore[Succ] & IntactOut);
+      if (Merged != IncomingLinkIntactBefore[Succ]) {
+        IncomingLinkIntactBefore[Succ] = Merged;
+        LinkWorklist.push_back(Succ);
+      }
+    }
+  }
+  for (size_t Source : BeginReentrySources) {
+    unsigned Local = static_cast<unsigned>(Source - BeginIndex);
+    if (IncomingLinkIntactBefore[Local] == 0)
+      return reject(Twine("internal transfer reenters the prologue with a "
+                          "clobbered s30 link at 0x") +
+                    utohexstr(Decoded[Source].Offset));
+  }
+
+  SmallVector<AbiVgprModeState, 0> ModeBefore(Count);
+  ModeBefore[0] = abiVgprModeState(0);
+  SmallVector<int8_t, 0> SavesBefore(Count, int8_t{-1});
+  SavesBefore[0] = 0;
+  SmallVector<unsigned, 64> Worklist(1, 0);
+  for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+    unsigned Local = Worklist[Next];
+    size_t Global = BeginIndex + Local;
+    const InternalDecodedInst &DI = Decoded[BeginIndex + Local];
+    AbiVgprModeState ModeOut = ModeBefore[Local];
+    if (std::optional<unsigned> Mode = getExactAbiVgprMode(DI, LS))
+      ModeOut = abiVgprModeState(*Mode);
+    else if (mayWriteAbiVgprBankUnknown(DI, LS))
+      ModeOut = {-1, -1, -1, -1};
+    int8_t SavesOut = SavesBefore[Local];
+    if (Global == *SaveLow)
+      SavesOut |= 1;
+    if (Global == *SaveHigh)
+      SavesOut |= 2;
+    for (unsigned Succ : Successors[Local]) {
+      AbiVgprModeState MergedMode = mergeAbiVgprMode(ModeBefore[Succ], ModeOut);
+      int8_t MergedSaves =
+          SavesBefore[Succ] == -1 ? SavesOut : (SavesBefore[Succ] & SavesOut);
+      if (!sameAbiVgprMode(MergedMode, ModeBefore[Succ]) ||
+          MergedSaves != SavesBefore[Succ]) {
+        ModeBefore[Succ] = MergedMode;
+        SavesBefore[Succ] = MergedSaves;
+        Worklist.push_back(Succ);
+      }
+    }
+  }
+
+  for (unsigned Local = 0; Local != Count; ++Local) {
+    if (isUnreachable(ModeBefore[Local]))
+      continue;
+    size_t Global = BeginIndex + Local;
+    const InternalDecodedInst &DI = Decoded[Global];
+    if (LS.MIA->isCall(DI.Inst) && !isAbiVgprModeZero(ModeBefore[Local])) {
+      log() << "hotswap: canonical s30 frame: call at 0x"
+            << utohexstr(DI.Offset) << " is not in full VGPR-MSB mode 0\n";
+      return false;
+    }
+    if (llvm::is_contained(ReturnIndices, Global) && SavesBefore[Local] != 3) {
+      log() << "hotswap: canonical s30 frame: prologue saves do not dominate "
+               "return at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return false;
+    }
+    if (llvm::is_contained(ReturnIndices, Global) &&
+        !isAbiVgprModeZero(ModeBefore[Local])) {
+      log() << "hotswap: canonical s30 frame: return at 0x"
+            << utohexstr(DI.Offset) << " is not in full VGPR-MSB mode 0\n";
+      return false;
+    }
+    if (RestoreInstructions.contains(Global) && ModeBefore[Local].Src0 != 0) {
+      log() << "hotswap: canonical s30 frame: readlane at 0x"
+            << utohexstr(DI.Offset) << " does not read VGPR bank 0\n";
+      return false;
+    }
+
+    bool DefinesLink = definesOverlappingRegister(DI, LS, NumberedSgprs[30]) ||
+                       definesOverlappingRegister(DI, LS, NumberedSgprs[31]);
+    if (DefinesLink && !RestoreInstructions.contains(Global) &&
+        SavesBefore[Local] != 3) {
+      log() << "hotswap: canonical s30 frame: link definition before both "
+               "prologue saves at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return false;
+    }
+
+    bool WritesSavedLow = instructionWritesRegister(DI, LS, SavedLow->Vgpr);
+    bool WritesSavedHigh = instructionWritesRegister(DI, LS, SavedHigh->Vgpr);
+    if (!WritesSavedLow && !WritesSavedHigh)
+      continue;
+    // The canonical epilogue may restore the caller's old callee-saved VGPR
+    // from scratch after both link halves have already been copied into
+    // s[30:31]. The entry/control-flow checks above make this a straight-line
+    // teardown interval, so that write cannot affect the return address.
+    if (PostRestoreTeardownInstructions.contains(Global))
+      continue;
+    if (Global == *SaveLow || Global == *SaveHigh) {
+      if (ModeBefore[Local].Dst != 0) {
+        log() << "hotswap: canonical s30 frame: writelane save at 0x"
+              << utohexstr(DI.Offset) << " does not write VGPR bank 0\n";
+        return false;
+      }
+      continue;
+    }
+    if (ModeBefore[Local].Dst > 0)
+      continue;
+    if (ModeBefore[Local].Dst < 0) {
+      log() << "hotswap: canonical s30 frame: saved-VGPR write at 0x"
+            << utohexstr(DI.Offset) << " has unknown destination bank\n";
+      return false;
+    }
+    if (DI.Mnemonic == "v_writelane_b32" && DI.Inst.getNumOperands() == 4 &&
+        DI.Inst.getOperand(0).isReg() && DI.Inst.getOperand(0).getReg() &&
+        isExactRegisterOperand(DI.Inst, 3,
+                               MCRegister(DI.Inst.getOperand(0).getReg())) &&
+        DI.Inst.getOperand(2).isImm()) {
+      CanonicalSavedLane Written{MCRegister(DI.Inst.getOperand(0).getReg()),
+                                 DI.Inst.getOperand(2).getImm()};
+      if (!(Written == *SavedLow) && !(Written == *SavedHigh))
+        continue;
+    }
+    log() << "hotswap: canonical s30 frame: saved lower-bank VGPR clobber at "
+             "0x"
+          << utohexstr(DI.Offset) << "\n";
+    return false;
+  }
+  for (const CanonicalAbiReturn &Return : Returns)
+    SafeReturns.insert(Return.ReturnIndex);
+  return true;
+}
+
+/// Validate the linked-code-object ABI entry set as a late, all-or-nothing
+/// fallback after the ordinary machine-level closed-world proof remains open.
+///
+/// A valid compiler-produced, linked AMDGPU HSA code object may contain calls
+/// whose selector is intentionally opaque to static analysis. This fallback
+/// relies on the linked-code ABI contract that every such selector denotes a
+/// defined STT_FUNC entry and that every callee obeys the AMDGPU calling
+/// convention, including preservation of CSR_AMDGPU_VGPRs. It is not a proof
+/// for arbitrary or adversarial machine code. Under that explicit contract,
+/// the ABI gives those transfers a finite local entry set when all of the
+/// following object-wide invariants hold:
+///   * every opaque register call is exactly
+///       s_swap_pc_i64 s[30:31], TargetPair;
+///   * every s_set_pc_i64 s[30:31] is a return to one of the syntactic call
+///     continuations;
+///   * every other set-PC is an exact local PC materialization;
+///   * no other indirect transfer exists; and
+///   * every function start, continuation, and exact jump target is a decoded
+///     instruction boundary outside the interior of a PC materialization.
+///
+/// This is deliberately not a replacement for auditFiniteIndirectControlFlow:
+/// callers invoke it only when that stronger proof did not close. Any opcode,
+/// register, symbol, boundary, or entry-set variation rejects the whole
+/// fallback and preserves the existing fail-closed result.
+static std::optional<WellFormedAbiEntrySet> validateWellFormedAbiEntrySet(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextSize,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    ArrayRef<uint64_t> NonCallEntries, const ControlFlowScanIndex &Index,
+    ArrayRef<FiniteSetPcTransfer> SetPcCandidates, const ElfView &Elf) {
+  const auto Header = Elf.file().getHeader();
+  std::optional<uint64_t> TextEnd =
+      checkedAddUint64(TextAddr, TextSize, "well-formed ABI text end");
+  if (Header.e_type != ELF::ET_DYN || Header.e_machine != ELF::EM_AMDGPU ||
+      Header.e_ident[ELF::EI_OSABI] != ELF::ELFOSABI_AMDGPU_HSA ||
+      TextAddr != Elf.textAddr() || TextSize != Elf.textSize() || !TextEnd ||
+      Decoded.empty() || !Elf.functionTextRangesComplete()) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "object preconditions do not hold\n";
+    return std::nullopt;
+  }
+
+  DenseMap<uint64_t, size_t> InstructionAt;
+  InstructionAt.reserve(Decoded.size());
+  uint64_t ExpectedOffset = 0;
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!DI.DecodeSucceeded || DI.Size == 0 || DI.Offset != ExpectedOffset ||
+        !InstructionAt.try_emplace(DI.Offset, I).second) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "non-contiguous decode at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return std::nullopt;
+    }
+    std::optional<uint64_t> End =
+        checkedAddUint64(DI.Offset, DI.Size, "well-formed ABI instruction end");
+    if (!End || *End > TextSize) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "instruction end exceeds .text at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return std::nullopt;
+    }
+    ExpectedOffset = *End;
+  }
+  if (ExpectedOffset != TextSize) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "decoded instructions do not cover .text\n";
+    return std::nullopt;
+  }
+
+  WellFormedAbiEntrySet Result;
+  auto addBoundary = [&](uint64_t Offset) {
+    if (Offset >= TextSize || !InstructionAt.contains(Offset))
+      return false;
+    Result.Targets.insert(Offset);
+    return true;
+  };
+
+  bool SawFunctionEntry = false;
+  SmallVector<uint64_t, 32> AbiRootEntries;
+  DenseSet<uint64_t> DefinedFunctionBeginOffsets;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+    // Internal users can supply synthetic ranges to the stronger machine
+    // audit. Only actual defined STT_FUNC symbols expand this ABI fallback's
+    // function-pointer target set.
+    if (!Range.Symbol || Range.Symbol->getType() != ELF::STT_FUNC)
+      continue;
+    bool SizedRangeValid =
+        Range.Symbol->st_size == 0 ||
+        (Range.Symbol->st_value <=
+             std::numeric_limits<uint64_t>::max() - Range.Symbol->st_size &&
+         Range.Symbol->st_value + Range.Symbol->st_size == Range.End &&
+         Range.End <= *TextEnd);
+    if (Range.Symbol->st_shndx != Elf.textSectionIndex() ||
+        Range.Symbol->st_value != Range.Begin || !SizedRangeValid ||
+        Range.Begin < TextAddr || Range.Begin >= *TextEnd ||
+        Range.End <= Range.Begin || Range.End > *TextEnd ||
+        !addBoundary(Range.Begin - TextAddr) ||
+        (Range.End != *TextEnd &&
+         !InstructionAt.contains(Range.End - TextAddr))) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "STT_FUNC range is not bounded by exact .text instructions\n";
+      return std::nullopt;
+    }
+    SawFunctionEntry = true;
+    uint64_t BeginOffset = Range.Begin - TextAddr;
+    AbiRootEntries.push_back(BeginOffset);
+    DefinedFunctionBeginOffsets.insert(BeginOffset);
+  }
+  if (!SawFunctionEntry) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "no defined STT_FUNC entry\n";
+    return std::nullopt;
+  }
+  for (uint64_t Entry : DeclaredEntries)
+    if (!addBoundary(Entry)) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "declared entry 0x"
+            << utohexstr(Entry) << " is not an instruction boundary\n";
+      return std::nullopt;
+    }
+  AbiRootEntries.append(DeclaredEntries.begin(), DeclaredEntries.end());
+  for (uint64_t Entry : ExternalEntries)
+    if (!addBoundary(Entry)) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "external entry 0x"
+            << utohexstr(Entry) << " is not an instruction boundary\n";
+      return std::nullopt;
+    }
+  AbiRootEntries.append(ExternalEntries.begin(), ExternalEntries.end());
+  llvm::sort(AbiRootEntries);
+  AbiRootEntries.erase(
+      std::unique(AbiRootEntries.begin(), AbiRootEntries.end()),
+      AbiRootEntries.end());
+  SmallVector<uint64_t, 32> ActualRootEntries(NonCallEntries.begin(),
+                                              NonCallEntries.end());
+  llvm::sort(ActualRootEntries);
+  ActualRootEntries.erase(
+      std::unique(ActualRootEntries.begin(), ActualRootEntries.end()),
+      ActualRootEntries.end());
+
+  DenseSet<size_t> FiniteCalls;
+  for (const KnownCallSite &Call : Index.Calls)
+    FiniteCalls.insert(Call.InstIndex);
+  for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
+    FiniteCalls.insert(Call.InstIndex);
+
+  std::optional<SmallVector<MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*LS.MRI, Gfx1250MaxSgprs);
+  if (!NumberedSgprs || NumberedSgprs->size() <= 31) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "numbered SGPR map is unavailable\n";
+    return std::nullopt;
+  }
+  MCRegister AbiLinkPair;
+  for (const InternalDecodedInst &DI : Decoded)
+    if (DI.DecodeSucceeded && DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
+        DI.Inst.getNumOperands() >= 1 && DI.Inst.getOperand(0).isReg()) {
+      std::optional<unsigned> Index =
+          numberedSgprPairLowIndex(*LS.MRI, DI.Inst.getOperand(0).getReg());
+      if (Index && *Index == 30) {
+        AbiLinkPair = DI.Inst.getOperand(0).getReg();
+        break;
+      }
+    }
+  if (!AbiLinkPair) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "no s30 ABI link pair\n";
+    return std::nullopt;
+  }
+
+  DenseMap<size_t, const FiniteSetPcTransfer *> ExactSetPcs;
+  for (const FiniteSetPcTransfer &Candidate : SetPcCandidates) {
+    auto Inserted = ExactSetPcs.try_emplace(Candidate.InstIndex, &Candidate);
+    if (!Inserted.second)
+      return std::nullopt;
+  }
+  if (!validateAbiControlTransferModes(Decoded, LS, TextSize, AbiRootEntries,
+                                       ExactSetPcs, AbiLinkPair))
+    return std::nullopt;
+
+  DenseSet<uint64_t> PotentialEntries(Result.Targets.begin(),
+                                      Result.Targets.end());
+  for (const DirectTargetSource &Source : Index.DirectTargetsByTarget)
+    if (Source.Target < TextSize)
+      PotentialEntries.insert(Source.Target);
+  SmallVector<CallContinuationSource, 16> AllCallContinuations;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    if (LS.MIA->isCall(Decoded[I].Inst)) {
+      std::optional<uint64_t> Continuation =
+          checkedAddUint64(Decoded[I].Offset, Decoded[I].Size,
+                           "canonical ABI call continuation");
+      if (!Continuation || !addBoundary(*Continuation))
+        return std::nullopt;
+      PotentialEntries.insert(*Continuation);
+      AllCallContinuations.push_back({I, *Continuation});
+    }
+  llvm::sort(AllCallContinuations, [](const CallContinuationSource &LHS,
+                                      const CallContinuationSource &RHS) {
+    return std::tie(LHS.Continuation, LHS.InstIndex) <
+           std::tie(RHS.Continuation, RHS.InstIndex);
+  });
+  SmallVector<DirectTargetSource, 16> ExactSetPcEntries;
+  for (const auto &Entry : ExactSetPcs)
+    if (Entry.second->LocalTargetIndex) {
+      uint64_t Target = Decoded[*Entry.second->LocalTargetIndex].Offset;
+      if (!addBoundary(Target))
+        return std::nullopt;
+      PotentialEntries.insert(Target);
+      ExactSetPcEntries.push_back({Entry.first, Target});
+    }
+  llvm::sort(ExactSetPcEntries,
+             [](const DirectTargetSource &LHS, const DirectTargetSource &RHS) {
+               return std::tie(LHS.Target, LHS.InstIndex) <
+                      std::tie(RHS.Target, RHS.InstIndex);
+             });
+
+  DenseMap<std::pair<uint64_t, uint64_t>, SmallVector<size_t, 4>>
+      ReturnsByFunction;
+  DenseMap<std::pair<uint64_t, uint64_t>, const ElfView::FunctionTextRange *>
+      ReturnFunctionRanges;
+  SmallVector<const ElfView::FunctionTextRange *, 32> LocalFunctionRanges;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Symbol && Range.Symbol->getType() == ELF::STT_FUNC &&
+        Range.Symbol->getBinding() == ELF::STB_LOCAL)
+      LocalFunctionRanges.push_back(&Range);
+  llvm::sort(LocalFunctionRanges, [](const ElfView::FunctionTextRange *LHS,
+                                     const ElfView::FunctionTextRange *RHS) {
+    if (LHS->Begin != RHS->Begin)
+      return LHS->Begin < RHS->Begin;
+    return LHS->End > RHS->End;
+  });
+  size_t RangeTreeBase = 1;
+  while (RangeTreeBase < LocalFunctionRanges.size())
+    RangeTreeBase *= 2;
+  SmallVector<uint64_t, 0> MaxRangeEnd(2 * RangeTreeBase);
+  for (size_t I = 0; I != LocalFunctionRanges.size(); ++I)
+    MaxRangeEnd[RangeTreeBase + I] = LocalFunctionRanges[I]->End;
+  for (size_t I = RangeTreeBase; I-- != 1;)
+    MaxRangeEnd[I] = std::max(MaxRangeEnd[2 * I], MaxRangeEnd[2 * I + 1]);
+  auto FindRightmostContaining =
+      [&](auto &&Self, size_t Node, size_t Begin, size_t End, size_t Limit,
+          uint64_t Address) -> std::optional<size_t> {
+    if (Begin >= Limit || MaxRangeEnd[Node] <= Address)
+      return std::nullopt;
+    if (End - Begin == 1)
+      return Begin;
+    size_t Middle = Begin + (End - Begin) / 2;
+    if (std::optional<size_t> Right =
+            Self(Self, 2 * Node + 1, Middle, End, Limit, Address))
+      return Right;
+    return Self(Self, 2 * Node, Begin, Middle, Limit, Address);
+  };
+  auto FindLocalFunction = [&](uint64_t Address) {
+    auto Candidate = llvm::upper_bound(
+        LocalFunctionRanges, Address,
+        [](uint64_t Value, const ElfView::FunctionTextRange *Range) {
+          return Value < Range->Begin;
+        });
+    size_t Limit = static_cast<size_t>(Candidate - LocalFunctionRanges.begin());
+    std::optional<size_t> BestIndex = FindRightmostContaining(
+        FindRightmostContaining, 1, 0, RangeTreeBase, Limit, Address);
+    return BestIndex ? LocalFunctionRanges[*BestIndex] : nullptr;
+  };
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.Inst.getOpcode() != LS.SSetPcI64Opcode || ExactSetPcs.contains(I) ||
+        DI.Inst.getNumOperands() != 1 ||
+        !isExactRegisterOperand(DI.Inst, 0, AbiLinkPair))
+      continue;
+    uint64_t Address = TextAddr + DI.Offset;
+    const ElfView::FunctionTextRange *Best = FindLocalFunction(Address);
+    if (!Best)
+      continue;
+    std::pair<uint64_t, uint64_t> Key{Best->Begin, Best->End};
+    ReturnsByFunction[Key].push_back(I);
+    ReturnFunctionRanges.try_emplace(Key, Best);
+  }
+
+  // A compiler tail thunk restores its incoming s30 link and then performs an
+  // exact set-PC to another defined function entry. Validate the source thunk
+  // with the same canonical save/restore proof used for ordinary s30 returns;
+  // only then may the target function accept that otherwise-external entry.
+  DenseMap<std::pair<uint64_t, uint64_t>, SmallVector<size_t, 2>>
+      TailExitsByFunction;
+  DenseMap<std::pair<uint64_t, uint64_t>, const ElfView::FunctionTextRange *>
+      TailFunctionRanges;
+  DenseSet<uint64_t> ReturningFunctionBegins;
+  for (const auto &Entry : ReturnsByFunction)
+    ReturningFunctionBegins.insert(Entry.first.first - TextAddr);
+  for (const auto &Exact : ExactSetPcs) {
+    size_t I = Exact.first;
+    if (!Exact.second->LocalTargetIndex)
+      continue;
+    uint64_t Target = Decoded[*Exact.second->LocalTargetIndex].Offset;
+    if (!DefinedFunctionBeginOffsets.contains(Target) ||
+        !ReturningFunctionBegins.contains(Target))
+      continue;
+    const ElfView::FunctionTextRange *Source =
+        FindLocalFunction(TextAddr + Decoded[I].Offset);
+    if (!Source || Source->Begin - TextAddr == Target)
+      continue;
+    std::pair<uint64_t, uint64_t> Key{Source->Begin, Source->End};
+    TailExitsByFunction[Key].push_back(I);
+    TailFunctionRanges.try_emplace(Key, Source);
+  }
+
+  // Phase 1 proves tail sources under the original strict entry policy. This
+  // deliberately rejects tail chains: no candidate is authorized merely by
+  // being present in the candidate set. A source function's ordinary s30
+  // returns are included so its complete local CFG remains closed.
+  const DenseSet<size_t> NoSafeTailTransfers;
+  DenseSet<size_t> SafeAbiTailTransfers;
+  for (const auto &Entry : TailExitsByFunction) {
+    const ElfView::FunctionTextRange *Range =
+        TailFunctionRanges.lookup(Entry.first);
+    SmallVector<size_t, 4> SourceExits(Entry.second.begin(),
+                                       Entry.second.end());
+    auto Returns = ReturnsByFunction.find(Entry.first);
+    if (Returns != ReturnsByFunction.end())
+      SourceExits.append(Returns->second.begin(), Returns->second.end());
+    llvm::sort(SourceExits);
+    SourceExits.erase(std::unique(SourceExits.begin(), SourceExits.end()),
+                      SourceExits.end());
+    DenseSet<size_t> ValidatedSourceExits;
+    if (!Range || !validateCanonicalAbiFrameReturns(
+                      Decoded, LS, TextAddr, *Range, SourceExits, ExactSetPcs,
+                      ExactSetPcEntries, AllCallContinuations, PotentialEntries,
+                      ActualRootEntries, AbiRootEntries, Index, AbiLinkPair,
+                      *NumberedSgprs, NoSafeTailTransfers,
+                      /*ForceFullCanonicalFrame=*/true, ValidatedSourceExits)) {
+      log() << "hotswap: tail source function at 0x"
+            << utohexstr(Entry.first.first - TextAddr)
+            << " was not certified to preserve the incoming s30 link\n";
+      continue;
+    }
+    for (size_t Tail : Entry.second)
+      if (ValidatedSourceExits.contains(Tail))
+        SafeAbiTailTransfers.insert(Tail);
+  }
+
+  // Phase 2 may now authorize only the exact source indices proven above
+  // while validating ordinary s30-return functions.
+  DenseSet<size_t> CanonicalAbiReturns;
+  DenseSet<uint64_t> CanonicalReturningFunctionBegins;
+  for (const auto &Entry : ReturnsByFunction) {
+    const ElfView::FunctionTextRange *Range =
+        ReturnFunctionRanges.lookup(Entry.first);
+    if (!Range || !validateCanonicalAbiFrameReturns(
+                      Decoded, LS, TextAddr, *Range, Entry.second, ExactSetPcs,
+                      ExactSetPcEntries, AllCallContinuations, PotentialEntries,
+                      ActualRootEntries, AbiRootEntries, Index, AbiLinkPair,
+                      *NumberedSgprs, SafeAbiTailTransfers,
+                      /*ForceFullCanonicalFrame=*/false, CanonicalAbiReturns)) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "local function at 0x"
+            << utohexstr(Entry.first.first - TextAddr)
+            << " does not use a provable canonical s30 call frame\n";
+      return std::nullopt;
+    }
+    for (size_t Return : Entry.second)
+      if (CanonicalAbiReturns.contains(Return)) {
+        CanonicalReturningFunctionBegins.insert(Entry.first.first - TextAddr);
+        break;
+      }
+  }
+
+  bool SawAbiCall = false;
+  bool SawAbiReturn = false;
+  SmallVector<std::pair<size_t, uint64_t>, 16> CallContinuations;
+  SmallVector<const FiniteSetPcTransfer *, 16> SelectedSetPcs;
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "well-formed ABI call continuation");
+      if (!Continuation || !addBoundary(*Continuation)) {
+        log() << "hotswap: linked-code-object ABI entry-set fallback "
+                 "rejected: call continuation at 0x"
+              << utohexstr(DI.Offset) << " is not an instruction boundary\n";
+        return std::nullopt;
+      }
+      CallContinuations.push_back({I, *Continuation});
+
+      const MCOperand *Target =
+          DI.Inst.getNumOperands() == 0
+              ? nullptr
+              : &DI.Inst.getOperand(DI.Inst.getNumOperands() - 1);
+      if (Target && Target->isReg()) {
+        if (DI.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+            DI.Inst.getNumOperands() != 2 ||
+            !isExactRegisterOperand(DI.Inst, 0, AbiLinkPair) ||
+            !Target->getReg() ||
+            LS.MRI->regsOverlap(AbiLinkPair, Target->getReg()) ||
+            !numberedSgprPairLowIndex(*LS.MRI, Target->getReg())) {
+          log() << "hotswap: linked-code-object ABI entry-set fallback "
+                   "rejected: register call at 0x"
+                << utohexstr(DI.Offset)
+                << " does not use the exact s30 swap-call shape\n";
+          return std::nullopt;
+        }
+        Result.Calls.insert(I);
+        if (!FiniteCalls.contains(I))
+          SawAbiCall = true;
+      } else if (!FiniteCalls.contains(I)) {
+        log() << "hotswap: linked-code-object ABI entry-set fallback "
+                 "rejected: non-register call at 0x"
+              << utohexstr(DI.Offset) << " is not finite\n";
+        return std::nullopt;
+      }
+    }
+
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      if (DI.Inst.getNumOperands() != 1 || !DI.Inst.getOperand(0).isReg() ||
+          !DI.Inst.getOperand(0).getReg()) {
+        log() << "hotswap: linked-code-object ABI entry-set fallback "
+                 "rejected: malformed set-PC at 0x"
+              << utohexstr(DI.Offset) << "\n";
+        return std::nullopt;
+      }
+      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator It =
+          ExactSetPcs.find(I);
+      if (It != ExactSetPcs.end()) {
+        if (!It->second->LocalTargetIndex ||
+            *It->second->LocalTargetIndex >= Decoded.size() ||
+            !addBoundary(Decoded[*It->second->LocalTargetIndex].Offset)) {
+          log() << "hotswap: linked-code-object ABI entry-set fallback "
+                   "rejected: exact set-PC at 0x"
+                << utohexstr(DI.Offset)
+                << " has an ambiguous or non-boundary target\n";
+          return std::nullopt;
+        }
+        Result.SetPcs.insert(I);
+        SelectedSetPcs.push_back(It->second);
+      } else if (isExactRegisterOperand(DI.Inst, 0, AbiLinkPair) &&
+                 CanonicalAbiReturns.contains(I)) {
+        SawAbiReturn = true;
+        Result.SetPcs.insert(I);
+      } else {
+        log() << "hotswap: linked-code-object ABI entry-set fallback "
+                 "rejected: non-s30 set-PC at 0x"
+              << utohexstr(DI.Offset)
+              << " is not an exact local PC materialization\n";
+        return std::nullopt;
+      }
+    }
+
+    if (DI.Inst.getOpcode() == LS.SAddPcI64Opcode) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "s_add_pc_i64 at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return std::nullopt;
+    }
+    if (LS.MIA->isIndirectBranch(DI.Inst) &&
+        DI.Inst.getOpcode() != LS.SSetPcI64Opcode &&
+        !(LS.MIA->isCall(DI.Inst) &&
+          DI.Inst.getOpcode() == LS.SSwapPcI64Opcode)) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "unsupported indirect transfer at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return std::nullopt;
+    }
+  }
+  bool SawExactCanonicalCall = false;
+  if (!SawAbiCall && SawAbiReturn)
+    for (const KnownCallSite &Call : Index.Calls)
+      if (Index.MaterializedCalls.contains(Call.InstIndex) &&
+          Call.ReturnRegister == AbiLinkPair &&
+          CanonicalReturningFunctionBegins.contains(Call.Target)) {
+        SawExactCanonicalCall = true;
+        break;
+      }
+  if (!SawAbiReturn || (!SawAbiCall && !SawExactCanonicalCall)) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "no opaque s30 call/return pair\n";
+    return std::nullopt;
+  }
+
+  if (!SawAbiCall) {
+    auto HasMaterializationEntry =
+        [&](const PcMaterializedCallInfo &Materialized) {
+          auto IsInterior = [&](uint64_t Offset) {
+            return Offset > Materialized.SequenceStart &&
+                   Offset <= Materialized.SequenceEnd;
+          };
+          for (uint64_t Entry : Result.Targets)
+            if (IsInterior(Entry))
+              return true;
+          for (const DirectTargetSource &Source : Index.DirectTargetsByTarget)
+            if (IsInterior(Source.Target))
+              return true;
+          for (const KnownCallSite &Call : Index.Calls)
+            if (IsInterior(Call.Target) || IsInterior(Call.Continuation))
+              return true;
+          for (const auto &Call : CallContinuations)
+            if (IsInterior(Call.second))
+              return true;
+          for (const FiniteSetPcTransfer *Transfer : SelectedSetPcs)
+            if (Transfer->LocalTargetIndex &&
+                IsInterior(Decoded[*Transfer->LocalTargetIndex].Offset))
+              return true;
+          return false;
+        };
+    for (const auto &Entry : Index.MaterializedCalls)
+      if (Result.Calls.contains(Entry.first) &&
+          HasMaterializationEntry(Entry.second)) {
+        log() << "hotswap: exact materialized-call/canonical-return closure "
+                 "rejected: alternate entry inside call materialization "
+                 "ending at 0x"
+              << utohexstr(Decoded[Entry.first].Offset) << "\n";
+        return std::nullopt;
+      }
+  }
+
+  auto hasInteriorEntry = [&](const FiniteSetPcTransfer &Candidate) {
+    uint64_t Begin = Decoded[Candidate.SequenceBeginIndex].Offset;
+    std::optional<uint64_t> End =
+        checkedAddUint64(Decoded[Candidate.SequenceEndIndex].Offset,
+                         Decoded[Candidate.SequenceEndIndex].Size,
+                         "well-formed ABI materialization end");
+    if (!End)
+      return true;
+    auto IsInterior = [&](uint64_t Offset) {
+      return Offset > Begin && Offset < *End;
+    };
+    auto SourceIsSequence = [&](size_t InstIndex) {
+      return InstIndex >= Candidate.SequenceBeginIndex &&
+             InstIndex <= Candidate.SequenceEndIndex;
+    };
+    for (uint64_t Entry : Result.Targets)
+      if (IsInterior(Entry))
+        return true;
+    for (const DirectTargetSource &Source : Index.DirectTargetsByTarget)
+      if (!SourceIsSequence(Source.InstIndex) && IsInterior(Source.Target))
+        return true;
+    for (const auto &Call : CallContinuations)
+      if (!SourceIsSequence(Call.first) && IsInterior(Call.second))
+        return true;
+    for (const FiniteSetPcTransfer *Transfer : SelectedSetPcs)
+      if (Transfer->LocalTargetIndex &&
+          IsInterior(Decoded[*Transfer->LocalTargetIndex].Offset))
+        return true;
+    return false;
+  };
+  for (const FiniteSetPcTransfer *Candidate : SelectedSetPcs)
+    if (Candidate->SequenceBeginIndex > Candidate->SequenceEndIndex ||
+        Candidate->SequenceEndIndex >= Decoded.size() ||
+        hasInteriorEntry(*Candidate)) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "alternate entry inside set-PC materialization ending at 0x"
+            << utohexstr(Decoded[Candidate->InstIndex].Offset) << "\n";
+      return std::nullopt;
+    }
+
+  for (const auto &Call : CallContinuations)
+    Result.Targets.insert(Call.second);
+  log() << "hotswap: accepted "
+        << (SawAbiCall ? "well-formed linked-code-object ABI entry set"
+                       : "exact materialized-call/canonical-return closure")
+        << " for " << Result.Calls.size() << " register call(s), "
+        << Result.SetPcs.size() << " set-PC transfer(s), and "
+        << Result.Targets.size() << " finite local entry point(s)\n";
+  return Result;
+}
+
+static bool addReusableCallsToIndex(ArrayRef<InternalDecodedInst> Decoded,
+                                    const LLVMState &LS, uint64_t TextAddr,
+                                    uint64_t TextEnd,
+                                    ArrayRef<ReachingCallTargets> ReusableCalls,
+                                    ControlFlowScanIndex &Index) {
+  for (size_t I = 0; I != ReusableCalls.size(); ++I) {
+    if (ReusableCalls[I].empty() || Index.MaterializedCalls.contains(I))
+      continue;
+    std::optional<MCRegister> ReturnRegister =
+        getCallReturnRegister(Decoded[I], LS);
+    if (!ReturnRegister)
+      continue;
+    std::optional<uint64_t> Continuation =
+        checkedAddUint64(Decoded[I].Offset, Decoded[I].Size,
+                         "known reusable call continuation address");
+    if (!Continuation)
+      return false;
+    bool HasExternalTarget = false;
+    for (uint64_t Target : ReusableCalls[I])
+      if (Target >= TextAddr && Target < TextEnd) {
+        Index.Calls.push_back(
+            {I, Target - TextAddr, *Continuation, *ReturnRegister});
+      } else {
+        HasExternalTarget = true;
+      }
+    if (HasExternalTarget)
+      Index.ExternalCallContinuations.push_back({I, *Continuation});
+  }
+  return true;
+}
+
+static void finalizeCallContinuationIndex(ControlFlowScanIndex &Index) {
+  Index.CallContinuationsByOffset.clear();
+  for (const KnownCallSite &Call : Index.Calls)
+    Index.CallContinuationsByOffset.push_back(
+        {Call.InstIndex, Call.Continuation});
+  llvm::sort(
+      Index.CallContinuationsByOffset,
+      [](const CallContinuationSource &LHS, const CallContinuationSource &RHS) {
+        return std::tie(LHS.Continuation, LHS.InstIndex) <
+               std::tie(RHS.Continuation, RHS.InstIndex);
+      });
+  llvm::sort(Index.ExternalCallContinuations,
+             [](const ExternalCallContinuation &LHS,
+                const ExternalCallContinuation &RHS) {
+               return std::tie(LHS.Continuation, LHS.InstIndex) <
+                      std::tie(RHS.Continuation, RHS.InstIndex);
+             });
+}
+
+static void
+addPotentialFiniteSetPcTransfersToIndex(ArrayRef<InternalDecodedInst> Decoded,
+                                        ArrayRef<FiniteSetPcTransfer> Transfers,
+                                        const BitVector &Reachable,
+                                        ControlFlowScanIndex &Index) {
+  for (const FiniteSetPcTransfer &Transfer : Transfers)
+    if (Reachable.test(Transfer.InstIndex) && Transfer.LocalTargetIndex)
+      Index.DirectTargetsByTarget.push_back(
+          {Transfer.InstIndex, Decoded[*Transfer.LocalTargetIndex].Offset});
+  llvm::sort(Index.DirectTargetsByTarget,
+             [](const DirectTargetSource &LHS, const DirectTargetSource &RHS) {
+               return std::tie(LHS.Target, LHS.InstIndex) <
+                      std::tie(RHS.Target, RHS.InstIndex);
+             });
 }
 
 /// Collect statically known direct branch and call destinations so an interior
@@ -1621,7 +5802,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-    ArrayRef<uint64_t> ExternalEntries) {
+    ArrayRef<uint64_t> ExternalEntries, ArrayRef<uint8_t> Text,
+    const ElfView *Elf, ArrayRef<uint64_t> NonCallEntries) {
   if (!LS.MIA) {
     log() << "hotswap: MC branch analysis is unavailable; adjacent far "
              "trampolines will not be coalesced\n";
@@ -1633,28 +5815,187 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   if (!TextEnd)
     return std::nullopt;
 
-  SmallVector<std::optional<PcMaterializedCallInfo>, 16> MaterializedCalls(
-      Decoded.size());
-  for (size_t I = 0; I != Decoded.size(); ++I)
-    MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
+  SmallVector<FiniteSetPcTransfer, 8> AllSetPcCandidates =
+      collectFiniteSetPcCandidates(Decoded, LS, TextAddr, *TextEnd,
+                                   FunctionRanges);
+  BitVector RejectedSetPcCandidates(AllSetPcCandidates.size());
+  BitVector ProvenSetPcCandidates(AllSetPcCandidates.size());
+  SmallVector<FiniteSetPcTransfer, 8> EnabledSetPcTransfers;
+  std::vector<ReachingCallTargets> ReusableCalls;
+  std::optional<ControlFlowScanIndex> Index;
+  SmallVector<BoundedSetPcReturn, 2> BoundedReturns;
+  SmallVector<SymbolLessReturnRegion, 8> SymbolLessRegions;
+  bool IndirectControlFlowClosed = false;
+  bool HasUnboundedIndirectEntries = false;
 
-  std::optional<SmallVector<KnownCallSite, 4>> Calls =
-      collectKnownCallSites(Decoded, LS, TextAddr, *TextEnd, MaterializedCalls);
-  if (!Calls)
-    return std::nullopt;
-  std::optional<SmallVector<BoundedSetPcReturn, 2>> BoundedReturns =
-      collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,
-                                 DeclaredEntries, FunctionRanges, *Calls,
-                                 ExternalEntries);
-  if (!BoundedReturns)
-    return std::nullopt;
+  // Exact set-PC edges are an optimistic over-approximation used only to
+  // discover later finite call targets. Rebuild from scratch whenever the
+  // closed-world audit removes an edge; never let a rejected edge leave
+  // self-supporting call or return facts behind.
+  for (;;) {
+    EnabledSetPcTransfers = selectLeastReachableSetPcCandidates(
+        Decoded, LS, DeclaredEntries, ExternalEntries, FunctionRanges, TextAddr,
+        AllSetPcCandidates, ProvenSetPcCandidates, RejectedSetPcCandidates);
+    ReusableCalls = resolveReusablePcCallTargets(
+        Decoded, LS, TextAddr, *TextEnd, FunctionRanges, EnabledSetPcTransfers);
+    Index = buildControlFlowScanIndex(Decoded, LS, TextAddr, *TextEnd,
+                                      FunctionRanges);
+    if (!Index || !addReusableCallsToIndex(Decoded, LS, TextAddr, *TextEnd,
+                                           ReusableCalls, *Index))
+      return std::nullopt;
+    indexKnownCalls(*Index);
+    finalizeCallContinuationIndex(*Index);
+    BitVector PotentialSetPcSources = computeFiniteControlFlowReachability(
+        Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
+        FunctionRanges, *Index, EnabledSetPcTransfers,
+        /*BoundedReturns=*/ArrayRef<BoundedSetPcReturn>{});
+    addPotentialFiniteSetPcTransfersToIndex(Decoded, AllSetPcCandidates,
+                                            PotentialSetPcSources, *Index);
+
+    std::optional<SmallVector<BoundedSetPcReturn, 2>> FunctionReturns =
+        collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,
+                                   DeclaredEntries, FunctionRanges,
+                                   ExternalEntries, *Index);
+    if (!FunctionReturns)
+      return std::nullopt;
+    BoundedReturns = std::move(*FunctionReturns);
+    BitVector CandidateReachability = computeFiniteControlFlowReachability(
+        Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
+        FunctionRanges, *Index, EnabledSetPcTransfers, BoundedReturns);
+    bool AddedCandidate = false;
+    for (size_t I = 0; I != AllSetPcCandidates.size(); ++I) {
+      if (RejectedSetPcCandidates.test(I) || ProvenSetPcCandidates.test(I) ||
+          !CandidateReachability.test(AllSetPcCandidates[I].InstIndex))
+        continue;
+      ProvenSetPcCandidates.set(I);
+      AddedCandidate = true;
+    }
+    if (AddedCandidate)
+      continue;
+    BitVector ReachableCallSources = computeFiniteControlFlowReachability(
+        Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
+        FunctionRanges, *Index, EnabledSetPcTransfers, BoundedReturns);
+    SymbolLessRegions = collectSymbolLessReturnRegions(
+        Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
+        ExternalEntries, *Index, EnabledSetPcTransfers, BoundedReturns,
+        ReachableCallSources);
+    SmallVector<BoundedSetPcReturn, 2> AllBoundedReturns = BoundedReturns;
+    for (const SymbolLessReturnRegion &Region : SymbolLessRegions)
+      for (size_t Return : Region.Returns) {
+        SmallVector<uint64_t, 2> Targets(Region.Continuations.begin(),
+                                         Region.Continuations.end());
+        AllBoundedReturns.push_back({Return, std::move(Targets)});
+      }
+    FiniteControlFlowAudit Audit = auditFiniteIndirectControlFlow(
+        Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
+        ExternalEntries, *Index, EnabledSetPcTransfers, AllBoundedReturns,
+        SymbolLessRegions);
+    if (Audit.InvalidSetPcCandidates.any()) {
+      for (size_t I = 0; I != EnabledSetPcTransfers.size(); ++I) {
+        if (!Audit.InvalidSetPcCandidates.test(I))
+          continue;
+        for (size_t J = 0; J != AllSetPcCandidates.size(); ++J)
+          if (AllSetPcCandidates[J].InstIndex ==
+              EnabledSetPcTransfers[I].InstIndex) {
+            RejectedSetPcCandidates.set(J);
+          }
+      }
+      // Every dynamic proof is conditional on the complete edge set used to
+      // reach it. A downstream candidate may have been reachable only through
+      // a just-rejected candidate, so rediscover the least fixed point from
+      // roots rather than retaining sticky proof bits.
+      ProvenSetPcCandidates.reset();
+      continue;
+    }
+    if (!Audit.Closed && !SymbolLessRegions.empty()) {
+      // Symbol-less returns depend on a closed object-wide entry proof. If
+      // any reachable entry source remains open, discard those inferred
+      // regions before finalizing; unlike symbol-backed local returns, they
+      // have no independent function boundary to constrain provenance.
+      SymbolLessRegions.clear();
+      AllBoundedReturns = BoundedReturns;
+      Audit = auditFiniteIndirectControlFlow(
+          Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
+          ExternalEntries, *Index, EnabledSetPcTransfers, AllBoundedReturns,
+          SymbolLessRegions);
+    }
+    if (!Audit.Closed && !EnabledSetPcTransfers.empty()) {
+      for (const FiniteSetPcTransfer &Enabled : EnabledSetPcTransfers)
+        for (size_t J = 0; J != AllSetPcCandidates.size(); ++J)
+          if (AllSetPcCandidates[J].InstIndex == Enabled.InstIndex) {
+            RejectedSetPcCandidates.set(J);
+          }
+      ProvenSetPcCandidates.reset();
+      continue;
+    }
+    IndirectControlFlowClosed = Audit.Closed;
+    HasUnboundedIndirectEntries = Audit.HasUnboundedIndirectEntries;
+    if (!Audit.Closed)
+      AllBoundedReturns.clear();
+    BoundedReturns = std::move(AllBoundedReturns);
+    break;
+  }
+
+  for (const FiniteSetPcTransfer &Transfer : EnabledSetPcTransfers) {
+    SmallVector<uint64_t, 2> Targets;
+    if (Transfer.LocalTargetIndex)
+      Targets.push_back(Decoded[*Transfer.LocalTargetIndex].Offset);
+    BoundedReturns.push_back({Transfer.InstIndex, std::move(Targets)});
+  }
+  indexKnownCalls(*Index);
+
+  DenseMap<size_t, size_t> BoundedReturnPositions;
+  for (size_t I = 0; I != BoundedReturns.size(); ++I)
+    BoundedReturnPositions.try_emplace(BoundedReturns[I].InstIndex, I);
+
+  // Canonical one-shot materializations also participate in the reusable
+  // reaching-value solver so CFG joins can prove their exact path. Preserve
+  // the established fail-closed entry proof once bounded returns are known:
+  // an interior alias, fallthrough, or unbounded transfer may still bypass
+  // the materialization even when its local dataflow token is exact.
+  BitVector LocallyProvenMaterializedCalls(Decoded.size());
+  for (const auto &Entry : Index->MaterializedCalls) {
+    size_t I = Entry.first;
+    if (ReusableCalls[I].empty())
+      continue;
+    if (hasKnownControlFlowEntry(
+            DeclaredEntries, BoundedReturns, BoundedReturnPositions, *Index,
+            HasUnboundedIndirectEntries, Entry.second.SequenceStart,
+            Entry.second.SequenceEnd)) {
+      ReusableCalls[I].clear();
+      continue;
+    }
+    LocallyProvenMaterializedCalls.set(I);
+  }
+
+  std::optional<WellFormedAbiEntrySet> AbiEntrySet;
+  if (!IndirectControlFlowClosed && Elf)
+    AbiEntrySet = validateWellFormedAbiEntrySet(
+        Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
+        ExternalEntries, NonCallEntries, *Index, AllSetPcCandidates, *Elf);
 
   DirectControlFlowInfo Info;
-  for (size_t InstIndex = 0; InstIndex != Decoded.size(); ++InstIndex) {
+  for (uint64_t Entry : DeclaredEntries)
+    if (Entry < TextSize)
+      Info.Targets.insert(Entry);
+  for (uint64_t Entry : ExternalEntries)
+    if (Entry < TextSize)
+      Info.Targets.insert(Entry);
+  for (const BoundedSetPcReturn &Return : BoundedReturns)
+    for (uint64_t Target : Return.Targets)
+      Info.Targets.insert(Target);
+  for (const ExternalCallContinuation &Call : Index->ExternalCallContinuations)
+    Info.Targets.insert(Call.Continuation);
+  if (AbiEntrySet) {
+    for (uint64_t Target : AbiEntrySet->Targets)
+      Info.Targets.insert(Target);
+    for (size_t InstIndex : AbiEntrySet->Calls)
+      Info.BoundedIndirectTransfers.insert(Decoded[InstIndex].Offset);
+    for (size_t InstIndex : AbiEntrySet->SetPcs)
+      Info.BoundedIndirectTransfers.insert(Decoded[InstIndex].Offset);
+  }
+  for (size_t InstIndex : Index->BranchOrCallIndices) {
     const InternalDecodedInst &DI = Decoded[InstIndex];
-    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
-        LS.MIA->isReturn(DI.Inst))
-      continue;
     // Existing indirect branches are handled by
     // collectIndirectControlFlowFunctions(), which protects their containing
     // function from source relocation. Calls without a statically resolvable
@@ -1677,15 +6018,36 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
           DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
         Target = static_cast<uint64_t>(
             DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
-      } else if (MaterializedCalls[InstIndex] &&
-                 !hasKnownControlFlowEntry(
-                     Decoded, LS, TextAddr, *TextEnd, DeclaredEntries,
-                     *BoundedReturns,
-                     MaterializedCalls[InstIndex]->SequenceStart,
-                     MaterializedCalls[InstIndex]->SequenceEnd)) {
-        Target = MaterializedCalls[InstIndex]->Target;
+      } else {
+        DenseMap<size_t, PcMaterializedCallInfo>::const_iterator Materialized =
+            Index->MaterializedCalls.find(InstIndex);
+        if (Materialized != Index->MaterializedCalls.end() &&
+            !hasKnownControlFlowEntry(
+                DeclaredEntries, BoundedReturns, BoundedReturnPositions, *Index,
+                HasUnboundedIndirectEntries, Materialized->second.SequenceStart,
+                Materialized->second.SequenceEnd))
+          Target = Materialized->second.Target;
+      }
+      if (!ReusableCalls[InstIndex].empty()) {
+        for (uint64_t ReusableTarget : ReusableCalls[InstIndex])
+          if (ReusableTarget >= TextAddr && ReusableTarget < *TextEnd)
+            Info.Targets.insert(ReusableTarget - TextAddr);
+        Info.BoundedIndirectTransfers.insert(DI.Offset);
+        if (LocallyProvenMaterializedCalls.test(InstIndex)) {
+          log() << "hotswap: resolved PC-materialized call at 0x"
+                << utohexstr(DI.Offset) << " to .text+0x"
+                << utohexstr(ReusableCalls[InstIndex].front() - TextAddr)
+                << "\n";
+        } else {
+          log() << "hotswap: resolved reusable PC-materialized call at 0x"
+                << utohexstr(DI.Offset) << " to "
+                << ReusableCalls[InstIndex].size() << " target(s)\n";
+        }
+        continue;
       }
       if (!Target) {
+        if (AbiEntrySet && AbiEntrySet->Calls.contains(InstIndex))
+          continue;
         log() << "hotswap: unresolved call target at 0x" << utohexstr(DI.Offset)
               << " (" << DI.Mnemonic << ")\n";
         Info.HasUnresolvedTargets = true;
@@ -1700,6 +6062,13 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
                 << utohexstr(DI.Offset) << " to .text+0x"
                 << utohexstr(RelativeTarget) << "\n";
       }
+      // A proven finite register target outside this object's .text cannot
+      // enter a local instruction or synthetic source range. Keep that
+      // control-flow proof separate from whether the target contributes a
+      // local offset to the mutation-protection set.
+      if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg()) {
+        Info.BoundedIndirectTransfers.insert(DI.Offset);
+      }
       continue;
     }
 
@@ -1711,8 +6080,20 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
             << "; adjacent far trampolines will not be coalesced\n";
       return std::nullopt;
     }
-    Info.Targets.insert(*Target);
+    if (*Target < TextSize) {
+      Info.Targets.insert(*Target);
+    } else if (LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "finite external direct call continuation");
+      if (!Continuation)
+        return std::nullopt;
+      Info.Targets.insert(*Continuation);
+    }
   }
+  for (const BoundedSetPcReturn &Return : BoundedReturns)
+    Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
+  if (!AbiEntrySet && !IndirectControlFlowClosed && HasUnboundedIndirectEntries)
+    Info.HasUnboundedIndirectEntries = true;
   return Info;
 }
 
@@ -1733,15 +6114,22 @@ mergeAdjacentLongTrampolines(std::vector<Trampoline> &Trampolines,
       Trampoline &Prev = Merged.back();
       std::optional<uint64_t> PrevEnd = checkedAddUint64(
           Prev.OriginalOffset, Prev.OriginalSize, "adjacent trampoline end");
+      uint32_t BackReserve = Prev.LongBranchPreservesVcc
+                                 ? VccPreservingReturnReserveBytes
+                                 : SetPcReturnReserveBytes;
+      uint32_t BodyPrefix =
+          Prev.LongBranchPreservesVcc ? VccRestoreSequenceBytes : 0;
       Adjacent = PrevEnd && *PrevEnd == T.OriginalOffset && Prev.Long &&
                  T.Long && Prev.UsesSetPCBack && T.UsesSetPCBack &&
+                 Prev.LongBranchPreservesVcc == T.LongBranchPreservesVcc &&
                  Prev.LongBranchSgprBase == T.LongBranchSgprBase &&
+                 Prev.LongBranchUsesVcc == T.LongBranchUsesVcc &&
                  Prev.HasFunctionRange && T.HasFunctionRange &&
                  Prev.FunctionStart == T.FunctionStart &&
                  Prev.FunctionEnd == T.FunctionEnd &&
                  !DirectBranchTargets.contains(T.OriginalOffset) &&
-                 Prev.Bytes.size() >= SetPcReturnReserveBytes &&
-                 T.Bytes.size() >= SetPcReturnReserveBytes;
+                 Prev.Bytes.size() >= BackReserve &&
+                 T.Bytes.size() >= BackReserve + BodyPrefix;
     }
 
     if (!Adjacent) {
@@ -1755,8 +6143,13 @@ mergeAdjacentLongTrampolines(std::vector<Trampoline> &Trampolines,
       Merged.emplace_back(std::move(T));
       continue;
     }
-    Prev.Bytes.resize(Prev.Bytes.size() - SetPcReturnReserveBytes);
-    Prev.Bytes.append(T.Bytes.begin(), T.Bytes.end());
+    uint32_t BackReserve = Prev.LongBranchPreservesVcc
+                               ? VccPreservingReturnReserveBytes
+                               : SetPcReturnReserveBytes;
+    size_t BodyPrefix =
+        Prev.LongBranchPreservesVcc ? VccRestoreSequenceBytes : 0;
+    Prev.Bytes.resize(Prev.Bytes.size() - BackReserve);
+    Prev.Bytes.append(T.Bytes.begin() + BodyPrefix, T.Bytes.end());
     Prev.OriginalSize += T.OriginalSize;
     ++MergeCount;
   }
@@ -1774,6 +6167,43 @@ static void appendPoolBranchIslands(std::vector<Trampoline> &Trampolines) {
     T.Bytes.append(PoolBranchIslandBytes, uint8_t{0});
     T.HasPoolBranchIsland = true;
   }
+}
+
+/// Live-VCC preservation can be selected for an original eight-byte site so
+/// adjacent patched sites can merge into a restore+delay landing. If
+/// coalescing cannot prove at least that 12-byte source window, fall back to
+/// the registerless route before gateway planning. Ordinary straight-line
+/// expansion deliberately skips these candidates: growing their pool bodies
+/// after initial layout could invalidate a later short-branch classification.
+static bool finalizeDeferredVccPreservation(PatchContext &Ctx) {
+  for (Trampoline &T : Ctx.OutTrampolines) {
+    if (!T.LongBranchPreservesVcc)
+      continue;
+    if (T.Bytes.size() <
+        VccRestoreSequenceBytes + VccPreservingReturnReserveBytes) {
+      log() << "hotswap: error: deferred live-VCC trampoline at 0x"
+            << utohexstr(T.OriginalOffset) << " is truncated\n";
+      return false;
+    }
+    if (T.OriginalSize < VccPreservingSourceBytes) {
+      T.Bytes.erase(T.Bytes.begin(), T.Bytes.begin() + VccRestoreSequenceBytes);
+      T.Bytes.resize(T.Bytes.size() - VccPreservingReturnReserveBytes);
+      T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
+      T.UsesSetPCBack = false;
+      T.LongBranchSgprBase = 0;
+      T.LongBranchUsesVcc = false;
+      T.LongBranchPreservesVcc = false;
+      log() << "hotswap: deferred live-VCC preservation at 0x"
+            << utohexstr(T.OriginalOffset)
+            << " fell back to a registerless far return\n";
+      continue;
+    }
+    SafeSgprScratchBlock Save{T.LongBranchSgprBase, 1};
+    if (!commitSafeSgprScratchBlock(Ctx, T.OriginalOffset, Save,
+                                    "activated VCC-preserving far return"))
+      return false;
+  }
+  return true;
 }
 
 static bool isEndProgram(const InternalDecodedInst &DI, const LLVMState &LS) {
@@ -1857,12 +6287,15 @@ collectRelocationProtectedOffsets(ArrayRef<InternalDecodedInst> Decoded,
 /// indirect destination, so leave the complete function in place.
 static DenseSet<uint64_t>
 collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
-                                    const LLVMState &LS, const ElfView &Elf) {
+                                    const LLVMState &LS, const ElfView &Elf,
+                                    const DenseSet<uint64_t> &Bounded) {
   DenseSet<uint64_t> Functions;
   if (!LS.MIA)
     return Functions;
 
   for (const InternalDecodedInst &DI : Decoded) {
+    if (Bounded.contains(DI.Offset))
+      continue;
     if (LS.MIA->isBarrier(DI.Inst) || isEndProgram(DI, LS))
       continue;
     if (!LS.MIA->isIndirectBranch(DI.Inst) &&
@@ -1882,7 +6315,8 @@ collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
 /// Grow undersized far-site windows only through proven straight-line code.
 /// Patched neighbors are merged; ordinary instructions are copied verbatim
 /// into the trampoline body and retain their original order. This is bounded
-/// to the 20 bytes required by the gfx12 SCC-neutral forward sequence.
+/// to the source bytes required by the selected gfx12 set-PC sequence and, for
+/// a live wave32 VCC, its restore landing pad.
 static void
 expandStraightLineTrampolines(PatchContext &Ctx,
                               const DenseSet<uint64_t> &DirectBranchTargets) {
@@ -1892,15 +6326,22 @@ expandStraightLineTrampolines(PatchContext &Ctx,
   DenseSet<uint64_t> Protected = collectRelocationProtectedOffsets(
       Ctx.Decoded, Ctx.LS, !Ctx.Config.RunB0A0Patches);
   DenseSet<uint64_t> IndirectControlFlowFunctions =
-      collectIndirectControlFlowFunctions(Ctx.Decoded, Ctx.LS, Ctx.Elf);
+      collectIndirectControlFlowFunctions(
+          Ctx.Decoded, Ctx.LS, Ctx.Elf,
+          Ctx.DirectControlFlow.BoundedIndirectTransfers);
 
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     if (Ctx.OutTrampolines[I].HasFunctionRange &&
         IndirectControlFlowFunctions.contains(
             Ctx.OutTrampolines[I].FunctionStart))
       continue;
-    while (Ctx.OutTrampolines[I].Long &&
-           Ctx.OutTrampolines[I].OriginalSize < SetPcForwardSequenceBytes) {
+    if (Ctx.OutTrampolines[I].LongBranchPreservesVcc)
+      continue;
+    while (Ctx.OutTrampolines[I].Long && Ctx.OutTrampolines[I].UsesSetPCBack &&
+           Ctx.OutTrampolines[I].OriginalSize <
+               (Ctx.OutTrampolines[I].LongBranchPreservesVcc
+                    ? VccPreservingReturnReserveBytes + VccLandingPadBytes
+                    : SetPcForwardSequenceBytes)) {
       Trampoline &T = Ctx.OutTrampolines[I];
       std::optional<uint64_t> End = checkedAddUint64(
           T.OriginalOffset, T.OriginalSize, "straight-line expansion end");
@@ -1909,9 +6350,13 @@ expandStraightLineTrampolines(PatchContext &Ctx,
 
       if (I + 1 < Ctx.OutTrampolines.size() &&
           Ctx.OutTrampolines[I + 1].OriginalOffset == *End) {
+        if (T.LongBranchPreservesVcc)
+          break;
         Trampoline &Next = Ctx.OutTrampolines[I + 1];
         if (!Next.Long || !Next.UsesSetPCBack ||
             Next.LongBranchSgprBase != T.LongBranchSgprBase ||
+            Next.LongBranchUsesVcc != T.LongBranchUsesVcc ||
+            Next.LongBranchPreservesVcc != T.LongBranchPreservesVcc ||
             !T.HasFunctionRange || !Next.HasFunctionRange ||
             T.FunctionStart != Next.FunctionStart ||
             T.FunctionEnd != Next.FunctionEnd ||
@@ -1933,21 +6378,27 @@ expandStraightLineTrampolines(PatchContext &Ctx,
       if (!Current)
         break;
       const InternalDecodedInst &DI = *Current;
+      uint32_t BackReserve = T.LongBranchPreservesVcc
+                                 ? VccPreservingReturnReserveBytes
+                                 : SetPcReturnReserveBytes;
       std::optional<ElfView::FunctionTextRange> Range =
           Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
       if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
           Range->End != T.FunctionEnd ||
           !isSafeStraightLineRelocation(DI, Ctx.LS, Protected) ||
-          T.Bytes.size() < SetPcReturnReserveBytes)
+          T.Bytes.size() < BackReserve)
         break;
 
-      T.Bytes.insert(T.Bytes.end() - SetPcReturnReserveBytes,
-                     Ctx.Text + DI.Offset, Ctx.Text + DI.Offset + DI.Size);
+      T.Bytes.insert(T.Bytes.end() - BackReserve, Ctx.Text + DI.Offset,
+                     Ctx.Text + DI.Offset + DI.Size);
       T.OriginalSize += DI.Size;
     }
 
-    while (Ctx.OutTrampolines[I].Long &&
-           Ctx.OutTrampolines[I].OriginalSize < SetPcForwardSequenceBytes) {
+    while (Ctx.OutTrampolines[I].Long && Ctx.OutTrampolines[I].UsesSetPCBack &&
+           Ctx.OutTrampolines[I].OriginalSize <
+               (Ctx.OutTrampolines[I].LongBranchPreservesVcc
+                    ? VccPreservingReturnReserveBytes + VccLandingPadBytes
+                    : SetPcForwardSequenceBytes)) {
       Trampoline &T = Ctx.OutTrampolines[I];
       if (DirectBranchTargets.contains(T.OriginalOffset))
         break;
@@ -1974,7 +6425,9 @@ expandStraightLineTrampolines(PatchContext &Ctx,
       if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
           Range->End != T.FunctionEnd)
         break;
-      T.Bytes.insert(T.Bytes.begin(), Ctx.Text + DI.Offset,
+      size_t BodyPrefix =
+          T.LongBranchPreservesVcc ? VccRestoreSequenceBytes : 0;
+      T.Bytes.insert(T.Bytes.begin() + BodyPrefix, Ctx.Text + DI.Offset,
                      Ctx.Text + DI.Offset + DI.Size);
       T.OriginalOffset = DI.Offset;
       T.OriginalSize += DI.Size;
@@ -2048,10 +6501,51 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
   return Sleds;
 }
 
+/// Gateway sleds are decoded before adjacent trampoline sites are coalesced.
+/// Remove every final source interval from those earlier views, then callers
+/// may add back only the explicitly unreachable source-tail subranges. This
+/// prevents two independently-derived sleds from aliasing the same bytes.
+static void subtractTrampolineSources(std::vector<NopSled> &Gateways,
+                                      ArrayRef<Trampoline> Trampolines) {
+  SmallVector<std::pair<uint64_t, uint64_t>, 64> Sources;
+  for (const Trampoline &T : Trampolines) {
+    std::optional<uint64_t> End = checkedAddUint64(
+        T.OriginalOffset, T.OriginalSize, "gateway source interval");
+    if (End)
+      Sources.push_back({T.OriginalOffset, *End});
+  }
+  llvm::sort(Sources);
+
+  std::vector<NopSled> Filtered;
+  for (const NopSled &Sled : Gateways) {
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    if (Sled.WritePos >= UsableEnd)
+      continue;
+    uint64_t Cursor = Sled.WritePos;
+    for (const auto &[SourceBegin, SourceEnd] : Sources) {
+      if (SourceEnd <= Cursor)
+        continue;
+      if (SourceBegin >= UsableEnd)
+        break;
+      if (SourceBegin > Cursor)
+        Filtered.push_back({Cursor, std::min(SourceBegin, UsableEnd), Cursor,
+                            Sled.FunctionStart, Sled.FunctionEnd});
+      Cursor = std::max(Cursor, SourceEnd);
+      if (Cursor >= UsableEnd)
+        break;
+    }
+    if (Cursor < UsableEnd)
+      Filtered.push_back(
+          {Cursor, UsableEnd, Cursor, Sled.FunctionStart, Sled.FunctionEnd});
+  }
+  Gateways = std::move(Filtered);
+}
+
 Expected<uint64_t>
 countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
                                 uint64_t FromOffset, uint64_t TargetOffset,
-                                unsigned SgprBase, uint64_t MaxSlots) {
+                                unsigned SgprBase, uint64_t MaxSlots,
+                                bool UseVcc, bool PreserveVcc) {
   uint64_t Slots = 0;
   for (const NopSled &Sled : Gateways) {
     if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
@@ -2064,10 +6558,9 @@ countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
       if (Distance >= MaxSledDistance ||
           LS.encodeSBranch(FromOffset, Candidate).empty())
         break;
-
-      std::optional<uint32_t> LayoutSize =
-          getSetPcLongBranchLayoutSize(Candidate, TargetOffset);
-      if ((SgprBase & 1u) != 0 || !LayoutSize)
+      std::optional<uint32_t> LayoutSize = getSetPcGatewayLayoutSize(
+          Candidate, TargetOffset, SgprBase, UseVcc, PreserveVcc);
+      if (!LayoutSize)
         return createStringError(
             Twine("invalid set-PC gateway while counting candidate "
                   "offset 0x") +
@@ -2083,70 +6576,1925 @@ countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
   return Slots;
 }
 
+struct BranchIslandFailure {
+  uint64_t CurrentOffset = 0;
+  uint64_t TargetOffset = 0;
+  uint64_t CorridorOffset = 0;
+  bool Forward = false;
+};
+
+using BranchIslandPromoter =
+    std::function<bool(const BranchIslandFailure &)>;
+
+using BranchGatewayHead = std::pair<uint64_t, size_t>;
+using BranchGatewayHeadSet = std::set<BranchGatewayHead>;
+
+static bool hasFreeBranchGatewaySlot(const NopSled &Sled) {
+  uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+  return !Sled.GatewayOnly && Sled.WritePos <= UsableEnd &&
+         MinInstSize <= UsableEnd - Sled.WritePos;
+}
+
+static BranchGatewayHeadSet
+buildBranchGatewayHeads(std::vector<NopSled> &Gateways,
+                        const DenseSet<uint64_t> &Occupied) {
+  BranchGatewayHeadSet Heads;
+  for (size_t I = 0; I != Gateways.size(); ++I) {
+    while (hasFreeBranchGatewaySlot(Gateways[I]) &&
+           Occupied.contains(Gateways[I].WritePos))
+      Gateways[I].WritePos += MinInstSize;
+    if (hasFreeBranchGatewaySlot(Gateways[I]))
+      Heads.insert({Gateways[I].WritePos, I});
+  }
+  return Heads;
+}
+
+static void
+subtractOccupiedBranchGatewaySlots(std::vector<NopSled> &Gateways,
+                                   const DenseSet<uint64_t> &Occupied) {
+  SmallVector<uint64_t, 32> SortedOccupied(Occupied.begin(), Occupied.end());
+  llvm::sort(SortedOccupied);
+  std::vector<NopSled> Available;
+  Available.reserve(Gateways.size());
+  for (const NopSled &Sled : Gateways) {
+    uint64_t Cursor = Sled.WritePos;
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    if (Cursor >= UsableEnd)
+      continue;
+    auto It = llvm::lower_bound(SortedOccupied, Cursor);
+    while (It != SortedOccupied.end() && *It < UsableEnd) {
+      if (Cursor < *It)
+        Available.push_back({Cursor, *It, Cursor, Sled.FunctionStart,
+                             Sled.FunctionEnd, Sled.GatewayOnly});
+      Cursor = std::max(Cursor, *It + MinInstSize);
+      ++It;
+    }
+    if (Cursor < UsableEnd)
+      Available.push_back({Cursor, UsableEnd, Cursor, Sled.FunctionStart,
+                           Sled.FunctionEnd, Sled.GatewayOnly});
+  }
+  Gateways = std::move(Available);
+}
+
 static std::optional<SmallVector<uint64_t, 4>>
 allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
-                             uint64_t FromOffset, uint64_t TargetOffset) {
+                             uint64_t FromOffset, uint64_t TargetOffset,
+                             BranchIslandFailure *Failure = nullptr,
+                             BranchGatewayHeadSet *PersistentHeads = nullptr,
+                             DenseSet<uint64_t> *PersistentOccupied = nullptr,
+                             BranchIslandPromoter Promote = {}) {
   struct Allocation {
     size_t SledIndex = 0;
     uint64_t PreviousWritePos = 0;
   };
+  BranchGatewayHeadSet LocalHeads;
+  DenseSet<uint64_t> LocalOccupied;
+  if (!PersistentOccupied)
+    PersistentOccupied = &LocalOccupied;
+  if (!PersistentHeads) {
+    LocalHeads =
+        buildBranchGatewayHeads(Gateways, *PersistentOccupied);
+    PersistentHeads = &LocalHeads;
+  }
+  BranchGatewayHeadSet &Heads = *PersistentHeads;
+  DenseSet<uint64_t> &Occupied = *PersistentOccupied;
   SmallVector<Allocation, 4> Allocations;
   SmallVector<uint64_t, 4> Islands;
-  DenseSet<size_t> UsedSleds;
   uint64_t Current = FromOffset;
 
   while (!isSBranchReachable(Current, TargetOffset)) {
+    bool Forward = TargetOffset > Current;
     size_t BestIndex = Gateways.size();
     uint64_t BestOffset = 0;
-    for (size_t I = 0; I != Gateways.size(); ++I) {
-      NopSled &Sled = Gateways[I];
-      if (UsedSleds.contains(I) || FromOffset < Sled.FunctionStart ||
-          FromOffset >= Sled.FunctionEnd)
-        continue;
-      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-      if (Sled.WritePos >= TargetOffset || Sled.WritePos <= Current ||
-          Sled.WritePos > UsableEnd ||
-          MinInstSize > UsableEnd - Sled.WritePos ||
-          !isSBranchReachable(Current, Sled.WritePos))
-        continue;
-      if (BestIndex == Gateways.size() || Sled.WritePos > BestOffset) {
-        BestIndex = I;
-        BestOffset = Sled.WritePos;
+    if (Forward) {
+      uint64_t ReachEnd =
+          Current > std::numeric_limits<uint64_t>::max() - MaxSledDistance
+              ? std::numeric_limits<uint64_t>::max()
+              : Current + MaxSledDistance;
+      uint64_t Upper = std::min(TargetOffset, ReachEnd);
+      auto It =
+          TargetOffset <= ReachEnd
+              ? Heads.lower_bound({Upper, 0})
+              : Heads.upper_bound(
+                    {Upper, std::numeric_limits<size_t>::max()});
+      while (It != Heads.begin()) {
+        --It;
+        if (It->first <= Current)
+          break;
+        const NopSled &Sled = Gateways[It->second];
+        if (FromOffset < Sled.FunctionStart ||
+            FromOffset >= Sled.FunctionEnd ||
+            Sled.WritePos != It->first ||
+            !isSBranchReachable(Current, It->first))
+          continue;
+        BestIndex = It->second;
+        BestOffset = It->first;
+        break;
+      }
+    } else {
+      uint64_t ReachBegin =
+          Current > MaxSledDistance ? Current - MaxSledDistance : 0;
+      uint64_t Lower =
+          TargetOffset == std::numeric_limits<uint64_t>::max()
+              ? TargetOffset
+              : TargetOffset + 1;
+      Lower = std::max(Lower, ReachBegin);
+      for (auto It = Heads.lower_bound({Lower, 0});
+           It != Heads.end() && It->first < Current; ++It) {
+        const NopSled &Sled = Gateways[It->second];
+        if (FromOffset < Sled.FunctionStart ||
+            FromOffset >= Sled.FunctionEnd ||
+            Sled.WritePos != It->first ||
+            !isSBranchReachable(Current, It->first))
+          continue;
+        BestIndex = It->second;
+        BestOffset = It->first;
+        break;
       }
     }
 
     if (BestIndex == Gateways.size()) {
+      uint64_t Corridor =
+          Forward ? std::numeric_limits<uint64_t>::max() : 0;
+      if (Forward) {
+        uint64_t AfterCurrent =
+            Current == std::numeric_limits<uint64_t>::max()
+                ? Current
+                : Current + 1;
+        for (auto It = Heads.lower_bound({AfterCurrent, 0});
+             It != Heads.end() && It->first < TargetOffset; ++It) {
+          const NopSled &Sled = Gateways[It->second];
+          if (FromOffset < Sled.FunctionStart ||
+              FromOffset >= Sled.FunctionEnd)
+            continue;
+          Corridor = It->first;
+          break;
+        }
+      } else {
+        auto It = Heads.lower_bound({Current, 0});
+        while (It != Heads.begin()) {
+          --It;
+          if (It->first <= TargetOffset)
+            break;
+          const NopSled &Sled = Gateways[It->second];
+          if (FromOffset < Sled.FunctionStart ||
+              FromOffset >= Sled.FunctionEnd)
+            continue;
+          Corridor = It->first;
+          break;
+        }
+      }
+      if (Forward && Corridor == std::numeric_limits<uint64_t>::max())
+        Corridor = TargetOffset;
+      if (!Forward && Corridor == 0)
+        Corridor = TargetOffset;
+      BranchIslandFailure ThisFailure{Current, TargetOffset, Corridor,
+                                      Forward};
+      if (Failure)
+        *Failure = ThisFailure;
+      // No Gateways reference or Heads iterator survives this call. The
+      // promoter may grow both vectors/sets; successful promotion resumes the
+      // same transaction with all prior heads still held.
+      if (Promote && Promote(ThisFailure))
+        continue;
       for (size_t I = Allocations.size(); I != 0; --I) {
         const Allocation &A = Allocations[I - 1];
         Gateways[A.SledIndex].WritePos = A.PreviousWritePos;
+        Heads.insert({A.PreviousWritePos, A.SledIndex});
       }
+      for (uint64_t Offset : Islands)
+        Occupied.erase(Offset);
       return std::nullopt;
     }
 
-    NopSled &Best = Gateways[BestIndex];
-    Allocations.push_back({BestIndex, Best.WritePos});
-    Islands.push_back(Best.WritePos);
-    Current = Best.WritePos;
-    Best.WritePos += MinInstSize;
-    UsedSleds.insert(BestIndex);
+    auto AliasBegin = Heads.lower_bound({BestOffset, 0});
+    auto AliasEnd =
+        Heads.upper_bound(
+            {BestOffset, std::numeric_limits<size_t>::max()});
+    for (auto It = AliasBegin; It != AliasEnd; ++It) {
+      NopSled &Alias = Gateways[It->second];
+      Allocations.push_back({It->second, Alias.WritePos});
+      Alias.WritePos += MinInstSize;
+    }
+    Heads.erase(AliasBegin, AliasEnd);
+    Occupied.insert(BestOffset);
+    Islands.push_back(BestOffset);
+    Current = BestOffset;
+  }
+  for (const Allocation &A : Allocations) {
+    NopSled &Sled = Gateways[A.SledIndex];
+    while (hasFreeBranchGatewaySlot(Sled) &&
+           Occupied.contains(Sled.WritePos))
+      Sled.WritePos += MinInstSize;
+    if (hasFreeBranchGatewaySlot(Sled))
+      Heads.insert({Gateways[A.SledIndex].WritePos, A.SledIndex});
   }
   return Islands;
+}
+
+static SmallVector<uint8_t> encodeScc1Branch(const LLVMState &LS,
+                                             uint64_t FromOffset,
+                                             uint64_t TargetOffset) {
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(FromOffset, MinInstSize, "conditional branch PC base");
+  if (!PcBase || ((TargetOffset - *PcBase) & (MinInstSize - 1)) != 0)
+    return {};
+  int64_t DwordDelta =
+      static_cast<int64_t>(TargetOffset - *PcBase) / MinInstSize;
+  if (DwordDelta < BranchOffsetMin || DwordDelta > BranchOffsetMax)
+    return {};
+  return assembleSingleInst("s_cbranch_scc1 " + std::to_string(DwordDelta), LS);
+}
+
+bool sourceHasUniqueFunctionRange(
+    const Trampoline &T, ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    uint64_t TextAddr) {
+  if (!T.HasFunctionRange)
+    return false;
+  std::optional<uint64_t> SourceEnd = checkedAddUint64(
+      T.OriginalOffset, T.OriginalSize, "source-tail unique function end");
+  if (!SourceEnd)
+    return false;
+
+  SmallVector<std::pair<uint64_t, uint64_t>, 2> DistinctCoveringRanges;
+  bool MatchesSelectedRange = false;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+    if (Range.Begin < TextAddr || Range.End < TextAddr)
+      continue;
+    uint64_t Begin = Range.Begin - TextAddr;
+    uint64_t End = Range.End - TextAddr;
+    if (Begin > T.OriginalOffset || End < *SourceEnd)
+      continue;
+    std::pair<uint64_t, uint64_t> Bounds{Begin, End};
+    if (!llvm::is_contained(DistinctCoveringRanges, Bounds))
+      DistinctCoveringRanges.push_back(Bounds);
+    MatchesSelectedRange |= Begin == T.FunctionStart && End == T.FunctionEnd;
+    if (DistinctCoveringRanges.size() > 1)
+      return false;
+  }
+  return DistinctCoveringRanges.size() == 1 && MatchesSelectedRange;
+}
+
+class FunctionRangeUniquenessIndex {
+  using Bounds = std::pair<uint64_t, uint64_t>;
+  static constexpr size_t NoRange = std::numeric_limits<size_t>::max();
+
+  struct PrefixMaximums {
+    size_t First = NoRange;
+    size_t Second = NoRange;
+  };
+
+  std::vector<Bounds> Ranges;
+  std::vector<PrefixMaximums> Prefix;
+
+public:
+  FunctionRangeUniquenessIndex(
+      ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+      uint64_t TextAddr) {
+    Ranges.reserve(FunctionRanges.size());
+    for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+      if (Range.Begin < TextAddr || Range.End < TextAddr)
+        continue;
+      Bounds Relative{Range.Begin - TextAddr, Range.End - TextAddr};
+      if (Relative.first < Relative.second)
+        Ranges.push_back(Relative);
+    }
+    llvm::sort(Ranges);
+    Ranges.erase(std::unique(Ranges.begin(), Ranges.end()), Ranges.end());
+
+    Prefix.reserve(Ranges.size());
+    PrefixMaximums Top;
+    for (size_t I = 0; I != Ranges.size(); ++I) {
+      if (Top.First == NoRange ||
+          Ranges[I].second > Ranges[Top.First].second) {
+        Top.Second = Top.First;
+        Top.First = I;
+      } else if (Top.Second == NoRange ||
+                 Ranges[I].second > Ranges[Top.Second].second) {
+        Top.Second = I;
+      }
+      Prefix.push_back(Top);
+    }
+  }
+
+  bool hasUniqueFunctionRange(const Trampoline &T) const {
+    if (!T.HasFunctionRange || T.FunctionStart >= T.FunctionEnd)
+      return false;
+    std::optional<uint64_t> SourceEnd = checkedAddUint64(
+        T.OriginalOffset, T.OriginalSize,
+        "indexed source-tail unique function end");
+    if (!SourceEnd || T.FunctionStart > T.OriginalOffset ||
+        T.FunctionEnd < *SourceEnd)
+      return false;
+
+    Bounds Selected{T.FunctionStart, T.FunctionEnd};
+    auto SelectedIt = llvm::lower_bound(Ranges, Selected);
+    if (SelectedIt == Ranges.end() || *SelectedIt != Selected)
+      return false;
+
+    auto PrefixEnd = std::upper_bound(
+        Ranges.begin(), Ranges.end(), T.OriginalOffset,
+        [](uint64_t Offset, const Bounds &Range) {
+          return Offset < Range.first;
+        });
+    if (PrefixEnd == Ranges.begin())
+      return false;
+    const PrefixMaximums &Top = Prefix[PrefixEnd - Ranges.begin() - 1];
+    size_t Other =
+        Top.First != NoRange && Ranges[Top.First] == Selected
+            ? Top.Second
+            : Top.First;
+    return Other == NoRange || Ranges[Other].second < *SourceEnd;
+  }
+};
+
+bool sourceHasUniqueFunctionRangeIndexedForTest(
+    const Trampoline &T, ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    uint64_t TextAddr) {
+  return FunctionRangeUniquenessIndex(FunctionRanges, TextAddr)
+      .hasUniqueFunctionRange(T);
+}
+
+bool isSafeSourceTailRange(const Trampoline &T,
+                           const DirectControlFlowInfo &ControlFlow,
+                           bool HasUniqueFunctionRange, uint64_t Begin,
+                           uint64_t End) {
+  if (ControlFlow.HasUnresolvedTargets ||
+      ControlFlow.HasUnboundedIndirectEntries || !HasUniqueFunctionRange ||
+      Begin >= End)
+    return false;
+  std::optional<uint64_t> FirstTailByte =
+      checkedAddUint64(T.OriginalOffset, MinInstSize, "source-tail first byte");
+  std::optional<uint64_t> SourceEnd = checkedAddUint64(
+      T.OriginalOffset, T.OriginalSize, "source-tail source end");
+  if (!FirstTailByte || !SourceEnd || Begin < *FirstTailByte ||
+      End > *SourceEnd)
+    return false;
+  // These intervals are at most a handful of instruction dwords. Checking
+  // every byte also catches an unusually-aligned declared alias rather than
+  // assuming every protected entry is four-byte aligned.
+  for (uint64_t Offset = Begin; Offset != End; ++Offset)
+    if (ControlFlow.Targets.contains(Offset))
+      return false;
+  return true;
+}
+
+bool mustReserveSourceTailForRegisterlessReturn(const Trampoline &T) {
+  return T.Long && !T.UsesSetPCBack && !T.LongBranchPreservesVcc &&
+         !T.UsesSharedDispatcherForward && T.OriginalSize >= 2 * MinInstSize;
+}
+
+std::optional<std::pair<uint64_t, uint64_t>>
+registerlessSourceAffineGatewayRange(const Trampoline &T) {
+  constexpr uint64_t GatewayStart = 2 * MinInstSize;
+  constexpr uint64_t GatewayBytes = 5 * MinInstSize;
+  if (!mustReserveSourceTailForRegisterlessReturn(T) ||
+      T.OriginalSize < GatewayStart + GatewayBytes)
+    return std::nullopt;
+  std::optional<uint64_t> Begin = checkedAddUint64(
+      T.OriginalOffset, GatewayStart, "registerless affine gateway begin");
+  std::optional<uint64_t> End =
+      checkedAddUint64(T.OriginalOffset, GatewayStart + GatewayBytes,
+                       "registerless affine gateway end");
+  if (!Begin || !End)
+    return std::nullopt;
+  return std::pair<uint64_t, uint64_t>{*Begin, *End};
+}
+
+static SmallVector<uint8_t> encodeDirectCall(const LLVMState &LS,
+                                             uint64_t FromOffset,
+                                             uint64_t TargetOffset,
+                                             StringRef ReturnPair) {
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(FromOffset, MinInstSize, "direct call PC base");
+  if (!PcBase)
+    return {};
+  uint64_t ByteDistance =
+      TargetOffset >= *PcBase ? TargetOffset - *PcBase : *PcBase - TargetOffset;
+  if ((ByteDistance & (MinInstSize - 1)) != 0)
+    return {};
+  uint64_t DwordDistance = ByteDistance / MinInstSize;
+  int64_t DwordDelta = 0;
+  if (TargetOffset >= *PcBase) {
+    if (DwordDistance > static_cast<uint64_t>(BranchOffsetMax))
+      return {};
+    DwordDelta = static_cast<int64_t>(DwordDistance);
+  } else {
+    const uint64_t MaxBackward =
+        static_cast<uint64_t>(-static_cast<int64_t>(BranchOffsetMin));
+    if (DwordDistance > MaxBackward)
+      return {};
+    DwordDelta = -static_cast<int64_t>(DwordDistance);
+  }
+  std::string Asm =
+      "s_call_i64 " + ReturnPair.str() + ", " + std::to_string(DwordDelta);
+  return assembleSingleInst(Asm, LS);
+}
+
+/// Plan common far gateways before the final pool layout. An 8-byte source
+/// cannot hold the 20-byte SCC-neutral set-PC sequence, but it can preserve
+/// its identity without touching SCC:
+///
+///   s_get_pc_i64 ScratchSource
+///   s_branch CommonGateway
+///
+/// The common gateway reaches a dispatcher in the pool through a second
+/// scratch pair. The dispatcher saves SCC, compares the recorded source PCs,
+/// restores SCC in the selected stub, and branches to the matching trampoline
+/// body. One 20-byte .text gateway can therefore serve hundreds of otherwise
+/// independent 8-byte patch sites.
+static bool planSharedDispatchGateways(PatchContext &Ctx,
+                                       std::vector<NopSled> &TextGateways) {
+  struct Candidate {
+    size_t Index = 0;
+    unsigned ScratchBase = 0;
+  };
+  SmallVector<Candidate, 64> Candidates;
+  uint64_t MissingScratchCandidates = 0;
+  uint64_t FirstMissingScratch = 0;
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
+    uint64_t ThisTP = TP;
+    std::optional<uint64_t> Next =
+        checkedAddUint64(TP, T.Bytes.size(), "shared dispatcher pool layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+    if (!T.Long || T.UsesMirroredStubForward ||
+        T.OriginalSize < 2 * MinInstSize ||
+        isSBranchReachable(T.OriginalOffset, ThisTP))
+      continue;
+    std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
+        Ctx.LS, T.OriginalOffset, ThisTP, T.LongBranchSgprBase);
+    if (Direct && Direct->size() <= T.OriginalSize)
+      continue;
+    std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
+        Ctx, T.OriginalOffset, /*Count=*/4,
+        /*Alignment=*/2, "shared far-dispatch gateway",
+        /*ReportNoSpace=*/false);
+    if (Scratch) {
+      Candidates.push_back({I, Scratch->Base});
+    } else {
+      if (MissingScratchCandidates == 0)
+        FirstMissingScratch = T.OriginalOffset;
+      ++MissingScratchCandidates;
+    }
+  }
+  if (MissingScratchCandidates != 0)
+    log() << "hotswap: shared far-dispatch skipped " << MissingScratchCandidates
+          << " site(s) without four safe SGPRs"
+          << " (first at 0x" << utohexstr(FirstMissingScratch) << ")\n";
+
+  // The ordinary planner is simpler and uses fewer scratch registers for
+  // small objects. Shared dispatch is a capacity mechanism for dense far-site
+  // workloads, not a replacement for individual gateways.
+  log() << "hotswap: shared planner considering " << Candidates.size()
+        << " source site(s) across " << TextGateways.size()
+        << " gateway/relay window(s)\n";
+  if (Candidates.size() < 8)
+    return true;
+
+  const std::vector<ElfView::FunctionTextRange> FunctionRanges =
+      Ctx.Elf.functionTextRanges();
+  const FunctionRangeUniquenessIndex FunctionRangeIndex(FunctionRanges,
+                                                          Ctx.Elf.textAddr());
+  auto HasSafeTail = [&](const Trampoline &T, uint64_t Begin, uint64_t End) {
+    bool HasUniqueFunctionRange =
+        FunctionRangeIndex.hasUniqueFunctionRange(T);
+    return isSafeSourceTailRange(T, Ctx.DirectControlFlow,
+                                 HasUniqueFunctionRange, Begin, End);
+  };
+
+  BitVector Assigned(Ctx.OutTrampolines.size());
+  SmallVector<SmallVector<size_t, 32>, 8> Groups;
+  constexpr size_t MaxGroupSites = 1024;
+  for (const Candidate &Seed : Candidates) {
+    if (Assigned.test(Seed.Index))
+      continue;
+    const Trampoline &SeedT = Ctx.OutTrampolines[Seed.Index];
+
+    size_t SledIndex = TextGateways.size();
+    uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
+    for (size_t I = 0; I != TextGateways.size(); ++I) {
+      const NopSled &Sled = TextGateways[I];
+      uint64_t From = SeedT.OriginalOffset;
+      if (SeedT.OriginalOffset < Sled.FunctionStart ||
+          SeedT.OriginalOffset >= Sled.FunctionEnd)
+        continue;
+      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+      if (Sled.WritePos > UsableEnd ||
+          SetPcForwardSequenceBytes > UsableEnd - Sled.WritePos ||
+          !isSBranchReachable(From, Sled.WritePos))
+        continue;
+      uint64_t Distance =
+          From > Sled.WritePos ? From - Sled.WritePos : Sled.WritePos - From;
+      if (Distance < BestDistance) {
+        BestDistance = Distance;
+        SledIndex = I;
+      }
+    }
+    uint64_t GatewayOffset = 0;
+    uint64_t SecondaryGatewayOffset = 0;
+    uint64_t GatewayFunctionStart = 0;
+    uint64_t GatewayFunctionEnd = std::numeric_limits<uint64_t>::max();
+    std::vector<NopSled> WorkingGateways;
+    SmallVector<uint64_t, 4> SeedIslands;
+    if (SledIndex != TextGateways.size()) {
+      GatewayOffset = TextGateways[SledIndex].WritePos;
+      GatewayFunctionStart = TextGateways[SledIndex].FunctionStart;
+      GatewayFunctionEnd = TextGateways[SledIndex].FunctionEnd;
+      WorkingGateways = TextGateways;
+      WorkingGateways[SledIndex].WritePos += SetPcForwardSequenceBytes;
+    } else {
+      size_t BestIslandCount = std::numeric_limits<size_t>::max();
+      for (size_t I = 0; I != TextGateways.size(); ++I) {
+        const NopSled &Sled = TextGateways[I];
+        uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+        if (SeedT.OriginalOffset < Sled.FunctionStart ||
+            SeedT.OriginalOffset >= Sled.FunctionEnd ||
+            Sled.WritePos > UsableEnd ||
+            SetPcForwardSequenceBytes > UsableEnd - Sled.WritePos)
+          continue;
+        std::vector<NopSled> Trial = TextGateways;
+        uint64_t TrialGateway = Trial[I].WritePos;
+        Trial[I].WritePos += SetPcForwardSequenceBytes;
+        std::optional<SmallVector<uint64_t, 4>> Islands =
+            allocateForwardBranchIslands(Trial, SeedT.OriginalOffset,
+                                         TrialGateway);
+        if (!Islands || Islands->empty() || Islands->size() >= BestIslandCount)
+          continue;
+        BestIslandCount = Islands->size();
+        GatewayOffset = TrialGateway;
+        GatewayFunctionStart = Sled.FunctionStart;
+        GatewayFunctionEnd = Sled.FunctionEnd;
+        WorkingGateways = std::move(Trial);
+        SeedIslands = std::move(*Islands);
+      }
+      if (WorkingGateways.empty()) {
+        // Split the SCC-neutral 20-byte sequence across an 8-byte get-PC
+        // segment and a 16-byte add/set-PC segment. This admits functions
+        // that have no single 20-byte padding window.
+        for (size_t I = 0; I != TextGateways.size() && WorkingGateways.empty();
+             ++I) {
+          const NopSled &First = TextGateways[I];
+          uint64_t FirstEnd = std::min(First.End, First.FunctionEnd);
+          uint64_t SourceBranch = SeedT.OriginalOffset;
+          if (SeedT.OriginalOffset < First.FunctionStart ||
+              SeedT.OriginalOffset >= First.FunctionEnd ||
+              First.WritePos > FirstEnd ||
+              2 * MinInstSize > FirstEnd - First.WritePos ||
+              !isSBranchReachable(SourceBranch, First.WritePos))
+            continue;
+          std::vector<NopSled> FirstReserved = TextGateways;
+          GatewayOffset = FirstReserved[I].WritePos;
+          FirstReserved[I].WritePos += 2 * MinInstSize;
+          for (size_t J = 0; J != FirstReserved.size(); ++J) {
+            const NopSled &Second = FirstReserved[J];
+            uint64_t SecondEnd = std::min(Second.End, Second.FunctionEnd);
+            if (SeedT.OriginalOffset < Second.FunctionStart ||
+                SeedT.OriginalOffset >= Second.FunctionEnd ||
+                Second.WritePos > SecondEnd ||
+                4 * MinInstSize > SecondEnd - Second.WritePos ||
+                !isSBranchReachable(GatewayOffset + MinInstSize,
+                                    Second.WritePos))
+              continue;
+            WorkingGateways = FirstReserved;
+            SecondaryGatewayOffset = WorkingGateways[J].WritePos;
+            WorkingGateways[J].WritePos += 4 * MinInstSize;
+            GatewayFunctionStart =
+                std::max(First.FunctionStart, Second.FunctionStart);
+            GatewayFunctionEnd =
+                std::min(First.FunctionEnd, Second.FunctionEnd);
+            break;
+          }
+        }
+      }
+      if (WorkingGateways.empty())
+        continue;
+    }
+
+    SmallVector<size_t, 32> Members;
+    DenseMap<size_t, SmallVector<uint64_t, 4>> MemberIslands;
+    DenseMap<size_t, uint64_t> MemberRelays;
+    uint64_t GroupBodyBytes = 0;
+    constexpr uint64_t MaxDispatcherSpan = 120 * 1024;
+    for (const Candidate &C : Candidates) {
+      if (Members.size() == MaxGroupSites || Assigned.test(C.Index) ||
+          C.ScratchBase != Seed.ScratchBase)
+        continue;
+      const Trampoline &T = Ctx.OutTrampolines[C.Index];
+      if (T.OriginalOffset < GatewayFunctionStart ||
+          T.OriginalOffset >= GatewayFunctionEnd)
+        continue;
+      uint64_t ProposedSpan =
+          8 + 28 * (Members.size() + 1) + GroupBodyBytes + T.Bytes.size();
+      if (ProposedSpan > MaxDispatcherSpan)
+        continue;
+      uint64_t From = T.OriginalOffset;
+      SmallVector<uint64_t, 4> Islands;
+      if (C.Index == Seed.Index && !SeedIslands.empty()) {
+        Islands = SeedIslands;
+      } else if (!isSBranchReachable(From, GatewayOffset)) {
+        continue;
+      }
+      Members.push_back(C.Index);
+      GroupBodyBytes += T.Bytes.size();
+      if (!Islands.empty())
+        MemberIslands[C.Index] = std::move(Islands);
+    }
+    DenseSet<size_t> LocalMembers;
+    SmallVector<std::pair<uint64_t, size_t>, 32> RelayAnchors;
+    for (size_t Index : Members) {
+      LocalMembers.insert(Index);
+      const Trampoline &T = Ctx.OutTrampolines[Index];
+      uint64_t Tail = T.OriginalOffset + MinInstSize;
+      if (HasSafeTail(T, Tail, Tail + MinInstSize))
+        RelayAnchors.push_back({Tail, Index});
+    }
+    llvm::sort(RelayAnchors);
+    bool AddedRelayMember;
+    do {
+      AddedRelayMember = false;
+      for (const Candidate &C : Candidates) {
+        if (Members.size() == MaxGroupSites || Assigned.test(C.Index) ||
+            LocalMembers.contains(C.Index) || C.ScratchBase != Seed.ScratchBase)
+          continue;
+        const Trampoline &T = Ctx.OutTrampolines[C.Index];
+        if (T.OriginalOffset < GatewayFunctionStart ||
+            T.OriginalOffset >= GatewayFunctionEnd)
+          continue;
+        uint64_t ProposedSpan =
+            8 + 28 * (Members.size() + 1) + GroupBodyBytes + T.Bytes.size();
+        if (ProposedSpan > MaxDispatcherSpan)
+          continue;
+        uint64_t From = T.OriginalOffset;
+        auto It =
+            llvm::lower_bound(RelayAnchors, std::make_pair(From, size_t{0}));
+        std::optional<uint64_t> Relay;
+        if (It != RelayAnchors.end() && isSBranchReachable(From, It->first))
+          Relay = It->first;
+        if (It != RelayAnchors.begin()) {
+          --It;
+          if (isSBranchReachable(From, It->first))
+            Relay = It->first;
+        }
+        if (!Relay)
+          continue;
+        Members.push_back(C.Index);
+        LocalMembers.insert(C.Index);
+        MemberRelays[C.Index] = *Relay;
+        GroupBodyBytes += T.Bytes.size();
+        uint64_t Tail = T.OriginalOffset + MinInstSize;
+        if (HasSafeTail(T, Tail, Tail + MinInstSize))
+          RelayAnchors.insert(
+              llvm::lower_bound(RelayAnchors, std::make_pair(Tail, C.Index)),
+              {Tail, C.Index});
+        AddedRelayMember = true;
+      }
+    } while (AddedRelayMember && Members.size() != MaxGroupSites);
+    // A single site with a normal 20-byte gateway gains nothing from the
+    // dispatcher and would unnecessarily consume two extra SGPRs. Leave it to
+    // the established direct planner. A split 8+16-byte gateway is retained
+    // because the established planner cannot represent it.
+    if (Members.size() == 1 && SecondaryGatewayOffset == 0)
+      continue;
+    if (Members.empty())
+      continue;
+    TextGateways = std::move(WorkingGateways);
+
+    uint32_t Group = Groups.size() + 1;
+    for (size_t Index : Members) {
+      Trampoline &T = Ctx.OutTrampolines[Index];
+      SafeSgprScratchBlock Scratch{Seed.ScratchBase, 4};
+      if (!commitSafeSgprScratchBlock(Ctx, T.OriginalOffset, Scratch,
+                                      "shared far-dispatch gateway"))
+        return false;
+      T.UsesSharedDispatcherForward = true;
+      T.SharedDispatcherGroup = Group;
+      T.SharedDispatcherSgprBase = Seed.ScratchBase;
+      T.SharedDispatcherGatewayOffset = GatewayOffset;
+      DenseMap<size_t, uint64_t>::const_iterator Relay =
+          MemberRelays.find(Index);
+      if (Relay != MemberRelays.end())
+        T.SharedDispatcherRelayOffset = Relay->second;
+      T.SharedDispatcherSecondaryGatewayOffset = SecondaryGatewayOffset;
+      DenseMap<size_t, SmallVector<uint64_t, 4>>::iterator Islands =
+          MemberIslands.find(Index);
+      if (Islands != MemberIslands.end()) {
+        T.ForwardBranchIslands = std::move(Islands->second);
+        T.ForwardBranchTargetOffset = GatewayOffset;
+      }
+      Assigned.set(Index);
+    }
+    Groups.push_back(std::move(Members));
+  }
+
+  if (Groups.empty())
+    return true;
+
+  std::vector<Trampoline> Reordered;
+  Reordered.reserve(Ctx.OutTrampolines.size());
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I)
+    if (!Assigned.test(I))
+      Reordered.push_back(std::move(Ctx.OutTrampolines[I]));
+  for (const SmallVector<size_t, 32> &Group : Groups)
+    for (size_t Index : Group)
+      Reordered.push_back(std::move(Ctx.OutTrampolines[Index]));
+  Ctx.OutTrampolines = std::move(Reordered);
+
+  for (size_t I = 0; I != Ctx.OutTrampolines.size();) {
+    Trampoline &First = Ctx.OutTrampolines[I];
+    if (!First.UsesSharedDispatcherForward) {
+      ++I;
+      continue;
+    }
+    uint32_t Group = First.SharedDispatcherGroup;
+    size_t Count = 0;
+    while (I + Count != Ctx.OutTrampolines.size() &&
+           Ctx.OutTrampolines[I + Count].SharedDispatcherGroup == Group)
+      ++Count;
+    uint64_t Prefix = 8 + 28 * Count;
+    if (Prefix > std::numeric_limits<uint32_t>::max())
+      return false;
+    First.PoolEntryPrefixBytes = static_cast<uint32_t>(Prefix);
+    First.Bytes.insert(First.Bytes.begin(), Prefix, uint8_t{0});
+    I += Count;
+  }
+
+  log() << "hotswap: planned " << Groups.size()
+        << " shared far-dispatch gateway group(s) for " << Assigned.count()
+        << " source site(s)\n";
+  return true;
+}
+
+/// Plan a relocation-neutral shared gateway for far sites that have only the
+/// pair already reserved for their return edge. Each source records its own PC
+/// and branches to a common SCC-neutral add/set-PC sequence:
+///
+///   s_call_i64 Pair, CommonGateway
+///
+/// The call records source S+4 without touching SCC. The common delta maps it
+/// to a sparse pool stub at
+/// StubBase + (S - MinSource). Thus the load bias cancels without a dispatcher
+/// classifier or another scratch pair. The stub branches to S's trampoline
+/// body. Sources are grouped only when their sparse prefix plus bodies stays
+/// within short-branch range.
+static bool planMirroredStubGateways(PatchContext &Ctx,
+                                     std::vector<NopSled> &TextGateways) {
+  const auto PlanStart = std::chrono::steady_clock::now();
+  struct Candidate {
+    size_t Index = 0;
+    unsigned PairBase = 0;
+    bool UsesVcc = false;
+  };
+  SmallVector<Candidate, 64> Candidates;
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
+    uint64_t ThisTP = TP;
+    std::optional<uint64_t> Next =
+        checkedAddUint64(TP, T.Bytes.size(), "mirrored-stub pool layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+    if (!T.Long || !T.UsesSetPCBack || T.LongBranchPreservesVcc ||
+        T.UsesSharedDispatcherForward || T.UsesMirroredStubForward ||
+        T.OriginalSize < 2 * MinInstSize ||
+        isSBranchReachable(T.OriginalOffset, ThisTP))
+      continue;
+    std::optional<SmallVector<uint8_t>> Direct =
+        encodeSetPCLongBranch(Ctx.LS, T.OriginalOffset, ThisTP,
+                              T.LongBranchSgprBase, T.LongBranchUsesVcc);
+    if (Direct && Direct->size() <= T.OriginalSize)
+      continue;
+    Candidates.push_back({I, T.LongBranchSgprBase, T.LongBranchUsesVcc});
+  }
+  if (Candidates.empty())
+    return true;
+  log() << "hotswap: affine planner considering " << Candidates.size()
+        << " pair-only source site(s) across " << TextGateways.size()
+        << " gateway/relay window(s)\n";
+  // Two sources are the first point where one 12-byte text gateway replaces
+  // multiple ordinary gateways and therefore adds real text-space capacity.
+  constexpr size_t MinSharedSites = 2;
+  if (Candidates.size() < MinSharedSites)
+    return true;
+
+  // The sparse stub is after .text and within 4 GiB, so its positive delta
+  // uses the eight-byte literal32 form of s_add_nc_u64 plus four-byte set-PC.
+  constexpr uint64_t GatewayReserve = 3 * MinInstSize;
+  constexpr uint64_t MaxGroupSpan = 120 * 1024;
+  constexpr size_t MaxGroupSites = 1024;
+  BitVector Assigned(Ctx.OutTrampolines.size());
+  SmallVector<SmallVector<size_t, 32>, 8> Groups;
+  uint64_t DirectGatewayGroups = 0;
+  uint64_t IslandGatewayGroups = 0;
+  uint32_t GroupBase = 1;
+  for (const Trampoline &T : Ctx.OutTrampolines)
+    GroupBase = std::max(GroupBase, T.MirroredStubGroup + 1);
+
+  // Prefer high-address seeds. Their gateway and pool are usually close, and
+  // lower sources can reuse their unreachable second dword as a safe relay.
+  llvm::stable_sort(Candidates,
+                    [&](const Candidate &LHS, const Candidate &RHS) {
+                      return Ctx.OutTrampolines[LHS.Index].OriginalOffset >
+                             Ctx.OutTrampolines[RHS.Index].OriginalOffset;
+                    });
+
+  for (const Candidate &Seed : Candidates) {
+    if (Assigned.test(Seed.Index))
+      continue;
+    const Trampoline &SeedT = Ctx.OutTrampolines[Seed.Index];
+
+    uint64_t GatewayOffset = 0;
+    uint64_t GatewayFunctionStart = 0;
+    uint64_t GatewayFunctionEnd = std::numeric_limits<uint64_t>::max();
+    std::vector<NopSled> WorkingGateways;
+    bool GatewayReservedInText = false;
+    SmallVector<uint64_t, 4> SeedIslands;
+    uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
+
+    // Dense objects can expose tens of thousands of one-dword relays. Find a
+    // directly reachable gateway without cloning that entire vector for every
+    // candidate. A direct route is always preferable to an island chain, so
+    // only use the copying fallback when no such gateway exists.
+    size_t DirectSledIndex = TextGateways.size();
+    uint64_t From = SeedT.OriginalOffset;
+    for (size_t I = 0; I != TextGateways.size(); ++I) {
+      const NopSled &Sled = TextGateways[I];
+      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+      if (From < Sled.FunctionStart || From >= Sled.FunctionEnd ||
+          Sled.WritePos > UsableEnd ||
+          GatewayReserve > UsableEnd - Sled.WritePos ||
+          !isSBranchReachable(From, Sled.WritePos))
+        continue;
+      uint64_t Distance =
+          From > Sled.WritePos ? From - Sled.WritePos : Sled.WritePos - From;
+      if (Distance >= BestDistance)
+        continue;
+      DirectSledIndex = I;
+      BestDistance = Distance;
+    }
+    if (DirectSledIndex != TextGateways.size()) {
+      // The group always contains its seed once a direct gateway has been
+      // found, so this reservation cannot need rollback. Commit it in place
+      // instead of copying every relay window into a trial vector.
+      GatewayOffset = TextGateways[DirectSledIndex].WritePos;
+      GatewayFunctionStart = TextGateways[DirectSledIndex].FunctionStart;
+      GatewayFunctionEnd = TextGateways[DirectSledIndex].FunctionEnd;
+      TextGateways[DirectSledIndex].WritePos += GatewayReserve;
+      GatewayReservedInText = true;
+    }
+
+    if (!GatewayReservedInText) {
+      SmallVector<size_t, 32> GatewayCandidates;
+      for (size_t I = 0; I != TextGateways.size(); ++I) {
+        const NopSled &Sled = TextGateways[I];
+        uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+        if (From < Sled.FunctionStart || From >= Sled.FunctionEnd ||
+            Sled.WritePos > UsableEnd ||
+            GatewayReserve > UsableEnd - Sled.WritePos)
+          continue;
+        GatewayCandidates.push_back(I);
+      }
+      llvm::sort(GatewayCandidates, [&](size_t LHS, size_t RHS) {
+        uint64_t L = TextGateways[LHS].WritePos;
+        uint64_t R = TextGateways[RHS].WritePos;
+        uint64_t LDistance = From > L ? From - L : L - From;
+        uint64_t RDistance = From > R ? From - R : R - From;
+        return LDistance < RDistance;
+      });
+
+      // Failed island allocation rolls its own reservations back, so one
+      // trial vector is enough for every possible gateway. This avoids the
+      // quadratic full-vector cloning that dense corpus objects otherwise
+      // trigger.
+      std::vector<NopSled> Trial = TextGateways;
+      for (size_t I : GatewayCandidates) {
+        uint64_t TrialGateway = Trial[I].WritePos;
+        Trial[I].WritePos += GatewayReserve;
+        std::optional<SmallVector<uint64_t, 4>> Allocated =
+            allocateForwardBranchIslands(Trial, From, TrialGateway);
+        if (!Allocated) {
+          Trial[I].WritePos -= GatewayReserve;
+          continue;
+        }
+        GatewayOffset = TrialGateway;
+        GatewayFunctionStart = TextGateways[I].FunctionStart;
+        GatewayFunctionEnd = TextGateways[I].FunctionEnd;
+        WorkingGateways = std::move(Trial);
+        SeedIslands = std::move(*Allocated);
+        break;
+      }
+    }
+    if (!GatewayReservedInText && WorkingGateways.empty())
+      continue;
+    SmallVector<size_t, 32> Members;
+    DenseMap<size_t, SmallVector<uint64_t, 4>> MemberIslands;
+    uint64_t MinSource = SeedT.OriginalOffset;
+    uint64_t MaxSource = SeedT.OriginalOffset;
+    uint64_t GroupBodyBytes = 0;
+    auto FitsGroup = [&](const Trampoline &T) {
+      uint64_t NewMin = std::min(MinSource, T.OriginalOffset);
+      uint64_t NewMax = std::max(MaxSource, T.OriginalOffset);
+      uint64_t Prefix = NewMax - NewMin + MinInstSize;
+      return Prefix <= MaxGroupSpan &&
+             GroupBodyBytes <= MaxGroupSpan - Prefix &&
+             T.Bytes.size() <= MaxGroupSpan - Prefix - GroupBodyBytes;
+    };
+    auto AddMember = [&](size_t Index) {
+      const Trampoline &T = Ctx.OutTrampolines[Index];
+      Members.push_back(Index);
+      MinSource = std::min(MinSource, T.OriginalOffset);
+      MaxSource = std::max(MaxSource, T.OriginalOffset);
+      GroupBodyBytes += T.Bytes.size();
+    };
+
+    AddMember(Seed.Index);
+    if (!SeedIslands.empty())
+      MemberIslands[Seed.Index] = SeedIslands;
+    for (const Candidate &C : Candidates) {
+      if (C.Index == Seed.Index || Members.size() == MaxGroupSites ||
+          Assigned.test(C.Index) || C.PairBase != Seed.PairBase ||
+          C.UsesVcc != Seed.UsesVcc)
+        continue;
+      const Trampoline &T = Ctx.OutTrampolines[C.Index];
+      if (T.OriginalOffset < GatewayFunctionStart ||
+          T.OriginalOffset >= GatewayFunctionEnd || !FitsGroup(T))
+        continue;
+      uint64_t From = T.OriginalOffset;
+      if (!isSBranchReachable(From, GatewayOffset))
+        continue;
+      AddMember(C.Index);
+    }
+
+    // Small affine groups only replace established ordinary gateways with a
+    // larger sparse pool prefix. Preserve those simpler paths and reserve
+    // mirrored stubs for dense cases where sharing materially adds capacity.
+    if (Members.size() < MinSharedSites) {
+      if (GatewayReservedInText)
+        TextGateways[DirectSledIndex].WritePos -= GatewayReserve;
+      continue;
+    }
+
+    if (GatewayReservedInText) {
+      ++DirectGatewayGroups;
+    } else {
+      TextGateways = std::move(WorkingGateways);
+      ++IslandGatewayGroups;
+    }
+    uint32_t Group = GroupBase + Groups.size();
+    for (size_t Index : Members) {
+      Trampoline &T = Ctx.OutTrampolines[Index];
+      T.UsesMirroredStubForward = true;
+      T.MirroredStubGroup = Group;
+      T.MirroredStubGatewayOffset = GatewayOffset;
+      DenseMap<size_t, SmallVector<uint64_t, 4>>::iterator Islands =
+          MemberIslands.find(Index);
+      if (Islands != MemberIslands.end()) {
+        T.ForwardBranchIslands = std::move(Islands->second);
+        T.ForwardBranchTargetOffset = GatewayOffset;
+      }
+      Assigned.set(Index);
+    }
+    Groups.push_back(std::move(Members));
+  }
+
+  if (Groups.empty())
+    return true;
+
+  // Preserve the pool offsets of unclaimed trampolines. The earlier planners
+  // may have proved their ordinary short edges using those offsets; inserting
+  // a sparse prefix ahead of them could invalidate that proof. Mirrored groups
+  // can sit at the end because their common gateway uses a full 64-bit delta.
+  std::vector<Trampoline> Reordered;
+  Reordered.reserve(Ctx.OutTrampolines.size());
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I)
+    if (!Assigned.test(I))
+      Reordered.push_back(std::move(Ctx.OutTrampolines[I]));
+  for (const SmallVector<size_t, 32> &Group : Groups)
+    for (size_t Index : Group)
+      Reordered.push_back(std::move(Ctx.OutTrampolines[Index]));
+  Ctx.OutTrampolines = std::move(Reordered);
+
+  for (size_t I = 0; I != Ctx.OutTrampolines.size();) {
+    Trampoline &First = Ctx.OutTrampolines[I];
+    if (!First.UsesMirroredStubForward) {
+      ++I;
+      continue;
+    }
+    uint32_t Group = First.MirroredStubGroup;
+    size_t Count = 0;
+    uint64_t MinSource = First.OriginalOffset;
+    uint64_t MaxSource = First.OriginalOffset;
+    while (I + Count != Ctx.OutTrampolines.size() &&
+           Ctx.OutTrampolines[I + Count].UsesMirroredStubForward &&
+           Ctx.OutTrampolines[I + Count].MirroredStubGroup == Group) {
+      MinSource =
+          std::min(MinSource, Ctx.OutTrampolines[I + Count].OriginalOffset);
+      MaxSource =
+          std::max(MaxSource, Ctx.OutTrampolines[I + Count].OriginalOffset);
+      ++Count;
+    }
+    uint64_t Prefix = MaxSource - MinSource + MinInstSize;
+    if (Prefix > std::numeric_limits<uint32_t>::max())
+      return false;
+    First.PoolEntryPrefixBytes = static_cast<uint32_t>(Prefix);
+    First.Bytes.insert(First.Bytes.begin(), Prefix, uint8_t{0});
+    I += Count;
+  }
+
+  log() << "hotswap: planned " << Groups.size()
+        << " mirrored-stub gateway group(s) for " << Assigned.count()
+        << " pair-only source site(s) (" << DirectGatewayGroups
+        << " direct gateway group(s), " << IslandGatewayGroups
+        << " island gateway group(s), "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - PlanStart)
+               .count()
+        << " ms)\n";
+  return true;
+}
+
+static bool emitSharedDispatchers(PatchContext &Ctx) {
+  DenseMap<uint32_t, SmallVector<size_t, 32>> Groups;
+  SmallVector<uint64_t, 64> PoolOffsets;
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    PoolOffsets.push_back(TP);
+    Trampoline &T = Ctx.OutTrampolines[I];
+    if (T.UsesSharedDispatcherForward)
+      Groups[T.SharedDispatcherGroup].push_back(I);
+    std::optional<uint64_t> Next =
+        checkedAddUint64(TP, T.Bytes.size(), "shared dispatcher final layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+  }
+
+  for (auto &KV : Groups) {
+    ArrayRef<size_t> Members = KV.second;
+    if (Members.empty())
+      continue;
+    Trampoline &Owner = Ctx.OutTrampolines[Members.front()];
+    uint64_t DispatcherOffset = PoolOffsets[Members.front()];
+    auto fail = [&](const Twine &Reason) {
+      log() << "hotswap: error: shared dispatcher group " << KV.first
+            << " at 0x" << utohexstr(DispatcherOffset) << ": " << Reason
+            << "\n";
+      return false;
+    };
+    unsigned Base = Owner.SharedDispatcherSgprBase;
+    const std::string SourceLow = "s" + std::to_string(Base);
+    const std::string CursorLow = "s" + std::to_string(Base + 2);
+    // After the SCC-neutral gateway has transferred control, only the low
+    // cursor half is needed: every source and pool address differs by less
+    // than 4 GiB, so modulo-2^32 deltas remain exact across a load-address
+    // wrap. Reuse the cursor high half to preserve SCC.
+    const std::string Save = "s" + std::to_string(Base + 3);
+
+    Owner.HasForwardGateway = true;
+    Owner.ForwardGatewayOffset = Owner.SharedDispatcherGatewayOffset;
+    if (Owner.SharedDispatcherSecondaryGatewayOffset == 0) {
+      std::optional<SmallVector<uint8_t>> Gateway =
+          encodeSetPCLongBranch(Ctx.LS, Owner.SharedDispatcherGatewayOffset,
+                                DispatcherOffset, Base + 2);
+      if (!Gateway || Gateway->size() > SetPcForwardSequenceBytes)
+        return fail("single-segment gateway encoding failed");
+      Owner.ForwardGatewayBytes = std::move(*Gateway);
+    } else {
+      const std::string GatewayPair = "s[" + std::to_string(Base + 2) + ":" +
+                                      std::to_string(Base + 3) + "]";
+      Owner.ForwardGatewayBytes =
+          assembleSingleInst("s_get_pc_i64 " + GatewayPair, Ctx.LS);
+      SmallVector<uint8_t> ToSecond =
+          Ctx.LS.encodeSBranch(Owner.SharedDispatcherGatewayOffset +
+                                   Owner.ForwardGatewayBytes.size(),
+                               Owner.SharedDispatcherSecondaryGatewayOffset);
+      if (Owner.ForwardGatewayBytes.size() != MinInstSize ||
+          ToSecond.size() != MinInstSize)
+        return fail("split gateway first segment encoding failed");
+      Owner.ForwardGatewayBytes.append(ToSecond);
+
+      uint64_t PcBase = Owner.SharedDispatcherGatewayOffset + MinInstSize;
+      uint64_t Delta = DispatcherOffset - PcBase;
+      SmallVector<std::string, 2> Lines;
+      Lines.push_back("s_add_nc_u64 " + GatewayPair + ", " + GatewayPair +
+                      ", 0x" + utohexstr(Delta));
+      Lines.push_back("s_set_pc_i64 " + GatewayPair);
+      Owner.SecondaryForwardGatewayBytes =
+          assembleInstructions(joinAsmLines(Lines), Ctx.LS);
+      if (Owner.SecondaryForwardGatewayBytes.empty() ||
+          Owner.SecondaryForwardGatewayBytes.size() > 4 * MinInstSize)
+        return fail("split gateway second segment encoding failed");
+      while (Owner.SecondaryForwardGatewayBytes.size() < 4 * MinInstSize)
+        Owner.SecondaryForwardGatewayBytes.append(Ctx.LS.SNopBytes);
+    }
+
+    SmallVector<uint64_t, 32> BodyOffsets;
+    for (size_t Member : Members)
+      BodyOffsets.push_back(PoolOffsets[Member] +
+                            Ctx.OutTrampolines[Member].PoolEntryPrefixBytes);
+
+    SmallVector<uint8_t> Bytes;
+    auto appendInst = [&](StringRef Asm) {
+      SmallVector<uint8_t> Encoded = assembleSingleInst(Asm, Ctx.LS);
+      if (Encoded.empty())
+        return false;
+      Bytes.append(Encoded);
+      return true;
+    };
+    if (!appendInst("s_cselect_b32 " + Save + ", 1, 0"))
+      return fail("SCC save encoding failed");
+
+    uint64_t CursorValue = DispatcherOffset;
+    uint64_t StubBase =
+        DispatcherOffset + 4 + 20 * Members.size() + MinInstSize;
+    for (size_t J = 0; J != Members.size(); ++J) {
+      const Trampoline &T = Ctx.OutTrampolines[Members[J]];
+      uint64_t SourcePc = T.OriginalOffset + MinInstSize;
+      uint64_t Distance = SourcePc > CursorValue ? SourcePc - CursorValue
+                                                 : CursorValue - SourcePc;
+      if (Distance >= (uint64_t{1} << 32))
+        return fail("source-to-dispatcher span exceeds 32 bits");
+      uint64_t Delta = SourcePc - CursorValue;
+      SmallVector<uint8_t> Add = assembleSingleInst(
+          "s_add_co_u32 " + CursorLow + ", " + CursorLow + ", 0x" +
+              utohexstr(static_cast<uint32_t>(Delta)),
+          Ctx.LS);
+      if (Add.empty() || Add.size() > 3 * MinInstSize)
+        return fail("source-PC cursor add encoding failed");
+      Bytes.append(Add);
+      while (Add.size() < 3 * MinInstSize) {
+        Bytes.append(Ctx.LS.SNopBytes);
+        Add.append(Ctx.LS.SNopBytes);
+      }
+      if (!appendInst("s_cmp_eq_u32 " + SourceLow + ", " + CursorLow))
+        return fail("source-PC compare encoding failed");
+      uint64_t BranchFrom = DispatcherOffset + Bytes.size();
+      SmallVector<uint8_t> Branch =
+          encodeScc1Branch(Ctx.LS, BranchFrom, StubBase + J * 2 * MinInstSize);
+      if (Branch.size() != MinInstSize)
+        return fail("source-PC conditional branch is out of range");
+      Bytes.append(Branch);
+      CursorValue = SourcePc;
+    }
+    if (!appendInst("s_trap 2"))
+      return fail("unmatched-source trap encoding failed");
+    for (size_t J = 0; J != Members.size(); ++J) {
+      if (!appendInst("s_cmp_lg_u32 " + Save + ", 0"))
+        return fail("SCC restore encoding failed");
+      uint64_t BranchFrom = DispatcherOffset + Bytes.size();
+      SmallVector<uint8_t> Branch =
+          Ctx.LS.encodeSBranch(BranchFrom, BodyOffsets[J]);
+      if (Branch.size() != MinInstSize)
+        return fail("selected trampoline body is out of branch range");
+      Bytes.append(Branch);
+    }
+    if (Bytes.size() != Owner.PoolEntryPrefixBytes)
+      return fail("dispatcher size differs from reserved prefix");
+    std::memcpy(Owner.Bytes.data(), Bytes.data(), Bytes.size());
+  }
+  return true;
+}
+
+static std::optional<SmallVector<uint64_t, 4>>
+allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
+                              uint64_t OwnerOffset, uint64_t FromOffset,
+                              uint64_t TargetOffset,
+                              BranchIslandFailure *Failure = nullptr,
+                              BranchGatewayHeadSet *PersistentHeads = nullptr,
+                              DenseSet<uint64_t> *PersistentOccupied = nullptr,
+                              BranchIslandPromoter Promote = {}) {
+  struct Allocation {
+    size_t SledIndex = 0;
+    uint64_t PreviousWritePos = 0;
+  };
+  BranchGatewayHeadSet LocalHeads;
+  DenseSet<uint64_t> LocalOccupied;
+  if (!PersistentOccupied)
+    PersistentOccupied = &LocalOccupied;
+  if (!PersistentHeads) {
+    LocalHeads =
+        buildBranchGatewayHeads(Gateways, *PersistentOccupied);
+    PersistentHeads = &LocalHeads;
+  }
+  BranchGatewayHeadSet &Heads = *PersistentHeads;
+  DenseSet<uint64_t> &Occupied = *PersistentOccupied;
+  SmallVector<Allocation, 4> Allocations;
+  SmallVector<uint64_t, 4> Islands;
+  uint64_t Current = FromOffset;
+
+  while (!isSBranchReachable(Current, TargetOffset)) {
+    size_t BestIndex = Gateways.size();
+    uint64_t BestOffset = std::numeric_limits<uint64_t>::max();
+    uint64_t ReachBegin =
+        Current > MaxSledDistance ? Current - MaxSledDistance : 0;
+    uint64_t Lower =
+        TargetOffset == std::numeric_limits<uint64_t>::max()
+            ? TargetOffset
+            : TargetOffset + 1;
+    Lower = std::max(Lower, ReachBegin);
+    for (auto It = Heads.lower_bound({Lower, 0});
+         It != Heads.end() && It->first < Current; ++It) {
+      const NopSled &Sled = Gateways[It->second];
+      if (OwnerOffset < Sled.FunctionStart ||
+          OwnerOffset >= Sled.FunctionEnd || Sled.WritePos != It->first ||
+          !isSBranchReachable(Current, It->first))
+        continue;
+      BestIndex = It->second;
+      BestOffset = It->first;
+      break;
+    }
+
+    if (BestIndex == Gateways.size()) {
+      uint64_t Corridor = TargetOffset;
+      auto CorridorIt = Heads.lower_bound({Current, 0});
+      while (CorridorIt != Heads.begin()) {
+        --CorridorIt;
+        if (CorridorIt->first <= TargetOffset)
+          break;
+        const NopSled &Sled = Gateways[CorridorIt->second];
+        if (OwnerOffset < Sled.FunctionStart ||
+            OwnerOffset >= Sled.FunctionEnd)
+          continue;
+        Corridor = CorridorIt->first;
+        break;
+      }
+      BranchIslandFailure ThisFailure{Current, TargetOffset, Corridor,
+                                      /*Forward=*/false};
+      if (Failure)
+        *Failure = ThisFailure;
+      // Keep the partial chain transactional while recoverable capacity is
+      // added. There are no live vector references or set iterators here.
+      if (Promote && Promote(ThisFailure))
+        continue;
+
+      uint64_t EligibleOwnerSleds = 0;
+      uint64_t FreeCorridorSleds = 0;
+      uint64_t ReachableFromCurrent = 0;
+      uint64_t ReachableToTarget = 0;
+      uint64_t LowestCorridor = std::numeric_limits<uint64_t>::max();
+      uint64_t HighestCorridor = 0;
+      uint64_t LowestReachableFromCurrent =
+          std::numeric_limits<uint64_t>::max();
+      uint64_t HighestReachableToTarget = 0;
+      for (const BranchGatewayHead &Head : Heads) {
+        const NopSled &Sled = Gateways[Head.second];
+        if (OwnerOffset < Sled.FunctionStart ||
+            OwnerOffset >= Sled.FunctionEnd)
+          continue;
+        ++EligibleOwnerSleds;
+        if (Head.first <= TargetOffset || Head.first >= Current)
+          continue;
+        ++FreeCorridorSleds;
+        LowestCorridor = std::min(LowestCorridor, Head.first);
+        HighestCorridor = std::max(HighestCorridor, Head.first);
+        if (isSBranchReachable(Current, Head.first)) {
+          ++ReachableFromCurrent;
+          LowestReachableFromCurrent =
+              std::min(LowestReachableFromCurrent, Head.first);
+        }
+        if (isSBranchReachable(Head.first, TargetOffset)) {
+          ++ReachableToTarget;
+          HighestReachableToTarget =
+              std::max(HighestReachableToTarget, Head.first);
+        }
+      }
+      if (Failure)
+        *Failure = {Current, TargetOffset,
+                    HighestCorridor ? HighestCorridor : TargetOffset,
+                    /*Forward=*/false};
+      log() << "hotswap: backward return allocator stranded owner 0x"
+            << utohexstr(OwnerOffset) << ": from=0x"
+            << utohexstr(FromOffset) << ", current=0x"
+            << utohexstr(Current) << ", target=0x"
+            << utohexstr(TargetOffset) << ", selected=" << Islands.size()
+            << ", owner-sleds=" << EligibleOwnerSleds
+            << ", free-corridor=" << FreeCorridorSleds
+            << ", reachable-from-current=" << ReachableFromCurrent
+            << ", reachable-to-target=" << ReachableToTarget;
+      if (LowestCorridor != std::numeric_limits<uint64_t>::max())
+        log() << ", corridor=[0x" << utohexstr(LowestCorridor) << ",0x"
+              << utohexstr(HighestCorridor) << "]";
+      if (LowestReachableFromCurrent != std::numeric_limits<uint64_t>::max())
+        log() << ", lowest-reachable-from-current=0x"
+              << utohexstr(LowestReachableFromCurrent);
+      if (HighestReachableToTarget)
+        log() << ", highest-reachable-to-target=0x"
+              << utohexstr(HighestReachableToTarget);
+      log() << "\n";
+      for (size_t I = Allocations.size(); I != 0; --I) {
+        const Allocation &A = Allocations[I - 1];
+        Gateways[A.SledIndex].WritePos = A.PreviousWritePos;
+        Heads.insert({A.PreviousWritePos, A.SledIndex});
+      }
+      for (uint64_t Offset : Islands)
+        Occupied.erase(Offset);
+      return std::nullopt;
+    }
+
+    auto AliasBegin = Heads.lower_bound({BestOffset, 0});
+    auto AliasEnd =
+        Heads.upper_bound(
+            {BestOffset, std::numeric_limits<size_t>::max()});
+    for (auto It = AliasBegin; It != AliasEnd; ++It) {
+      NopSled &Alias = Gateways[It->second];
+      Allocations.push_back({It->second, Alias.WritePos});
+      Alias.WritePos += MinInstSize;
+    }
+    Heads.erase(AliasBegin, AliasEnd);
+    Occupied.insert(BestOffset);
+    Islands.push_back(BestOffset);
+    Current = BestOffset;
+  }
+  for (const Allocation &A : Allocations) {
+    NopSled &Sled = Gateways[A.SledIndex];
+    while (hasFreeBranchGatewaySlot(Sled) &&
+           Occupied.contains(Sled.WritePos))
+      Sled.WritePos += MinInstSize;
+    if (hasFreeBranchGatewaySlot(Sled))
+      Heads.insert({Gateways[A.SledIndex].WritePos, A.SledIndex});
+  }
+  return Islands;
+}
+
+BranchIslandAllocatorTestResult runBranchIslandAllocatorForTest(
+    std::vector<NopSled> Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
+    uint64_t TargetOffset, bool Backward, DenseSet<uint64_t> Occupied) {
+  BranchGatewayHeadSet Heads =
+      buildBranchGatewayHeads(Gateways, Occupied);
+  std::optional<SmallVector<uint64_t, 4>> Islands =
+      Backward
+          ? allocateBackwardBranchIslands(
+                Gateways, OwnerOffset, FromOffset, TargetOffset, nullptr,
+                &Heads, &Occupied)
+          : allocateForwardBranchIslands(
+                Gateways, FromOffset, TargetOffset, nullptr, &Heads,
+                &Occupied);
+  BranchIslandAllocatorTestResult Result;
+  Result.Success = Islands.has_value();
+  if (Islands)
+    Result.Islands = std::move(*Islands);
+  Result.Gateways = std::move(Gateways);
+  Result.Occupied = std::move(Occupied);
+  return Result;
+}
+
+BranchIslandAllocatorTestResult
+runBranchIslandAllocatorWithPromotionsForTest(
+    std::vector<NopSled> Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
+    uint64_t TargetOffset, bool Backward, ArrayRef<NopSled> Promotions) {
+  DenseSet<uint64_t> Occupied;
+  BranchGatewayHeadSet Heads =
+      buildBranchGatewayHeads(Gateways, Occupied);
+  SmallVector<size_t, 4> HeldCounts;
+  size_t NextPromotion = 0;
+  BranchIslandPromoter Promote = [&](const BranchIslandFailure &) {
+    if (NextPromotion == Promotions.size())
+      return false;
+    HeldCounts.push_back(Occupied.size());
+    size_t Index = Gateways.size();
+    Gateways.push_back(Promotions[NextPromotion++]);
+    NopSled &Added = Gateways.back();
+    while (hasFreeBranchGatewaySlot(Added) &&
+           Occupied.contains(Added.WritePos))
+      Added.WritePos += MinInstSize;
+    if (hasFreeBranchGatewaySlot(Added))
+      Heads.insert({Added.WritePos, Index});
+    return true;
+  };
+  std::optional<SmallVector<uint64_t, 4>> Islands =
+      Backward
+          ? allocateBackwardBranchIslands(
+                Gateways, OwnerOffset, FromOffset, TargetOffset, nullptr,
+                &Heads, &Occupied, Promote)
+          : allocateForwardBranchIslands(
+                Gateways, FromOffset, TargetOffset, nullptr, &Heads,
+                &Occupied, Promote);
+  BranchIslandAllocatorTestResult Result;
+  Result.Success = Islands.has_value();
+  if (Islands)
+    Result.Islands = std::move(*Islands);
+  Result.HeldIslandCountsAtPromotion = std::move(HeldCounts);
+  Result.Gateways = std::move(Gateways);
+  Result.Occupied = std::move(Occupied);
+  return Result;
+}
+
+std::vector<NopSled> subtractOccupiedBranchGatewaySlotsForTest(
+    std::vector<NopSled> Gateways, const DenseSet<uint64_t> &Occupied) {
+  subtractOccupiedBranchGatewaySlots(Gateways, Occupied);
+  return Gateways;
+}
+
+std::pair<uint64_t, uint64_t>
+branchPromotionSearchRangeForTest(uint64_t CurrentOffset,
+                                  uint64_t CorridorOffset, bool Forward) {
+  constexpr uint64_t MinSourceBytes =
+      SetPcForwardSequenceBytes + MinInstSize;
+  if (Forward) {
+    uint64_t ReachEnd =
+        CurrentOffset >
+                std::numeric_limits<uint64_t>::max() - MaxSledDistance
+            ? std::numeric_limits<uint64_t>::max()
+            : CurrentOffset + MaxSledDistance;
+    return {CurrentOffset, std::min(CorridorOffset, ReachEnd)};
+  }
+
+  uint64_t CorridorBegin =
+      CorridorOffset > MinSourceBytes ? CorridorOffset - MinSourceBytes : 0;
+  constexpr uint64_t ReachWithPrefix =
+      MaxSledDistance + SetPcForwardSequenceBytes;
+  uint64_t ReachBegin =
+      CurrentOffset > ReachWithPrefix ? CurrentOffset - ReachWithPrefix : 0;
+  return {std::max(CorridorBegin, ReachBegin), CurrentOffset};
+}
+
+static int findNextPromotionCandidateIndex(
+    const BitVector &StillPossible, size_t BeginIndex, size_t EndIndex,
+    bool Forward, std::optional<size_t> Previous = std::nullopt) {
+  BeginIndex = std::min(BeginIndex, static_cast<size_t>(StillPossible.size()));
+  EndIndex = std::min(EndIndex, static_cast<size_t>(StillPossible.size()));
+  if (BeginIndex >= EndIndex)
+    return -1;
+
+  int Found = -1;
+  if (Forward) {
+    size_t Before = Previous.value_or(EndIndex);
+    if (Before == 0)
+      return -1;
+    Found = StillPossible.find_prev(static_cast<unsigned>(Before));
+    if (Found < 0 || static_cast<size_t>(Found) < BeginIndex)
+      return -1;
+  } else {
+    if (Previous)
+      Found = StillPossible.find_next(static_cast<unsigned>(*Previous));
+    else if (BeginIndex == 0)
+      Found = StillPossible.find_first();
+    else
+      Found =
+          StillPossible.find_next(static_cast<unsigned>(BeginIndex - 1));
+    if (Found < 0 || static_cast<size_t>(Found) >= EndIndex)
+      return -1;
+  }
+  return Found;
+}
+
+SmallVector<size_t, 8> promotionCandidateOrderForTest(
+    size_t CandidateCount, ArrayRef<size_t> PermanentlyRejected,
+    size_t BeginIndex, size_t EndIndex, bool Forward) {
+  BitVector StillPossible(CandidateCount, true);
+  for (size_t Index : PermanentlyRejected)
+    if (Index < CandidateCount)
+      StillPossible.reset(Index);
+
+  SmallVector<size_t, 8> Order;
+  std::optional<size_t> Previous;
+  while (true) {
+    int Found = findNextPromotionCandidateIndex(
+        StillPossible, BeginIndex, EndIndex, Forward, Previous);
+    if (Found < 0)
+      break;
+    size_t Index = static_cast<size_t>(Found);
+    Order.push_back(Index);
+    Previous = Index;
+  }
+  return Order;
+}
+
+static bool emitMirroredStubGateways(PatchContext &Ctx) {
+  DenseMap<uint32_t, SmallVector<size_t, 32>> Groups;
+  SmallVector<uint64_t, 64> PoolOffsets;
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    PoolOffsets.push_back(TP);
+    Trampoline &T = Ctx.OutTrampolines[I];
+    if (T.UsesMirroredStubForward)
+      Groups[T.MirroredStubGroup].push_back(I);
+    std::optional<uint64_t> Next =
+        checkedAddUint64(TP, T.Bytes.size(), "mirrored-stub final layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+  }
+
+  for (auto &KV : Groups) {
+    ArrayRef<size_t> Members = KV.second;
+    if (Members.empty())
+      continue;
+    Trampoline &Owner = Ctx.OutTrampolines[Members.front()];
+    uint64_t StubBase = PoolOffsets[Members.front()];
+    auto fail = [&](const Twine &Reason) {
+      log() << "hotswap: error: mirrored-stub group " << KV.first << " at 0x"
+            << utohexstr(StubBase) << ": " << Reason << "\n";
+      return false;
+    };
+
+    uint64_t MinSource = Owner.OriginalOffset;
+    for (size_t Member : Members)
+      MinSource =
+          std::min(MinSource, Ctx.OutTrampolines[Member].OriginalOffset);
+    std::optional<uint64_t> SourcePc = checkedAddUint64(
+        MinSource, MinInstSize, "mirrored-stub minimum source PC");
+    if (!SourcePc)
+      return false;
+    const std::string Pair =
+        Owner.LongBranchUsesVcc
+            ? "vcc"
+            : "s[" + std::to_string(Owner.LongBranchSgprBase) + ":" +
+                  std::to_string(Owner.LongBranchSgprBase + 1) + "]";
+    if (StubBase < *SourcePc)
+      return fail("common gateway target precedes its source-PC base");
+    uint64_t Delta = StubBase - *SourcePc;
+    if (Delta > std::numeric_limits<uint32_t>::max())
+      return fail("common gateway delta does not fit literal32");
+    SmallVector<std::string, 2> GatewayLines;
+    GatewayLines.push_back("s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" +
+                           utohexstr(Delta));
+    GatewayLines.push_back("s_set_pc_i64 " + Pair);
+    Owner.ForwardGatewayBytes =
+        assembleInstructions(joinAsmLines(GatewayLines), Ctx.LS);
+    if (Owner.ForwardGatewayBytes.empty() ||
+        Owner.ForwardGatewayBytes.size() > 3 * MinInstSize)
+      return fail("common add/set-PC gateway encoding failed");
+    Owner.HasForwardGateway = true;
+    Owner.ForwardGatewayOffset = Owner.MirroredStubGatewayOffset;
+
+    if (Owner.PoolEntryPrefixBytes < MinInstSize ||
+        Owner.PoolEntryPrefixBytes > Owner.Bytes.size())
+      return fail("sparse stub prefix reservation is invalid");
+    for (uint64_t Offset = 0;
+         Offset + MinInstSize <= Owner.PoolEntryPrefixBytes;
+         Offset += MinInstSize)
+      std::memcpy(Owner.Bytes.data() + Offset, Ctx.LS.SNopBytes.data(),
+                  MinInstSize);
+
+    for (size_t Member : Members) {
+      const Trampoline &T = Ctx.OutTrampolines[Member];
+      uint64_t StubDisplacement = T.OriginalOffset - MinSource;
+      if (StubDisplacement > Owner.PoolEntryPrefixBytes - MinInstSize ||
+          StubDisplacement + MinInstSize > Owner.Bytes.size())
+        return fail("source-selected stub lies outside the sparse prefix");
+      uint64_t BodyOffset = PoolOffsets[Member] + T.PoolEntryPrefixBytes;
+      SmallVector<uint8_t> Branch =
+          Ctx.LS.encodeSBranch(StubBase + StubDisplacement, BodyOffset);
+      if (Branch.size() != MinInstSize)
+        return fail("source-selected body branch is out of range");
+      std::memcpy(Owner.Bytes.data() + StubDisplacement, Branch.data(),
+                  Branch.size());
+    }
+  }
+  return true;
+}
+
+static std::optional<uint64_t>
+sourceTailBranchTarget(const Trampoline &T, uint64_t Offset) {
+  for (const auto &[RelayOffset, TargetOffset] :
+       T.SourceTailBranchIslands)
+    if (RelayOffset == Offset)
+      return TargetOffset;
+  return std::nullopt;
+}
+
+static bool recordSourceTailBranchIsland(Trampoline &T, uint64_t Offset,
+                                         uint64_t Target) {
+  if (std::optional<uint64_t> Existing =
+          sourceTailBranchTarget(T, Offset))
+    return *Existing == Target;
+  T.SourceTailBranchIslands.push_back({Offset, Target});
+  return true;
 }
 
 static bool
 assignLongBranchGateways(PatchContext &Ctx,
                          const DenseSet<uint64_t> &DirectBranchTargets,
                          bool AllowTextGateways) {
+  struct PoolIslandOwner {
+    size_t TrampolineIndex = 0;
+    uint64_t RelativeOffset = 0;
+  };
   std::vector<NopSled> Gateways;
+  DenseMap<uint64_t, PoolIslandOwner> PoolIslandOwners;
+  DenseMap<uint64_t, size_t> SourceTailIslandOwners;
+  DenseMap<uint64_t, size_t> SourceTailGatewayOwners;
+  DenseMap<uint64_t, uint64_t> EarlySourceTailOwnerOffsets;
+  DenseMap<uint64_t, uint64_t> EarlySourceGatewayOwnerOffsets;
+  DenseMap<uint64_t, uint64_t> ReservedBackboneOwnerOffsets;
+  DenseMap<uint64_t, uint64_t> LateDirectSuffixOwnerOffsets;
+  const std::vector<ElfView::FunctionTextRange> FunctionRanges =
+      Ctx.Elf.functionTextRanges();
+  const FunctionRangeUniquenessIndex FunctionRangeIndex(FunctionRanges,
+                                                          Ctx.Elf.textAddr());
+  auto HasSafeTail = [&](const Trampoline &T, uint64_t Begin, uint64_t End) {
+    bool HasUniqueFunctionRange =
+        FunctionRangeIndex.hasUniqueFunctionRange(T);
+    return isSafeSourceTailRange(T, Ctx.DirectControlFlow,
+                                 HasUniqueFunctionRange, Begin, End);
+  };
   if (AllowTextGateways) {
     Gateways = buildExternalGatewaySleds(
         Ctx.Decoded, Ctx.LS, Ctx.Elf, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
         DirectBranchTargets);
     for (const NopSled &Sled : Ctx.NopSleds)
       Gateways.push_back(Sled);
+    subtractTrampolineSources(Gateways, Ctx.OutTrampolines);
+
+    // Keep one 12-byte tail from each safe padding window available for the
+    // pair-only affine gateway. The four-register planner otherwise consumes
+    // these scarce tails as one-dword branch islands before it discovers the
+    // pair-only residuals. Its 20-byte gateways continue to use the prefix.
+    bool HasPairOnlyAffineDemand = false;
+    uint64_t CandidateTP = Ctx.PoolBaseOffset;
+    for (const Trampoline &T : Ctx.OutTrampolines) {
+      uint64_t ThisTP = CandidateTP;
+      std::optional<uint64_t> Next = checkedAddUint64(
+          CandidateTP, T.Bytes.size(), "affine reserve demand pool layout");
+      if (!Next)
+        return false;
+      CandidateTP = *Next;
+      if (!T.Long || !T.UsesSetPCBack || T.LongBranchPreservesVcc ||
+          T.UsesSharedDispatcherForward || T.UsesMirroredStubForward ||
+          T.OriginalSize < 2 * MinInstSize ||
+          isSBranchReachable(T.OriginalOffset, ThisTP))
+        continue;
+      std::optional<SmallVector<uint8_t>> Direct =
+          encodeSetPCLongBranch(Ctx.LS, T.OriginalOffset, ThisTP,
+                                T.LongBranchSgprBase, T.LongBranchUsesVcc);
+      if (Direct && Direct->size() <= T.OriginalSize)
+        continue;
+      if (!findSafeSgprScratchBlock(Ctx, T.OriginalOffset, /*Count=*/4,
+                                    /*Alignment=*/2, "affine reserve demand",
+                                    /*ReportNoSpace=*/false)) {
+        HasPairOnlyAffineDemand = true;
+        break;
+      }
+    }
+
+    std::vector<NopSled> MirroredGatewayReserves;
+    if (HasPairOnlyAffineDemand) {
+      constexpr uint64_t ReserveBytes = 3 * MinInstSize;
+      for (NopSled &Sled : Gateways) {
+        uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+        if (Sled.WritePos > UsableEnd ||
+            ReserveBytes > UsableEnd - Sled.WritePos)
+          continue;
+        uint64_t ReserveStart = UsableEnd - ReserveBytes;
+        MirroredGatewayReserves.push_back({ReserveStart, UsableEnd,
+                                           ReserveStart, Sled.FunctionStart,
+                                           Sled.FunctionEnd});
+        Sled.End = ReserveStart;
+      }
+    }
+
+    const auto SharedPlanStart = std::chrono::steady_clock::now();
+    if (!planSharedDispatchGateways(Ctx, Gateways))
+      return false;
+    log() << "hotswap: shared gateway planning took "
+          << std::chrono::duration_cast<std::chrono::milliseconds>(
+                 std::chrono::steady_clock::now() - SharedPlanStart)
+                 .count()
+          << " ms\n";
+    Gateways.insert(Gateways.end(), MirroredGatewayReserves.begin(),
+                    MirroredGatewayReserves.end());
+
+    // Collect pair-backed source tails into one sparse backbone. These tails
+    // are withheld from affine planning below, then reactivated after
+    // forward-mode selection proves that their second dword is unreachable.
+    SmallVector<std::pair<uint64_t, uint64_t>, 64>
+        SourceTailBackboneCandidates;
+
+    // Shared-dispatch sources can also use one-dword direct calls: their link
+    // pair is exactly the source-PC identity consumed by the dispatcher. Keep
+    // tails that the shared planner already selected as relays on that route,
+    // collect independent tails for the sparse backbone, and
+    // expose every other tail to the later affine planner.
+    DenseSet<uint64_t> RequiredSharedRelayTails;
+    for (const Trampoline &T : Ctx.OutTrampolines)
+      if (T.UsesSharedDispatcherForward && T.SharedDispatcherRelayOffset != 0)
+        RequiredSharedRelayTails.insert(T.SharedDispatcherRelayOffset);
+    for (Trampoline &T : Ctx.OutTrampolines) {
+      if (!T.UsesSharedDispatcherForward || T.OriginalSize < 2 * MinInstSize ||
+          T.LongBranchPreservesVcc)
+        continue;
+      uint64_t Tail = T.OriginalOffset + MinInstSize;
+      if (!HasSafeTail(T, Tail, Tail + MinInstSize))
+        continue;
+      uint64_t Route =
+          T.SharedDispatcherRelayOffset    ? T.SharedDispatcherRelayOffset
+          : T.ForwardBranchIslands.empty() ? T.SharedDispatcherGatewayOffset
+                                           : T.ForwardBranchIslands.front();
+      if (RequiredSharedRelayTails.contains(Tail)) {
+        if (!recordSourceTailBranchIsland(T, Tail, Route))
+          return false;
+        continue;
+      }
+      SourceTailBackboneCandidates.push_back({Tail, T.OriginalOffset});
+      continue;
+    }
+
+    // Shared-dispatch sources reserve one direct call in their first dword,
+    // while their second dword remains available as an independent relay.
+    // Expose up to five dwords after that relay: three hold an affine gateway,
+    // while five can hold the save-VCC + set-PC sequence needed by live-VCC
+    // sources. A five-dword window has only eight bytes left after an affine
+    // allocation, so every source owner still hosts at most one gateway.
+    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+      const Trampoline &T = Ctx.OutTrampolines[I];
+      constexpr uint64_t ForwardBytes = 2 * MinInstSize;
+      constexpr uint64_t AffineGatewayBytes = 3 * MinInstSize;
+      constexpr uint64_t VccGatewayBytes = 5 * MinInstSize;
+      if (!T.UsesSharedDispatcherForward ||
+          T.OriginalSize < ForwardBytes + AffineGatewayBytes)
+        continue;
+      uint64_t GatewayBytes = T.OriginalSize >= ForwardBytes + VccGatewayBytes
+                                  ? VccGatewayBytes
+                                  : AffineGatewayBytes;
+      uint64_t Start = T.OriginalOffset + ForwardBytes;
+      if (!HasSafeTail(T, Start, Start + GatewayBytes))
+        continue;
+      EarlySourceGatewayOwnerOffsets[Start] = T.OriginalOffset;
+      Gateways.push_back({Start, Start + GatewayBytes, Start, 0,
+                          std::numeric_limits<uint64_t>::max(),
+                          /*GatewayOnly=*/true});
+    }
+
+    // s_call_i64 records source+4 in the reserved pair and transfers control
+    // in one dword. Most now-unreachable second dwords are offered to affine
+    // planning. Withhold a sparse 96-KiB backbone, however: affine routes can
+    // consume every relay in a dense text interval and leave no path for a
+    // later registerless return. Only pair-backed sources with a proven-safe
+    // second dword participate, so a member that receives a mirrored
+    // one-dword call has an independently-proven unreachable +4 dword.
+    CandidateTP = Ctx.PoolBaseOffset;
+    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+      const Trampoline &T = Ctx.OutTrampolines[I];
+      uint64_t ThisTP = CandidateTP;
+      std::optional<uint64_t> Next = checkedAddUint64(
+          CandidateTP, T.Bytes.size(), "affine candidate pool layout");
+      if (!Next)
+        return false;
+      CandidateTP = *Next;
+      if (!T.Long || !T.UsesSetPCBack || T.LongBranchPreservesVcc ||
+          T.UsesSharedDispatcherForward || T.OriginalSize < 2 * MinInstSize ||
+          isSBranchReachable(T.OriginalOffset, ThisTP))
+        continue;
+      std::optional<SmallVector<uint8_t>> Direct =
+          encodeSetPCLongBranch(Ctx.LS, T.OriginalOffset, ThisTP,
+                                T.LongBranchSgprBase, T.LongBranchUsesVcc);
+      if (Direct && Direct->size() <= T.OriginalSize) {
+        // A direct set-PC sequence consumes only its prefix. Once ordinary
+        // mode selection commits that sequence, a safe dword in the remaining
+        // source window is unreachable and can serve the same sparse
+        // backbone. Keep at most one suffix candidate per owner.
+        if (!T.LongBranchPreservesVcc &&
+            Direct->size() + MinInstSize <= T.OriginalSize) {
+          for (uint64_t RelativeOffset = Direct->size();
+               RelativeOffset + MinInstSize <= T.OriginalSize;
+               RelativeOffset += MinInstSize) {
+            uint64_t Suffix = T.OriginalOffset + RelativeOffset;
+            if (!HasSafeTail(T, Suffix, Suffix + MinInstSize))
+              continue;
+            LateDirectSuffixOwnerOffsets[Suffix] = T.OriginalOffset;
+            break;
+          }
+        }
+        continue;
+      }
+      uint64_t Tail = T.OriginalOffset + MinInstSize;
+      if (!HasSafeTail(T, Tail, Tail + MinInstSize))
+        continue;
+      SourceTailBackboneCandidates.push_back({Tail, T.OriginalOffset});
+      continue;
+    }
+    llvm::sort(SourceTailBackboneCandidates);
+    SourceTailBackboneCandidates.erase(
+        std::unique(SourceTailBackboneCandidates.begin(),
+                    SourceTailBackboneCandidates.end()),
+        SourceTailBackboneCandidates.end());
+    constexpr uint64_t SourceTailBackboneSpacing = 96 * 1024;
+    BitVector ReservedSourceTails(SourceTailBackboneCandidates.size());
+    if (!SourceTailBackboneCandidates.empty()) {
+      ReservedSourceTails.set(0);
+      size_t LastReserved = 0;
+      for (size_t I = 1; I != SourceTailBackboneCandidates.size(); ++I) {
+        if (SourceTailBackboneCandidates[I].first -
+                SourceTailBackboneCandidates[LastReserved].first <=
+            SourceTailBackboneSpacing)
+          continue;
+        ReservedSourceTails.set(I - 1);
+        LastReserved = I - 1;
+        // A gap between adjacent candidates cannot be filled by this
+        // backbone. Preserve both sides so other stable text/pool relays can
+        // still connect to the nearest available endpoint.
+        if (SourceTailBackboneCandidates[I].first -
+                SourceTailBackboneCandidates[LastReserved].first >
+            SourceTailBackboneSpacing) {
+          ReservedSourceTails.set(I);
+          LastReserved = I;
+        }
+      }
+      ReservedSourceTails.set(SourceTailBackboneCandidates.size() - 1);
+    }
+    for (size_t I = 0; I != SourceTailBackboneCandidates.size(); ++I) {
+      const auto &[Tail, Owner] = SourceTailBackboneCandidates[I];
+      if (ReservedSourceTails.test(I)) {
+        ReservedBackboneOwnerOffsets[Tail] = Owner;
+      } else {
+        EarlySourceTailOwnerOffsets[Tail] = Owner;
+        Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
+                            std::numeric_limits<uint64_t>::max()});
+      }
+    }
+
+    // A registerless far source needs its second dword for its own return
+    // chain. Do not expose that owner tail to the affine planner: a greedy
+    // forward chain could consume it and strand the source before return
+    // allocation runs. Bytes after the reserved second dword remain eligible
+    // as a source-local gateway when the original window is large enough.
+    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+      const Trampoline &T = Ctx.OutTrampolines[I];
+      std::optional<std::pair<uint64_t, uint64_t>> Range =
+          registerlessSourceAffineGatewayRange(T);
+      if (!Range)
+        continue;
+      uint64_t Start = Range->first;
+      uint64_t End = Range->second;
+      if (!HasSafeTail(T, Start, End))
+        continue;
+      EarlySourceGatewayOwnerOffsets[Start] = T.OriginalOffset;
+      Gateways.push_back({Start, End, Start, 0,
+                          std::numeric_limits<uint64_t>::max(),
+                          /*GatewayOnly=*/true});
+    }
+
+    if (!planMirroredStubGateways(Ctx, Gateways))
+      return false;
+    DenseMap<uint64_t, size_t> TrampolineAtOriginalOffset;
+    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I)
+      TrampolineAtOriginalOffset[Ctx.OutTrampolines[I].OriginalOffset] = I;
+    for (const auto &KV : EarlySourceTailOwnerOffsets) {
+      DenseMap<uint64_t, size_t>::const_iterator Owner =
+          TrampolineAtOriginalOffset.find(KV.second);
+      if (Owner != TrampolineAtOriginalOffset.end())
+        SourceTailIslandOwners[KV.first] = Owner->second;
+    }
+    for (const auto &KV : EarlySourceGatewayOwnerOffsets) {
+      DenseMap<uint64_t, size_t>::const_iterator Owner =
+          TrampolineAtOriginalOffset.find(KV.second);
+      if (Owner != TrampolineAtOriginalOffset.end())
+        SourceTailGatewayOwners[KV.first] = Owner->second;
+    }
+    for (const Trampoline &T : Ctx.OutTrampolines) {
+      if (!T.UsesMirroredStubForward)
+        continue;
+      for (size_t I = 0; I != T.ForwardBranchIslands.size(); ++I) {
+        uint64_t From = T.ForwardBranchIslands[I];
+        DenseMap<uint64_t, size_t>::const_iterator Owner =
+            SourceTailIslandOwners.find(From);
+        if (Owner == SourceTailIslandOwners.end())
+          continue;
+        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+        if (OwnerT.UsesSetPCBack && !OwnerT.UsesMirroredStubForward &&
+            !OwnerT.UsesSharedDispatcherForward) {
+          log() << "hotswap: error: affine relay owner at 0x"
+                << utohexstr(OwnerT.OriginalOffset)
+                << " did not receive a mirrored route\n";
+          return false;
+        }
+        uint64_t To = I + 1 == T.ForwardBranchIslands.size()
+                          ? T.ForwardBranchTargetOffset
+                          : T.ForwardBranchIslands[I + 1];
+        if (!recordSourceTailBranchIsland(OwnerT, From, To)) {
+          log() << "hotswap: error: affine source tail at 0x" << utohexstr(From)
+                << " has conflicting relay targets\n";
+          return false;
+        }
+      }
+    }
+    for (const Trampoline &T : Ctx.OutTrampolines) {
+      if (!T.UsesMirroredStubForward)
+        continue;
+      DenseMap<uint64_t, size_t>::const_iterator Owner =
+          SourceTailGatewayOwners.find(T.MirroredStubGatewayOffset);
+      if (Owner == SourceTailGatewayOwners.end())
+        continue;
+      Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+      OwnerT.HasSourceTailGateway = true;
+      OwnerT.SourceTailGatewayOffset = T.MirroredStubGatewayOffset;
+      OwnerT.SourceTailGatewayBytes = 3 * MinInstSize;
+    }
+    const auto DispatcherEmitStart = std::chrono::steady_clock::now();
+    if (!emitSharedDispatchers(Ctx) || !emitMirroredStubGateways(Ctx))
+      return false;
+    log() << "hotswap: shared/affine gateway emission took "
+          << std::chrono::duration_cast<std::chrono::milliseconds>(
+                 std::chrono::steady_clock::now() - DispatcherEmitStart)
+                 .count()
+          << " ms\n";
   }
 
-  DenseMap<uint64_t, size_t> PoolIslandOwners;
   uint64_t IslandLayoutOffset = Ctx.PoolBaseOffset;
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     Trampoline &T = Ctx.OutTrampolines[I];
@@ -2156,7 +8504,8 @@ assignLongBranchGateways(PatchContext &Ctx,
       return false;
     if (T.HasPoolBranchIsland) {
       T.PoolBranchIslandOffset = *Next - PoolBranchIslandBytes;
-      PoolIslandOwners[T.PoolBranchIslandOffset] = I;
+      PoolIslandOwners[T.PoolBranchIslandOffset] = {
+          I, T.Bytes.size() - PoolBranchIslandBytes};
       Gateways.push_back({T.PoolBranchIslandOffset,
                           T.PoolBranchIslandOffset + PoolBranchIslandBytes,
                           T.PoolBranchIslandOffset, 0,
@@ -2171,6 +8520,8 @@ assignLongBranchGateways(PatchContext &Ctx,
     uint64_t InitialCandidateSlots = 0;
   };
   std::vector<PendingGateway> Pending;
+  const auto OrdinaryPlanStart = std::chrono::steady_clock::now();
+  uint64_t ReturnBranchIslandChains = 0;
   uint64_t TrampOffset = Ctx.PoolBaseOffset;
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     Trampoline &T = Ctx.OutTrampolines[I];
@@ -2182,25 +8533,589 @@ assignLongBranchGateways(PatchContext &Ctx,
     TrampOffset = *Next;
     if (!T.Long)
       continue;
+    if (T.UsesSharedDispatcherForward || T.UsesMirroredStubForward)
+      continue;
 
     if (isSBranchReachable(T.OriginalOffset, TP)) {
       T.UsesShortBranchForward = true;
+      if (T.LongBranchPreservesVcc)
+        std::memcpy(T.Bytes.data(), Ctx.LS.SNopBytes.data(), MinInstSize);
       continue;
     }
-    std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
-        Ctx.LS, T.OriginalOffset, TP, T.LongBranchSgprBase);
-    if (Direct && Direct->size() <= T.OriginalSize) {
-      T.UsesDirectSetPCForward = true;
-      T.DirectSetPCForwardBytes = std::move(*Direct);
-      continue;
+    if (T.UsesSetPCBack) {
+      std::optional<SmallVector<uint8_t>> Direct =
+          T.LongBranchPreservesVcc
+              ? encodeSetPcGateway(Ctx.LS, T.OriginalOffset, TP,
+                                   T.LongBranchSgprBase, T.LongBranchUsesVcc,
+                                   /*PreserveVcc=*/true)
+              : encodeSetPCLongBranch(Ctx.LS, T.OriginalOffset, TP,
+                                      T.LongBranchSgprBase,
+                                      T.LongBranchUsesVcc);
+      uint64_t RequiredSourceBytes =
+          Direct ? Direct->size() +
+                       (T.LongBranchPreservesVcc ? VccLandingPadBytes : 0)
+                 : 0;
+      if (Direct && RequiredSourceBytes <= T.OriginalSize) {
+        T.UsesDirectSetPCForward = true;
+        T.DirectSetPCForwardBytes = std::move(*Direct);
+        continue;
+      }
     }
     Pending.push_back({I, TP, 0});
   }
+  log() << "hotswap: ordinary gateway planner collected " << Pending.size()
+        << " pending site(s) across " << Gateways.size()
+        << " gateway/relay window(s) in "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - OrdinaryPlanStart)
+               .count()
+        << " ms\n";
+  uint64_t PoolEndOffset = TrampOffset;
+
+  // Affine planning has finished and ordinary mode selection has now either
+  // committed a direct set-PC source or left a pair-backed owner on its
+  // one-dword branch path. Reactivate the withheld backbone only at this
+  // point: its +4 dword is provably unreachable for both mirrored calls and
+  // pending ordinary branches, while it could not be consumed by an earlier
+  // affine route.
+  DenseMap<uint64_t, size_t> FinalTrampolineAtOriginalOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I)
+    FinalTrampolineAtOriginalOffset[Ctx.OutTrampolines[I].OriginalOffset] = I;
+  uint64_t ActivatedBackboneRelays = 0;
+  for (const auto &KV : ReservedBackboneOwnerOffsets) {
+    DenseMap<uint64_t, size_t>::const_iterator Owner =
+        FinalTrampolineAtOriginalOffset.find(KV.second);
+    if (Owner == FinalTrampolineAtOriginalOffset.end())
+      continue;
+    const Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+    if (KV.first < OwnerT.OriginalOffset)
+      continue;
+    uint64_t RelativeOffset = KV.first - OwnerT.OriginalOffset;
+    bool HasOneDwordForward =
+        RelativeOffset == MinInstSize &&
+        (OwnerT.UsesSharedDispatcherForward ||
+         (OwnerT.UsesSetPCBack && !OwnerT.UsesDirectSetPCForward));
+    if (!OwnerT.Long || OwnerT.LongBranchPreservesVcc ||
+        !HasOneDwordForward ||
+        !HasSafeTail(OwnerT, KV.first, KV.first + MinInstSize) ||
+        sourceTailBranchTarget(OwnerT, KV.first))
+      continue;
+    SourceTailIslandOwners[KV.first] = Owner->second;
+    Gateways.push_back({KV.first, KV.first + MinInstSize, KV.first, 0,
+                        std::numeric_limits<uint64_t>::max()});
+    ++ActivatedBackboneRelays;
+  }
+  uint64_t ActivatedDirectSuffixRelays = 0;
+  for (const auto &KV : LateDirectSuffixOwnerOffsets) {
+    DenseMap<uint64_t, size_t>::const_iterator Owner =
+        FinalTrampolineAtOriginalOffset.find(KV.second);
+    if (Owner == FinalTrampolineAtOriginalOffset.end())
+      continue;
+    const Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+    if (KV.first < OwnerT.OriginalOffset)
+      continue;
+    uint64_t RelativeOffset = KV.first - OwnerT.OriginalOffset;
+    if (!OwnerT.Long || OwnerT.LongBranchPreservesVcc ||
+        !OwnerT.UsesDirectSetPCForward ||
+        RelativeOffset < OwnerT.DirectSetPCForwardBytes.size() ||
+        RelativeOffset + MinInstSize > OwnerT.OriginalSize ||
+        !HasSafeTail(OwnerT, KV.first, KV.first + MinInstSize) ||
+        sourceTailBranchTarget(OwnerT, KV.first))
+      continue;
+    SourceTailIslandOwners[KV.first] = Owner->second;
+    Gateways.push_back({KV.first, KV.first + MinInstSize, KV.first, 0,
+                        std::numeric_limits<uint64_t>::max()});
+    ++ActivatedDirectSuffixRelays;
+  }
+  if (ActivatedBackboneRelays != 0)
+    log() << "hotswap: reserved " << ActivatedBackboneRelays
+          << " source-tail backbone relay(s) from affine planning\n";
+  if (ActivatedDirectSuffixRelays != 0)
+    log() << "hotswap: exposed " << ActivatedDirectSuffixRelays
+          << " direct set-PC source-suffix relay(s) after affine planning\n";
+
+  // Once a source is replaced by a one-dword branch, the remainder of its
+  // original instruction window is unreachable and can provide a safe relay.
+  // Add these only after selecting direct set-PC sources, whose longer forward
+  // sequence consumes the tail. Shared dispatch and VCC preservation likewise
+  // reserve the second dword. Relays are object-wide: unlike an arbitrary NOP
+  // sled they cannot be reached by the owning function's original fallthrough.
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    const Trampoline &T = Ctx.OutTrampolines[I];
+    if (!AllowTextGateways ||
+        Ctx.DirectControlFlow.HasUnboundedIndirectEntries ||
+        T.OriginalSize < 2 * MinInstSize || T.UsesDirectSetPCForward ||
+        T.UsesSharedDispatcherForward || T.UsesMirroredStubForward ||
+        T.LongBranchPreservesVcc)
+      continue;
+    uint64_t Tail = T.OriginalOffset + MinInstSize;
+    if (SourceTailIslandOwners.contains(Tail) ||
+        !HasSafeTail(T, Tail, Tail + MinInstSize))
+      continue;
+    SourceTailIslandOwners[Tail] = I;
+    Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
+                        std::numeric_limits<uint64_t>::max()});
+  }
+
+  // Forward-mode selection above exposes every source that will execute a
+  // one-dword branch. Allocate registerless returns only now, so they can use
+  // the complete set of unreachable source tails. Returns retain first access
+  // to those relays before ordinary forward gateways and island chains.
+  //
+  // Reserve each registerless source's own second dword before allocating any
+  // chain. That dword lies four bytes before ReturnTo, so the generic
+  // monotonically-backward allocator cannot select it directly; without this
+  // reservation an earlier return can consume it as an ordinary relay and
+  // strand its owner. The owner's chain targets the reserved tail, whose final
+  // branch then advances to ReturnTo.
+  DenseMap<size_t, uint64_t> ReservedReturnTails;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    const Trampoline &T = Ctx.OutTrampolines[I];
+    if (!mustReserveSourceTailForRegisterlessReturn(T))
+      continue;
+    uint64_t Tail = T.OriginalOffset + MinInstSize;
+    DenseMap<uint64_t, size_t>::const_iterator Owner =
+        SourceTailIslandOwners.find(Tail);
+    if (Owner == SourceTailIslandOwners.end() || Owner->second != I)
+      continue;
+    for (NopSled &Gateway : Gateways) {
+      if (Gateway.WritePos != Tail || Gateway.End < Tail + MinInstSize)
+        continue;
+      Gateway.WritePos += MinInstSize;
+      ReservedReturnTails[I] = Tail;
+      break;
+    }
+  }
+
+  DenseSet<uint64_t> OccupiedBranchGatewaySlots;
+  BranchGatewayHeadSet BranchGatewayHeads =
+      buildBranchGatewayHeads(Gateways, OccupiedBranchGatewaySlots);
+  uint64_t RemainingRelayDemand = 0;
+  for (const Trampoline &T : Ctx.OutTrampolines)
+    RemainingRelayDemand += T.Long && !T.UsesSetPCBack;
+  RemainingRelayDemand += Pending.size();
+
+  BitVector PromotionStillPossible(Ctx.Decoded.size(), true);
+  DenseSet<uint64_t> PromotionProtectedOffsets =
+      collectRelocationProtectedOffsets(Ctx.Decoded, Ctx.LS,
+                                        /*ProtectClauseMembers=*/true);
+  DenseSet<uint64_t> PromotionEntryOffsets = Ctx.DirectControlFlow.Targets;
+  PromotionEntryOffsets.insert(DirectBranchTargets.begin(),
+                               DirectBranchTargets.end());
+  PromotionEntryOffsets.insert(Ctx.DeclaredEntries.begin(),
+                               Ctx.DeclaredEntries.end());
+  DenseSet<uint64_t> PromotionIndirectFunctions =
+      collectIndirectControlFlowFunctions(
+          Ctx.Decoded, Ctx.LS, Ctx.Elf,
+          Ctx.DirectControlFlow.BoundedIndirectTransfers);
+  DenseMap<std::pair<uint64_t, uint64_t>,
+           std::optional<DenseSet<uint64_t>>>
+      PromotionVccNeedsCache;
+  std::optional<SmallVector<MCRegister, 128>> PromotionNumberedSgprs =
+      resolveNumberedSgprRegisters(*Ctx.LS.MRI, Ctx.Config.MaxSgprs);
+  BatchedSgprContinuationCache PromotionSgprContinuationCache;
+  uint64_t PromotionSgprContinuationAnalyses = 0;
+  using PromotionRange = std::pair<uint64_t, uint64_t>;
+  std::set<PromotionRange> PromotionReservedRanges;
+  auto ReservePromotionRange = [&](uint64_t Begin, uint64_t End) {
+    if (Begin >= End)
+      return;
+    auto It = PromotionReservedRanges.lower_bound({Begin, 0});
+    if (It != PromotionReservedRanges.begin()) {
+      auto Previous = std::prev(It);
+      if (Previous->second >= Begin)
+        It = Previous;
+    }
+    while (It != PromotionReservedRanges.end() && It->first <= End) {
+      Begin = std::min(Begin, It->first);
+      End = std::max(End, It->second);
+      It = PromotionReservedRanges.erase(It);
+    }
+    PromotionReservedRanges.insert(It, {Begin, End});
+  };
+  auto OverlapsPromotionRange = [&](uint64_t Begin, uint64_t End) {
+    if (Begin >= End)
+      return false;
+    auto It = PromotionReservedRanges.lower_bound({End, 0});
+    if (It == PromotionReservedRanges.begin())
+      return false;
+    --It;
+    return It->second > Begin;
+  };
+  for (const Trampoline &T : Ctx.OutTrampolines)
+    ReservePromotionRange(T.OriginalOffset,
+                          T.OriginalOffset + T.OriginalSize);
+  for (const NopSled &Gateway : Gateways)
+    ReservePromotionRange(Gateway.Start, Gateway.End);
+  auto IsVccDeadAtContinuation =
+      [&](const ElfView::FunctionTextRange &Function, uint64_t Start,
+          uint32_t Size) {
+    std::optional<uint64_t> Continuation = checkedAddUint64(
+        Start, Size, "promoted VCC liveness continuation");
+    if (!Continuation || *Continuation < Function.Begin ||
+        *Continuation >= Function.End)
+      return false;
+    auto ContinuationIt = llvm::lower_bound(
+        Ctx.Decoded, *Continuation,
+        [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
+    if (ContinuationIt == Ctx.Decoded.end() ||
+        ContinuationIt->Offset != *Continuation)
+      return false;
+
+    std::pair<uint64_t, uint64_t> Key{Function.Begin, Function.End};
+    auto CacheIt = PromotionVccNeedsCache.find(Key);
+    if (CacheIt == PromotionVccNeedsCache.end()) {
+      std::optional<DenseSet<uint64_t>> Needs =
+          computeIncomingRegisterNeeds(Ctx.Decoded, Ctx.LS, Function.Begin,
+                                       Function.End, Ctx.LS.VCCRegister);
+      CacheIt =
+          PromotionVccNeedsCache.try_emplace(Key, std::move(Needs)).first;
+    }
+    return CacheIt->second &&
+           !CacheIt->second->contains(*Continuation);
+  };
+  uint64_t PromotedBranchCapacityRelays = 0;
+  SmallVector<std::pair<size_t, uint64_t>, 8>
+      ReturnPromotionBranchOnlyRanges;
+  bool PlanningRegisterlessReturns = true;
+  constexpr uint64_t MinBranchCapacitySourceBytes =
+      SetPcForwardSequenceBytes + MinInstSize;
+  auto PromoteBranchCapacityRelay =
+      [&](const BranchIslandFailure &Failure) -> bool {
+    auto [SearchBegin, SearchEnd] = branchPromotionSearchRangeForTest(
+        Failure.CurrentOffset, Failure.CorridorOffset, Failure.Forward);
+    if (SearchBegin >= SearchEnd)
+      return false;
+    auto TryPromote = [&](bool AllowLocalPair) -> bool {
+      auto Begin = llvm::lower_bound(
+          Ctx.Decoded, SearchBegin,
+          [](const InternalDecodedInst &DI, uint64_t Offset) {
+            return DI.Offset < Offset;
+          });
+      auto End = llvm::lower_bound(
+          Ctx.Decoded, SearchEnd,
+          [](const InternalDecodedInst &DI, uint64_t Offset) {
+            return DI.Offset < Offset;
+          });
+      size_t BeginIndex = static_cast<size_t>(Begin - Ctx.Decoded.begin());
+      size_t EndIndex = static_cast<size_t>(End - Ctx.Decoded.begin());
+      std::optional<size_t> PreviousIndex;
+      while (true) {
+        int CandidateIndex = findNextPromotionCandidateIndex(
+            PromotionStillPossible, BeginIndex, EndIndex, Failure.Forward,
+            PreviousIndex);
+        if (CandidateIndex < 0)
+          break;
+        size_t Index = static_cast<size_t>(CandidateIndex);
+        PreviousIndex = Index;
+        auto It = Ctx.Decoded.begin() + Index;
+        uint64_t Start = It->Offset;
+
+        // Scratch selection does not change the fixed set-PC width. Reject
+        // offsets outside the depleted branch corridor before function,
+        // overlap, or liveness analysis.
+        std::optional<uint32_t> ProbeDirectSize =
+            getSetPcLongBranchLayoutSize(Start, PoolEndOffset);
+        if (!ProbeDirectSize) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        uint64_t Tail = Start + *ProbeDirectSize;
+        bool MakesReachableProgress =
+            Failure.Forward
+                ? Tail > Failure.CurrentOffset &&
+                      Tail < Failure.CorridorOffset &&
+                      Tail < Failure.TargetOffset &&
+                      isSBranchReachable(Failure.CurrentOffset, Tail)
+                : Tail < Failure.CurrentOffset &&
+                      Tail > Failure.CorridorOffset &&
+                      Tail > Failure.TargetOffset &&
+                      isSBranchReachable(Failure.CurrentOffset, Tail);
+        if (!MakesReachableProgress)
+          continue;
+
+        std::optional<ElfView::FunctionTextRange> Function =
+            Ctx.Elf.findFunctionTextRangeAtOffset(Start);
+        if (!Function ||
+            PromotionIndirectFunctions.contains(Function->Begin)) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+
+        uint64_t DemandBytes =
+            RemainingRelayDemand >
+                    (std::numeric_limits<uint32_t>::max() -
+                     *ProbeDirectSize) /
+                        MinInstSize
+                ? std::numeric_limits<uint32_t>::max() -
+                      *ProbeDirectSize
+                : RemainingRelayDemand * MinInstSize;
+        uint64_t DesiredSourceBytes = *ProbeDirectSize + DemandBytes;
+        DesiredSourceBytes =
+            std::max(DesiredSourceBytes, MinBranchCapacitySourceBytes);
+        DesiredSourceBytes =
+            std::min(DesiredSourceBytes, Function->End - Start);
+
+        SmallVector<uint8_t, 32> Replacement;
+        uint64_t Cursor = Start;
+        auto Member = It;
+        uint32_t MinimumReplacementSize = 0;
+        uint32_t BestVccReplacementSize = 0;
+        bool NeedsIncomingVcc = false;
+        bool FullyWritesVcc = false;
+        while (Replacement.size() < DesiredSourceBytes) {
+          if (Member == Ctx.Decoded.end() || Member->Offset != Cursor ||
+              PromotionEntryOffsets.contains(Member->Offset))
+            break;
+          std::optional<ElfView::FunctionTextRange> MemberFunction =
+              Ctx.Elf.findFunctionTextRangeAtOffset(Member->Offset);
+          std::optional<InternalDecodedInst> Current =
+              decodeCurrentInstruction(Ctx, *Member);
+          if (!MemberFunction || MemberFunction->Begin != Function->Begin ||
+              MemberFunction->End != Function->End || !Current ||
+              !isSafeStraightLineRelocation(*Current, Ctx.LS,
+                                            PromotionProtectedOffsets) ||
+              Current->Inst.getOpcode() == Ctx.LS.SNopOpcode)
+            break;
+          std::optional<uint64_t> MemberEnd = checkedAddUint64(
+              Member->Offset, Member->Size,
+              "promoted branch-capacity member end");
+          if (!MemberEnd || *MemberEnd > Function->End ||
+              Replacement.size() + Member->Size > DesiredSourceBytes ||
+              OverlapsPromotionRange(Member->Offset, *MemberEnd))
+            break;
+
+          if (!FullyWritesVcc &&
+              instructionReadsRegister(*Current, Ctx.LS,
+                                       Ctx.LS.VCCRegister))
+            NeedsIncomingVcc = true;
+          if (instructionFullyWritesRegister(*Current, Ctx.LS,
+                                             Ctx.LS.VCCRegister))
+            FullyWritesVcc = true;
+          Replacement.append(Ctx.Text + Member->Offset,
+                             Ctx.Text + Member->Offset + Member->Size);
+          Cursor = *MemberEnd;
+          ++Member;
+
+          if (!MinimumReplacementSize &&
+              Replacement.size() >= MinBranchCapacitySourceBytes)
+            MinimumReplacementSize = Replacement.size();
+          if (Replacement.size() >= MinBranchCapacitySourceBytes &&
+              !NeedsIncomingVcc && Ctx.LS.VCCRegister.isValid() &&
+              IsVccDeadAtContinuation(*Function, Start,
+                                      Replacement.size()))
+            BestVccReplacementSize = Replacement.size();
+        }
+        if (!MinimumReplacementSize ||
+            Replacement.size() > std::numeric_limits<uint32_t>::max()) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        bool UseVcc = BestVccReplacementSize != 0;
+        if (!UseVcc && !AllowLocalPair)
+          continue;
+        Replacement.resize(UseVcc ? BestVccReplacementSize
+                                  : MinimumReplacementSize);
+        std::optional<unsigned> Scratch;
+        if (!UseVcc && PromotionNumberedSgprs)
+          Scratch = findLocallyDeadSgprPairWithCache(
+              Ctx, *Function, Start, Replacement.size(), Replacement,
+              *PromotionNumberedSgprs, PromotionSgprContinuationCache,
+              PromotionSgprContinuationAnalyses);
+        if (!Scratch && !UseVcc) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        uint64_t End = Start + Replacement.size();
+        Trampoline Promoted;
+        Promoted.OriginalOffset = Start;
+        Promoted.OriginalSize = Replacement.size();
+        Promoted.HasFunctionRange = true;
+        Promoted.FunctionStart = Function->Begin;
+        Promoted.FunctionEnd = Function->End;
+        if (!HasSafeTail(Promoted, Tail, End)) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
+            Ctx.LS, Start, PoolEndOffset, Scratch.value_or(0), UseVcc);
+        if (!Direct || Direct->size() != *ProbeDirectSize) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        if (Scratch) {
+          SafeSgprScratchBlock ScratchBlock{*Scratch, 2};
+          if (!commitSafeSgprScratchBlock(
+                  Ctx, Start, ScratchBlock,
+                  "promoted branch-capacity trampoline SGPR pair")) {
+            PromotionStillPossible.reset(Index);
+            continue;
+          }
+        }
+        Promoted.Bytes.append(Replacement.begin(), Replacement.end());
+        Promoted.Bytes.append(SetPcReturnReserveBytes, uint8_t{0});
+        Promoted.Bytes.append(PoolBranchIslandBytes, uint8_t{0});
+        Promoted.Long = true;
+        Promoted.UsesSetPCBack = true;
+        Promoted.LongBranchSgprBase = Scratch.value_or(0);
+        Promoted.LongBranchUsesVcc = UseVcc;
+        Promoted.UsesDirectSetPCForward = true;
+        Promoted.DirectSetPCForwardBytes = std::move(*Direct);
+        Promoted.HasPoolBranchIsland = true;
+
+        std::optional<uint64_t> NewPoolEnd = checkedAddUint64(
+            PoolEndOffset, Promoted.Bytes.size(),
+            "promoted branch-capacity trampoline layout");
+        if (!NewPoolEnd)
+          return false;
+        Promoted.PoolBranchIslandOffset =
+            *NewPoolEnd - PoolBranchIslandBytes;
+        size_t NewIndex = Ctx.OutTrampolines.size();
+        Ctx.OutTrampolines.emplace_back(std::move(Promoted));
+        PoolIslandOwners[*NewPoolEnd - PoolBranchIslandBytes] = {
+            NewIndex, Ctx.OutTrampolines.back().Bytes.size() -
+                          PoolBranchIslandBytes};
+        size_t PoolGatewayIndex = Gateways.size();
+        Gateways.push_back({*NewPoolEnd - PoolBranchIslandBytes, *NewPoolEnd,
+                            *NewPoolEnd - PoolBranchIslandBytes, 0,
+                            std::numeric_limits<uint64_t>::max()});
+        BranchGatewayHeads.insert(
+            {*NewPoolEnd - PoolBranchIslandBytes, PoolGatewayIndex});
+        FinalTrampolineAtOriginalOffset[Start] = NewIndex;
+        for (uint64_t Relay = Tail; Relay + MinInstSize <= End;
+             Relay += MinInstSize)
+          SourceTailIslandOwners[Relay] = NewIndex;
+        size_t SourceGatewayIndex = Gateways.size();
+        Gateways.push_back({Tail, End, Tail, 0,
+                            std::numeric_limits<uint64_t>::max()});
+        BranchGatewayHeads.insert({Tail, SourceGatewayIndex});
+        if (PlanningRegisterlessReturns)
+          ReturnPromotionBranchOnlyRanges.push_back(
+              {SourceGatewayIndex, End});
+        ReservePromotionRange(Start, End);
+
+        PromotionStillPossible.reset(Index);
+        PoolEndOffset = *NewPoolEnd;
+        Ctx.QueuedTrampolineBytes = PoolEndOffset - Ctx.PoolBaseOffset;
+        Ctx.Profile.count(HotswapMetric::JumpLong);
+        ++PromotedBranchCapacityRelays;
+        // Keep small fixtures fully observable while bounding verbose output
+        // for giant objects with tens of thousands of promotions.
+        if (PromotedBranchCapacityRelays <= 16 ||
+            isPowerOf2_64(PromotedBranchCapacityRelays))
+          log() << "hotswap: promoted safe straight-line source at 0x"
+                << utohexstr(Start) << " (size=" << Replacement.size()
+                << ") to provide "
+                << (Failure.Forward ? "forward" : "return")
+                << "-capacity relay window [0x" << utohexstr(Tail) << ",0x"
+                << utohexstr(End) << ") with "
+                << (End - Tail) / MinInstSize << " slot(s) using "
+                << (UseVcc ? "VCC" : "a local SGPR pair")
+                << " (promotion " << PromotedBranchCapacityRelays << ")\n";
+        return true;
+      }
+      return false;
+    };
+    if (TryPromote(/*AllowLocalPair=*/false))
+      return true;
+    return TryPromote(/*AllowLocalPair=*/true);
+  };
+
+  const auto ReturnBranchPlanStart = std::chrono::steady_clock::now();
+  TrampOffset = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
+    std::optional<uint64_t> Next = checkedAddUint64(
+        TrampOffset, T.Bytes.size(), "return-island trampoline layout");
+    if (!Next)
+      return false;
+    TrampOffset = *Next;
+    if (!T.Long || T.UsesSetPCBack)
+      continue;
+    const uint64_t TrailingIsland =
+        T.HasPoolBranchIsland ? PoolBranchIslandBytes : 0;
+    if (T.Bytes.size() < TrailingIsland + MinInstSize) {
+      log() << "hotswap: error: registerless return reservation is "
+               "truncated at 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      return false;
+    }
+    uint64_t BackSlot = *Next - TrailingIsland - MinInstSize;
+    std::optional<uint64_t> ReturnTo =
+        checkedAddUint64(T.OriginalOffset, T.OriginalSize,
+                         "registerless trampoline return target");
+    if (!ReturnTo)
+      return false;
+    uint64_t OwnerOffset = T.OriginalOffset;
+    uint32_t OwnerSize = T.OriginalSize;
+    bool OwnerPreservesVcc = T.LongBranchPreservesVcc;
+    bool OwnerUsesShared = T.UsesSharedDispatcherForward;
+    bool OwnerUsesMirrored = T.UsesMirroredStubForward;
+    uint64_t ChainTarget = ReservedReturnTails.lookup(I);
+    BranchIslandFailure Failure;
+    std::optional<SmallVector<uint64_t, 4>> ReturnIslands =
+        allocateBackwardBranchIslands(
+            Gateways, OwnerOffset, BackSlot,
+            ChainTarget ? ChainTarget : *ReturnTo, &Failure,
+            &BranchGatewayHeads, &OccupiedBranchGatewaySlots,
+            PromoteBranchCapacityRelay);
+    if (!ReturnIslands) {
+      log() << "hotswap: error: no safe return s_branch island chain for far "
+               "site 0x"
+            << utohexstr(OwnerOffset) << " (size=" << OwnerSize
+            << ", pool-back-slot=0x" << utohexstr(BackSlot)
+            << ", return-to=0x" << utohexstr(*ReturnTo)
+            << ", reserved-tail=0x" << utohexstr(ChainTarget)
+            << ", preserve-vcc=" << OwnerPreservesVcc
+            << ", shared=" << OwnerUsesShared
+            << ", mirrored=" << OwnerUsesMirrored << ")\n";
+      return false;
+    }
+    if (ChainTarget)
+      ReturnIslands->push_back(ChainTarget);
+    Trampoline &Planned = Ctx.OutTrampolines[I];
+    Planned.ReturnBranchIslands = std::move(*ReturnIslands);
+    Planned.ReturnBranchTargetOffset = *ReturnTo;
+    ReturnBranchIslandChains += !Planned.ReturnBranchIslands.empty();
+    if (RemainingRelayDemand)
+      --RemainingRelayDemand;
+  }
+  log() << "hotswap: return branch-island planning took "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - ReturnBranchPlanStart)
+               .count()
+        << " ms\n";
+  PlanningRegisterlessReturns = false;
+  // A return-phase promotion reserves its source suffix specifically for
+  // registerless branch relays. Hide its remaining slots from the ordinary
+  // set-PC planners, which do not record source-tail gateway ownership and
+  // would otherwise have their bytes overwritten by final source padding.
+  SmallVector<std::pair<uint64_t, uint64_t>, 8>
+      HiddenReturnPromotionRanges;
+  for (const auto &[GatewayIndex, OriginalEnd] :
+       ReturnPromotionBranchOnlyRanges) {
+    if (Gateways[GatewayIndex].WritePos < OriginalEnd)
+      HiddenReturnPromotionRanges.push_back(
+          {Gateways[GatewayIndex].WritePos, OriginalEnd});
+    Gateways[GatewayIndex].End = Gateways[GatewayIndex].WritePos;
+  }
+  // Remove every committed branch dword from all physical aliases before a
+  // variable-width ordinary gateway can cross and overwrite it. Splitting a
+  // range preserves the free prefix and suffix while making the occupied
+  // dword a hard layout boundary.
+  subtractOccupiedBranchGatewaySlots(Gateways,
+                                     OccupiedBranchGatewaySlots);
+  const auto CandidateCountStart = std::chrono::steady_clock::now();
   for (PendingGateway &P : Pending) {
     const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    if (!T.UsesSetPCBack)
+      continue;
     Expected<uint64_t> CandidateSlots = countReachableSetPcGatewaySlots(
         Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
-        T.LongBranchSgprBase, Pending.size());
+        T.LongBranchSgprBase, Pending.size(), T.LongBranchUsesVcc,
+        T.LongBranchPreservesVcc);
     if (!CandidateSlots) {
       log() << "hotswap: error: failed to count gateways for far site 0x"
             << utohexstr(T.OriginalOffset) << ": "
@@ -2209,24 +9124,11 @@ assignLongBranchGateways(PatchContext &Ctx,
     }
     P.InitialCandidateSlots = *CandidateSlots;
   }
-
-  std::vector<PendingGateway> StillPending;
-  StillPending.reserve(Pending.size());
-  uint64_t BranchIslandChains = 0;
-  for (const PendingGateway &P : Pending) {
-    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
-    std::optional<SmallVector<uint64_t, 4>> Islands =
-        allocateForwardBranchIslands(Gateways, T.OriginalOffset,
-                                     P.TargetOffset);
-    if (!Islands || Islands->empty()) {
-      StillPending.push_back(P);
-      continue;
-    }
-    T.ForwardBranchIslands = std::move(*Islands);
-    T.ForwardBranchTargetOffset = P.TargetOffset;
-    ++BranchIslandChains;
-  }
-  Pending = std::move(StillPending);
+  log() << "hotswap: ordinary gateway candidate counting took "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - CandidateCountStart)
+               .count()
+        << " ms\n";
 
   std::stable_sort(Pending.begin(), Pending.end(),
                    [](const PendingGateway &LHS, const PendingGateway &RHS) {
@@ -2234,12 +9136,25 @@ assignLongBranchGateways(PatchContext &Ctx,
                             RHS.InitialCandidateSlots;
                    });
 
+  std::vector<PendingGateway> StillPending;
+  StillPending.reserve(Pending.size());
   uint64_t AssignedGateways = 0;
+  uint64_t AssignedSplitVccGateways = 0;
+  auto OccupyOrdinaryGateway = [&](uint64_t Begin, uint64_t Size) {
+    for (uint64_t Offset = 0; Offset < Size; Offset += MinInstSize)
+      OccupiedBranchGatewaySlots.insert(Begin + Offset);
+  };
   for (const PendingGateway &P : Pending) {
     Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    if (!T.UsesSetPCBack) {
+      StillPending.push_back(P);
+      continue;
+    }
     Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
         findNearestSetPcGateway(Gateways, Ctx.LS, T.OriginalOffset,
-                                P.TargetOffset, T.LongBranchSgprBase);
+                                P.TargetOffset, T.LongBranchSgprBase,
+                                T.LongBranchUsesVcc, T.LongBranchPreservesVcc,
+                                &OccupiedBranchGatewaySlots);
     if (!GatewayOrErr) {
       log() << "hotswap: error: failed to plan gateway for far site 0x"
             << utohexstr(T.OriginalOffset) << ": "
@@ -2248,23 +9163,154 @@ assignLongBranchGateways(PatchContext &Ctx,
     }
     std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
     if (!Gateway) {
-      log() << "hotswap: error: no safe short-branch gateway for far site 0x"
-            << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
-            << " initial candidate slot(s))\n";
-      return false;
+      if (T.LongBranchPreservesVcc) {
+        std::optional<EncodedSplitVccGateway> Split =
+            findSplitVccGateway(Gateways, Ctx.LS, T.OriginalOffset,
+                                P.TargetOffset, T.LongBranchSgprBase,
+                                &OccupiedBranchGatewaySlots);
+        if (Split) {
+          NopSled &Primary = Gateways[Split->PrimaryIndex];
+          NopSled &Secondary = Gateways[Split->SecondaryIndex];
+          T.HasForwardGateway = true;
+          T.ForwardGatewayOffset = Primary.WritePos;
+          T.ForwardGatewayBytes = std::move(Split->PrimaryBytes);
+          T.SharedDispatcherSecondaryGatewayOffset = Secondary.WritePos;
+          T.SecondaryForwardGatewayBytes = std::move(Split->SecondaryBytes);
+          DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
+              SourceTailGatewayOwners.find(
+                  T.SharedDispatcherSecondaryGatewayOffset);
+          if (SourceOwner != SourceTailGatewayOwners.end()) {
+            Trampoline &OwnerT = Ctx.OutTrampolines[SourceOwner->second];
+            if (OwnerT.HasSourceTailGateway) {
+              log() << "hotswap: error: split VCC source-tail gateway at 0x"
+                    << utohexstr(T.SharedDispatcherSecondaryGatewayOffset)
+                    << " has conflicting allocations\n";
+              return false;
+            }
+            OwnerT.HasSourceTailGateway = true;
+            OwnerT.SourceTailGatewayOffset =
+                T.SharedDispatcherSecondaryGatewayOffset;
+            OwnerT.SourceTailGatewayBytes =
+                T.SecondaryForwardGatewayBytes.size();
+          }
+          Primary.WritePos += T.ForwardGatewayBytes.size();
+          Secondary.WritePos += T.SecondaryForwardGatewayBytes.size();
+          OccupyOrdinaryGateway(T.ForwardGatewayOffset,
+                                T.ForwardGatewayBytes.size());
+          OccupyOrdinaryGateway(T.SharedDispatcherSecondaryGatewayOffset,
+                                T.SecondaryForwardGatewayBytes.size());
+          ++AssignedGateways;
+          ++AssignedSplitVccGateways;
+          if (RemainingRelayDemand)
+            --RemainingRelayDemand;
+          continue;
+        }
+      }
+      StillPending.push_back(P);
+      continue;
     }
     T.HasForwardGateway = true;
     T.ForwardGatewayOffset = Gateway->Sled->WritePos;
     T.ForwardGatewayBytes = std::move(Gateway->Bytes);
+    DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
+        SourceTailGatewayOwners.find(T.ForwardGatewayOffset);
+    if (SourceOwner != SourceTailGatewayOwners.end()) {
+      Trampoline &OwnerT = Ctx.OutTrampolines[SourceOwner->second];
+      if (OwnerT.HasSourceTailGateway &&
+          (OwnerT.SourceTailGatewayOffset != T.ForwardGatewayOffset ||
+           OwnerT.SourceTailGatewayBytes != T.ForwardGatewayBytes.size())) {
+        log() << "hotswap: error: source-tail gateway at 0x"
+              << utohexstr(T.ForwardGatewayOffset)
+              << " has conflicting allocations\n";
+        return false;
+      }
+      OwnerT.HasSourceTailGateway = true;
+      OwnerT.SourceTailGatewayOffset = T.ForwardGatewayOffset;
+      OwnerT.SourceTailGatewayBytes = T.ForwardGatewayBytes.size();
+    }
     Gateway->Sled->WritePos += T.ForwardGatewayBytes.size();
+    OccupyOrdinaryGateway(T.ForwardGatewayOffset,
+                          T.ForwardGatewayBytes.size());
     ++AssignedGateways;
+    if (RemainingRelayDemand)
+      --RemainingRelayDemand;
   }
-  if (!Pending.empty())
+  Pending = std::move(StillPending);
+
+  for (const auto &[Begin, End] : HiddenReturnPromotionRanges)
+    Gateways.push_back({Begin, End, Begin, 0,
+                        std::numeric_limits<uint64_t>::max()});
+  subtractOccupiedBranchGatewaySlots(Gateways,
+                                     OccupiedBranchGatewaySlots);
+  BranchGatewayHeads =
+      buildBranchGatewayHeads(Gateways, OccupiedBranchGatewaySlots);
+  uint64_t BranchIslandChains = 0;
+  StillPending.clear();
+  StillPending.reserve(Pending.size());
+  const auto ForwardBranchPlanStart = std::chrono::steady_clock::now();
+  for (const PendingGateway &P : Pending) {
+    uint64_t OwnerOffset =
+        Ctx.OutTrampolines[P.TrampolineIndex].OriginalOffset;
+    BranchIslandFailure Failure;
+    std::optional<SmallVector<uint64_t, 4>> Islands =
+        allocateForwardBranchIslands(
+            Gateways, OwnerOffset, P.TargetOffset, &Failure,
+            &BranchGatewayHeads, &OccupiedBranchGatewaySlots,
+            PromoteBranchCapacityRelay);
+    if (!Islands || Islands->empty()) {
+      StillPending.push_back(P);
+      continue;
+    }
+    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    T.ForwardBranchIslands = std::move(*Islands);
+    T.ForwardBranchTargetOffset = P.TargetOffset;
+    if (T.LongBranchPreservesVcc)
+      std::memcpy(T.Bytes.data(), Ctx.LS.SNopBytes.data(), MinInstSize);
+    ++BranchIslandChains;
+    if (RemainingRelayDemand)
+      --RemainingRelayDemand;
+  }
+  Pending = std::move(StillPending);
+  log() << "hotswap: forward branch-island planning took "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - ForwardBranchPlanStart)
+               .count()
+        << " ms\n";
+  if (PromotionSgprContinuationAnalyses != 0)
+    log() << "hotswap: batched promotion SGPR continuation analysis built "
+          << PromotionSgprContinuationAnalyses << " function cache(s)\n";
+
+  if (!Pending.empty()) {
+    const PendingGateway &P = Pending.front();
+    const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    if (!T.UsesSetPCBack)
+      log() << "hotswap: error: no safe forward s_branch island chain for "
+               "registerless far site 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+    else
+      log() << "hotswap: error: no safe short-branch gateway for far site 0x"
+            << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
+            << " initial candidate slot(s), source_bytes=" << T.OriginalSize
+            << ", setpc_back=" << T.UsesSetPCBack
+            << ", preserve_vcc=" << T.LongBranchPreservesVcc
+            << ", use_vcc=" << T.LongBranchUsesVcc << ")\n";
+    return false;
+  }
+  if (AssignedGateways != 0)
     log() << "hotswap: assigned " << AssignedGateways
           << " SCC-neutral forward gateway(s)\n";
+  if (AssignedSplitVccGateways != 0)
+    log() << "hotswap: assigned " << AssignedSplitVccGateways
+          << " split VCC-preserving gateway(s)\n";
   if (BranchIslandChains != 0)
     log() << "hotswap: assigned " << BranchIslandChains
           << " forward s_branch island chain(s)\n";
+  if (ReturnBranchIslandChains != 0)
+    log() << "hotswap: assigned " << ReturnBranchIslandChains
+          << " return s_branch island chain(s)\n";
+  if (PromotedBranchCapacityRelays != 0)
+    log() << "hotswap: promoted " << PromotedBranchCapacityRelays
+          << " safe straight-line source(s) for branch-island capacity\n";
 
   for (Trampoline &T : Ctx.OutTrampolines) {
     if (T.HasForwardGateway) {
@@ -2277,6 +9323,17 @@ assignLongBranchGateways(PatchContext &Ctx,
       }
       std::memcpy(Ctx.Text + T.ForwardGatewayOffset,
                   T.ForwardGatewayBytes.data(), T.ForwardGatewayBytes.size());
+      if (!T.SecondaryForwardGatewayBytes.empty()) {
+        uint64_t Offset = T.SharedDispatcherSecondaryGatewayOffset;
+        if (Offset > Ctx.TextSize ||
+            T.SecondaryForwardGatewayBytes.size() > Ctx.TextSize - Offset) {
+          log() << "hotswap: error: secondary forward gateway at 0x"
+                << utohexstr(Offset) << " extends past .text.\n";
+          return false;
+        }
+        std::memcpy(Ctx.Text + Offset, T.SecondaryForwardGatewayBytes.data(),
+                    T.SecondaryForwardGatewayBytes.size());
+      }
     }
     for (size_t I = 0; I != T.ForwardBranchIslands.size(); ++I) {
       uint64_t From = T.ForwardBranchIslands[I];
@@ -2290,16 +9347,61 @@ assignLongBranchGateways(PatchContext &Ctx,
               << utohexstr(From) << "\n";
         return false;
       }
-      DenseMap<uint64_t, size_t>::const_iterator Owner =
+      DenseMap<uint64_t, PoolIslandOwner>::const_iterator Owner =
           PoolIslandOwners.find(From);
-      if (Owner != PoolIslandOwners.end()) {
-        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
-        std::memcpy(OwnerT.Bytes.data() + OwnerT.Bytes.size() -
-                        PoolBranchIslandBytes,
+      DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
+          SourceTailIslandOwners.find(From);
+      if (SourceOwner != SourceTailIslandOwners.end()) {
+        Trampoline &OwnerT = Ctx.OutTrampolines[SourceOwner->second];
+        if (!recordSourceTailBranchIsland(OwnerT, From, To)) {
+          log() << "hotswap: error: forward source-tail relay at 0x"
+                << utohexstr(From) << " has conflicting targets\n";
+          return false;
+        }
+      } else if (Owner != PoolIslandOwners.end()) {
+        Trampoline &OwnerT =
+            Ctx.OutTrampolines[Owner->second.TrampolineIndex];
+        std::memcpy(OwnerT.Bytes.data() + Owner->second.RelativeOffset,
                     Branch.data(), Branch.size());
       } else {
         if (From > Ctx.TextSize || Branch.size() > Ctx.TextSize - From) {
           log() << "hotswap: error: forward branch island at 0x"
+                << utohexstr(From) << " is outside .text and trampoline pool\n";
+          return false;
+        }
+        std::memcpy(Ctx.Text + From, Branch.data(), Branch.size());
+      }
+    }
+    for (size_t I = 0; I != T.ReturnBranchIslands.size(); ++I) {
+      uint64_t From = T.ReturnBranchIslands[I];
+      uint64_t To = I + 1 == T.ReturnBranchIslands.size()
+                        ? T.ReturnBranchTargetOffset
+                        : T.ReturnBranchIslands[I + 1];
+      SmallVector<uint8_t> Branch = Ctx.LS.encodeSBranch(From, To);
+      if (Branch.size() != MinInstSize) {
+        log() << "hotswap: error: failed to encode return branch island at 0x"
+              << utohexstr(From) << "\n";
+        return false;
+      }
+      DenseMap<uint64_t, PoolIslandOwner>::const_iterator Owner =
+          PoolIslandOwners.find(From);
+      DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
+          SourceTailIslandOwners.find(From);
+      if (SourceOwner != SourceTailIslandOwners.end()) {
+        Trampoline &OwnerT = Ctx.OutTrampolines[SourceOwner->second];
+        if (!recordSourceTailBranchIsland(OwnerT, From, To)) {
+          log() << "hotswap: error: return source-tail relay at 0x"
+                << utohexstr(From) << " has conflicting targets\n";
+          return false;
+        }
+      } else if (Owner != PoolIslandOwners.end()) {
+        Trampoline &OwnerT =
+            Ctx.OutTrampolines[Owner->second.TrampolineIndex];
+        std::memcpy(OwnerT.Bytes.data() + Owner->second.RelativeOffset,
+                    Branch.data(), Branch.size());
+      } else {
+        if (From > Ctx.TextSize || Branch.size() > Ctx.TextSize - From) {
+          log() << "hotswap: error: return branch island at 0x"
                 << utohexstr(From) << " is outside .text and trampoline pool\n";
           return false;
         }
@@ -2394,7 +9496,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       Elf.functionTextRanges();
   std::optional<DirectControlFlowInfo> ControlFlow = collectDirectBranchTargets(
       Decoded, LS, Elf.textAddr(), Elf.textSize(), DeclaredEntries->Entries,
-      FunctionRanges, DeclaredEntries->ExternalEntries);
+      FunctionRanges, DeclaredEntries->ExternalEntries,
+      ArrayRef<uint8_t>(Text, TextSize), &Elf, DeclaredEntries->NonCallEntries);
   if (!ControlFlow)
     return std::nullopt;
   if (ControlFlow->HasUnresolvedTargets) {
@@ -2524,9 +9627,12 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       expandStraightLineTrampolines(Ctx, ControlFlow->Targets);
       mergeAdjacentLongTrampolines(OutTrampolines, ControlFlow->Targets);
     }
+    if (!finalizeDeferredVccPreservation(Ctx))
+      return std::nullopt;
     appendPoolBranchIslands(OutTrampolines);
-    if (!assignLongBranchGateways(Ctx, ControlFlow->Targets,
-                                  !ControlFlow->HasUnresolvedTargets))
+    bool AllowTextGateways = !ControlFlow->HasUnresolvedTargets &&
+                             !ControlFlow->HasUnboundedIndirectEntries;
+    if (!assignLongBranchGateways(Ctx, ControlFlow->Targets, AllowTextGateways))
       return std::nullopt;
   }
 
@@ -2672,13 +9778,10 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
       return false;
     TrampOffset = *NextTrampOffset;
 
-    if (T.Long && !T.UsesSetPCBack) {
-      log() << "hotswap: error: far trampoline lacks safe set-PC return at 0x"
-            << utohexstr(T.OriginalOffset) << "\n";
-      return false;
-    }
     const uint32_t BackReserve =
-        T.UsesSetPCBack ? SetPcReturnReserveBytes : MinInstSize;
+        T.LongBranchPreservesVcc
+            ? VccPreservingReturnReserveBytes
+            : (T.UsesSetPCBack ? SetPcReturnReserveBytes : MinInstSize);
     const uint32_t TrailingIsland =
         T.HasPoolBranchIsland ? PoolBranchIslandBytes : 0;
     if (T.Bytes.size() < BackReserve + TrailingIsland) {
@@ -2695,11 +9798,35 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
       return false;
 
     std::optional<SmallVector<uint8_t>> BrBack;
-    if (T.UsesSetPCBack) {
-      BrBack =
-          encodeSetPCLongBranch(LS, BackSlot, *ReturnTo, T.LongBranchSgprBase);
+    if (T.LongBranchPreservesVcc) {
+      SmallVector<uint8_t> Save = assembleSingleInst(
+          "s_mov_b32 s" + std::to_string(T.LongBranchSgprBase) + ", vcc_lo",
+          LS);
+      std::optional<uint64_t> SetPcOffset = checkedAddUint64(
+          BackSlot, Save.size(), "VCC-preserving return set-PC offset");
+      uint64_t LandingDisplacement = T.UsesDirectSetPCForward
+                                         ? T.DirectSetPCForwardBytes.size()
+                                         : MinInstSize;
+      std::optional<uint64_t> Landing =
+          checkedAddUint64(T.OriginalOffset, LandingDisplacement,
+                           "VCC-preserving return landing offset");
+      if (Save.size() != VccMoveBytes || !SetPcOffset || !Landing)
+        return false;
+      std::optional<SmallVector<uint8_t>> SetPc = encodeSetPCLongBranch(
+          LS, *SetPcOffset, *Landing, T.LongBranchSgprBase, /*UseVcc=*/true);
+      if (SetPc) {
+        Save.append(SetPc->begin(), SetPc->end());
+        BrBack = std::move(Save);
+      }
+    } else if (T.UsesSetPCBack) {
+      BrBack = encodeSetPCLongBranch(LS, BackSlot, *ReturnTo,
+                                     T.LongBranchSgprBase, T.LongBranchUsesVcc);
     } else {
-      SmallVector<uint8_t> ShortBranch = LS.encodeSBranch(BackSlot, *ReturnTo);
+      uint64_t BranchTarget = T.ReturnBranchIslands.empty()
+                                  ? *ReturnTo
+                                  : T.ReturnBranchIslands.front();
+      SmallVector<uint8_t> ShortBranch =
+          LS.encodeSBranch(BackSlot, BranchTarget);
       if (!ShortBranch.empty())
         BrBack = std::move(ShortBranch);
     }
@@ -2716,7 +9843,30 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
 
     SmallVector<uint8_t> BrFwd;
     if (T.Long) {
-      if (T.UsesShortBranchForward) {
+      if (T.UsesSharedDispatcherForward) {
+        const std::string Pair =
+            "s[" + std::to_string(T.SharedDispatcherSgprBase) + ":" +
+            std::to_string(T.SharedDispatcherSgprBase + 1) + "]";
+        uint64_t BranchTarget =
+            T.SharedDispatcherRelayOffset    ? T.SharedDispatcherRelayOffset
+            : T.ForwardBranchIslands.empty() ? T.SharedDispatcherGatewayOffset
+                                             : T.ForwardBranchIslands.front();
+        BrFwd = encodeDirectCall(LS, T.OriginalOffset, BranchTarget, Pair);
+        if (BrFwd.size() != MinInstSize)
+          return false;
+      } else if (T.UsesMirroredStubForward) {
+        const std::string Pair =
+            T.LongBranchUsesVcc
+                ? "vcc"
+                : "s[" + std::to_string(T.LongBranchSgprBase) + ":" +
+                      std::to_string(T.LongBranchSgprBase + 1) + "]";
+        uint64_t BranchTarget = T.ForwardBranchIslands.empty()
+                                    ? T.MirroredStubGatewayOffset
+                                    : T.ForwardBranchIslands.front();
+        BrFwd = encodeDirectCall(LS, T.OriginalOffset, BranchTarget, Pair);
+        if (BrFwd.size() != MinInstSize)
+          return false;
+      } else if (T.UsesShortBranchForward) {
         BrFwd = LS.encodeSBranch(T.OriginalOffset, TP);
       } else if (!T.ForwardBranchIslands.empty()) {
         BrFwd =
@@ -2739,11 +9889,82 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
       return false;
     }
     std::memcpy(Text + T.OriginalOffset, BrFwd.data(), BrFwd.size());
+    uint32_t PadStart = BrFwd.size();
+    if (T.LongBranchPreservesVcc) {
+      uint64_t LandingDisplacement =
+          T.UsesDirectSetPCForward ? BrFwd.size() : MinInstSize;
+      if ((!T.UsesDirectSetPCForward && BrFwd.size() != MinInstSize) ||
+          LandingDisplacement > T.OriginalSize ||
+          VccLandingPadBytes > T.OriginalSize - LandingDisplacement) {
+        log() << "hotswap: error: VCC-preserving source window is invalid at "
+                 "0x"
+              << utohexstr(T.OriginalOffset) << "\n";
+        return false;
+      }
+      SmallVector<std::string, 2> RestoreLines;
+      RestoreLines.push_back("s_mov_b32 vcc_lo, s" +
+                             std::to_string(T.LongBranchSgprBase));
+      RestoreLines.push_back("s_delay_alu instid0(SALU_CYCLE_1)");
+      SmallVector<uint8_t> Restore =
+          assembleInstructions(joinAsmLines(RestoreLines), LS);
+      if (Restore.size() != VccRestoreSequenceBytes) {
+        log() << "hotswap: error: failed to encode VCC restore landing at 0x"
+              << utohexstr(T.OriginalOffset + LandingDisplacement) << "\n";
+        return false;
+      }
+      std::memcpy(Text + T.OriginalOffset + LandingDisplacement, Restore.data(),
+                  Restore.size());
+      PadStart = LandingDisplacement + VccLandingPadBytes;
+    }
+    if (T.HasSourceTailGateway) {
+      std::optional<uint64_t> GatewayEnd =
+          checkedAddUint64(T.SourceTailGatewayOffset, T.SourceTailGatewayBytes,
+                           "source-tail gateway end");
+      std::optional<uint64_t> SourceEnd = checkedAddUint64(
+          T.OriginalOffset, T.OriginalSize, "source-tail gateway source end");
+      if (!GatewayEnd || !SourceEnd ||
+          T.SourceTailGatewayOffset < T.OriginalOffset + PadStart ||
+          *GatewayEnd > *SourceEnd) {
+        log() << "hotswap: error: source-tail gateway overlaps the forward "
+                 "sequence at 0x"
+              << utohexstr(T.OriginalOffset) << "\n";
+        return false;
+      }
+    }
     // Pad the tail of the replaced slot with cached s_nop bytes.
-    for (uint32_t I = BrFwd.size(); I + MinInstSize <= T.OriginalSize;
-         I += MinInstSize)
+    for (uint32_t I = PadStart; I + MinInstSize <= T.OriginalSize;
+         I += MinInstSize) {
+      uint64_t Offset = T.OriginalOffset + I;
+      if (T.HasSourceTailGateway && Offset >= T.SourceTailGatewayOffset &&
+          Offset - T.SourceTailGatewayOffset < T.SourceTailGatewayBytes)
+        continue;
       std::memcpy(Text + T.OriginalOffset + I, LS.SNopBytes.data(),
                   MinInstSize);
+    }
+    for (const auto &[RelayOffset, RelayTarget] :
+         T.SourceTailBranchIslands) {
+      if (RelayOffset < T.OriginalOffset ||
+          RelayOffset - T.OriginalOffset < PadStart ||
+          RelayOffset - T.OriginalOffset > T.OriginalSize - MinInstSize ||
+          (T.HasSourceTailGateway &&
+           RelayOffset >= T.SourceTailGatewayOffset &&
+           RelayOffset - T.SourceTailGatewayOffset <
+               T.SourceTailGatewayBytes)) {
+        log() << "hotswap: error: source-tail branch island overlaps the "
+                 "forward sequence at 0x"
+              << utohexstr(T.OriginalOffset) << "\n";
+        return false;
+      }
+      SmallVector<uint8_t> Relay =
+          LS.encodeSBranch(RelayOffset, RelayTarget);
+      if (Relay.size() != MinInstSize) {
+        log() << "hotswap: error: source-tail branch island encoding failed "
+                 "at 0x"
+              << utohexstr(RelayOffset) << "\n";
+        return false;
+      }
+      std::memcpy(Text + RelayOffset, Relay.data(), Relay.size());
+    }
   }
   return true;
 }
@@ -2843,12 +10064,22 @@ static amd_comgr_status_t retargetCodeObjectImpl(
           << "parseable ELF64 (" << toString(ViewOrErr.takeError()) << ").\n";
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
   }
-  if (ViewOrErr->textSize() == 0) {
-    log() << "hotswap: error: retargetCodeObject: input ELF has empty "
-          << ".text section; nothing to rewrite.\n";
-    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
-  }
   ElfView &Elf = *ViewOrErr;
+  if (ViewOrErr->textSize() == 0) {
+    if (!Elf.isValidDataOnlyObject()) {
+      log() << "hotswap: error: retargetCodeObject: empty .text does not "
+               "describe a valid data-only code object.\n";
+      return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+    std::unique_ptr<WritableMemoryBuffer> Result =
+        copyOutputBuffer(ElfData, ElfSize, "data-only");
+    if (!Result)
+      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+    Out = std::move(Result);
+    log() << "hotswap: accepted data-only code object with empty .text; "
+             "returning a byte-identical copy.\n";
+    return AMD_COMGR_STATUS_SUCCESS;
+  }
   if (Prof)
     Profile.add(HotswapMetric::ElfParse, profNowNs() - ParseT0, 0);
 

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -243,7 +243,6 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
       }
       PendingWrites.push_back({DescOffset, std::move(NewBlob)});
     }
-
     if (Err) {
       log() << "hotswap: error: " << Context
             << ": failed to iterate AMDGPU notes: " << toString(std::move(Err))
@@ -479,6 +478,7 @@ ArrayRef<ElfView::FunctionTextRange> ElfView::cachedFunctionTextRanges() const {
   if (TextSizeValue > std::numeric_limits<uint64_t>::max() - TextBegin) {
     log() << "hotswap: error: function text range scan: .text virtual "
           << "address range overflows uint64_t.\n";
+    FunctionRangeCacheComplete = false;
     FunctionRangeCache.emplace();
     return *FunctionRangeCache;
   }
@@ -491,6 +491,7 @@ ArrayRef<ElfView::FunctionTextRange> ElfView::cachedFunctionTextRanges() const {
 
     Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
     if (!SymsOrErr) {
+      FunctionRangeCacheComplete = false;
       consumeError(SymsOrErr.takeError());
       continue;
     }
@@ -544,6 +545,168 @@ ArrayRef<ElfView::FunctionTextRange> ElfView::cachedFunctionTextRanges() const {
 std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
   ArrayRef<FunctionTextRange> Ranges = cachedFunctionTextRanges();
   return std::vector<FunctionTextRange>(Ranges.begin(), Ranges.end());
+}
+
+bool ElfView::functionTextRangesComplete() const {
+  (void)cachedFunctionTextRanges();
+  return FunctionRangeCacheComplete;
+}
+
+bool ElfView::isValidDataOnlyObject() const {
+  if (textSize() != 0) {
+    log() << "hotswap: error: data-only validation requires an empty .text "
+             "section.\n";
+    return false;
+  }
+
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if ((Shdr.sh_flags & ELF::SHF_EXECINSTR) != 0 && Shdr.sh_size != 0) {
+      Expected<StringRef> NameOrErr = File.getSectionName(Shdr);
+      if (!NameOrErr) {
+        log() << "hotswap: error: data-only validation found a non-empty "
+                 "executable section with an unreadable name: "
+              << toString(NameOrErr.takeError()) << "\n";
+        return false;
+      }
+      log() << "hotswap: error: data-only object has non-empty executable "
+               "section '"
+            << *NameOrErr << "'.\n";
+      return false;
+    }
+
+    if (Shdr.sh_type != ELF::SHT_SYMTAB && Shdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&Shdr);
+    if (!SymsOrErr) {
+      log() << "hotswap: error: data-only validation failed to read symbols: "
+            << toString(SymsOrErr.takeError()) << "\n";
+      return false;
+    }
+    Expected<StringRef> StrTabOrErr =
+        File.getStringTableForSymtab(Shdr, Sections);
+    if (!StrTabOrErr) {
+      log() << "hotswap: error: data-only validation failed to read the "
+               "symbol string table: "
+            << toString(StrTabOrErr.takeError()) << "\n";
+      return false;
+    }
+
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
+      if (!NameOrErr) {
+        log() << "hotswap: error: data-only validation found an unreadable "
+                 "symbol name: "
+              << toString(NameOrErr.takeError()) << "\n";
+        return false;
+      }
+      if ((Sym.getType() == ELF::STT_FUNC ||
+           Sym.getType() == ELF::STT_GNU_IFUNC) &&
+          Sym.st_shndx != ELF::SHN_UNDEF) {
+        if (Sym.st_shndx == TextSectionIndex)
+          log() << "hotswap: error: data-only object has a function/ifunc "
+                   "symbol in empty .text.\n";
+        else
+          log() << "hotswap: error: data-only object has defined "
+                   "function/ifunc symbol '"
+                << *NameOrErr << "'.\n";
+        return false;
+      }
+      if (NameOrErr->ends_with(".kd")) {
+        log() << "hotswap: error: data-only object has kernel descriptor "
+                 "symbol '"
+              << *NameOrErr << "'.\n";
+        return false;
+      }
+    }
+  }
+
+  bool SawMetadataNote = false;
+  auto validateMetadataNote = [&](ELFT::Note Note) {
+    if (Note.getName() != "AMDGPU" || Note.getType() != ELF::NT_AMDGPU_METADATA)
+      return true;
+    SawMetadataNote = true;
+
+    ArrayRef<uint8_t> Desc = Note.getDesc(4);
+    if (Desc.empty()) {
+      log() << "hotswap: error: data-only AMDGPU metadata note has an "
+               "empty descriptor.\n";
+      return false;
+    }
+    StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
+    msgpack::Document Doc;
+    if (!Doc.readFromBlob(Blob, false)) {
+      log() << "hotswap: error: failed to parse data-only AMDGPU metadata "
+               "note.\n";
+      return false;
+    }
+
+    msgpack::DocNode Root = Doc.getRoot();
+    if (!Root.isMap()) {
+      log() << "hotswap: error: data-only AMDGPU metadata root is not a map.\n";
+      return false;
+    }
+    msgpack::MapDocNode &RootMap = Root.getMap();
+    msgpack::DocNode::MapTy::iterator KernelsIt =
+        RootMap.find("amdhsa.kernels");
+    if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray()) {
+      log() << "hotswap: error: data-only AMDGPU metadata has no valid "
+               "amdhsa.kernels array.\n";
+      return false;
+    }
+    if (!KernelsIt->second.getArray().empty()) {
+      log() << "hotswap: error: data-only AMDGPU metadata claims "
+            << KernelsIt->second.getArray().size() << " kernel(s).\n";
+      return false;
+    }
+    return true;
+  };
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: data-only validation failed to read program "
+             "headers: "
+          << toString(PhdrsOrErr.takeError()) << "\n";
+    return false;
+  }
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_NOTE)
+      continue;
+
+    Error Err = Error::success();
+    for (ELFT::Note Note : File.notes(Phdr, Err))
+      if (!validateMetadataNote(Note))
+        return false;
+    if (Err) {
+      log() << "hotswap: error: data-only validation failed to iterate AMDGPU "
+               "notes: "
+            << toString(std::move(Err)) << "\n";
+      return false;
+    }
+  }
+
+  // Linked code objects normally expose metadata through PT_NOTE. Match
+  // COMGR's metadata lookup fallback for relocatable/unusual objects whose
+  // note exists only in the section table.
+  if (!SawMetadataNote) {
+    for (const ELFT::Shdr &Shdr : Sections) {
+      if (Shdr.sh_type != ELF::SHT_NOTE)
+        continue;
+
+      Error Err = Error::success();
+      for (ELFT::Note Note : File.notes(Shdr, Err))
+        if (!validateMetadataNote(Note))
+          return false;
+      if (Err) {
+        log()
+            << "hotswap: error: data-only validation failed to iterate AMDGPU "
+               "note sections: "
+            << toString(std::move(Err)) << "\n";
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 // -- ElfView::findKernelAtAddress ---------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -337,8 +337,7 @@ struct Trampoline {
   // dwords in a larger/coalesced source window can therefore serve as
   // independent registerless relays for other far edges. Each pair is
   // {source offset, branch target}.
-  llvm::SmallVector<std::pair<uint64_t, uint64_t>, 4>
-      SourceTailBranchIslands;
+  llvm::SmallVector<std::pair<uint64_t, uint64_t>, 4> SourceTailBranchIslands;
   // A larger unreachable source tail may hold a pair-only affine gateway.
   // fixupTrampolineBranches preserves this range instead of NOP-padding it.
   bool HasSourceTailGateway = false;
@@ -497,19 +496,18 @@ struct BranchIslandAllocatorTestResult {
 
 /// Exercise the late branch-island allocator without constructing an ELF.
 /// This is exposed for focused transactional/index invariant unit coverage.
-BranchIslandAllocatorTestResult runBranchIslandAllocatorForTest(
-    std::vector<NopSled> Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
-    uint64_t TargetOffset, bool Backward,
-    llvm::DenseSet<uint64_t> Occupied = {});
+BranchIslandAllocatorTestResult
+runBranchIslandAllocatorForTest(std::vector<NopSled> Gateways,
+                                uint64_t OwnerOffset, uint64_t FromOffset,
+                                uint64_t TargetOffset, bool Backward,
+                                llvm::DenseSet<uint64_t> Occupied = {});
 
 /// As above, but append one supplied gateway window at each recoverable
 /// strand. Records the number of provisional occupied dwords held when every
 /// promotion succeeds.
-BranchIslandAllocatorTestResult
-runBranchIslandAllocatorWithPromotionsForTest(
+BranchIslandAllocatorTestResult runBranchIslandAllocatorWithPromotionsForTest(
     std::vector<NopSled> Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
-    uint64_t TargetOffset, bool Backward,
-    llvm::ArrayRef<NopSled> Promotions);
+    uint64_t TargetOffset, bool Backward, llvm::ArrayRef<NopSled> Promotions);
 
 /// Return the decoded-source search band for one recoverable promotion. The
 /// band is clamped to starts whose set-PC tail can be one s_branch hop from
@@ -527,8 +525,7 @@ llvm::SmallVector<size_t, 8> promotionCandidateOrderForTest(
 
 /// Split free gateway ranges at already committed branch dwords.
 std::vector<NopSled> subtractOccupiedBranchGatewaySlotsForTest(
-    std::vector<NopSled> Gateways,
-    const llvm::DenseSet<uint64_t> &Occupied);
+    std::vector<NopSled> Gateways, const llvm::DenseSet<uint64_t> &Occupied);
 
 enum class MaskWorkaroundPolicy {
   None,
@@ -1674,24 +1671,24 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
 
 /// Return whether \p DI fully defines \p Register. A definition of a strict
 /// subregister is not a kill of the incoming full-register value.
-[[nodiscard]] bool
-instructionFullyWritesRegister(const InternalDecodedInst &DI,
-                               const LLVMState &LS,
-                               llvm::MCRegister Register);
+[[nodiscard]] bool instructionFullyWritesRegister(const InternalDecodedInst &DI,
+                                                  const LLVMState &LS,
+                                                  llvm::MCRegister Register);
 
 /// Return whether \p Replacement can observe the incoming value of \p
 /// Register before a full-register definition.
-[[nodiscard]] bool replacementNeedsIncomingRegister(
-    llvm::ArrayRef<uint8_t> Replacement, const LLVMState &LS,
-    llvm::MCRegister Register);
+[[nodiscard]] bool
+replacementNeedsIncomingRegister(llvm::ArrayRef<uint8_t> Replacement,
+                                 const LLVMState &LS,
+                                 llvm::MCRegister Register);
 
 /// Compute instruction offsets in one function range where the incoming value
 /// of \p Register may be observed before a full definition. Unknown control
 /// flow and exits are conservative.
-std::optional<llvm::DenseSet<uint64_t>> computeIncomingRegisterNeeds(
-    llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-    uint64_t FunctionBegin, uint64_t FunctionEnd,
-    llvm::MCRegister Register);
+std::optional<llvm::DenseSet<uint64_t>>
+computeIncomingRegisterNeeds(llvm::ArrayRef<InternalDecodedInst> Decoded,
+                             const LLVMState &LS, uint64_t FunctionBegin,
+                             uint64_t FunctionEnd, llvm::MCRegister Register);
 
 /// Resolve s0 through s(MaxSgprs - 1) to their physical MC registers.
 std::optional<llvm::SmallVector<llvm::MCRegister, 128>>
@@ -1727,8 +1724,7 @@ struct BatchedSgprContinuationTestResult {
 /// Build one compact per-function numbered-SGPR continuation analysis and
 /// query it at every requested offset. Exposed for scalar-oracle and cache
 /// reuse unit coverage.
-BatchedSgprContinuationTestResult
-runBatchedSgprContinuationAnalysisForTest(
+BatchedSgprContinuationTestResult runBatchedSgprContinuationAnalysisForTest(
     llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t FunctionBegin, uint64_t FunctionEnd,
     llvm::ArrayRef<uint64_t> Continuations,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -313,12 +313,19 @@ struct Trampoline {
   uint64_t OriginalOffset = 0;
   uint32_t OriginalSize = 0;
   llvm::SmallVector<uint8_t> Bytes;
-  // When set, the pool is beyond s_branch reach. The source site branches to a
-  // nearby NOP gateway, which uses the scratch-backed gfx12 set-PC sequence
-  // to reach the pool without executing s_add_pc_i64.
+  // When set, the pool is beyond s_branch reach. The source and return edges
+  // use safe branch islands and, when a dead register pair is available, the
+  // scratch-backed gfx12 set-PC sequence. Neither executes s_add_pc_i64.
   bool Long = false;
   bool UsesSetPCBack = false;
   unsigned LongBranchSgprBase = 0;
+  // When numbered SGPRs are exhausted, a far edge may use VCC after proving
+  // that the replacement does not consume its incoming value and that VCC is
+  // dead at the continuation.
+  bool LongBranchUsesVcc = false;
+  // A wave32 far edge may preserve live VCC_LO in one safe numbered SGPR.
+  // Its source tail is a restore-and-fallthrough landing pad.
+  bool LongBranchPreservesVcc = false;
   bool HasPoolBranchIsland = false;
   uint64_t PoolBranchIslandOffset = 0;
   bool UsesShortBranchForward = false;
@@ -326,9 +333,44 @@ struct Trampoline {
   llvm::SmallVector<uint8_t> DirectSetPCForwardBytes;
   llvm::SmallVector<uint64_t, 4> ForwardBranchIslands;
   uint64_t ForwardBranchTargetOffset = 0;
+  // Dwords after the source's forward sequence are unreachable. Safe tail
+  // dwords in a larger/coalesced source window can therefore serve as
+  // independent registerless relays for other far edges. Each pair is
+  // {source offset, branch target}.
+  llvm::SmallVector<std::pair<uint64_t, uint64_t>, 4>
+      SourceTailBranchIslands;
+  // A larger unreachable source tail may hold a pair-only affine gateway.
+  // fixupTrampolineBranches preserves this range instead of NOP-padding it.
+  bool HasSourceTailGateway = false;
+  uint64_t SourceTailGatewayOffset = 0;
+  uint32_t SourceTailGatewayBytes = 0;
+  llvm::SmallVector<uint64_t, 4> ReturnBranchIslands;
+  uint64_t ReturnBranchTargetOffset = 0;
   bool HasForwardGateway = false;
   uint64_t ForwardGatewayOffset = 0;
   llvm::SmallVector<uint8_t> ForwardGatewayBytes;
+  // Multiple 8-byte far sites can share one SCC-neutral gateway. Each source
+  // records its PC and branches to that gateway; a dispatcher prefixed to the
+  // first group trampoline maps the source PC to the corresponding body.
+  bool UsesSharedDispatcherForward = false;
+  uint32_t SharedDispatcherGroup = 0;
+  unsigned SharedDispatcherSgprBase = 0;
+  uint64_t SharedDispatcherGatewayOffset = 0;
+  uint64_t SharedDispatcherRelayOffset = 0;
+  uint64_t SharedDispatcherSecondaryGatewayOffset = 0;
+  llvm::SmallVector<uint8_t> SecondaryForwardGatewayBytes;
+  // Sites that only have their reserved far-return pair use s_call_i64 to
+  // record source+4 and share a relocation-neutral add/set-PC gateway. The
+  // recorded PC selects a sparse mirrored branch stub in the pool without a
+  // register-hungry classifier.
+  bool UsesMirroredStubForward = false;
+  uint32_t MirroredStubGroup = 0;
+  uint64_t MirroredStubGatewayOffset = 0;
+  uint32_t PoolEntryPrefixBytes = 0;
+  // A mirrored sparse prefix is initialized to NOPs except at its
+  // source-selected branch stubs. One unused dword near its midpoint can
+  // therefore be reserved as an unreachable object-wide branch relay without
+  // growing or shifting the pool layout.
   // A far-site run may only be coalesced within one known function. Unknown
   // ranges stay unmerged because adjacent symbols are independent entries.
   bool HasFunctionRange = false;
@@ -440,7 +482,53 @@ struct NopSled {
   uint64_t WritePos = 0;
   uint64_t FunctionStart = 0;
   uint64_t FunctionEnd = 0;
+  // Some unreachable source-tail ranges are reserved for one contiguous
+  // set-PC gateway. Branch-island allocators must not fragment these ranges.
+  bool GatewayOnly = false;
 };
+
+struct BranchIslandAllocatorTestResult {
+  bool Success = false;
+  llvm::SmallVector<uint64_t, 4> Islands;
+  llvm::SmallVector<size_t, 4> HeldIslandCountsAtPromotion;
+  std::vector<NopSled> Gateways;
+  llvm::DenseSet<uint64_t> Occupied;
+};
+
+/// Exercise the late branch-island allocator without constructing an ELF.
+/// This is exposed for focused transactional/index invariant unit coverage.
+BranchIslandAllocatorTestResult runBranchIslandAllocatorForTest(
+    std::vector<NopSled> Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
+    uint64_t TargetOffset, bool Backward,
+    llvm::DenseSet<uint64_t> Occupied = {});
+
+/// As above, but append one supplied gateway window at each recoverable
+/// strand. Records the number of provisional occupied dwords held when every
+/// promotion succeeds.
+BranchIslandAllocatorTestResult
+runBranchIslandAllocatorWithPromotionsForTest(
+    std::vector<NopSled> Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
+    uint64_t TargetOffset, bool Backward,
+    llvm::ArrayRef<NopSled> Promotions);
+
+/// Return the decoded-source search band for one recoverable promotion. The
+/// band is clamped to starts whose set-PC tail can be one s_branch hop from
+/// CurrentOffset; exact reachability remains a per-candidate check.
+std::pair<uint64_t, uint64_t>
+branchPromotionSearchRangeForTest(uint64_t CurrentOffset,
+                                  uint64_t CorridorOffset, bool Forward);
+
+/// Return the decoded candidate indices visited by the promotion cursor after
+/// permanently rejected starts are removed. Forward corridors scan from high
+/// to low addresses; backward corridors scan from low to high addresses.
+llvm::SmallVector<size_t, 8> promotionCandidateOrderForTest(
+    size_t CandidateCount, llvm::ArrayRef<size_t> PermanentlyRejected,
+    size_t BeginIndex, size_t EndIndex, bool Forward);
+
+/// Split free gateway ranges at already committed branch dwords.
+std::vector<NopSled> subtractOccupiedBranchGatewaySlotsForTest(
+    std::vector<NopSled> Gateways,
+    const llvm::DenseSet<uint64_t> &Occupied);
 
 enum class MaskWorkaroundPolicy {
   None,
@@ -477,6 +565,13 @@ static constexpr uint32_t MinInstSize = 4;
 static constexpr uint32_t SetPcReturnReserveBytes = 20;
 
 static constexpr uint32_t SetPcForwardSequenceBytes = SetPcReturnReserveBytes;
+static constexpr uint32_t VccMoveBytes = MinInstSize;
+static constexpr uint32_t VccRestoreSequenceBytes = 2 * MinInstSize;
+static constexpr uint32_t VccPreservingReturnReserveBytes =
+    VccMoveBytes + SetPcReturnReserveBytes;
+static constexpr uint32_t VccLandingPadBytes = VccRestoreSequenceBytes;
+static constexpr uint32_t VccPreservingSourceBytes =
+    MinInstSize + VccLandingPadBytes;
 static constexpr uint32_t PoolBranchIslandBytes = MinInstSize;
 
 // s_branch encoding: 16-bit signed dword offset field bounds. Used by
@@ -558,6 +653,17 @@ public:
   /// Enumerate function symbol ranges in `.text` using virtual addresses.
   /// Zero-size symbols extend to the next function symbol or `.text` end.
   std::vector<FunctionTextRange> functionTextRanges() const;
+
+  /// Return whether every symbol table was parsed while building the function
+  /// range cache. Consumers that use the ranges as a closed-world target set
+  /// must reject an incomplete cache.
+  bool functionTextRangesComplete() const;
+
+  /// Validate that an object with a present, empty `.text` section contains
+  /// data only: no executable section contents, no defined function/ifunc
+  /// symbols, no kernel descriptor symbols, and no AMDGPU metadata kernel
+  /// entries. Malformed symbol tables, notes, or metadata fail closed.
+  bool isValidDataOnlyObject() const;
 
   /// Find the kernel function symbol whose range includes \p TextAddress.
   /// Returns "" if no matching function symbol exists.
@@ -738,6 +844,7 @@ private:
   const ELFT::Shdr *TextSection;
   unsigned TextSectionIndex;
   mutable std::optional<std::vector<FunctionTextRange>> FunctionRangeCache;
+  mutable bool FunctionRangeCacheComplete = true;
   mutable std::optional<std::vector<KernelDescriptorInfo>>
       KernelDescriptorCache;
   mutable llvm::StringMap<uint64_t> KernelDescriptorFileOffsetCache;
@@ -1122,6 +1229,31 @@ struct VgprAllocator {
     return Base;
   }
 
+  /// Allocate \p N contiguous VGPRs above the kernel count without crossing a
+  /// \p BankSize-register boundary. Textual AMDGPU assembly only names
+  /// v0-v255; keeping a generated operand in one physical bank lets a caller
+  /// encode its low bits under one s_set_vgpr_msb mode.
+  std::optional<unsigned>
+  allocContiguousAboveKdInBank(unsigned N, unsigned Align = 2,
+                               unsigned BankSize = 256) {
+    if (N == 0 || N > BankSize)
+      return std::nullopt;
+    unsigned OldNext = NextAboveKd;
+    unsigned Base = NextAboveKd;
+    if (Align > 1 && (Base % Align) != 0)
+      Base += Align - (Base % Align);
+    if (Base / BankSize != (Base + N - 1) / BankSize)
+      Base = ((Base / BankSize) + 1) * BankSize;
+    if (Align > 1 && (Base % Align) != 0)
+      Base += Align - (Base % Align);
+    if (Base + N > MaxVgprs)
+      return std::nullopt;
+    ExtraAllocated += (Base + N) - OldNext;
+    LiveAtPoint.set(Base, Base + N);
+    NextAboveKd = Base + N;
+    return Base;
+  }
+
   unsigned extraVgprsNeeded() const { return ExtraAllocated; }
 };
 
@@ -1211,8 +1343,53 @@ struct SafeSgprUsageSummary {
 
 struct DirectControlFlowInfo {
   llvm::DenseSet<uint64_t> Targets;
+  // Register-based transfers whose complete finite target set was proven.
+  // These do not make every instruction in their containing function a
+  // potential indirect destination.
+  llvm::DenseSet<uint64_t> BoundedIndirectTransfers;
+  // A reachable indirect transfer can enter bytes that are not represented
+  // by an original instruction or symbol, including synthetic source tails
+  // created while planning gateways. Keep this distinct from unresolved call
+  // targets, which conservatively disable all control-flow-sensitive
+  // mutations.
+  bool HasUnboundedIndirectEntries = false;
   bool HasUnresolvedTargets = false;
 };
+
+/// A synthetic source-tail interval is only safe when the complete replaced
+/// source belongs to exactly one distinct function range. Equal bounds from a
+/// global function's .symtab/.dynsym records are one logical range; differing
+/// nested or overlapping function bounds fail closed.
+bool sourceHasUniqueFunctionRange(
+    const Trampoline &T,
+    llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    uint64_t TextAddr);
+
+/// Indexed implementation of the same uniqueness predicate, exposed so unit
+/// tests can compare it against the simple linear oracle.
+bool sourceHasUniqueFunctionRangeIndexedForTest(
+    const Trampoline &T,
+    llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    uint64_t TextAddr);
+
+/// Return whether [Begin, End) is an entry-free interval strictly after the
+/// first source dword. The caller supplies the unique-function proof so dense
+/// objects can cache it per function instead of rescanning their symbol table
+/// for every patch site.
+bool isSafeSourceTailRange(const Trampoline &T,
+                           const DirectControlFlowInfo &ControlFlow,
+                           bool HasUniqueFunctionRange, uint64_t Begin,
+                           uint64_t End);
+
+/// Return whether the source's second dword must remain owner-only until its
+/// registerless far-return chain is allocated. Such a tail must not be offered
+/// to an earlier affine forward planner.
+bool mustReserveSourceTailForRegisterlessReturn(const Trampoline &T);
+
+/// Return the only source-local window a registerless source may offer to the
+/// early affine planner. The owner-reserved second dword is excluded.
+std::optional<std::pair<uint64_t, uint64_t>>
+registerlessSourceAffineGatewayRange(const Trampoline &T);
 
 // Per-instruction persistent gfx1250 VGPR-MSB mode (packed src0/src1/src2/dst,
 // two bits each, values 0-255) recovered by the WMMA split pass's
@@ -1281,6 +1458,32 @@ struct PatchContext {
   llvm::StringMap<unsigned> KernelVgprGranuleCache;
 };
 
+enum class VgprMsbOperand : unsigned {
+  Src0 = 0,
+  Src1 = 2,
+  Src2 = 4,
+  Dst = 6,
+};
+
+/// Populate PatchContext::VgprMsbModeBefore if it has not been computed yet.
+void ensureVgprMsbModes(PatchContext &Ctx);
+
+/// Return the exact VGPR-MSB mode before Decoded[Idx] proven by whole-function
+/// CFG analysis.
+[[nodiscard]] std::optional<unsigned> getActiveVgprMsbMode(PatchContext &Ctx,
+                                                           size_t Idx);
+
+/// Recover an exact mode by scanning backward through the local straight-line
+/// instruction sequence containing \p Idx. This is intentionally separate
+/// from CFG mode recovery: only a lowering whose original operands already
+/// depend on the local setter may use it when unrelated opaque control flow
+/// prevents object-wide analysis.
+[[nodiscard]] std::optional<unsigned>
+getLocallyEstablishedVgprMsbMode(PatchContext &Ctx, size_t Idx);
+
+unsigned getVgprMsbBank(unsigned Mode, VgprMsbOperand Operand);
+void setVgprMsbBank(unsigned &Mode, VgprMsbOperand Operand, unsigned Bank);
+
 /// Return occupancy limits for \p Processor from COMGR's ISA metadata table.
 std::optional<SubtargetOccupancyLimits>
 getSubtargetOccupancyLimits(llvm::StringRef Processor);
@@ -1322,7 +1525,8 @@ struct SafeSgprScratchBlock {
 /// nullopt after logging when no block fits below RewriteConfig::MaxSgprs.
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
-                         unsigned Alignment, llvm::StringRef Context);
+                         unsigned Alignment, llvm::StringRef Context,
+                         bool ReportNoSpace = true);
 
 /// Charge a previously selected global block to the kernel owning \p
 /// TextOffset. If the site is in an ordinary device function, conservatively
@@ -1341,33 +1545,56 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                     uint32_t InstSize,
                                     llvm::ArrayRef<uint8_t> Replacement);
 
-/// Encode an SCC-neutral indirect long branch using the aligned SGPR pair at
-/// \p SgprBase. The displacement uses gfx12's s_add_nc_u64; no s_add_pc_i64
+/// Encode an SCC-neutral indirect long branch using either the aligned
+/// numbered pair at \p SgprBase or VCC when \p UseVcc is true. The caller must
+/// prove VCC dead across the edge or preserve its wave32 low half before
+/// selecting it. The displacement uses gfx12's s_add_nc_u64; no s_add_pc_i64
 /// is emitted.
 std::optional<llvm::SmallVector<uint8_t>>
 encodeSetPCLongBranch(const LLVMState &LS, uint64_t FromOffset,
-                      uint64_t TargetOffset, unsigned SgprBase);
+                      uint64_t TargetOffset, unsigned SgprBase,
+                      bool UseVcc = false);
 
 struct EncodedSetPcGateway {
   NopSled *Sled = nullptr;
   llvm::SmallVector<uint8_t> Bytes;
 };
 
+struct EncodedSplitVccGateway {
+  size_t PrimaryIndex = 0;
+  size_t SecondaryIndex = 0;
+  llvm::SmallVector<uint8_t> PrimaryBytes;
+  llvm::SmallVector<uint8_t> SecondaryBytes;
+};
+
+/// Plan an eight-byte VCC-save/branch primary and a disjoint 16-byte
+/// VCC-backed set-PC secondary. The returned plan does not advance either
+/// sled or modify text.
+std::optional<EncodedSplitVccGateway>
+findSplitVccGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
+                    uint64_t FromOffset, uint64_t TargetOffset,
+                    unsigned SaveSgpr,
+                    const llvm::DenseSet<uint64_t> *Occupied = nullptr);
+
 /// Find the nearest short-branch-reachable gateway whose remaining space fits
 /// the set-PC sequence. Candidate widths are computed from the displacement;
-/// only the selected candidate is encoded. The returned plan does not advance
-/// the sled or modify text.
+/// only the selected candidate is encoded. When \p PreserveVcc is true,
+/// prepend a VCC_LO save to \p SgprBase. The returned plan does not advance the
+/// sled or modify text.
 llvm::Expected<std::optional<EncodedSetPcGateway>>
 findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                         uint64_t FromOffset, uint64_t TargetOffset,
-                        unsigned SgprBase);
+                        unsigned SgprBase, bool UseVcc = false,
+                        bool PreserveVcc = false,
+                        const llvm::DenseSet<uint64_t> *Occupied = nullptr);
 
 /// Count set-PC gateway slots reachable from \p FromOffset, up to \p MaxSlots.
 /// Candidate widths are computed without assembly. Zero means that no
 /// candidate fits; an Error means that a reachable candidate is invalid.
 llvm::Expected<uint64_t> countReachableSetPcGatewaySlots(
     llvm::ArrayRef<NopSled> Gateways, const LLVMState &LS, uint64_t FromOffset,
-    uint64_t TargetOffset, unsigned SgprBase, uint64_t MaxSlots);
+    uint64_t TargetOffset, unsigned SgprBase, uint64_t MaxSlots,
+    bool UseVcc = false, bool PreserveVcc = false);
 
 /// Return whether an s_branch at \p From can encode \p To, including the
 /// instruction-relative PC base, alignment, signed range, and overflow checks.
@@ -1379,6 +1606,18 @@ bool isSBranchReachable(uint64_t From, uint64_t To);
 std::optional<uint64_t>
 evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
                                 const LLVMState &LS);
+
+/// Match the exact decoded operand layout of a canonical v_readlane_b32 or
+/// v_writelane_b32 frame transfer. Writelane additionally requires its tied
+/// incoming-VGPR operand to equal the destination.
+bool matchesCanonicalLaneTransfer(const InternalDecodedInst &DI,
+                                  llvm::StringRef Mnemonic,
+                                  llvm::MCRegister Dst, llvm::MCRegister Src,
+                                  int64_t Lane);
+
+/// Return whether an instruction truly changes the hardware PC. This excludes
+/// EXEC-mask operations that generic MC analysis may classify as branches.
+bool isTruePcTransfer(const InternalDecodedInst &DI, const LLVMState &LS);
 
 /// A canonical get-PC/add materialized address feeding a PC-materialized
 /// transfer (s_get_pc_i64 / s_add_nc_u64 / s_{swap,set}_pc_i64). \p Target is
@@ -1413,15 +1652,87 @@ resolveMaterializedPcTarget(llvm::ArrayRef<InternalDecodedInst> Decoded,
 /// contains text-relative function and kernel entry offsets; \p FunctionRanges
 /// supplies the symbol ranges used for the return proof; \p ExternalEntries
 /// identifies externally reachable symbol and kernel entries, including
-/// aliases at a local function's start. Other register-target control flow
-/// sets HasUnresolvedTargets so callers can disable transformations that
-/// consume possible destinations.
+/// aliases at a local function's start. Unresolved calls set
+/// HasUnresolvedTargets so callers can disable transformations that consume
+/// possible destinations. Other reachable register-target control flow sets
+/// HasUnboundedIndirectEntries so synthetic source tails are not created.
 std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextSize,
     llvm::ArrayRef<uint64_t> DeclaredEntries,
     llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges = {},
-    llvm::ArrayRef<uint64_t> ExternalEntries = {});
+    llvm::ArrayRef<uint64_t> ExternalEntries = {},
+    llvm::ArrayRef<uint8_t> Text = {}, const ElfView *Elf = nullptr,
+    llvm::ArrayRef<uint64_t> NonCallEntries = {});
+
+/// Return whether \p DI consumes the incoming value of \p Register, including
+/// explicit read/modify/write destinations represented by MC tied-operand
+/// constraints. This conservative query underpins scratch-register liveness.
+[[nodiscard]] bool instructionReadsRegister(const InternalDecodedInst &DI,
+                                            const LLVMState &LS,
+                                            llvm::MCRegister Register);
+
+/// Return whether \p DI fully defines \p Register. A definition of a strict
+/// subregister is not a kill of the incoming full-register value.
+[[nodiscard]] bool
+instructionFullyWritesRegister(const InternalDecodedInst &DI,
+                               const LLVMState &LS,
+                               llvm::MCRegister Register);
+
+/// Return whether \p Replacement can observe the incoming value of \p
+/// Register before a full-register definition.
+[[nodiscard]] bool replacementNeedsIncomingRegister(
+    llvm::ArrayRef<uint8_t> Replacement, const LLVMState &LS,
+    llvm::MCRegister Register);
+
+/// Compute instruction offsets in one function range where the incoming value
+/// of \p Register may be observed before a full definition. Unknown control
+/// flow and exits are conservative.
+std::optional<llvm::DenseSet<uint64_t>> computeIncomingRegisterNeeds(
+    llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t FunctionBegin, uint64_t FunctionEnd,
+    llvm::MCRegister Register);
+
+/// Resolve s0 through s(MaxSgprs - 1) to their physical MC registers.
+std::optional<llvm::SmallVector<llvm::MCRegister, 128>>
+resolveNumberedSgprRegisters(const llvm::MCRegisterInfo &MRI,
+                             unsigned MaxSgprs);
+
+/// Collect numbered SGPR uses and definitions using MC register overlap, so
+/// tuple and subregister operands conservatively affect their numbered SGPRs.
+void getNumberedSgprUsesAndDefs(const InternalDecodedInst &DI,
+                                const LLVMState &LS,
+                                llvm::ArrayRef<llvm::MCRegister> NumberedSgprs,
+                                llvm::BitVector &Uses, llvm::BitVector &Defs);
+
+/// Return numbered SGPR incoming values observed by a replacement before a
+/// definition, conservatively retaining values at malformed or opaque control
+/// flow.
+llvm::BitVector unsafeIncomingNumberedSgprsInReplacement(
+    llvm::ArrayRef<uint8_t> Replacement, const LLVMState &LS,
+    llvm::ArrayRef<llvm::MCRegister> NumberedSgprs);
+
+/// Return numbered SGPR incoming values that may be read before a definition,
+/// or remain live at an opaque or invalid control-flow boundary.
+std::optional<llvm::BitVector> unsafeIncomingNumberedSgprsInRange(
+    llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t FunctionBegin, uint64_t FunctionEnd, uint64_t Continuation,
+    llvm::ArrayRef<llvm::MCRegister> NumberedSgprs);
+
+struct BatchedSgprContinuationTestResult {
+  uint64_t Analyses = 0;
+  llvm::SmallVector<std::optional<llvm::BitVector>, 8> Queries;
+};
+
+/// Build one compact per-function numbered-SGPR continuation analysis and
+/// query it at every requested offset. Exposed for scalar-oracle and cache
+/// reuse unit coverage.
+BatchedSgprContinuationTestResult
+runBatchedSgprContinuationAnalysisForTest(
+    llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t FunctionBegin, uint64_t FunctionEnd,
+    llvm::ArrayRef<uint64_t> Continuations,
+    llvm::ArrayRef<llvm::MCRegister> NumberedSgprs);
 
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
@@ -1435,6 +1746,14 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
 [[nodiscard]] std::optional<std::vector<std::string>>
 expandDs2Addr(const llvm::MCInst &Inst, llvm::StringRef FromMnem,
               llvm::StringRef ToMnem, const LLVMState &LS);
+
+/// Rewrite a representable gfx1250 B0 DS2 offset pair to A0 byte offsets
+/// without changing the instruction's opcode, registers, or size. The narrow
+/// entry-local form is exposed so MC tests can verify its exact bytes.
+[[nodiscard]] bool
+rewriteDs2AddrOffsetsInPlace(llvm::MutableArrayRef<uint8_t> InstBytes,
+                             const llvm::MCInst &Inst, llvm::StringRef Mnemonic,
+                             const LLVMState &LS);
 
 // -- Patch dispatch vtable ----------------------------------------------------
 //

--- a/amd/comgr/src/comgr-hotswap-occupancy.cpp
+++ b/amd/comgr/src/comgr-hotswap-occupancy.cpp
@@ -225,6 +225,19 @@ VgprBumpDecision checkKernelVgprBump(PatchContext &Ctx, StringRef KernelName,
   if (!Capacity)
     return failOrDeclineVgprBump(Ctx, Requirement);
 
+  // Some input kernels already reserve enough VGPRs that their declared
+  // maximum workgroup cannot meet the generic waves/EU target. Do not reject
+  // a bump merely because it cannot repair that pre-existing condition: the
+  // patch is occupancy-neutral when the proposed allocation admits at least
+  // as many waves as the input allocation.
+  std::optional<WorkgroupCapacity> CurrentCapacity = computeWorkgroupCapacity(
+      *CurrentVgprs, Cached->second->MaxFlatWorkgroupSize,
+      Cached->second->WavefrontSize, *Limits);
+  if (!CurrentCapacity)
+    return failOrDeclineVgprBump(Ctx, Requirement);
+  if (Capacity->AchievableWavesPerEU >= CurrentCapacity->AchievableWavesPerEU)
+    return VgprBumpDecision::Apply;
+
   VgprBumpDecision Decision = decideVgprBump(Requirement, *Capacity);
   if (Decision == VgprBumpDecision::Apply)
     return Decision;

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -42,6 +42,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <vector>
 
 using namespace llvm;
@@ -167,6 +168,12 @@ std::string fmtOffset(uint32_t Offset) {
 // this field directly, so any scaled byte offset that exceeds it cannot
 // be represented and the patch must be skipped.
 constexpr uint32_t Ds1AddrOffsetMax = 0xFFFF;
+// The gfx1250 DS two-address encoding has two eight-bit offset fields in the
+// low 16 bits of the instruction. B0 interprets non-stride64 fields as element
+// indices, while A0 requires byte offsets aligned to the payload size. When
+// both scaled byte offsets still fit in eight bits, rewriting the two fields
+// in place is an exact, entry-local fix and avoids a trampoline entirely.
+constexpr uint32_t Ds2AddrOffsetMax = 0xFF;
 
 struct DsOperands {
   SmallVector<MCRegister, 4> Regs;
@@ -402,6 +409,115 @@ std::optional<std::vector<std::string>> expandDs2AddrImpl(const MCInst &Inst,
   return std::nullopt;
 }
 
+bool rewriteDs2AddrOffsetsInPlaceImpl(MutableArrayRef<uint8_t> InstBytes,
+                                      StringRef Mnemonic,
+                                      const DsOperands &Ops) {
+  // Every non-stride64 DS2 family uses the same two eight-bit fields. This
+  // rewrite changes only those fields, so load/exchange destination overlap
+  // and split-counter concerns do not apply: the opcode, register operands,
+  // modifiers, instruction count, and entry behavior are unchanged.
+  if (getDs2AddrReplacement(Mnemonic).empty() ||
+      Mnemonic.contains("_stride64_") ||
+      Ops.Off0 > Ds2AddrOffsetMax || Ops.Off1 > Ds2AddrOffsetMax ||
+      InstBytes.size() != 2 * MinInstSize)
+    return false;
+
+  // gfx1250 DS2 offset0/offset1 occupy instruction bits [7:0]/[15:8].
+  // Keep every opcode/register/modifier bit byte-for-byte identical.
+  InstBytes[0] = static_cast<uint8_t>(Ops.Off0);
+  InstBytes[1] = static_cast<uint8_t>(Ops.Off1);
+  return true;
+}
+
+bool hasUnencodableVgprName(StringRef Asm) {
+  for (size_t Pos = Asm.find('v'); Pos != StringRef::npos;
+       Pos = Asm.find('v', Pos + 1)) {
+    StringRef Tail = Asm.substr(Pos + 1);
+    Tail.consume_front("[");
+    unsigned Index = 0;
+    if (!Tail.consumeInteger(10, Index) && Index > 255)
+      return true;
+  }
+  return false;
+}
+
+bool normalizeVgprOperand(StringRef Input, VgprMsbOperand Role, unsigned &Mode,
+                          std::string &Output) {
+  StringRef Operand = Input.trim();
+  StringRef Suffix;
+  size_t Space = Operand.find(' ');
+  if (Space != StringRef::npos) {
+    Suffix = Operand.substr(Space);
+    Operand = Operand.take_front(Space);
+  }
+  if (!Operand.consume_front("v")) {
+    Output = Input.trim().str();
+    return true;
+  }
+
+  bool IsRange = Operand.consume_front("[");
+  if (IsRange && !Operand.consume_back("]"))
+    return false;
+  StringRef LoText;
+  StringRef HiText;
+  std::tie(LoText, HiText) = Operand.split(':');
+  if (!IsRange)
+    LoText = HiText = Operand;
+  if (LoText.empty() || HiText.empty())
+    return false;
+
+  unsigned Lo = 0;
+  unsigned Hi = 0;
+  if (LoText.getAsInteger(10, Lo) || HiText.getAsInteger(10, Hi) || Hi < Lo ||
+      Lo / 256 != Hi / 256)
+    return false;
+  unsigned Bank = Lo / 256;
+  if (Bank > 3)
+    return false;
+  setVgprMsbBank(Mode, Role, Bank);
+  if (IsRange)
+    Output =
+        ("v[" + Twine(Lo & 255) + ":" + Twine(Hi & 255) + "]" + Suffix).str();
+  else
+    Output = ("v" + Twine(Lo & 255) + Suffix).str();
+  return true;
+}
+
+std::optional<std::pair<std::string, unsigned>>
+normalizeDsVgprBanks(StringRef Asm, StringRef FromMnem, unsigned OldMode) {
+  size_t MnemEnd = Asm.find(' ');
+  if (MnemEnd == StringRef::npos)
+    return std::nullopt;
+  StringRef Mnem = Asm.take_front(MnemEnd);
+  SmallVector<StringRef, 3> Operands;
+  Asm.substr(MnemEnd + 1)
+      .split(Operands, ',', /*MaxSplit=*/-1,
+             /*KeepEmpty=*/false);
+
+  SmallVector<VgprMsbOperand, 3> Roles;
+  if (FromMnem.starts_with("ds_load_"))
+    Roles = {VgprMsbOperand::Dst, VgprMsbOperand::Src0};
+  else if (FromMnem.starts_with("ds_storexchg_"))
+    Roles = {VgprMsbOperand::Dst, VgprMsbOperand::Src0, VgprMsbOperand::Src1};
+  else if (FromMnem.starts_with("ds_store_"))
+    Roles = {VgprMsbOperand::Src0, VgprMsbOperand::Src1};
+  else
+    return std::nullopt;
+  if (Operands.size() != Roles.size())
+    return std::nullopt;
+
+  unsigned NewMode = OldMode;
+  std::string Normalized = Mnem.str();
+  for (unsigned I = 0; I != Operands.size(); ++I) {
+    std::string Operand;
+    if (!normalizeVgprOperand(Operands[I], Roles[I], NewMode, Operand))
+      return std::nullopt;
+    Normalized += I == 0 ? " " : ", ";
+    Normalized += Operand;
+  }
+  return std::pair<std::string, unsigned>{std::move(Normalized), NewMode};
+}
+
 // -- patchDs2Addr -----------------------------------------------------------
 //
 // Expand one ds_*_2addr_* instruction (stride64 or non-stride64) into two
@@ -416,14 +532,63 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   StringRef ToMnem = getDs2AddrReplacement(DI.Mnemonic);
   if (ToMnem.empty())
     return false;
+  std::optional<DsOperands> Ops =
+      extractDsOperands(DI.Inst, DI.Mnemonic, Ctx.LS);
+  if (!Ops)
+    return failRequiredPatch(Ctx);
+  if (DI.Offset <= Ctx.TextSize && DI.Size <= Ctx.TextSize - DI.Offset &&
+      rewriteDs2AddrOffsetsInPlaceImpl(
+          MutableArrayRef<uint8_t>(Ctx.Text + DI.Offset, DI.Size), DI.Mnemonic,
+          *Ops)) {
+    log() << "hotswap: rewrote " << DI.Mnemonic << " at 0x"
+          << utohexstr(DI.Offset) << " in place with A0 byte offsets "
+          << Ops->Off0 << ", " << Ops->Off1 << "\n";
+    DI.Mnemonic = "<replaced>";
+    return true;
+  }
   std::optional<std::vector<std::string>> Expanded =
       expandDs2AddrImpl(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
   if (!Expanded)
     return failRequiredPatch(Ctx);
 
+  bool NeedsBankNormalization =
+      llvm::any_of(*Expanded, [](const std::string &Asm) {
+        return hasUnencodableVgprName(Asm);
+      });
+  std::optional<unsigned> ActiveMode;
+  if (NeedsBankNormalization) {
+    ActiveMode = getActiveVgprMsbMode(Ctx, Idx);
+    if (!ActiveMode) {
+      log() << "hotswap: error: ds_2addr at 0x" << utohexstr(DI.Offset)
+            << " crosses v255 but the active VGPR-MSB mode is unknown\n";
+      return failRequiredPatch(Ctx);
+    }
+  }
+
   std::string Combined;
-  for (const std::string &Line : *Expanded)
-    Combined += Line + "\n";
+  for (const std::string &Line : *Expanded) {
+    if (!NeedsBankNormalization) {
+      Combined += Line + "\n";
+      continue;
+    }
+    std::optional<std::pair<std::string, unsigned>> Normalized =
+        normalizeDsVgprBanks(Line, DI.Mnemonic, *ActiveMode);
+    if (!Normalized) {
+      log() << "hotswap: error: ds_2addr at 0x" << utohexstr(DI.Offset)
+            << " has a VGPR operand that crosses a 256-register bank\n";
+      return failRequiredPatch(Ctx);
+    }
+    unsigned NewMode = Normalized->second;
+    if (NewMode != *ActiveMode)
+      Combined +=
+          ("s_set_vgpr_msb " + Twine(NewMode | (*ActiveMode << 8)) + "\n")
+              .str();
+    Combined += Normalized->first + "\n";
+    if (NewMode != *ActiveMode)
+      Combined +=
+          ("s_set_vgpr_msb " + Twine(*ActiveMode | (NewMode << 8)) + "\n")
+              .str();
+  }
   // Drain the DS counter right after the split pair so both halves are
   // guaranteed complete before any downstream consumer. The original code
   // tracked completion of the single 2-addr instruction via a later
@@ -1846,6 +2011,14 @@ std::optional<std::vector<std::string>> expandDs2Addr(const MCInst &Inst,
                                                       StringRef ToMnem,
                                                       const LLVMState &LS) {
   return expandDs2AddrImpl(Inst, FromMnem, ToMnem, LS);
+}
+
+bool rewriteDs2AddrOffsetsInPlace(MutableArrayRef<uint8_t> InstBytes,
+                                  const MCInst &Inst, StringRef Mnemonic,
+                                  const LLVMState &LS) {
+  std::optional<DsOperands> Ops = extractDsOperands(Inst, Mnemonic, LS);
+  return Ops &&
+         rewriteDs2AddrOffsetsInPlaceImpl(InstBytes, Mnemonic, *Ops);
 }
 
 // -- applyTrampolinePatches -------------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -417,9 +417,8 @@ bool rewriteDs2AddrOffsetsInPlaceImpl(MutableArrayRef<uint8_t> InstBytes,
   // and split-counter concerns do not apply: the opcode, register operands,
   // modifiers, instruction count, and entry behavior are unchanged.
   if (getDs2AddrReplacement(Mnemonic).empty() ||
-      Mnemonic.contains("_stride64_") ||
-      Ops.Off0 > Ds2AddrOffsetMax || Ops.Off1 > Ds2AddrOffsetMax ||
-      InstBytes.size() != 2 * MinInstSize)
+      Mnemonic.contains("_stride64_") || Ops.Off0 > Ds2AddrOffsetMax ||
+      Ops.Off1 > Ds2AddrOffsetMax || InstBytes.size() != 2 * MinInstSize)
     return false;
 
   // gfx1250 DS2 offset0/offset1 occupy instruction bits [7:0]/[15:8].
@@ -2017,8 +2016,7 @@ bool rewriteDs2AddrOffsetsInPlace(MutableArrayRef<uint8_t> InstBytes,
                                   const MCInst &Inst, StringRef Mnemonic,
                                   const LLVMState &LS) {
   std::optional<DsOperands> Ops = extractDsOperands(Inst, Mnemonic, LS);
-  return Ops &&
-         rewriteDs2AddrOffsetsInPlaceImpl(InstBytes, Mnemonic, *Ops);
+  return Ops && rewriteDs2AddrOffsetsInPlaceImpl(InstBytes, Mnemonic, *Ops);
 }
 
 // -- applyTrampolinePatches -------------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -34,9 +34,12 @@
 /// Each pass's block-32 scale is a byte-gather of the block-16 scale bytes:
 /// even bytes feed the low subblocks, odd bytes the high ones.
 ///
-/// The masked A copy lands in a contiguous VGPR block allocated above the
-/// kernel's VGPR count and below MaxVgprs (256 on GFX1250), so it stays in VGPR
-/// bank 0 and needs no s_set_vgpr_msb switch.
+/// The replacement is assembled from textual register names, for which the
+/// AMDGPU parser accepts v0-v255. Scratch may nevertheless live above v255:
+/// the generated assembly encodes each scratch VGPR's low byte and brackets
+/// mixed-bank instructions with role-specific s_set_vgpr_msb transitions.
+/// Matrix B is copied into the scratch bank so the lowered WMMA can use one
+/// src1 bank for both its gathered scale and matrix-B operands.
 ///
 /// Fail-closed fallback: when the scratch budget (A-width VGPRs plus a few
 /// scale/temp VGPRs and one scratch SGPR) is unavailable, the pass marks the
@@ -56,6 +59,8 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <initializer_list>
+
 using namespace llvm;
 
 namespace COMGR {
@@ -68,8 +73,13 @@ static constexpr unsigned VOP3PXSize = 16;
 
 // AMDGPU SRC operand encoding: VGPRs are 256 + N.
 static constexpr unsigned VgprEncBase = 256;
+static constexpr unsigned VgprBankSize = 256;
 
 static std::string vgprName(unsigned N) { return ("v" + Twine(N)).str(); }
+
+static std::string encodedVgprName(unsigned Physical) {
+  return vgprName(Physical % VgprBankSize);
+}
 
 static bool isVgprEncoding(unsigned Enc) { return Enc >= VgprEncBase; }
 
@@ -105,6 +115,7 @@ static void writeScaleSrc1(uint8_t *Raw, unsigned Enc) {
 // -- Base WMMA uop field accessors (bytes 8-15) ------------------------------
 //   VDST: byte[8] (8-bit raw VGPR number, no +256)
 //   SRC0: byte[12] + byte[13] bit[0] (9-bit; matrix A)
+//   SRC1: byte[13] bits[7:1] + byte[14] bits[1:0] (9-bit; matrix B)
 //   SRC2: byte[14] bits[7:2] + byte[15] bits[2:0] (9-bit; accumulator C)
 
 static unsigned extractVdst(const uint8_t *Raw) { return Raw[8]; }
@@ -112,6 +123,11 @@ static unsigned extractVdst(const uint8_t *Raw) { return Raw[8]; }
 static void writeSrc0(uint8_t *Raw, unsigned Enc) {
   Raw[12] = Enc & 0xFF;
   Raw[13] = (Raw[13] & 0xFE) | ((Enc >> 8) & 0x01);
+}
+
+static void writeSrc1(uint8_t *Raw, unsigned Enc) {
+  Raw[13] = (Raw[13] & 0x01) | ((Enc & 0x7F) << 1);
+  Raw[14] = (Raw[14] & 0xFC) | ((Enc >> 7) & 0x03);
 }
 
 static void writeSrc2(uint8_t *Raw, unsigned Enc) {
@@ -162,28 +178,105 @@ static SmallVector<uint8_t> rewriteScale16ToScale(const uint8_t *OrigRaw,
 // (odd byte 2j+1) for pass-high, packed into one VGPR as
 // [byte0..3] = k-block 0..3.
 
-static void emitGatherEven(raw_string_ostream &OS, StringRef Lo, StringRef Hi,
-                           StringRef Dst, StringRef T) {
-  // Dst = { Lo[7:0], Lo[23:16], Hi[7:0], Hi[23:16] } (bytes 0,2,4,6)
-  OS << "v_and_b32 " << Dst << ", 0xff, " << Lo << "\n";
-  OS << "v_bfe_u32 " << T << ", " << Lo << ", 16, 8\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 8, " << Dst << "\n";
-  OS << "v_and_b32 " << T << ", 0xff, " << Hi << "\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 16, " << Dst << "\n";
-  OS << "v_bfe_u32 " << T << ", " << Hi << ", 16, 8\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 24, " << Dst << "\n";
+using VgprBankRequirement = std::pair<VgprMsbOperand, unsigned>;
+
+static void
+emitModeForOperands(raw_string_ostream &OS, unsigned &CurrentMode,
+                    std::initializer_list<VgprBankRequirement> Requirements) {
+  unsigned NewMode = CurrentMode;
+  for (const VgprBankRequirement &Requirement : Requirements)
+    setVgprMsbBank(NewMode, Requirement.first, Requirement.second);
+  if (NewMode == CurrentMode)
+    return;
+  OS << "s_set_vgpr_msb " << (NewMode | (CurrentMode << 8)) << "\n";
+  CurrentMode = NewMode;
 }
 
-static void emitGatherOdd(raw_string_ostream &OS, StringRef Lo, StringRef Hi,
-                          StringRef Dst, StringRef T) {
+static void emitGatherEven(raw_string_ostream &OS, unsigned Lo, unsigned Hi,
+                           unsigned Dst, unsigned T, unsigned ScratchBank,
+                           unsigned &CurrentMode) {
+  std::string LoName = encodedVgprName(Lo);
+  std::string HiName = encodedVgprName(Hi);
+  std::string DstName = encodedVgprName(Dst);
+  std::string TName = encodedVgprName(T);
+
+  // Dst = { Lo[7:0], Lo[23:16], Hi[7:0], Hi[23:16] } (bytes 0,2,4,6)
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src1, Lo / VgprBankSize}});
+  OS << "v_and_b32 " << DstName << ", 0xff, " << LoName << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, Lo / VgprBankSize}});
+  OS << "v_bfe_u32 " << TName << ", " << LoName << ", 16, 8\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 8, " << DstName
+     << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src1, Hi / VgprBankSize}});
+  OS << "v_and_b32 " << TName << ", 0xff, " << HiName << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 16, " << DstName
+     << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, Hi / VgprBankSize}});
+  OS << "v_bfe_u32 " << TName << ", " << HiName << ", 16, 8\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 24, " << DstName
+     << "\n";
+}
+
+static void emitGatherOdd(raw_string_ostream &OS, unsigned Lo, unsigned Hi,
+                          unsigned Dst, unsigned T, unsigned ScratchBank,
+                          unsigned &CurrentMode) {
+  std::string LoName = encodedVgprName(Lo);
+  std::string HiName = encodedVgprName(Hi);
+  std::string DstName = encodedVgprName(Dst);
+  std::string TName = encodedVgprName(T);
+
   // Dst = { Lo[15:8], Lo[31:24], Hi[15:8], Hi[31:24] } (bytes 1,3,5,7)
-  OS << "v_bfe_u32 " << Dst << ", " << Lo << ", 8, 8\n";
-  OS << "v_bfe_u32 " << T << ", " << Lo << ", 24, 8\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 8, " << Dst << "\n";
-  OS << "v_bfe_u32 " << T << ", " << Hi << ", 8, 8\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 16, " << Dst << "\n";
-  OS << "v_lshrrev_b32 " << T << ", 24, " << Hi << "\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 24, " << Dst << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, Lo / VgprBankSize}});
+  OS << "v_bfe_u32 " << DstName << ", " << LoName << ", 8, 8\n";
+  OS << "v_bfe_u32 " << TName << ", " << LoName << ", 24, 8\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 8, " << DstName
+     << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, Hi / VgprBankSize}});
+  OS << "v_bfe_u32 " << TName << ", " << HiName << ", 8, 8\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 16, " << DstName
+     << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src1, Hi / VgprBankSize}});
+  OS << "v_lshrrev_b32 " << TName << ", 24, " << HiName << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 24, " << DstName
+     << "\n";
 }
 
 // A' = mask ? A : 0, per lane, for W consecutive VGPRs from ABase into SBase.
@@ -193,11 +286,16 @@ static void emitGatherOdd(raw_string_ostream &OS, StringRef Lo, StringRef Hi,
 // high-16 in lanes 16-31, so a lane mask isolates a subblock.
 static void emitLaneMaskCopy(raw_string_ostream &OS, StringRef MaskSgpr,
                              uint32_t MaskImm, unsigned SBase, unsigned ABase,
-                             unsigned W) {
+                             unsigned W, unsigned ScratchBank,
+                             unsigned &CurrentMode) {
   OS << "s_mov_b32 " << MaskSgpr << ", 0x" << utohexstr(MaskImm) << "\n";
-  for (unsigned I = 0; I < W; ++I)
-    OS << "v_cndmask_b32_e64 " << vgprName(SBase + I) << ", 0, "
-       << vgprName(ABase + I) << ", " << MaskSgpr << "\n";
+  for (unsigned I = 0; I < W; ++I) {
+    emitModeForOperands(OS, CurrentMode,
+                        {{VgprMsbOperand::Dst, ScratchBank},
+                         {VgprMsbOperand::Src1, (ABase + I) / VgprBankSize}});
+    OS << "v_cndmask_b32_e64 " << encodedVgprName(SBase + I) << ", 0, "
+       << encodedVgprName(ABase + I) << ", " << MaskSgpr << "\n";
+  }
 }
 
 // A' keeps the VGPRs of the low (KeepLow=true) or high 16-K subblocks and zeros
@@ -210,25 +308,45 @@ static void emitLaneMaskCopy(raw_string_ostream &OS, StringRef MaskSgpr,
 // subblock's VGPRs instead.
 static void emitVgprSelectCopy(raw_string_ostream &OS, bool KeepLow,
                                unsigned SBase, unsigned ABase, unsigned W,
-                               unsigned SubW) {
+                               unsigned SubW, unsigned ScratchBank,
+                               unsigned &CurrentMode) {
   for (unsigned I = 0; I < W; ++I) {
     bool IsLow = ((I / SubW) % 2) == 0;
-    if (IsLow == KeepLow)
-      OS << "v_mov_b32 " << vgprName(SBase + I) << ", " << vgprName(ABase + I)
-         << "\n";
-    else
-      OS << "v_mov_b32 " << vgprName(SBase + I) << ", 0\n";
+    if (IsLow == KeepLow) {
+      emitModeForOperands(OS, CurrentMode,
+                          {{VgprMsbOperand::Dst, ScratchBank},
+                           {VgprMsbOperand::Src0, (ABase + I) / VgprBankSize}});
+      OS << "v_mov_b32 " << encodedVgprName(SBase + I) << ", "
+         << encodedVgprName(ABase + I) << "\n";
+    } else {
+      emitModeForOperands(OS, CurrentMode,
+                          {{VgprMsbOperand::Dst, ScratchBank}});
+      OS << "v_mov_b32 " << encodedVgprName(SBase + I) << ", 0\n";
+    }
   }
 }
 
-// Parse the matrix-A (src0) VGPR range from the printer's canonical form.
+static void emitVgprCopy(raw_string_ostream &OS, unsigned DstBase,
+                         unsigned SrcBase, unsigned W, unsigned ScratchBank,
+                         unsigned &CurrentMode) {
+  for (unsigned I = 0; I < W; ++I) {
+    emitModeForOperands(OS, CurrentMode,
+                        {{VgprMsbOperand::Dst, ScratchBank},
+                         {VgprMsbOperand::Src0, (SrcBase + I) / VgprBankSize}});
+    OS << "v_mov_b32 " << encodedVgprName(DstBase + I) << ", "
+       << encodedVgprName(SrcBase + I) << "\n";
+  }
+}
+
+// Parse a matrix VGPR range from the printer's canonical form.
 struct VgprRange {
   unsigned Base;
   unsigned Width;
 };
 
 static std::optional<VgprRange>
-matrixAOperandRange(PatchContext &Ctx, const InternalDecodedInst &DI) {
+matrixOperandRange(PatchContext &Ctx, const InternalDecodedInst &DI,
+                   unsigned OperandIndex) {
   SmallString<256> Buf;
   raw_svector_ostream OS(Buf);
   Ctx.LS.MCIP->printInst(&DI.Inst, /*Address=*/0, /*Annot=*/"", *Ctx.LS.STI,
@@ -238,17 +356,18 @@ matrixAOperandRange(PatchContext &Ctx, const InternalDecodedInst &DI) {
   if (MnemEnd == StringRef::npos)
     return std::nullopt;
   StringRef Rest = S.substr(MnemEnd).ltrim();
-  // Operand 0 = vdst, operand 1 = src0 (matrix A).
-  size_t Comma0 = Rest.find(',');
-  if (Comma0 == StringRef::npos)
+  for (unsigned I = 0; I < OperandIndex; ++I) {
+    size_t Comma = Rest.find(',');
+    if (Comma == StringRef::npos)
+      return std::nullopt;
+    Rest = Rest.substr(Comma + 1).ltrim();
+  }
+  size_t End = Rest.find(',');
+  StringRef Operand = (End == StringRef::npos) ? Rest : Rest.substr(0, End);
+  Operand = Operand.trim();
+  if (!Operand.starts_with("v[") || !Operand.ends_with("]"))
     return std::nullopt;
-  Rest = Rest.substr(Comma0 + 1).ltrim();
-  size_t Comma1 = Rest.find(',');
-  StringRef A = (Comma1 == StringRef::npos) ? Rest : Rest.substr(0, Comma1);
-  A = A.trim();
-  if (!A.starts_with("v[") || !A.ends_with("]"))
-    return std::nullopt;
-  StringRef Inside = A.drop_front(2).drop_back(1);
+  StringRef Inside = Operand.drop_front(2).drop_back(1);
   StringRef LoS, HiS;
   std::tie(LoS, HiS) = Inside.split(':');
   unsigned Lo = 0, Hi = 0;
@@ -329,14 +448,40 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   if (!ScaleABase || !ScaleBBase)
     return failClosed(Ctx, DI, "non-VGPR block-16 scale operand");
 
-  unsigned ScaleALo = *ScaleABase, ScaleAHi = ScaleALo + 1;
-  unsigned ScaleBLo = *ScaleBBase, ScaleBHi = ScaleBLo + 1;
+  std::optional<unsigned> ActiveMode = getActiveVgprMsbMode(Ctx, Idx);
+  // A compiler-emitted scale16 whose immediately preceding instruction sets
+  // the mode already depends on that setter for the original fused operands.
+  // Preserve that local contract when unrelated opaque control flow prevents
+  // object-wide mode recovery.
+  if (!ActiveMode)
+    ActiveMode = getLocallyEstablishedVgprMsbMode(Ctx, Idx);
+  if (!ActiveMode)
+    return failClosed(Ctx, DI, "cannot determine active VGPR-MSB mode");
 
-  std::optional<VgprRange> ARange = matrixAOperandRange(Ctx, DI);
-  if (!ARange)
-    return failClosed(Ctx, DI, "could not determine matrix-A VGPR range");
-  unsigned ABase = ARange->Base;
+  unsigned OrigSrc0Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0);
+  unsigned OrigSrc1Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1);
+  unsigned OrigDstBank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst);
+
+  unsigned ScaleALo = *ScaleABase + OrigSrc0Bank * VgprBankSize;
+  unsigned ScaleAHi = ScaleALo + 1;
+  unsigned ScaleBLo = *ScaleBBase + OrigSrc1Bank * VgprBankSize;
+  unsigned ScaleBHi = ScaleBLo + 1;
+  if (ScaleAHi >= Ctx.Config.MaxVgprs || ScaleBHi >= Ctx.Config.MaxVgprs)
+    return failClosed(Ctx, DI, "block-16 scale tuple exceeds VGPR capacity");
+
+  std::optional<VgprRange> ARange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/1);
+  std::optional<VgprRange> BRange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/2);
+  if (!ARange || !BRange)
+    return failClosed(Ctx, DI, "could not determine matrix-A/B VGPR ranges");
+  unsigned ABase = ARange->Base + OrigSrc0Bank * VgprBankSize;
   unsigned AWidth = ARange->Width;
+  unsigned BBase = BRange->Base + OrigSrc1Bank * VgprBankSize;
+  unsigned BWidth = BRange->Width;
+  if (ABase + AWidth > Ctx.Config.MaxVgprs ||
+      BBase + BWidth > Ctx.Config.MaxVgprs)
+    return failClosed(Ctx, DI, "matrix operand exceeds VGPR capacity");
 
   // The masking scheme depends on the matrix-A data format.
   std::optional<AMaskPlan> Plan = matrixAMaskPlan(Ctx, DI);
@@ -362,18 +507,28 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   VgprAllocator Alloc(Ctx.Liveness.liveBefore(Idx), KdCount,
                       Ctx.Config.MaxVgprs);
 
-  // Four block-32 scale VGPRs (A/B x low/high) plus one byte-extraction temp,
-  // then a contiguous, even-aligned block for the masked A copy.
-  std::optional<unsigned> ScaleAloReg = Alloc.alloc();
-  std::optional<unsigned> ScaleBloReg = Alloc.alloc();
-  std::optional<unsigned> ScaleAhiReg = Alloc.alloc();
-  std::optional<unsigned> ScaleBhiReg = Alloc.alloc();
-  std::optional<unsigned> TmpReg = Alloc.alloc();
-  std::optional<unsigned> SBase =
-      Alloc.allocContiguousAboveKd(AWidth, /*Align=*/2);
-  if (!ScaleAloReg || !ScaleBloReg || !ScaleAhiReg || !ScaleBhiReg || !TmpReg ||
-      !SBase)
-    return failClosed(Ctx, DI, "insufficient scratch VGPRs for exact K-split");
+  // Keep every generated operand in one physical VGPR bank. Five scalar
+  // temporaries precede an even-aligned masked-A block and a matrix-B copy.
+  // Copying B is necessary because both scale-B and matrix-B use the WMMA
+  // src1 VGPR-MSB field.
+  constexpr unsigned ScalarScratchCount = 5;
+  unsigned AOffset = (ScalarScratchCount + 1) & ~1u;
+  unsigned BOffset = AOffset + AWidth;
+  unsigned ScratchCount = BOffset + BWidth;
+  std::optional<unsigned> ScratchBase = Alloc.allocContiguousAboveKdInBank(
+      ScratchCount, /*Align=*/2, VgprBankSize);
+  if (!ScratchBase)
+    return failClosed(Ctx, DI,
+                      "no single-bank above-KD VGPR block for exact K-split");
+
+  unsigned ScaleAloReg = *ScratchBase;
+  unsigned ScaleBloReg = *ScratchBase + 1;
+  unsigned ScaleAhiReg = *ScratchBase + 2;
+  unsigned ScaleBhiReg = *ScratchBase + 3;
+  unsigned TmpReg = *ScratchBase + 4;
+  unsigned SBase = *ScratchBase + AOffset;
+  unsigned BCopyBase = *ScratchBase + BOffset;
+  unsigned ScratchBank = *ScratchBase / VgprBankSize;
 
   // The lane-mask scheme (FP8/BF8) needs one scratch SGPR for the wave-lane
   // bitmask; the VGPR-select scheme (FP4/FP6) uses plain v_mov and needs none.
@@ -389,52 +544,96 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   }
 
   // Preamble + pass-low masked copy (assembled together), then pass-high copy.
-  std::string PreAsm, HiAsm;
-  raw_string_ostream PreOS(PreAsm), HiOS(HiAsm);
+  std::string PreAsm, HiAsm, PostAsm;
+  raw_string_ostream PreOS(PreAsm), HiOS(HiAsm), PostOS(PostAsm);
+  unsigned PreMode = *ActiveMode;
 
-  emitGatherEven(PreOS, vgprName(ScaleALo), vgprName(ScaleAHi),
-                 vgprName(*ScaleAloReg), vgprName(*TmpReg));
-  emitGatherEven(PreOS, vgprName(ScaleBLo), vgprName(ScaleBHi),
-                 vgprName(*ScaleBloReg), vgprName(*TmpReg));
-  emitGatherOdd(PreOS, vgprName(ScaleALo), vgprName(ScaleAHi),
-                vgprName(*ScaleAhiReg), vgprName(*TmpReg));
-  emitGatherOdd(PreOS, vgprName(ScaleBLo), vgprName(ScaleBHi),
-                vgprName(*ScaleBhiReg), vgprName(*TmpReg));
+  emitGatherEven(PreOS, ScaleALo, ScaleAHi, ScaleAloReg, TmpReg, ScratchBank,
+                 PreMode);
+  emitGatherEven(PreOS, ScaleBLo, ScaleBHi, ScaleBloReg, TmpReg, ScratchBank,
+                 PreMode);
+  emitGatherOdd(PreOS, ScaleALo, ScaleAHi, ScaleAhiReg, TmpReg, ScratchBank,
+                PreMode);
+  emitGatherOdd(PreOS, ScaleBLo, ScaleBHi, ScaleBhiReg, TmpReg, ScratchBank,
+                PreMode);
+  emitVgprCopy(PreOS, BCopyBase, BBase, BWidth, ScratchBank, PreMode);
   if (Plan->Scheme == AMaskScheme::Lane) {
     // pass-low keeps lanes 0-15 (low-16 subblocks); pass-high lanes 16-31.
-    emitLaneMaskCopy(PreOS, MaskS, 0x0000FFFFu, *SBase, ABase, AWidth);
-    emitLaneMaskCopy(HiOS, MaskS, 0xFFFF0000u, *SBase, ABase, AWidth);
+    emitLaneMaskCopy(PreOS, MaskS, 0x0000FFFFu, SBase, ABase, AWidth,
+                     ScratchBank, PreMode);
   } else {
     // pass-low keeps the low-16 subblock VGPRs; pass-high the high-16 ones.
-    emitVgprSelectCopy(PreOS, /*KeepLow=*/true, *SBase, ABase, AWidth,
-                       Plan->SubW);
-    emitVgprSelectCopy(HiOS, /*KeepLow=*/false, *SBase, ABase, AWidth,
-                       Plan->SubW);
+    emitVgprSelectCopy(PreOS, /*KeepLow=*/true, SBase, ABase, AWidth,
+                       Plan->SubW, ScratchBank, PreMode);
   }
 
-  SmallVector<uint8_t> PreBytes = assembleInstructions(PreAsm, Ctx.LS);
-  SmallVector<uint8_t> HiBytes = assembleInstructions(HiAsm, Ctx.LS);
-  if (PreBytes.empty() || HiBytes.empty())
-    return failClosed(Ctx, DI, "preamble assembly failed");
+  unsigned WmmaLoMode = *ActiveMode;
+  setVgprMsbBank(WmmaLoMode, VgprMsbOperand::Src0, ScratchBank);
+  setVgprMsbBank(WmmaLoMode, VgprMsbOperand::Src1, ScratchBank);
+  emitModeForOperands(
+      PreOS, PreMode,
+      {{VgprMsbOperand::Src0, ScratchBank},
+       {VgprMsbOperand::Src1, ScratchBank},
+       {VgprMsbOperand::Src2, getVgprMsbBank(WmmaLoMode, VgprMsbOperand::Src2)},
+       {VgprMsbOperand::Dst, getVgprMsbBank(WmmaLoMode, VgprMsbOperand::Dst)}});
 
   // pass-low WMMA: matrix A = masked copy, scales = even-byte gathers, src2 =
   // original C (preserved by the byte copy).
-  SmallVector<uint8_t> WmmaLo =
-      rewriteScale16ToScale(Raw, DI.Size, VgprEncBase + *ScaleAloReg,
-                            VgprEncBase + *ScaleBloReg, Ctx.LS);
+  SmallVector<uint8_t> WmmaLo = rewriteScale16ToScale(
+      Raw, DI.Size, VgprEncBase + (ScaleAloReg % VgprBankSize),
+      VgprEncBase + (ScaleBloReg % VgprBankSize), Ctx.LS);
   if (WmmaLo.empty())
     return failClosed(Ctx, DI, "pass-low WMMA rewrite failed");
-  writeSrc0(WmmaLo.data(), VgprEncBase + *SBase);
+  writeSrc0(WmmaLo.data(), VgprEncBase + (SBase % VgprBankSize));
+  writeSrc1(WmmaLo.data(), VgprEncBase + (BCopyBase % VgprBankSize));
 
   // pass-high WMMA: odd-byte gathers, and src2 = D so it accumulates onto the
   // pass-low result.
-  SmallVector<uint8_t> WmmaHi =
-      rewriteScale16ToScale(Raw, DI.Size, VgprEncBase + *ScaleAhiReg,
-                            VgprEncBase + *ScaleBhiReg, Ctx.LS);
+  SmallVector<uint8_t> WmmaHi = rewriteScale16ToScale(
+      Raw, DI.Size, VgprEncBase + (ScaleAhiReg % VgprBankSize),
+      VgprEncBase + (ScaleBhiReg % VgprBankSize), Ctx.LS);
   if (WmmaHi.empty())
     return failClosed(Ctx, DI, "pass-high WMMA rewrite failed");
-  writeSrc0(WmmaHi.data(), VgprEncBase + *SBase);
+  writeSrc0(WmmaHi.data(), VgprEncBase + (SBase % VgprBankSize));
+  writeSrc1(WmmaHi.data(), VgprEncBase + (BCopyBase % VgprBankSize));
   writeSrc2(WmmaHi.data(), VgprEncBase + extractVdst(Raw));
+
+  unsigned HiMode = WmmaLoMode;
+  if (Plan->Scheme == AMaskScheme::Lane) {
+    emitLaneMaskCopy(HiOS, MaskS, 0xFFFF0000u, SBase, ABase, AWidth,
+                     ScratchBank, HiMode);
+  } else {
+    emitVgprSelectCopy(HiOS, /*KeepLow=*/false, SBase, ABase, AWidth,
+                       Plan->SubW, ScratchBank, HiMode);
+  }
+  unsigned WmmaHiMode = WmmaLoMode;
+  setVgprMsbBank(WmmaHiMode, VgprMsbOperand::Src2, OrigDstBank);
+  emitModeForOperands(
+      HiOS, HiMode,
+      {{VgprMsbOperand::Src0, ScratchBank},
+       {VgprMsbOperand::Src1, ScratchBank},
+       {VgprMsbOperand::Src2, OrigDstBank},
+       {VgprMsbOperand::Dst, getVgprMsbBank(WmmaHiMode, VgprMsbOperand::Dst)}});
+
+  unsigned PostMode = WmmaHiMode;
+  unsigned ActiveSrc0 = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0);
+  unsigned ActiveSrc1 = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1);
+  unsigned ActiveSrc2 = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src2);
+  unsigned ActiveDst = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst);
+  emitModeForOperands(PostOS, PostMode,
+                      {{VgprMsbOperand::Src0, ActiveSrc0},
+                       {VgprMsbOperand::Src1, ActiveSrc1},
+                       {VgprMsbOperand::Src2, ActiveSrc2},
+                       {VgprMsbOperand::Dst, ActiveDst}});
+
+  SmallVector<uint8_t> PreBytes = assembleInstructions(PreAsm, Ctx.LS);
+  SmallVector<uint8_t> HiBytes = assembleInstructions(HiAsm, Ctx.LS);
+  SmallVector<uint8_t> PostBytes;
+  if (!PostAsm.empty())
+    PostBytes = assembleInstructions(PostAsm, Ctx.LS);
+  if (PreBytes.empty() || HiBytes.empty() ||
+      (!PostAsm.empty() && PostBytes.empty()))
+    return failClosed(Ctx, DI, "mode-aware preamble assembly failed");
 
   // gfx1250 WMMA co-exec hazard: the pass-high copy (VALU) overwrites the
   // masked-A block the pass-low WMMA still reads, so it must not co-execute
@@ -454,6 +653,7 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
     Replacement.append(VNop.begin(), VNop.end());
   Replacement.append(HiBytes.begin(), HiBytes.end());
   Replacement.append(WmmaHi.begin(), WmmaHi.end());
+  Replacement.append(PostBytes.begin(), PostBytes.end());
 
   unsigned Extra = Alloc.extraVgprsNeeded();
   if (checkKernelVgprBump(Ctx, KernelName, Extra, PatchRequirement::Required) !=
@@ -481,8 +681,9 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
         << utohexstr(DI.Offset) << " ("
         << (Plan->Scheme == AMaskScheme::Lane ? "lane-mask" : "vgpr-select")
         << ", A=v" << ABase << ":" << (ABase + AWidth - 1) << " -> masked v"
-        << *SBase << ", +" << Extra << " vgpr, " << A0Nops << " hazard v_nop, "
-        << Replacement.size() << " bytes)\n";
+        << SBase << ", B copy=v" << BCopyBase << ":" << (BCopyBase + BWidth - 1)
+        << ", scratch bank " << ScratchBank << ", +" << Extra << " vgpr, "
+        << A0Nops << " hazard v_nop, " << Replacement.size() << " bytes)\n";
   return 1;
 }
 

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -966,13 +966,6 @@ findActiveVgprMsbMode(const PatchContext &Ctx, size_t Idx) {
   return static_cast<unsigned>(Ctx.VgprMsbModeBefore[Idx]);
 }
 
-enum class VgprMsbOperand : unsigned {
-  Src0 = 0,
-  Src1 = 2,
-  Src2 = 4,
-  Dst = 6,
-};
-
 unsigned getVgprMsbs(unsigned Mode, VgprMsbOperand Operand) {
   return (Mode >> static_cast<unsigned>(Operand)) & 0x3;
 }
@@ -1131,6 +1124,53 @@ buildSplit32x16Asm(StringRef Replacement, const PrintedAsm &P, const WmmaOps &R,
 
 } // anonymous namespace
 
+void ensureVgprMsbModes(PatchContext &Ctx) {
+  if (Ctx.VgprMsbModeBefore.empty())
+    computeVgprMsbModes(Ctx);
+}
+
+std::optional<unsigned> getActiveVgprMsbMode(PatchContext &Ctx, size_t Idx) {
+  ensureVgprMsbModes(Ctx);
+  return findActiveVgprMsbMode(Ctx, Idx);
+}
+
+std::optional<unsigned> getLocallyEstablishedVgprMsbMode(PatchContext &Ctx,
+                                                         size_t Idx) {
+  while (Idx > 0) {
+    const InternalDecodedInst &Prev = Ctx.Decoded[Idx - 1];
+    const InternalDecodedInst &Current = Ctx.Decoded[Idx];
+    if (Prev.Offset + Prev.Size != Current.Offset)
+      return std::nullopt;
+
+    if (Ctx.DirectControlFlow.Targets.contains(Current.Offset))
+      return std::nullopt;
+    for (uint64_t Entry : Ctx.DeclaredEntries)
+      if (Entry == Current.Offset)
+        return std::nullopt;
+
+    if (std::optional<unsigned> Mode = getExactVgprMsbModeWritten(Prev, Ctx.LS))
+      return Mode;
+
+    if (Prev.Mnemonic == "<unknown>" ||
+        Prev.Inst.getOpcode() == Ctx.LS.SSetVgprMsbOpcode ||
+        instructionDefinesNamedRegister(Prev, "MODE", Ctx.LS) ||
+        (Ctx.LS.MIA &&
+         (Ctx.LS.MIA->isBranch(Prev.Inst) || Ctx.LS.MIA->isCall(Prev.Inst) ||
+          Ctx.LS.MIA->isReturn(Prev.Inst))))
+      return std::nullopt;
+    --Idx;
+  }
+  return std::nullopt;
+}
+
+unsigned getVgprMsbBank(unsigned Mode, VgprMsbOperand Operand) {
+  return getVgprMsbs(Mode, Operand);
+}
+
+void setVgprMsbBank(unsigned &Mode, VgprMsbOperand Operand, unsigned Bank) {
+  setVgprMsbs(Mode, Operand, Bank);
+}
+
 // Return-value semantics (current shared dispatcher API in b0a0.cpp):
 //   0  = either "this patch did not match the instruction" OR "matched
 //        but failed to apply" -- the dispatcher cannot distinguish the
@@ -1221,8 +1261,7 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   // the transition and restore it. K-splits always consult the mode (the
   // upper half reuses dst as src2). M-splits consult it only when a half
   // actually crosses v255.
-  if (Ctx.VgprMsbModeBefore.empty())
-    computeVgprMsbModes(Ctx);
+  ensureVgprMsbModes(Ctx);
 
   bool UsesVgprMsbTransition = false;
   bool NeedsKnownVgprMsbMode = Match->Kind == SplitKind::Split128to64FP8BF8;
@@ -1235,7 +1274,7 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
 
   unsigned ActiveVgprMsbMode = 0;
   if (NeedsKnownVgprMsbMode) {
-    std::optional<unsigned> Mode = findActiveVgprMsbMode(Ctx, Idx);
+    std::optional<unsigned> Mode = getActiveVgprMsbMode(Ctx, Idx);
     if (!Mode) {
       log() << "hotswap: error: WMMA split: cannot determine VGPR-MSB mode "
                "for "

--- a/amd/comgr/test-lit/hotswap-absolute-call.s
+++ b/amd/comgr/test-lit/hotswap-absolute-call.s
@@ -15,9 +15,9 @@
 
 // DISASM-LABEL: <test_absolute_call>:
 // DISASM-NEXT: s_swap_pc_i64 s[0:1], 0x1010
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-control-flow-index-scale.s
+++ b/amd/comgr/test-lit/hotswap-control-flow-index-scale.s
@@ -1,0 +1,59 @@
+// COM: Exercise the public rewrite path with thousands of unrelated local
+// COM: set-PC functions. Control-flow proof must remain fail-closed without
+// COM: forming the Cartesian product of every set-PC and function range.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+// RUN: %llvm-readelf --file-header --section-headers --program-headers \
+// RUN:   %t.out.elf > /dev/null
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.macro local_set_pc_function
+.type local_set_pc_\@,@function
+local_set_pc_\@:
+  s_set_pc_i64 s[0:1]
+.Llocal_set_pc_end_\@:
+.size local_set_pc_\@, .Llocal_set_pc_end_\@-local_set_pc_\@
+.endm
+
+.rept 4096
+  local_set_pc_function
+.endr
+
+.globl control_flow_index_kernel
+.protected control_flow_index_kernel
+.type control_flow_index_kernel,@function
+control_flow_index_kernel:
+  s_endpgm
+.Lcontrol_flow_index_kernel_end:
+.size control_flow_index_kernel, .Lcontrol_flow_index_kernel_end-control_flow_index_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel control_flow_index_kernel
+  .amdhsa_next_free_vgpr 0
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: control_flow_index_kernel
+      .symbol: control_flow_index_kernel.kd
+      .sgpr_count: 0
+      .vgpr_count: 0
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-data-only-empty-text.s
+++ b/amd/comgr/test-lit/hotswap-data-only-empty-text.s
@@ -1,0 +1,191 @@
+// COM: Data-only HIP device objects can carry global constants and variables
+// COM: but no kernels or device functions. Such an object has a present,
+// COM: zero-size .text section and an empty amdhsa.kernels array. There are no
+// COM: instructions or kernel revision tags to transform, so return a
+// COM: byte-identical successful output after validating that shape.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %llvm-readobj --sections --symbols --notes %t.elf \
+// RUN:   | %FileCheck --check-prefix=SHAPE --implicit-check-not=.kd %s
+// SHAPE: Name: .text
+// SHAPE: Size: 0
+// SHAPE: Name: data_only_constant
+// SHAPE: Type: Object
+// SHAPE: AMDGPU Metadata: ---
+// SHAPE-NEXT: amdhsa.kernels:  []
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=ACCEPT %s
+// ACCEPT: hotswap: accepted data-only code object with empty .text;
+// ACCEPT-SAME: returning a byte-identical copy.
+// ACCEPT: RESULT: SUCCESS
+// RUN: cmp %t.elf %t.out.elf
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// RUN: sed 's/^\.set claimed_function, 0$/.set claimed_function, 1/' \
+// RUN:   %s > %t.function.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.function.s -o %t.function.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.function.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=FUNCTION,REJECT %s
+// FUNCTION: hotswap: error: data-only object has a function/ifunc symbol
+// FUNCTION-SAME: in empty .text.
+
+// RUN: sed 's/^\.set claimed_other_function, 0$/.set claimed_other_function, 1/' \
+// RUN:   %s > %t.other-function.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.other-function.s -o %t.other-function.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   hotswap-rewrite %t.other-function.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=OTHER-FUNCTION,REJECT %s
+// OTHER-FUNCTION: hotswap: error: data-only object has defined function/ifunc
+// OTHER-FUNCTION-SAME: symbol 'claimed_other_function'.
+
+// RUN: sed 's/^\.set executable_section, 0$/.set executable_section, 1/' \
+// RUN:   %s > %t.executable.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.executable.s -o %t.executable.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.executable.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=EXECUTABLE,REJECT %s
+// EXECUTABLE: hotswap: error: data-only object has non-empty executable
+// EXECUTABLE-SAME: section '.other_text'.
+
+// RUN: sed 's/^\.set claimed_descriptor, 0$/.set claimed_descriptor, 1/' \
+// RUN:   %s > %t.descriptor.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.descriptor.s -o %t.descriptor.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.descriptor.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=DESCRIPTOR,REJECT %s
+// DESCRIPTOR: hotswap: error: data-only object has kernel descriptor symbol
+// DESCRIPTOR-SAME: 'claimed_kernel.kd'.
+
+// RUN: sed 's/^\.set claimed_kernel, 0$/.set claimed_kernel, 1/' \
+// RUN:   %s > %t.kernel.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.kernel.s -o %t.kernel.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.kernel.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=KERNEL,REJECT %s
+// KERNEL: hotswap: error: data-only AMDGPU metadata claims 1 kernel(s).
+
+// RUN: sed 's/^\.set malformed_metadata, 0$/.set malformed_metadata, 1/' \
+// RUN:   %s > %t.malformed.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.malformed.s -o %t.malformed.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.malformed.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=MALFORMED,REJECT %s
+// MALFORMED: hotswap: error: failed to parse data-only AMDGPU metadata note.
+
+// RUN: %llvm-objcopy --remove-section=.text %t.elf %t.missing-text.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.missing-text.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefix=MISSING %s
+// MISSING: no .text section found
+// MISSING: RESULT: INVALID_ARGUMENT
+
+// REJECT: hotswap: error: retargetCodeObject:
+// REJECT-SAME: does not describe a valid data-only code object.
+// REJECT: RESULT: INVALID_ARGUMENT
+
+.set claimed_function, 0
+.set claimed_other_function, 0
+.set executable_section, 0
+.set claimed_descriptor, 0
+.set claimed_kernel, 0
+.set malformed_metadata, 0
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.if claimed_function
+.globl claimed_function
+.type claimed_function,@function
+claimed_function:
+.size claimed_function, .-claimed_function
+.endif
+
+.rodata
+.globl data_only_constant
+.type data_only_constant,@object
+.p2align 2
+data_only_constant:
+  .long 1
+.size data_only_constant, .-data_only_constant
+
+.if claimed_other_function
+.globl claimed_other_function
+.type claimed_other_function,@function
+claimed_other_function:
+.size claimed_other_function, .-claimed_other_function
+.endif
+
+.if executable_section
+.section .other_text,"ax",@progbits
+  v_nop
+.endif
+
+.if claimed_descriptor
+.globl claimed_kernel.kd
+.type claimed_kernel.kd,@object
+.p2align 6
+claimed_kernel.kd:
+  .zero 64
+.size claimed_kernel.kd, .-claimed_kernel.kd
+.endif
+
+.if malformed_metadata
+.section .note,"a",@note
+.p2align 2
+  .long 7
+  .long 4
+  .long 32
+  .asciz "AMDGPU"
+.p2align 2
+  .byte 0xc1, 0xc1, 0xc1, 0xc1
+.p2align 2
+.else
+.section .note,"a",@note
+.p2align 2
+  .long 7
+  .long .Lmetadata_desc_end-.Lmetadata_desc_begin
+  .long 32
+  .asciz "AMDGPU"
+.p2align 2
+.Lmetadata_desc_begin:
+.if claimed_kernel
+  // {"amdhsa.kernels": [{}]}
+  .byte 0x81, 0xae
+  .ascii "amdhsa.kernels"
+  .byte 0x91, 0x80
+.else
+  // Match the corpus note:
+  // {"amdhsa.kernels": [], "amdhsa.target": "...gfx1250",
+  //  "amdhsa.version": [1, 2]}
+  .byte 0x83, 0xae
+  .ascii "amdhsa.kernels"
+  .byte 0x90, 0xad
+  .ascii "amdhsa.target"
+  .byte 0xba
+  .ascii "amdgcn-amd-amdhsa--gfx1250"
+  .byte 0xae
+  .ascii "amdhsa.version"
+  .byte 0x92, 0x01, 0x02
+.endif
+.Lmetadata_desc_end:
+.p2align 2
+.endif

--- a/amd/comgr/test-lit/hotswap-ds2-entry-local-offset.s
+++ b/amd/comgr/test-lit/hotswap-ds2-entry-local-offset.s
@@ -1,0 +1,81 @@
+// COM: Reduced from corpus object
+// COM: 8737ad6b480494d2a19aa82de8dfdd53e6c4b788975bd57e3c3437bc368ea780.
+// COM: The original B0 ds_store_2addr_b64 uses element offsets (0, 1), which
+// COM: A0 must interpret as byte offsets (0, 8). Both corrected values fit the
+// COM: original DS2 fields, so patch the two immediate bytes in place.
+// COM:
+// COM: The unresolved register call deliberately keeps indirect entry points
+// COM: unbounded, and the filler makes any appended pool unreachable by
+// COM: s_branch. Success therefore proves that this rewrite is entry-local:
+// COM: it neither consumes neighboring instructions nor weakens the unknown
+// COM: control-flow guards.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: unresolved call target
+// LOG: hotswap: unresolved control-flow target disables NOP-sled emission,
+// LOG-SAME: trampoline coalescing, source relocation, and .text gateways
+// LOG: hotswap: rewrote ds_store_2addr_b64 at 0x{{[0-9A-F]+}} in place with A0 byte offsets 0, 8
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_ds2_entry_local>:
+// DISASM-NEXT: s_swap_pc_i64 s[30:31], s[0:1]
+// DISASM-NEXT: ds_store_2addr_b64 v19, v[14:15], v[20:21] offset1:8
+// DISASM-NEXT: s_wait_loadcnt_dscnt 0x1
+// DISASM-NEXT: s_endpgm
+
+// COM: Relabel the first pass's output as A0 source. This disables the B0-to-A0
+// COM: family and must produce a byte-identical second object; legacy ISA names
+// COM: intentionally default the source to B0 on every independent invocation.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out2.elf | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds2_entry_local
+.p2align 8
+.type test_ds2_entry_local,@function
+test_ds2_entry_local:
+  s_swap_pc_i64 s[30:31], s[0:1]
+  ds_store_2addr_b64 v19, v[14:15], v[20:21] offset1:1
+  s_wait_loadcnt_dscnt 0x1
+  s_endpgm
+.size test_ds2_entry_local, .-test_ds2_entry_local
+
+// Keep a hypothetical appended trampoline pool outside signed s_branch reach.
+.rept 40000
+  s_mov_b32 s2, s3
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds2_entry_local
+  .amdhsa_next_free_vgpr 22
+  .amdhsa_next_free_sgpr 32
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_ds2_entry_local
+      .symbol: test_ds2_entry_local.kd
+      .sgpr_count: 32
+      .vgpr_count: 22
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-finite-materialized-call-closure.s
+++ b/amd/comgr/test-lit/hotswap-finite-materialized-call-closure.s
@@ -1,0 +1,65 @@
+// COM: An exact PC-materialized singleton call enters a defined local helper.
+// COM: The helper uses s[30:31] as scratch only after saving the incoming link
+// COM: in callee-saved VGPR lanes, then restores it before returning. Prove the
+// COM: call, canonical return, and call continuation together without falling
+// COM: back to an object-wide unknown indirect-entry assumption.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: accepted exact materialized-call/canonical-return closure for 1 register call(s)
+// LOG-NOT: hotswap: unresolved call target
+// LOG-NOT: hotswap: unresolved control-flow target disables
+// LOG: RESULT: SUCCESS
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl exact_closure_kernel
+.type exact_closure_kernel,@function
+exact_closure_kernel:
+  s_get_pc_i64 s[0:1]
+  // PC after get-PC is 4; exact_closure_helper begins at 16.
+  s_add_nc_u64 s[0:1], s[0:1], 12
+  s_swap_pc_i64 s[30:31], s[0:1]
+  s_endpgm
+.size exact_closure_kernel, .-exact_closure_kernel
+
+.local exact_closure_helper
+.type exact_closure_helper,@function
+exact_closure_helper:
+  v_writelane_b32 v40, s30, 0
+  v_writelane_b32 v41, s31, 1
+  s_mov_b32 s30, 0
+  s_mov_b32 s31, 0
+  v_readlane_b32 s30, v40, 0
+  v_readlane_b32 s31, v41, 1
+  s_set_pc_i64 s[30:31]
+  s_endpgm
+.size exact_closure_helper, .-exact_closure_helper
+
+.rodata
+.p2align 8
+.amdhsa_kernel exact_closure_kernel
+  .amdhsa_next_free_vgpr 42
+  .amdhsa_next_free_sgpr 42
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: exact_closure_kernel
+      .symbol: exact_closure_kernel.kd
+      .sgpr_count: 42
+      .vgpr_count: 42
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-materialized-call-joint-gateway.s
+++ b/amd/comgr/test-lit/hotswap-materialized-call-joint-gateway.s
@@ -1,0 +1,101 @@
+// COM: The production corpus contains compiler PC-materialized s30 calls into
+// COM: a helper with exact materialized set-PC jumps and an s30 return. Those
+// COM: three edge families form one finite component. MC also classifies the
+// COM: swap-call as an indirect branch; that generic classification must not
+// COM: create an unbounded self-edge after the same call has been proven
+// COM: finite. Closing the component keeps external zero padding available as
+// COM: a gateway for an otherwise-stranded far eight-byte DS2 patch.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: accepted exact materialized-call/canonical-return closure
+// LOG-NOT: hotswap: unresolved call target
+// LOG-NOT: hotswap: unresolved control-flow target disables
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-NOT: ds_load_2addr
+// DISASM: ds_load_b64
+// DISASM-NEXT: ds_load_b64
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local joint_helper
+.type joint_helper,@function
+joint_helper:
+  // Match the production helper: preserve its incoming link in callee-saved
+  // VGPR lanes, use s30:s31 as scratch, then restore it before returning.
+  v_writelane_b32 v40, s30, 0
+  v_writelane_b32 v41, s31, 1
+  s_mov_b32 s30, 0
+  s_mov_b32 s31, 0
+
+  // This exact local set-PC jump is needed to reach the restore/return path.
+  s_get_pc_i64 s[4:5]
+.Lhelper_pc:
+  s_add_nc_u64 s[4:5], s[4:5], .Lhelper_restore-.Lhelper_pc
+  s_set_pc_i64 s[4:5]
+  s_endpgm
+.Lhelper_restore:
+  v_readlane_b32 s30, v40, 0
+  v_readlane_b32 s31, v41, 1
+  s_set_pc_i64 s[30:31]
+  s_endpgm
+.size joint_helper, .-joint_helper
+
+.globl test_materialized_call_joint_gateway
+.p2align 8
+.type test_materialized_call_joint_gateway,@function
+test_materialized_call_joint_gateway:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+
+  // The call target is the exact local helper entry. Its continuation is the
+  // following s_endpgm instruction.
+  s_get_pc_i64 s[0:1]
+.Lcaller_pc:
+  s_add_nc_u64 s[0:1], s[0:1], joint_helper-.Lcaller_pc
+  s_swap_pc_i64 s[30:31], s[0:1]
+  s_endpgm
+.size test_materialized_call_joint_gateway, .-test_materialized_call_joint_gateway
+
+// Safe external gateway space. A falsely-unbounded call clears this map and
+// makes the far eight-byte patch fail closed.
+.fill 64, 1, 0
+
+// Keep the appended trampoline pool beyond one signed s_branch span.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_materialized_call_joint_gateway
+  .amdhsa_next_free_vgpr 42
+  .amdhsa_next_free_sgpr 42
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_materialized_call_joint_gateway
+      .symbol: test_materialized_call_joint_gateway.kd
+      .sgpr_count: 42
+      .vgpr_count: 42
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-mixed-abi-materialized-call-interior-entry.s
+++ b/amd/comgr/test-lit/hotswap-mixed-abi-materialized-call-interior-entry.s
@@ -1,0 +1,87 @@
+// COM: An unrelated opaque ABI call must not suppress alternate-entry
+// COM: validation for an exact PC-materialized call in the same object. A
+// COM: direct call enters the exact call at its add, bypassing s_get_pc_i64.
+// COM: The exact call therefore remains unresolved, disables .text gateways,
+// COM: and makes the required far DS2 patch fail closed.
+
+// RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 \
+// RUN:   --amdhsa-code-object-version=6 -filetype=obj %s -o %t.o
+// RUN: %ld.lld -flavor gnu -m elf64_amdgpu --no-undefined -shared \
+// RUN:   -plugin-opt=mcpu=gfx1250 %t.o -o %t.elf
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: exact materialized-call/canonical-return closure rejected:
+// LOG-SAME: alternate entry inside call materialization ending at 0x
+// LOG: hotswap: unresolved call target
+// LOG: hotswap: unresolved control-flow target disables NOP-sled emission,
+// LOG-SAME: trampoline coalescing, source relocation, and .text gateways
+// LOG: hotswap: error: no safe short-branch gateway for far site
+// API: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local mixed_abi_helper
+.type mixed_abi_helper,@function
+mixed_abi_helper:
+  s_set_pc_i64 s[30:31]
+  s_endpgm
+.size mixed_abi_helper, .-mixed_abi_helper
+
+.globl test_mixed_abi_materialized_call_interior_entry
+.p2align 8
+.type test_mixed_abi_materialized_call_interior_entry,@function
+test_mixed_abi_materialized_call_interior_entry:
+  // This call's target is intentionally opaque but has the exact ABI shape.
+  s_swap_pc_i64 s[30:31], s[8:9]
+
+  // Enter the exact materialization after its defining get-PC.
+  s_call_i64 s[4:5], .Lexact_add
+
+  // This required patch needs the external zero-filled gateway below because
+  // the appended trampoline pool is outside the signed s_branch range.
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+
+  s_get_pc_i64 s[0:1]
+.Lexact_pc:
+.Lexact_add:
+  s_add_nc_u64 s[0:1], s[0:1], mixed_abi_helper-.Lexact_pc
+  s_swap_pc_i64 s[30:31], s[0:1]
+  s_endpgm
+.size test_mixed_abi_materialized_call_interior_entry, .-test_mixed_abi_materialized_call_interior_entry
+
+// This padding is usable as a gateway only when every original control-flow
+// destination is known.
+.fill 64, 1, 0
+
+// Keep the appended trampoline pool beyond one signed s_branch span.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_mixed_abi_materialized_call_interior_entry
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 32
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_mixed_abi_materialized_call_interior_entry
+      .symbol: test_mixed_abi_materialized_call_interior_entry.kd
+      .sgpr_count: 32
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call.s
@@ -24,9 +24,9 @@
 // DISASM-NEXT: s_get_pc_i64 s[2:3]
 // DISASM-NEXT: s_add_nc_u64 s[2:3], s[2:3], 16
 // DISASM-NEXT: s_swap_pc_i64 s[0:1], s[2:3]
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[6:7],
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[6:7],
 
 // COM: A second rewrite must preserve the resolved call and patched object.
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -1,0 +1,187 @@
+// COM: Production activation kernels select one of several local callees with
+// COM: get-PC/carry materialization, merge the selected address, and reuse it
+// COM: across many register calls. Resolve the finite reaching-target set so
+// COM: an unrelated required far rewrite may safely use external gateway
+// COM: padding. A selector bypass would leave the target unknown and must
+// COM: continue to fail closed.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: resolved reusable PC-materialized call
+// LOG-SAME: to 2 target(s)
+// LOG-NOT: hotswap: unresolved call target
+// LOG: hotswap: planned 1 shared far-dispatch gateway group(s) for 8 source site(s)
+// LOG: RESULT: SUCCESS
+
+// RUN: sed 's/^\.set unsafe_selector, 0$/.set unsafe_selector, 1/' \
+// RUN:   %s > %t.bypass.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.bypass.s -o %t.bypass.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.bypass.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=BYPASS,FAIL %s
+// BYPASS: hotswap: unresolved call target
+// FAIL: hotswap: unresolved control-flow target disables NOP-sled emission,
+// FAIL-SAME: trampoline coalescing, source relocation, and .text gateways
+// FAIL: hotswap: error: no safe short-branch gateway for far site
+// FAIL: RESULT: ERROR
+
+// RUN: sed 's/^\.set outside_selector, 0$/.set outside_selector, 1/' \
+// RUN:   %s > %t.outside.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.outside.s -o %t.outside.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.outside.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.outside.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=OUTSIDE %s
+// OUTSIDE: hotswap: resolved reusable PC-materialized call
+// OUTSIDE-SAME: to 3 target(s)
+// OUTSIDE-NOT: hotswap: unresolved call target
+// OUTSIDE: hotswap: planned 1 shared far-dispatch gateway group(s) for 8 source site(s)
+// OUTSIDE: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.outside.out.elf \
+// RUN:   | %FileCheck --check-prefix=OUTSIDE-DISASM %s
+// OUTSIDE-DISASM-LABEL: <reusable_pc_targets>:
+// OUTSIDE-DISASM: s_swap_pc_i64
+// OUTSIDE-DISASM-NEXT: s_branch
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// DISASM-LABEL: <reusable_pc_targets>:
+// DISASM: s_swap_pc_i64
+// DISASM: s_call_i64 s[12:13]
+// DISASM-NEXT: s_nop 0
+// DISASM-LABEL: <gateway_barrier>:
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+// DISASM: ds_load_b32 v0, v2 offset:256
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:768
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.set unsafe_selector, 0
+.set outside_selector, 0
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl reusable_pc_targets
+.p2align 8
+.type reusable_pc_targets,@function
+reusable_pc_targets:
+.if unsafe_selector
+  // This edge reaches the call without executing either get-PC sequence.
+  s_cmp_eq_u32 s0, 2
+  s_cbranch_scc1 .Lselected
+.endif
+.if outside_selector
+  s_cmp_eq_u32 s0, 3
+  s_cbranch_scc1 .Lselect_outside
+.endif
+  s_cmp_eq_u32 s0, 0
+  s_cbranch_scc1 .Lselect_second
+.Lselect_first:
+  s_get_pc_i64 s[2:3]
+  s_add_co_i32 s4, callee_first-(.Lselect_first+4)-4, 4
+  s_add_co_u32 s2, s2, s4
+  s_add_co_ci_u32 s3, s3, 0
+  s_branch .Lselected
+.Lselect_second:
+  s_get_pc_i64 s[2:3]
+  s_add_co_i32 s4, callee_second-(.Lselect_second+4)-4, 4
+  s_add_co_u32 s2, s2, s4
+  s_add_co_ci_u32 s3, s3, 0
+.if outside_selector
+  s_branch .Lselected
+.Lselect_outside:
+  s_get_pc_i64 s[2:3]
+  s_add_co_i32 s4, outside_text_end-(.Lselect_outside+4)-4, 4
+  s_add_co_u32 s2, s2, s4
+  s_add_co_ci_u32 s3, s3, 0
+.endif
+.Lselected:
+  s_swap_pc_i64 s[6:7], s[2:3]
+  s_branch .Lpatch0
+.Lpatch0:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch1
+.Lpatch1:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch2
+.Lpatch2:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch3
+.Lpatch3:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch4
+.Lpatch4:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch5
+.Lpatch5:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch6
+.Lpatch6:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch7
+.Lpatch7:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+.Lpatch_done:
+  s_wait_dscnt 0x0
+  s_endpgm
+.size reusable_pc_targets, .-reusable_pc_targets
+
+.local callee_first
+.type callee_first,@function
+callee_first:
+  s_mov_b32 s8, 1
+  s_set_pc_i64 s[6:7]
+.size callee_first, .-callee_first
+
+.local callee_second
+.type callee_second,@function
+callee_second:
+  s_mov_b32 s8, 2
+  s_set_pc_i64 s[6:7]
+.size callee_second, .-callee_second
+
+.type gateway_barrier,@function
+gateway_barrier:
+  s_endpgm
+.size gateway_barrier, .-gateway_barrier
+.fill 20, 1, 0
+
+.rept 40000
+  s_mov_b32 s10, s11
+.endr
+
+outside_text_end:
+.rodata
+.p2align 8
+.amdhsa_kernel reusable_pc_targets
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: reusable_pc_targets
+      .symbol: reusable_pc_targets.kd
+      .sgpr_count: 12
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
@@ -27,7 +27,7 @@
 // COM: Case 1 (2-address load, RCCL's pattern).
 // DISASM-NOT: s_add_pc_i64
 // DISASM-LABEL: <test_ds2addr_far_load>:
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // COM: Case 2 (adjacent sites coalesced into a set-PC forward gateway).
 // DISASM-LABEL: <test_ds2addr_far_adjacent>:
@@ -38,20 +38,20 @@
 // COM: Case 3 (an interior direct-branch target must prevent coalescing).
 // DISASM-LABEL: <test_ds2addr_far_branch_target>:
 // DISASM-NEXT: s_cbranch_scc1
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // COM: Case 4 (a direct-call target is also an interior entry point).
 // DISASM-LABEL: <test_ds2addr_far_call_target>:
 // DISASM-NEXT: s_call_i64
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // COM: Case 5 (2-address store).
 // DISASM-LABEL: <test_ds2addr_far_store>:
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // DISASM-NOT: ds_load_2addr
 // DISASM-NOT: ds_store_2addr

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
@@ -29,26 +29,26 @@
 // COM: expansion sleds. The single shared s_wait_dscnt stays at 0x0
 // COM: (drain preservation under stacking in the non-stride64 path).
 // COM: The two sleds together expand to 4 single-address ds_load_b32
-// COM: instructions; offsets (raw 1/2 and 3/4) scale by ElemBytes=4 to
-// COM: byte offsets 4/8 and 12/16 across the two sites.
+// COM: instructions. Raw offsets start at 64 so the scaled byte offsets no
+// COM: longer fit the in-place DS2 fields; they become 256/260 and 264/268.
 // DISASM-LABEL: <test_multi_ds_nostride64>:
 // DISASM-NOT: ds_load_2addr_b32
 // DISASM: s_branch
 // DISASM: s_branch
 // DISASM: s_wait_dscnt 0x0
 // COM: Sled 1 (first DS2 site, vdst pair v[0:1]).
-// DISASM: ds_load_b32 v0, v4 offset:4
-// DISASM-NEXT: ds_load_b32 v1, v4 offset:8
+// DISASM: ds_load_b32 v0, v4 offset:256
+// DISASM-NEXT: ds_load_b32 v1, v4 offset:260
 // COM: Sled 2 (second DS2 site, vdst pair v[2:3]).
-// DISASM: ds_load_b32 v2, v4 offset:12
-// DISASM-NEXT: ds_load_b32 v3, v4 offset:16
+// DISASM: ds_load_b32 v2, v4 offset:264
+// DISASM-NEXT: ds_load_b32 v3, v4 offset:268
 
 .globl test_multi_ds_nostride64
 .p2align 8
 .type test_multi_ds_nostride64,@function
 test_multi_ds_nostride64:
-  ds_load_2addr_b32 v[0:1], v4 offset0:1 offset1:2
-  ds_load_2addr_b32 v[2:3], v4 offset0:3 offset1:4
+  ds_load_2addr_b32 v[0:1], v4 offset0:64 offset1:65
+  ds_load_2addr_b32 v[2:3], v4 offset0:66 offset1:67
   s_wait_dscnt 0x0
   s_endpgm
   s_nop 0

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
@@ -6,12 +6,13 @@
 // COM: in applyTrampolinePatchesImpl across multiple variant types in a
 // COM: single trampoline pass.
 // COM:
-// COM: These differ from the stride64 forms only in the byte-offset scale
-// COM: applied to each per-operand index (ElemBytes vs 64 * ElemBytes), so
-// COM: the trampoline shape (s_branch forward + sled + s_branch back) and
-// COM: the s_wait_dscnt handling are shared with the stride64 path. Each
-// COM: split emits its own s_wait_dscnt 0x0 drain after the two
-// COM: single-address ops; a pre-existing downstream drain is left in place.
+// COM: These differ from the stride64 forms in the byte-offset scale applied
+// COM: to each per-operand index (ElemBytes vs 64 * ElemBytes). Every
+// COM: non-stride family whose scaled offsets fit the two DS2 eight-bit fields
+// COM: is rewritten in place. Only bytes 0 and 1 change; opcode, registers,
+// COM: modifiers, instruction count, waits, and arbitrary-entry behavior stay
+// COM: identical. The fallback kernel pins the established split path when a
+// COM: scaled field is not representable.
 // COM:
 // COM: Companion tests:
 // COM:   hotswap-trampoline-ds-nostride64-multi.s -- drain insertion
@@ -22,7 +23,8 @@
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
@@ -34,15 +36,11 @@
 
 // ---- Kernel 1: ds_load_2addr_b32 (non-stride64, byte offset = idx*4) -------
 // COM: Kernel 1 (b32 load, non-stride64): offsets index*4. Source
-// COM: offset0:4 offset1:8 -> byte offsets 16 and 32. The input wait is
-// COM: s_wait_dscnt 0x0 (drain) and stays at 0x0 after the split.
+// COM: offset0:4 offset1:8 -> byte offsets 16 and 32.
 // DISASM-LABEL: <test_ds_load_b32_nostride64>:
-// DISASM-NOT: ds_load_2addr_b32
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_load_b32 v0, v2 offset:16
-// DISASM-NEXT: ds_load_b32 v1, v2 offset:32
-// DISASM: s_branch
+// DISASM-NEXT: ds_load_2addr_b32 v[0:1], v2 offset0:16 offset1:32
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_load_b32_nostride64
 .p2align 8
@@ -73,14 +71,11 @@ test_ds_load_b32_nostride64:
 // ---- Kernel 2: ds_load_2addr_b64 (non-stride64, byte offset = idx*8) -------
 // COM: Kernel 2 (b64 load, non-stride64): offsets index*8. Source
 // COM: offset0:1 offset1:2 -> byte offsets 8 and 16. b64 destinations
-// COM: format as v[X:Y] register pairs; drain wait stays at 0x0.
+// COM: format as v[X:Y] register pairs.
 // DISASM-LABEL: <test_ds_load_b64_nostride64>:
-// DISASM-NOT: ds_load_2addr_b64
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_load_b64 v[0:1], v4 offset:8
-// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:16
-// DISASM: s_branch
+// DISASM-NEXT: ds_load_2addr_b64 v[0:3], v4 offset0:8 offset1:16
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_load_b64_nostride64
 .p2align 8
@@ -111,14 +106,11 @@ test_ds_load_b64_nostride64:
 // ---- Kernel 3: ds_store_2addr_b32 (non-stride64 store operand layout) ------
 // COM: Kernel 3 (b32 store, non-stride64): store operand layout
 // COM: (addr, data0, data1). Source offset0:1 offset1:2 -> byte
-// COM: offsets 4 and 8; drain wait stays at 0x0.
+// COM: offsets 4 and 8.
 // DISASM-LABEL: <test_ds_store_b32_nostride64>:
-// DISASM-NOT: ds_store_2addr_b32
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_store_b32 v2, v0 offset:4
-// DISASM-NEXT: ds_store_b32 v2, v1 offset:8
-// DISASM: s_branch
+// DISASM-NEXT: ds_store_2addr_b32 v2, v0, v1 offset0:4 offset1:8
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_store_b32_nostride64
 .p2align 8
@@ -149,14 +141,11 @@ test_ds_store_b32_nostride64:
 // ---- Kernel 4: ds_storexchg_2addr_rtn_b32 (non-stride64 exchange layout) ---
 // COM: Kernel 4 (b32 exchange, non-stride64): exchange operand layout
 // COM: (dst, addr, data0, data1). Source offset0:1 offset1:3 -> byte
-// COM: offsets 4 and 12; drain wait stays at 0x0.
+// COM: offsets 4 and 12.
 // DISASM-LABEL: <test_ds_xchg_b32_nostride64>:
-// DISASM-NOT: ds_storexchg_2addr_rtn_b32
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_storexchg_rtn_b32 v0, v2, v3 offset:4
-// DISASM-NEXT: ds_storexchg_rtn_b32 v1, v2, v4 offset:12
-// DISASM: s_branch
+// DISASM-NEXT: ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 offset0:4 offset1:12
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_xchg_b32_nostride64
 .p2align 8
@@ -185,19 +174,13 @@ test_ds_xchg_b32_nostride64:
 .size test_ds_xchg_b32_nostride64, .Ltest_ds_xchg_b32_nostride64_end-test_ds_xchg_b32_nostride64
 
 // ---- Kernel 5: ds_store_2addr_b64 (non-stride64 store, b64 data pairs) -----
-// COM: Kernel 5 (b64 store, non-stride64): store operand layout (addr,
-// COM: data0_pair, data1_pair). Source offset0:1 offset1:2 -> byte
-// COM: offsets 8 and 16. b64 data operands format as v[X:Y] register
-// COM: pairs (exercises fmtRegOperand on the data side, complementing
-// COM: kernel 2 which exercises it on the destination side); drain
-// COM: wait stays at 0x0.
+// COM: Kernel 5 (b64 store, non-stride64): byte offsets 8 and 16 still fit
+// COM: the DS2 encoding's two eight-bit fields. Re-encode those fields in
+// COM: place for A0 instead of splitting the instruction or using a sled.
 // DISASM-LABEL: <test_ds_store_b64_nostride64>:
-// DISASM-NOT: ds_store_2addr_b64
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_store_b64 v4, v[0:1] offset:8
-// DISASM-NEXT: ds_store_b64 v4, v[2:3] offset:16
-// DISASM: s_branch
+// DISASM-NEXT: ds_store_2addr_b64 v4, v[0:1], v[2:3] offset0:8 offset1:16
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_store_b64_nostride64
 .p2align 8
@@ -225,21 +208,51 @@ test_ds_store_b64_nostride64:
 .Ltest_ds_store_b64_nostride64_end:
 .size test_ds_store_b64_nostride64, .Ltest_ds_store_b64_nostride64_end-test_ds_store_b64_nostride64
 
+// ---- Kernel 5b: b64 scaled offset no longer fits the DS2 field -------------
+// COM: Raw offsets 32 and 33 scale to 256 and 264. They fit the DS1 16-bit
+// COM: field but not the DS2 8-bit fields, so retain the established split
+// COM: path rather than truncating an in-place rewrite.
+// DISASM-LABEL: <test_ds_store_b64_nostride64_fallback>:
+// DISASM-NOT: ds_store_2addr_b64
+// DISASM: s_branch
+// DISASM: ds_store_b64 v4, v[0:1] offset:256
+// DISASM-NEXT: ds_store_b64 v4, v[2:3] offset:264
+
+.globl test_ds_store_b64_nostride64_fallback
+.p2align 8
+.type test_ds_store_b64_nostride64_fallback,@function
+test_ds_store_b64_nostride64_fallback:
+  ds_store_2addr_b64 v4, v[0:1], v[2:3] offset0:32 offset1:33
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_store_b64_nostride64_fallback_end:
+.size test_ds_store_b64_nostride64_fallback, .Ltest_ds_store_b64_nostride64_fallback_end-test_ds_store_b64_nostride64_fallback
+
 // ---- Kernel 6: ds_storexchg_2addr_rtn_b64 (non-stride64 b64 exchange) ------
 // COM: Kernel 6 (b64 exchange, non-stride64): exchange operand layout
 // COM: (dst_pair, addr, data0_pair, data1_pair). Source offset0:1
 // COM: offset1:2 -> byte offsets 8 and 16. Both vdst halves AND the data
-// COM: operands format as v[X:Y] register pairs (exercises splitDstPair
-// COM: AND fmtRegOperand on b64 within the xchg dispatch path, complementing
-// COM: kernel 4 which exercises the b32 xchg layout); drain wait stays
-// COM: at 0x0.
+// COM: operands format as v[X:Y] register pairs.
 // DISASM-LABEL: <test_ds_xchg_b64_nostride64>:
-// DISASM-NOT: ds_storexchg_2addr_rtn_b64
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_storexchg_rtn_b64 v[0:1], v8, v[4:5] offset:8
-// DISASM-NEXT: ds_storexchg_rtn_b64 v[2:3], v8, v[6:7] offset:16
-// DISASM: s_branch
+// DISASM-NEXT: ds_storexchg_2addr_rtn_b64 v[0:3], v8, v[4:5], v[6:7] offset0:8 offset1:16
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_xchg_b64_nostride64
 .p2align 8
@@ -272,30 +285,16 @@ test_ds_xchg_b64_nostride64:
 // COM: ds_load_2addr_b32, ds_store_2addr_b32, and ds_storexchg_2addr_rtn_b32
 // COM: before a single drain s_wait_dscnt 0x0. Verifies that the per-
 // COM: instruction dispatcher in applyTrampolinePatchesImpl correctly
-// COM: routes each variant to its own expansion type without state leakage
-// COM: across types in a single trampoline pass; drain wait stays at 0x0
-// COM: across all three split sites. Sleds appear in source order: load,
-// COM: store, xchg. All offsets scale by ElemBytes=4.
+// COM: routes each variant to the common byte-field rewrite without state
+// COM: leakage across types. All offsets scale by ElemBytes=4.
 // COM:   ds_load_2addr_b32  offset0:1 offset1:2 -> byte 4, 8
 // COM:   ds_store_2addr_b32 offset0:3 offset1:4 -> byte 12, 16
 // COM:   ds_storexchg_*_b32 offset0:5 offset1:6 -> byte 20, 24
 // DISASM-LABEL: <test_ds_combo_nostride64>:
-// DISASM-NOT: ds_load_2addr_b32
-// DISASM-NOT: ds_store_2addr_b32
-// DISASM-NOT: ds_storexchg_2addr_rtn_b32
-// DISASM: s_branch
-// DISASM: s_branch
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// COM: Sled 1: load expansion.
-// DISASM: ds_load_b32 v0, v8 offset:4
-// DISASM-NEXT: ds_load_b32 v1, v8 offset:8
-// COM: Sled 2: store expansion.
-// DISASM: ds_store_b32 v8, v2 offset:12
-// DISASM-NEXT: ds_store_b32 v8, v3 offset:16
-// COM: Sled 3: xchg expansion.
-// DISASM: ds_storexchg_rtn_b32 v4, v8, v6 offset:20
-// DISASM-NEXT: ds_storexchg_rtn_b32 v5, v8, v7 offset:24
+// DISASM-NEXT: ds_load_2addr_b32 v[0:1], v8 offset0:4 offset1:8
+// DISASM-NEXT: ds_store_2addr_b32 v8, v2, v3 offset0:12 offset1:16
+// DISASM-NEXT: ds_storexchg_2addr_rtn_b32 v[4:5], v8, v6, v7 offset0:20 offset1:24
+// DISASM-NEXT: s_wait_dscnt 0x0
 
 .globl test_ds_combo_nostride64
 .p2align 8
@@ -342,12 +341,19 @@ test_ds_combo_nostride64:
 .size test_ds_combo_nostride64, .Ltest_ds_combo_nostride64_end-test_ds_combo_nostride64
 
 // COM: Idempotency: rewriting the output again should produce identical
-// COM: bytes (no DS2 mnemonic remains, second pass is a no-op).
+// COM: bytes. Feeding the output back with its A0 stepping as the source
+// COM: disables B0-to-A0 patches, so the surviving A0-correct DS2 instruction
+// COM: is not scaled a second time.
+// COM: Legacy ISA names without a stepping deliberately declare their source
+// COM: as B0 on every invocation; repeating those arguments is not the
+// COM: idempotence contract for a transformation whose opcode survives.
 // RUN: hotswap-rewrite %t.out.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --check-idempotent \
-// RUN:   | %FileCheck --check-prefix=IDEM %s
-// IDEM: IDEMPOTENT: YES
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
 
 .rodata
 .p2align 8
@@ -372,6 +378,11 @@ test_ds_combo_nostride64:
 .end_amdhsa_kernel
 
 .amdhsa_kernel test_ds_store_b64_nostride64
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds_store_b64_nostride64_fallback
   .amdhsa_next_free_vgpr 5
   .amdhsa_next_free_sgpr 1
 .end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-overlap-cyclic.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-overlap-cyclic.s
@@ -18,7 +18,7 @@
 .p2align 8
 .type test_ds_overlap_cyclic,@function
 test_ds_overlap_cyclic:
-  ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset0:0 offset1:1
+  ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset0:32 offset1:33
   s_wait_dscnt 0
   s_endpgm
 .Ltest_ds_overlap_cyclic_end:

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
@@ -18,28 +18,28 @@
 // DISASM-LABEL: <test_ds_overlap>:
 
 // COM: Address overlaps the first b64 destination half: issue half 1 first.
-// DISASM:      ds_load_b64 v[14:15], v12 offset:8
-// DISASM-NEXT: ds_load_b64 v[12:13], v12
+// DISASM:      ds_load_b64 v[14:15], v12 offset:264
+// DISASM-NEXT: ds_load_b64 v[12:13], v12 offset:256
 
 // COM: The same rule applies to b32.
-// DISASM:      ds_load_b32 v5, v4 offset:8
-// DISASM-NEXT: ds_load_b32 v4, v4 offset:4
+// DISASM:      ds_load_b32 v5, v4 offset:260
+// DISASM-NEXT: ds_load_b32 v4, v4 offset:256
 
 // COM: Address overlaps the second half: natural order is already safe.
-// DISASM:      ds_load_b64 v[16:17], v18
-// DISASM-NEXT: ds_load_b64 v[18:19], v18 offset:8
+// DISASM:      ds_load_b64 v[16:17], v18 offset:256
+// DISASM-NEXT: ds_load_b64 v[18:19], v18 offset:264
 
 // COM: Exchange op0 would clobber op1's address, so reverse the operations.
-// DISASM:      ds_storexchg_rtn_b64 v[10:11], v8, v[14:15] offset:8
-// DISASM-NEXT: ds_storexchg_rtn_b64 v[8:9], v8, v[12:13]
+// DISASM:      ds_storexchg_rtn_b64 v[10:11], v8, v[14:15] offset:264
+// DISASM-NEXT: ds_storexchg_rtn_b64 v[8:9], v8, v[12:13] offset:256
 
 // COM: A data1 dependency also reverses a b32 exchange.
-// DISASM:      ds_storexchg_rtn_b32 v31, v40, v30 offset:4
-// DISASM-NEXT: ds_storexchg_rtn_b32 v30, v40, v41
+// DISASM:      ds_storexchg_rtn_b32 v31, v40, v30 offset:260
+// DISASM-NEXT: ds_storexchg_rtn_b32 v30, v40, v41 offset:256
 
 // COM: A data0 dependency on destination half 1 keeps the natural order.
-// DISASM:      ds_storexchg_rtn_b32 v32, v40, v33
-// DISASM-NEXT: ds_storexchg_rtn_b32 v33, v40, v41 offset:4
+// DISASM:      ds_storexchg_rtn_b32 v32, v40, v33 offset:256
+// DISASM-NEXT: ds_storexchg_rtn_b32 v33, v40, v41 offset:260
 
 // COM: Stride64 loads and exchanges use the same dependency ordering while
 // COM: scaling offset1 by 64 elements.
@@ -54,12 +54,12 @@
 .p2align 8
 .type test_ds_overlap,@function
 test_ds_overlap:
-  ds_load_2addr_b64 v[12:15], v12 offset0:0 offset1:1
-  ds_load_2addr_b32 v[4:5], v4 offset0:1 offset1:2
-  ds_load_2addr_b64 v[16:19], v18 offset0:0 offset1:1
-  ds_storexchg_2addr_rtn_b64 v[8:11], v8, v[12:13], v[14:15] offset0:0 offset1:1
-  ds_storexchg_2addr_rtn_b32 v[30:31], v40, v41, v30 offset0:0 offset1:1
-  ds_storexchg_2addr_rtn_b32 v[32:33], v40, v33, v41 offset0:0 offset1:1
+  ds_load_2addr_b64 v[12:15], v12 offset0:32 offset1:33
+  ds_load_2addr_b32 v[4:5], v4 offset0:64 offset1:65
+  ds_load_2addr_b64 v[16:19], v18 offset0:32 offset1:33
+  ds_storexchg_2addr_rtn_b64 v[8:11], v8, v[12:13], v[14:15] offset0:32 offset1:33
+  ds_storexchg_2addr_rtn_b32 v[30:31], v40, v41, v30 offset0:64 offset1:65
+  ds_storexchg_2addr_rtn_b32 v[32:33], v40, v33, v41 offset0:64 offset1:65
   ds_load_2addr_stride64_b64 v[42:45], v42 offset0:0 offset1:1
   ds_storexchg_2addr_stride64_rtn_b64 v[46:49], v46, v[50:51], v[52:53] offset0:0 offset1:1
   s_wait_dscnt 0x0

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-vgpr-msb.s
@@ -1,0 +1,62 @@
+// Verify that splitting a two-address DS load whose second destination crosses
+// v255 rebases that half to v0 under a temporary destination VGPR-MSB mode.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_ds_vgpr_msb>:
+// DISASM:      s_branch
+// DISASM:      ds_load_b64 v[254:255], v88 offset:680
+// DISASM-NEXT: s_set_vgpr_msb 64
+// DISASM-NEXT: ds_load_b64 v[0:1]{{.*v\[256:257\].*}}v88 offset:688
+// DISASM-NEXT: s_set_vgpr_msb 0x4000
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM:      s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds_vgpr_msb
+.p2align 8
+.type test_ds_vgpr_msb,@function
+test_ds_vgpr_msb:
+  s_set_vgpr_msb 0
+  ds_load_2addr_b64 v[254:257], v88 offset0:85 offset1:86
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_ds_vgpr_msb_end:
+.size test_ds_vgpr_msb, .Ltest_ds_vgpr_msb_end-test_ds_vgpr_msb
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds_vgpr_msb
+  .amdhsa_next_free_vgpr 688
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_ds_vgpr_msb
+      .symbol: test_ds_vgpr_msb.kd
+      .sgpr_count: 2
+      .vgpr_count: 688
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
@@ -1,0 +1,93 @@
+// COM: A far eight-byte trampoline site may tentatively reserve one SGPR to
+// COM: preserve live wave32 VCC_LO. Direct control-flow and a following branch
+// COM: prevent expansion to the required 12-byte source landing, so the plan
+// COM: must downgrade cleanly to the registerless island route. Its second
+// COM: source dword is the owner-reserved final return relay, so it branches
+// COM: to the continuation instead of remaining padding.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: safe far return: deferring live wave32 VCC_LO preservation in s105
+// LOG: hotswap: deferred live-VCC preservation at 0x{{[0-9A-F]+}} fell back to a registerless far return
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_deferred_vcc>:
+// DISASM-NEXT: s_branch 0
+// DISASM-NEXT: s_mov_b32 s104, 0
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_cbranch_vccz
+
+// RUN: %llvm-readelf --notes %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=METADATA %s
+// METADATA: .name:           test_deferred_vcc
+// METADATA: .sgpr_count:     105
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_deferred_vcc
+.p2align 8
+.type test_deferred_vcc,@function
+test_deferred_vcc:
+  s_branch 0
+  s_mov_b32 s104, 0
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_cbranch_vccz 0
+.irp live_reg, s0, s2, s4, s6, s8, s10, s12, s14, s16, s18, s20, s22, s24, s26, s28, s30, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104
+  s_mov_b32 s1, \live_reg
+.endr
+  s_endpgm
+.size test_deferred_vcc, .-test_deferred_vcc
+
+.type gateway_0,@function
+gateway_0:
+  s_endpgm
+.size gateway_0, .-gateway_0
+.fill 32, 1, 0
+
+.rept 20000
+  s_mov_b32 s0, s1
+.endr
+
+.type gateway_1,@function
+gateway_1:
+  s_endpgm
+.size gateway_1, .-gateway_1
+.fill 32, 1, 0
+
+.rept 20000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_deferred_vcc
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 105
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_deferred_vcc
+      .symbol: test_deferred_vcc.kd
+      .sgpr_count: 105
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -38,17 +38,142 @@
 // RUN:   | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES
 
-// COM: A kernel with no aligned two-SGPR block fails closed instead of
-// COM: emitting the unsafe return or clobbering a live register.
-// RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s105, 0/' \
-// RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 106/' \
-// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.full-sgpr.s
+// COM: A kernel with no aligned numbered SGPR pair can reuse VCC when the
+// COM: replacement does not consume its incoming value and the continuation
+// COM: ends before reading it.
+// RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s104, 0/' \
+// RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 105/' \
+// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 105/' %s > %t.full-sgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.full-sgpr.s -o %t.full-sgpr.elf
-// RUN: hotswap-rewrite %t.full-sgpr.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.full-sgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
-// FAIL: RESULT: ERROR
+// RUN:   --output %t.full-sgpr.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=FULL-LOG %s
+// FULL-LOG: hotswap: safe far return: reusing dead VCC
+// FULL-LOG: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.full-sgpr.out.elf \
+// RUN:   | %FileCheck --check-prefix=FULL-DISASM %s
+// FULL-DISASM: s_get_pc_i64 vcc
+// FULL-DISASM-NEXT: s_add_nc_u64 vcc, vcc,
+// FULL-DISASM-NEXT: s_set_pc_i64 vcc
+// FULL-DISASM: s_get_pc_i64 vcc
+// FULL-DISASM-NEXT: s_add_nc_u64 vcc, vcc,
+// FULL-DISASM-NEXT: s_set_pc_i64 vcc
+
+// COM: A live VCC can instead use an already-allocated numbered pair after
+// COM: CFG liveness proves that neither half is consumed by the replacement or
+// COM: continuation before being redefined.
+// RUN: sed '/^  tensor_load_to_lds/a\  s_cbranch_vccz 0' %t.full-sgpr.s \
+// RUN:   > %t.local-pair.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.local-pair.s -o %t.local-pair.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.local-pair.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.local-pair.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=LOCAL-PAIR-LOG %s
+// LOCAL-PAIR-LOG: hotswap: safe far return: reusing locally dead s[104:105]
+// LOCAL-PAIR-LOG: RESULT: SUCCESS
+
+// COM: Search every aligned pair, not just the highest eight. Every pair above
+// COM: s[30:31] has a reachable incoming-value read; s[30:31] is overwritten
+// COM: first and is therefore the highest locally dead pair.
+// RUN: sed -e '/^  tensor_load_to_lds/a\  s_cbranch_vccz 0' \
+// RUN:   -e 's|^// LOW-PAIR-ONLY:|  |' %t.full-sgpr.s > %t.low-pair.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.low-pair.s -o %t.low-pair.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.low-pair.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.low-pair.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=LOW-PAIR-LOG %s
+// LOW-PAIR-LOG: hotswap: safe far return: reusing locally dead s[30:31]
+// LOW-PAIR-LOG: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.low-pair.out.elf \
+// RUN:   | %FileCheck --check-prefix=LOW-PAIR-DISASM %s
+// LOW-PAIR-DISASM: s_get_pc_i64 s[30:31]
+// LOW-PAIR-DISASM-NEXT: s_add_nc_u64 s[30:31], s[30:31],
+// LOW-PAIR-DISASM-NEXT: s_set_pc_i64 s[30:31]
+
+// COM: When the continuation reads VCC before redefining it, a wave32 rewrite
+// COM: preserves VCC_LO in the one remaining numbered SGPR. The source reaches
+// COM: a save/set-PC gateway, and its tail becomes the restore landing pad.
+// RUN: sed 's|^// LIVE-ONLY:|  |' %t.full-sgpr.s \
+// RUN:   > %t.live-vcc.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.live-vcc.s -o %t.live-vcc.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.live-vcc.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.live-vcc.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=LIVE-LOG %s
+// LIVE-LOG: hotswap: safe far return: deferring live wave32 VCC_LO preservation in s105
+// LIVE-LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// LIVE-LOG: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.live-vcc.out.elf \
+// RUN:   | %FileCheck --check-prefix=LIVE-DISASM %s
+// LIVE-DISASM-LABEL: <test_far>:
+// LIVE-DISASM: s_branch
+// LIVE-DISASM-NEXT: s_mov_b32 vcc_lo, s105
+// LIVE-DISASM-NEXT: s_delay_alu instid0(SALU_CYCLE_1)
+// LIVE-DISASM: s_cbranch_vccz
+// LIVE-DISASM: s_mov_b32 s105, vcc_lo
+// LIVE-DISASM-NEXT: s_get_pc_i64 vcc
+
+// COM: Fragment both ordinary NOP windows below 20 bytes. The live-VCC
+// COM: source then needs an eight-byte save/branch primary and a disjoint
+// COM: sixteen-byte VCC-backed set-PC secondary. Both the pool-side restore
+// COM: before the replacement and the source-side continuation restore carry
+// COM: the required one-cycle SALU delay.
+// RUN: sed -e 's|^// LIVE-ONLY:|  |' \
+// RUN:   -e 's/\.fill 32, 1, 0/.fill 16, 1, 0/g' \
+// RUN:   %t.full-sgpr.s > %t.split-vcc.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.split-vcc.s -o %t.split-vcc.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.split-vcc.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.split-vcc.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=SPLIT-LOG %s
+// SPLIT-LOG: hotswap: assigned 1 split VCC-preserving gateway(s)
+// SPLIT-LOG: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.split-vcc.out.elf \
+// RUN:   | %FileCheck --check-prefix=SPLIT-DISASM %s
+// SPLIT-DISASM-LABEL: <test_far>:
+// SPLIT-DISASM-NEXT: s_mov_b32 s104, 0
+// SPLIT-DISASM-NEXT: s_branch
+// SPLIT-DISASM-NEXT: s_mov_b32 vcc_lo, s105
+// SPLIT-DISASM-NEXT: s_delay_alu instid0(SALU_CYCLE_1)
+// SPLIT-DISASM-LABEL: <gateway_barrier>:
+// SPLIT-DISASM-NEXT: s_endpgm
+// SPLIT-DISASM-NEXT: s_mov_b32 s105, vcc_lo
+// SPLIT-DISASM-NEXT: s_branch
+// SPLIT-DISASM-LABEL: <midpoint_gateway_barrier>:
+// SPLIT-DISASM-NEXT: s_endpgm
+// SPLIT-DISASM-NEXT: s_get_pc_i64 vcc
+// SPLIT-DISASM-NEXT: s_add_nc_u64 vcc, vcc,
+// SPLIT-DISASM-NEXT: s_set_pc_i64 vcc
+// SPLIT-DISASM: s_mov_b32 vcc_lo, s105
+// SPLIT-DISASM-NEXT: s_delay_alu instid0(SALU_CYCLE_1)
+// SPLIT-DISASM: tensor_load_to_lds
+// RUN: hotswap-rewrite %t.split-vcc.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=SPLIT-IDEM %s
+// SPLIT-IDEM: IDEMPOTENT: YES
+
+// COM: Seven nearby trampolines raise the object-wide count above the old
+// COM: blanket affine-reservation threshold, but the sole far source preserves
+// COM: live VCC and is not an affine candidate. Its exact 20-byte gateway must
+// COM: remain intact instead of being carved into unusable 8+12-byte pieces.
+// RUN: sed -e 's|^// LIVE-ONLY:|  |' \
+// RUN:   -e 's|^// EXACT20-ONLY:|  |' \
+// RUN:   -e 's/\.fill 32, 1, 0/.fill 20, 1, 0/g' \
+// RUN:   %t.full-sgpr.s > %t.exact20.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.exact20.s -o %t.exact20.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.exact20.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.exact20.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=EXACT20-LOG %s
+// EXACT20-LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// EXACT20-LOG: RESULT: SUCCESS
 
 // COM: A metadata-less object also fails closed because scratch usage cannot
 // COM: be charged to its owning kernel.
@@ -58,6 +183,7 @@
 // RUN: hotswap-rewrite %t.nometa.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
+// FAIL: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -67,6 +193,14 @@
 test_far:
   s_mov_b64 vcc, -1
   tensor_load_to_lds s[0:3], s[4:11]
+// LOW-PAIR-ONLY:s_mov_b64 s[30:31], 0
+// LOW-PAIR-ONLY:.irp live_reg, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104
+// LOW-PAIR-ONLY:s_mov_b32 s1, \live_reg
+// LOW-PAIR-ONLY:.endr
+// LIVE-ONLY:s_cbranch_vccz 0
+// LIVE-ONLY:.irp live_reg, s0, s2, s4, s6, s8, s10, s12, s14, s16, s18, s20, s22, s24, s26, s28, s30, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104
+// LIVE-ONLY:s_mov_b32 s1, \live_reg
+// LIVE-ONLY:.endr
   s_endpgm
 .size test_far, .-test_far
 
@@ -81,17 +215,44 @@ gateway_barrier:
   // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
   // s_branch's +-128 KB reach from the tensor_load above (forces the
   // long-branch path).
-  .rept 40000
+  .rept 20000
+    s_mov_b32 s0, s1
+  .endr
+
+// A safe midpoint sled gives a registerless far edge an s_branch island in
+// each direction.
+.type midpoint_gateway_barrier,@function
+midpoint_gateway_barrier:
+  s_endpgm
+.size midpoint_gateway_barrier, .-midpoint_gateway_barrier
+.fill 32, 1, 0
+
+  .rept 20000
     s_mov_b32 s0, s1
   .endr
 .Ltest_far_end:
+
+// EXACT20-ONLY:.globl near_sites
+// EXACT20-ONLY:.type near_sites,@function
+// EXACT20-ONLY:near_sites:
+// EXACT20-ONLY:.rept 7
+// EXACT20-ONLY:  tensor_load_to_lds s[0:3], s[4:11]
+// EXACT20-ONLY:  s_mov_b32 s0, s1
+// EXACT20-ONLY:.endr
+// EXACT20-ONLY:  s_endpgm
+// EXACT20-ONLY:.size near_sites, .-near_sites
 
 .rodata
 .p2align 8
 .amdhsa_kernel test_far
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 12
+  .amdhsa_wavefront_size32 1
 .end_amdhsa_kernel
+// EXACT20-ONLY:.amdhsa_kernel near_sites
+// EXACT20-ONLY:  .amdhsa_next_free_vgpr 1
+// EXACT20-ONLY:  .amdhsa_next_free_sgpr 12
+// EXACT20-ONLY:.end_amdhsa_kernel
 
 .amdgpu_metadata
   amdhsa.version:
@@ -106,6 +267,16 @@ gateway_barrier:
       .group_segment_fixed_size: 0
       .private_segment_fixed_size: 0
       .kernarg_segment_align: 8
-      .wavefront_size: 64
+      .wavefront_size: 32
       .max_flat_workgroup_size: 256
+// EXACT20-ONLY:  - .name: near_sites
+// EXACT20-ONLY:    .symbol: near_sites.kd
+// EXACT20-ONLY:    .sgpr_count: 14
+// EXACT20-ONLY:    .vgpr_count: 1
+// EXACT20-ONLY:    .kernarg_segment_size: 0
+// EXACT20-ONLY:    .group_segment_fixed_size: 0
+// EXACT20-ONLY:    .private_segment_fixed_size: 0
+// EXACT20-ONLY:    .kernarg_segment_align: 8
+// EXACT20-ONLY:    .wavefront_size: 64
+// EXACT20-ONLY:    .max_flat_workgroup_size: 256
 .end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-mirrored-stub-gateway.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-mirrored-stub-gateway.s
@@ -1,0 +1,114 @@
+// COM: Dense far sites can exhaust numbered SGPRs and leave only the pair
+// COM: already reserved for their return edge. The source PC plus one shared
+// COM: relocation-neutral delta selects a sparse branch stub in the pool.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: shared far-dispatch skipped 10 site(s) without four safe SGPRs
+// LOG: hotswap: planned 1 mirrored-stub gateway group(s) for 10 pair-only source site(s)
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <source0>:
+// DISASM-NEXT: s_call_i64 s[104:105],
+// DISASM-NEXT: s_{{(nop|branch)}}
+// DISASM-LABEL: <gateway_pad>:
+// DISASM-NEXT: s_add_nc_u64 s[104:105], s[104:105],
+// DISASM-NEXT: s_set_pc_i64 s[104:105]
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// COM: An in-function NOP run belongs only to that function. Even though the
+// COM: foreign run is branch-reachable from every source below, the affine
+// COM: planner must not use it as a gateway for a different function.
+// RUN: sed 's|^// FOREIGN-ONLY:|  |' %s > %t.foreign.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.foreign.s -o %t.foreign.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.foreign.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=FOREIGN %s
+// FOREIGN-NOT: hotswap: planned {{.*}} mirrored-stub gateway group
+// FOREIGN: hotswap: error: no safe short-branch gateway for far site
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.macro PATCH_SOURCE name, binding
+  \binding \name
+  .type \name,@function
+\name:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+\name\()_after:
+  s_mov_b32 s103, s103
+  s_mov_b32 s0, vcc_lo
+  s_endpgm
+  .size \name, .-\name
+.endm
+
+.local targeter
+.type targeter,@function
+targeter:
+  s_branch source0_after
+  s_branch source1_after
+  s_branch source2_after
+  s_branch source3_after
+  s_branch source4_after
+  s_branch source5_after
+  s_branch source6_after
+  s_branch source7_after
+  s_branch source8_after
+  s_branch source9_after
+  s_endpgm
+  .size targeter, .-targeter
+
+PATCH_SOURCE source0, .globl
+.local gateway_pad
+// FOREIGN-ONLY:.type gateway_pad,@function
+gateway_pad:
+  .rept 3
+    s_nop 0
+  .endr
+// FOREIGN-ONLY:.size gateway_pad, .-gateway_pad
+PATCH_SOURCE source1, .local
+PATCH_SOURCE source2, .local
+PATCH_SOURCE source3, .local
+PATCH_SOURCE source4, .local
+PATCH_SOURCE source5, .local
+PATCH_SOURCE source6, .local
+PATCH_SOURCE source7, .local
+PATCH_SOURCE source8, .local
+PATCH_SOURCE source9, .local
+
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel source0
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 104
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: source0
+      .symbol: source0.kd
+      .sgpr_count: 106
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-pair-backed-promotion.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-pair-backed-promotion.s
@@ -1,0 +1,134 @@
+// COM: An eight-byte far patch source has room for only its one-dword forward
+// COM: branch and one unreachable relay dword. A locally dead SGPR pair makes
+// COM: the trampoline return pair-backed, but there is no variable-width
+// COM: gateway and the source-to-pool corridor is wider than two s_branch
+// COM: spans. The forward branch allocator must promote safe straight-line
+// COM: source windows even though the owner has an SGPR-backed set-PC return.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: affine planner considering 1 pair-only source site(s)
+// LOG: hotswap: ordinary gateway planner collected 1 pending site(s)
+// LOG: hotswap: promoted safe straight-line source at {{.*}} to provide forward-capacity relay window
+// LOG: hotswap: promoted safe straight-line source at {{.*}} to provide forward-capacity relay window
+// LOG: hotswap: assigned 1 forward s_branch island chain(s)
+// LOG: hotswap: promoted 2 safe straight-line source(s) for branch-island capacity
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d --no-symbolize-operands %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <pair_backed_source>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <promotion_candidate>:
+// DISASM-NEXT: s_mov_b32 s0, s1
+// DISASM-NEXT: s_mov_b32 s0, s2
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+// DISASM: ds_load_b32
+// DISASM-NEXT: ds_load_b32
+// DISASM-NEXT: s_wait_dscnt
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local targeter
+.type targeter,@function
+targeter:
+  s_branch pair_backed_source_after
+  s_endpgm
+.size targeter, .-targeter
+
+// Put the source near the positive s_branch boundary of the page-aligned
+// trampoline pool.
+.rept 690
+  s_mov_b32 s0, s1
+.endr
+
+.globl pair_backed_source
+.type pair_backed_source,@function
+pair_backed_source:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+pair_backed_source_after:
+  // The numbered SGPRs are dead here, so the trampoline return uses a local
+  // SGPR pair rather than the registerless return planner.
+  s_mov_b32 s0, s1
+  s_endpgm
+.size pair_backed_source, .-pair_backed_source
+
+// Only typed function bodies are promotion candidates. The untyped filler
+// cannot become an accidental gateway.
+.rept 15400
+  s_mov_b32 s0, s1
+.endr
+
+.globl promotion_candidate
+.type promotion_candidate,@function
+promotion_candidate:
+  s_mov_b32 s0, s1
+  s_mov_b32 s0, s2
+  s_mov_b32 s0, s3
+  s_mov_b32 s0, s4
+  s_mov_b32 s0, s5
+  s_mov_b32 s0, s6
+  s_mov_b32 s0, s7
+  s_mov_b32 s0, s8
+  s_endpgm
+.size promotion_candidate, .-promotion_candidate
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.globl promotion_candidate_far
+.type promotion_candidate_far,@function
+promotion_candidate_far:
+  s_mov_b32 s0, s9
+  s_mov_b32 s0, s10
+  s_mov_b32 s0, s11
+  s_mov_b32 s0, s12
+  s_mov_b32 s0, s13
+  s_mov_b32 s0, s14
+  s_mov_b32 s0, s15
+  s_mov_b32 s0, s16
+  s_endpgm
+.size promotion_candidate_far, .-promotion_candidate_far
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel pair_backed_source
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 17
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: pair_backed_source
+      .symbol: pair_backed_source.kd
+      .sgpr_count: 17
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-registerless-owner-tail.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-registerless-owner-tail.s
@@ -1,0 +1,169 @@
+// COM: A far trampoline can have a directly reachable forward edge while its
+// COM: longer copied body makes the return edge just exceed s_branch range.
+// COM: With no scratch pair at the original source, the return allocator must
+// COM: promote safe straight-line windows across a gap wider than two s_branch
+// COM: spans. Each demand-sized promoted window supplies two suffix dwords:
+// COM: the return chain consumes the first and the registerless forward chain
+// COM: reuses the same source window's second slot. All numbered SGPRs are live
+// COM: after every window, so both promotions must use proven-dead VCC.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: safe far return: no register pair at
+// LOG: hotswap: promoted safe straight-line source at {{.*}} to provide return-capacity relay window {{.*}} with 2 slot(s) using VCC
+// LOG: hotswap: promoted safe straight-line source at {{.*}} to provide return-capacity relay window {{.*}} with 2 slot(s) using VCC
+// LOG: hotswap: assigned 1 forward s_branch island chain(s)
+// LOG: hotswap: assigned 1 return s_branch island chain(s)
+// LOG: hotswap: promoted 2 safe straight-line source(s) for branch-island capacity
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d --no-symbolize-operands %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <registerless_source>:
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <promotion_candidate>:
+// DISASM-NEXT: s_mov_b32 s0, s1
+// DISASM-NEXT: s_get_pc_i64 vcc
+// DISASM-NEXT: s_add_nc_u64 vcc, vcc,
+// DISASM-NEXT: s_set_pc_i64 vcc
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_mov_b32 s0, s8
+// DISASM-LABEL: <promotion_candidate_far>:
+// DISASM-NEXT: s_mov_b32 s0, s17
+// DISASM-NEXT: s_get_pc_i64 vcc
+// DISASM-NEXT: s_add_nc_u64 vcc, vcc,
+// DISASM-NEXT: s_set_pc_i64 vcc
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_mov_b32 s0, s24
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local targeter
+.type targeter,@function
+targeter:
+  s_branch registerless_source_after
+  s_endpgm
+  .size targeter, .-targeter
+
+// Put the source close to the positive s_branch boundary of the page-aligned
+// trampoline pool. The count is tuned together with the tail padding below.
+.rept 690
+  s_mov_b32 s0, s1
+.endr
+
+.globl registerless_source
+.type registerless_source,@function
+registerless_source:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+registerless_source_after:
+  // Keep every numbered pair live-in so neither local nor object-wide
+  // scratch analysis can manufacture a set-PC return pair.
+  .irp reg,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105
+    s_mov_b32 s\reg, s\reg
+  .endr
+  s_mov_b32 s0, vcc_lo
+  s_endpgm
+  .size registerless_source, .-registerless_source
+
+// Keep the candidate near the midpoint of the source-to-pool span.
+.rept 15400
+  s_mov_b32 s0, s1
+.endr
+
+.globl promotion_candidate
+.type promotion_candidate,@function
+promotion_candidate:
+  // Distinct source operands make each six-instruction relocated body
+  // identifiable in the appended pool.
+  s_mov_b32 s0, s1
+  s_mov_b32 s0, s2
+  s_mov_b32 s0, s3
+  s_mov_b32 s0, s4
+  s_mov_b32 s0, s5
+  s_mov_b32 s0, s6
+  s_mov_b32 s0, s7
+  s_mov_b32 s0, s8
+  s_mov_b32 s0, s9
+  s_mov_b32 s0, s10
+  s_mov_b32 s0, s11
+  s_mov_b32 s0, s12
+  s_mov_b32 s0, s13
+  s_mov_b32 s0, s14
+  s_mov_b32 s0, s15
+  s_mov_b32 s0, s16
+  // The relocatable prefix does not need incoming VCC, while every numbered
+  // pair remains live at its continuation. This selects dead VCC conservatively.
+  .irp reg,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105
+    s_mov_b32 s\reg, s\reg
+  .endr
+  s_endpgm
+  .size promotion_candidate, .-promotion_candidate
+
+// The second promotion region is over one branch span from the first, and the
+// final pool is over one further span away.
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.globl promotion_candidate_far
+.type promotion_candidate_far,@function
+promotion_candidate_far:
+  s_mov_b32 s0, s17
+  s_mov_b32 s0, s18
+  s_mov_b32 s0, s19
+  s_mov_b32 s0, s20
+  s_mov_b32 s0, s21
+  s_mov_b32 s0, s22
+  s_mov_b32 s0, s23
+  s_mov_b32 s0, s24
+  s_mov_b32 s0, s25
+  s_mov_b32 s0, s26
+  s_mov_b32 s0, s27
+  s_mov_b32 s0, s28
+  s_mov_b32 s0, s29
+  s_mov_b32 s0, s30
+  s_mov_b32 s0, s31
+  s_mov_b32 s0, s32
+  .irp reg,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105
+    s_mov_b32 s\reg, s\reg
+  .endr
+  s_endpgm
+  .size promotion_candidate_far, .-promotion_candidate_far
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel registerless_source
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: registerless_source
+      .symbol: registerless_source.kd
+      .sgpr_count: 106
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-shared-gateway-ownership.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-shared-gateway-ownership.s
@@ -1,0 +1,82 @@
+// COM: A shared dispatcher gateway and every source it serves must belong to
+// COM: the same function. An otherwise reachable NOP run in a foreign function
+// COM: is not a legal gateway.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=GOOD %s
+// GOOD: hotswap: planned 1 shared far-dispatch gateway group(s) for 10 source site(s)
+// GOOD: RESULT: SUCCESS
+
+// RUN: sed 's|^// FOREIGN-ONLY:|  |' %s > %t.foreign.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.foreign.s -o %t.foreign.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.foreign.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=FOREIGN %s
+// FOREIGN-NOT: hotswap: planned {{.*}} shared far-dispatch gateway group
+// FOREIGN: hotswap: error: no safe short-branch gateway for far site
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.macro PATCH_SOURCE number
+  s_branch source\number\()_after
+source\number:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+source\number\()_after:
+.endm
+
+.globl sources
+.type sources,@function
+sources:
+PATCH_SOURCE 0
+PATCH_SOURCE 1
+PATCH_SOURCE 2
+PATCH_SOURCE 3
+PATCH_SOURCE 4
+PATCH_SOURCE 5
+PATCH_SOURCE 6
+PATCH_SOURCE 7
+PATCH_SOURCE 8
+PATCH_SOURCE 9
+  s_endpgm
+.size sources, .-sources
+
+.local gateway_pad
+// FOREIGN-ONLY:.type gateway_pad,@function
+gateway_pad:
+  .rept 5
+    s_nop 0
+  .endr
+// FOREIGN-ONLY:.size gateway_pad, .-gateway_pad
+
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel sources
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 96
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: sources
+      .symbol: sources.kd
+      .sgpr_count: 98
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-shared-relay-chain.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-shared-relay-chain.s
@@ -1,0 +1,82 @@
+// COM: A shared dispatcher may admit a distant source through another
+// COM: member's second dword. Each newly admitted member must publish its
+// COM: source+4 tail, never its source s_call at source+0, as the next relay.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: planned 1 shared far-dispatch gateway group(s) for 8 source site(s)
+// LOG: RESULT: SUCCESS
+
+// COM: source5 is admitted through source7's tail, then publishes its own tail
+// COM: for source3. That second hop locks the newly admitted anchor at
+// COM: source+4 instead of source+0.
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <source5>:
+// DISASM-NEXT: s_call_i64
+// DISASM-NEXT: s_branch
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.macro PATCH_SOURCE number
+  s_branch source\number\()_after
+source\number:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+source\number\()_after:
+  .rept 15000
+    s_mov_b32 s0, s1
+  .endr
+.endm
+
+.globl chain
+.type chain,@function
+chain:
+PATCH_SOURCE 0
+PATCH_SOURCE 1
+PATCH_SOURCE 2
+PATCH_SOURCE 3
+PATCH_SOURCE 4
+PATCH_SOURCE 5
+PATCH_SOURCE 6
+PATCH_SOURCE 7
+PATCH_SOURCE 8
+  s_branch source9_after
+source9:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+source9_after:
+  s_mov_b32 s0, s1
+gateway_pad:
+  .rept 5
+    s_nop 0
+  .endr
+  .rept 15000
+    s_mov_b32 s0, s1
+  .endr
+  s_endpgm
+.size chain, .-chain
+
+.rodata
+.p2align 8
+.amdhsa_kernel chain
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 32
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: chain
+      .symbol: chain.kd
+      .sgpr_count: 34
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-source-tail-islands.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-source-tail-islands.s
@@ -1,0 +1,86 @@
+// COM: Far eight-byte patch sites have no padding inside their tiny owning
+// COM: functions. Their unreachable second dwords form a registerless relay
+// COM: chain to the appended trampoline pool.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: assigned 1 forward s_branch island chain(s)
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <source0>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop
+// DISASM-LABEL: <source1>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl source0
+.p2align 8
+.type source0,@function
+source0:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_endpgm
+.size source0, .-source0
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.globl source1
+.type source1,@function
+source1:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_endpgm
+.size source1, .-source1
+
+.rept 12500
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel source0
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+.amdhsa_kernel source1
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: source0
+      .symbol: source0.kd
+      .sgpr_count: 14
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: source1
+      .symbol: source1.kd
+      .sgpr_count: 14
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-scale16-fp4.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16-fp4.s
@@ -17,14 +17,14 @@
 // COM: VGPR select, never a lane mask, so no v_cndmask appears in either pass.
 // DISASM-NOT: v_cndmask_b32_e64
 // DISASM: v_mov_b32{{(_e32)?}} v{{[0-9]+}}, 0
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:39], v[0:7],{{.*}}matrix_a_fmt:MATRIX_FMT_FP4
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[0:7],{{.*}}matrix_a_fmt:MATRIX_FMT_FP4
 // COM: exactly one gfx1250 hazard v_nop before the pass-high masked-A VALU.
 // DISASM-COUNT-1: v_nop
 // DISASM-NEXT: v_mov_b32{{(_e32)?}} v{{[0-9]+}}, 0
 // DISASM-NOT: v_cndmask_b32_e64
 // COM: pass-high keeps the high-16 subblock VGPRs, odd-byte scale gather,
 // COM: accumulating onto pass-low through v[0:7].
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:39], v[0:7],{{.*}}matrix_a_fmt:MATRIX_FMT_FP4
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[0:7],{{.*}}matrix_a_fmt:MATRIX_FMT_FP4
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-wmma-scale16-large-vgpr-count.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16-large-vgpr-count.s
@@ -1,0 +1,75 @@
+// A kernel may allocate more than 256 physical VGPRs through gfx1250's
+// VGPR-MSB mode. The scale16 lowering's generated assembly must still use
+// encodable v0-v255 names and select its above-KD scratch bank explicitly.
+// The bump is occupancy-neutral (the original and rewritten allocations both
+// admit one wave/EU), despite the maximum-workgroup metadata asking for two.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: wmma_scale16: exact K-split
+// API-NOT: register index is out of range
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_scale16_large_vgpr_count>:
+// DISASM-NOT: v_wmma_scale16
+// DISASM: v_mov_b32_e32 v191 /*v703*/, v255
+// DISASM-NEXT: s_set_vgpr_msb 0xa0a1
+// DISASM-NEXT: v_mov_b32_e32 v192 /*v704*/, v0 /*v256*/
+// DISASM: s_set_vgpr_msb 0xa00a
+// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[182:189] /*v[694:701]*/, v[190:197] /*v[702:709]*/, 0,
+// DISASM: s_set_vgpr_msb 0x880a
+// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[182:189] /*v[694:701]*/, v[190:197] /*v[702:709]*/, v[38:45],
+// DISASM-NEXT: s_set_vgpr_msb 0xa00
+// DISASM: s_set_vgpr_msb 0xa00a
+// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[182:189] /*v[694:701]*/, v[190:197] /*v[702:709]*/, 0,
+// DISASM: s_set_vgpr_msb 0x880a
+// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[182:189] /*v[694:701]*/, v[190:197] /*v[702:709]*/, v[38:45],
+// DISASM-NEXT: s_set_vgpr_msb 0xa00
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_scale16_large_vgpr_count
+.p2align 8
+.type test_wmma_scale16_large_vgpr_count,@function
+test_wmma_scale16_large_vgpr_count:
+  s_set_vgpr_msb 0x100
+  v_mov_b32 v10, v10
+  v_wmma_scale16_f32_16x16x128_f8f6f4 v[38:45], v[174:181], v[254:261], 0, v[0:1], v[18:19] matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4 matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3
+  v_wmma_scale16_f32_16x16x128_f8f6f4 v[38:45], v[174:181], v[240:247], 0, v[0:1], v[18:19] matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4 matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3
+  s_endpgm
+.Ltest_wmma_scale16_large_vgpr_count_end:
+.size test_wmma_scale16_large_vgpr_count, .Ltest_wmma_scale16_large_vgpr_count_end-test_wmma_scale16_large_vgpr_count
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_scale16_large_vgpr_count
+  .amdhsa_next_free_vgpr 688
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_scale16_large_vgpr_count
+      .symbol: test_wmma_scale16_large_vgpr_count.kd
+      .sgpr_count: 2
+      .vgpr_count: 688
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-scale16.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16.s
@@ -1,8 +1,9 @@
 // COM: The target gfx1250 has no block-16 scaled WMMA, so the rewrite lowers
 // COM: 16x16x128_f8f6f4 exactly into two block-32 WMMAs chained through the
 // COM: accumulator: each pass masks matrix A to one 16-K subblock (a lane mask
-// COM: for FP8) and byte-gathers the matching block-16 scales. When the scratch
-// COM: budget is unavailable it fails closed (see the 32x16 refuse test).
+// COM: for FP8), copies matrix B into the same scratch bank, and byte-gathers
+// COM: the matching block-16 scales. When the scratch budget is unavailable it
+// COM: fails closed (see the 32x16 refuse test).
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
@@ -18,13 +19,13 @@
 // DISASM-NOT: v_wmma_scale16
 // DISASM: s_mov_b32 s{{[0-9]+}}, 0xffff {{.*$}}
 // DISASM: v_cndmask_b32_e64
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:47], v[0:7],
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[0:7],
 // COM: exactly one gfx1250 hazard v_nop before the pass-high lane-mask VALU that
 // COM: overwrites the masked-A scratch block.
 // DISASM-COUNT-1: v_nop
 // DISASM-NEXT: s_mov_b32 s{{[0-9]+}}, 0xffff0000
 // DISASM: v_cndmask_b32_e64
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:47], v[0:7],
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[0:7],
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -118,6 +118,9 @@ config.substitutions.append(
 config.substitutions.append(
     ("%llvm-readelf", _fwd(config.llvm_tools_dir, "llvm-readelf"))
 )
+config.substitutions.append(
+    ("%llvm-readobj", _fwd(config.llvm_tools_dir, "llvm-readobj"))
+)
 config.substitutions.append(("%ld.lld", _fwd(config.llvm_tools_dir, "ld.lld")))
 config.substitutions.append(("%yaml2obj", _fwd(config.llvm_tools_dir, "yaml2obj")))
 config.substitutions.append(("%FileCheck", _fwd(config.llvm_tools_dir, "FileCheck")))

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1859,6 +1859,25 @@ TEST(CollectDirectBranchTargets,
             /*CallerEndIndex=*/4, /*ExternalEntries=*/{},
             /*Target1BeginIndex=*/8);
   ASSERT_TRUE(SharedCanonicalLeaf);
+  llvm::SmallVector<uint8_t> SharedCanonicalLeafBytes =
+      assembleInstructions(TwoExactCallers + LeafFrame, S);
+  std::vector<InternalDecodedInst> SharedCanonicalLeafDecoded;
+  ASSERT_TRUE(decodeTextSection(SharedCanonicalLeafBytes.data(),
+                                SharedCanonicalLeafBytes.size(), S,
+                                SharedCanonicalLeafDecoded));
+  ASSERT_EQ(SharedCanonicalLeafDecoded.size(), 16u);
+  EXPECT_TRUE(SharedCanonicalLeaf->Targets.contains(
+      SharedCanonicalLeafDecoded[2].Offset +
+      SharedCanonicalLeafDecoded[2].Size));
+  EXPECT_TRUE(SharedCanonicalLeaf->Targets.contains(
+      SharedCanonicalLeafDecoded[6].Offset +
+      SharedCanonicalLeafDecoded[6].Size));
+  EXPECT_TRUE(SharedCanonicalLeaf->BoundedIndirectTransfers.contains(
+      SharedCanonicalLeafDecoded[2].Offset));
+  EXPECT_TRUE(SharedCanonicalLeaf->BoundedIndirectTransfers.contains(
+      SharedCanonicalLeafDecoded[6].Offset));
+  EXPECT_TRUE(SharedCanonicalLeaf->BoundedIndirectTransfers.contains(
+      SharedCanonicalLeafDecoded[14].Offset));
   EXPECT_FALSE(SharedCanonicalLeaf->HasUnresolvedTargets);
   EXPECT_FALSE(SharedCanonicalLeaf->HasUnboundedIndirectEntries);
 

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -153,10 +153,11 @@ static bool scalarIncomingSgprIsUnsafe(
   return false;
 }
 
-static bool scalarIncomingRegisterIsNeeded(
-    llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &S,
-    uint64_t FunctionBegin, uint64_t FunctionEnd, uint64_t Continuation,
-    llvm::MCRegister Register) {
+static bool
+scalarIncomingRegisterIsNeeded(llvm::ArrayRef<InternalDecodedInst> Decoded,
+                               const LLVMState &S, uint64_t FunctionBegin,
+                               uint64_t FunctionEnd, uint64_t Continuation,
+                               llvm::MCRegister Register) {
   auto FindInstruction = [&](uint64_t Offset) -> std::optional<size_t> {
     if (Offset < FunctionBegin || Offset >= FunctionEnd)
       return std::nullopt;
@@ -217,21 +218,20 @@ static bool scalarIncomingRegisterIsNeeded(
   return false;
 }
 
-static void expectBatchRegisterNeedsMatchesScalar(
-    const LLVMState &S, llvm::ArrayRef<llvm::StringRef> Lines,
-    llvm::MCRegister Register) {
+static void
+expectBatchRegisterNeedsMatchesScalar(const LLVMState &S,
+                                      llvm::ArrayRef<llvm::StringRef> Lines,
+                                      llvm::MCRegister Register) {
   std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(S, Lines);
   ASSERT_FALSE(Decoded.empty());
   uint64_t FunctionEnd = Decoded.back().Offset + Decoded.back().Size;
-  std::optional<llvm::DenseSet<uint64_t>> Batch =
-      computeIncomingRegisterNeeds(Decoded, S, /*FunctionBegin=*/0,
-                                   FunctionEnd, Register);
+  std::optional<llvm::DenseSet<uint64_t>> Batch = computeIncomingRegisterNeeds(
+      Decoded, S, /*FunctionBegin=*/0, FunctionEnd, Register);
   ASSERT_TRUE(Batch);
   for (const InternalDecodedInst &DI : Decoded)
     EXPECT_EQ(Batch->contains(DI.Offset),
-              scalarIncomingRegisterIsNeeded(
-                  Decoded, S, /*FunctionBegin=*/0, FunctionEnd, DI.Offset,
-                  Register))
+              scalarIncomingRegisterIsNeeded(Decoded, S, /*FunctionBegin=*/0,
+                                             FunctionEnd, DI.Offset, Register))
         << "continuation 0x" << llvm::utohexstr(DI.Offset);
 }
 
@@ -249,27 +249,26 @@ expectBatchSgprProofMatchesScalar(const LLVMState &S,
     Continuations.push_back(DI.Offset);
   Continuations.push_back(1);
   BatchedSgprContinuationTestResult Batch =
-      runBatchedSgprContinuationAnalysisForTest(
-          Decoded, S, /*FunctionBegin=*/0, FunctionEnd, Continuations,
-          *NumberedSgprs);
+      runBatchedSgprContinuationAnalysisForTest(Decoded, S, /*FunctionBegin=*/0,
+                                                FunctionEnd, Continuations,
+                                                *NumberedSgprs);
   EXPECT_EQ(Batch.Analyses, 1u);
   ASSERT_EQ(Batch.Queries.size(), Continuations.size());
   for (size_t Query = 0; Query != Decoded.size(); ++Query) {
-    std::optional<llvm::BitVector> Scalar =
-        unsafeIncomingNumberedSgprsInRange(
-            Decoded, S, /*FunctionBegin=*/0, FunctionEnd,
-            Continuations[Query], *NumberedSgprs);
+    std::optional<llvm::BitVector> Scalar = unsafeIncomingNumberedSgprsInRange(
+        Decoded, S, /*FunctionBegin=*/0, FunctionEnd, Continuations[Query],
+        *NumberedSgprs);
     ASSERT_TRUE(Scalar);
     ASSERT_TRUE(Batch.Queries[Query]);
     EXPECT_EQ(*Batch.Queries[Query], *Scalar)
         << "continuation 0x" << llvm::utohexstr(Continuations[Query]);
     for (unsigned I = 0; I != NumberedSgprs->size(); ++I)
       EXPECT_EQ(Batch.Queries[Query]->test(I),
-                scalarIncomingSgprIsUnsafe(
-                    Decoded, S, /*FunctionBegin=*/0, FunctionEnd,
-                    Continuations[Query], *NumberedSgprs, I))
-          << "continuation 0x" << llvm::utohexstr(Continuations[Query])
-          << ", s" << I;
+                scalarIncomingSgprIsUnsafe(Decoded, S, /*FunctionBegin=*/0,
+                                           FunctionEnd, Continuations[Query],
+                                           *NumberedSgprs, I))
+          << "continuation 0x" << llvm::utohexstr(Continuations[Query]) << ", s"
+          << I;
   }
   EXPECT_FALSE(Batch.Queries.back());
 }
@@ -1844,6 +1843,25 @@ TEST(CollectDirectBranchTargets,
   EXPECT_FALSE(ExactCanonicalLeaf->HasUnresolvedTargets);
   EXPECT_FALSE(ExactCanonicalLeaf->HasUnboundedIndirectEntries);
 
+  // Two independently entered exact callers may share one canonical leaf.
+  // The finite closure must union both validated continuations instead of
+  // accepting only the first caller that proves the callee.
+  std::string TwoExactCallers = "s_get_pc_i64 s[0:1]\n"
+                                "s_add_nc_u64 s[0:1], s[0:1], 28\n"
+                                "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                                "s_endpgm\n"
+                                "s_get_pc_i64 s[2:3]\n"
+                                "s_add_nc_u64 s[2:3], s[2:3], 12\n"
+                                "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                                "s_endpgm\n";
+  std::optional<DirectControlFlowInfo> SharedCanonicalLeaf =
+      Audit(TwoExactCallers + LeafFrame, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/4, /*ExternalEntries=*/{},
+            /*Target1BeginIndex=*/8);
+  ASSERT_TRUE(SharedCanonicalLeaf);
+  EXPECT_FALSE(SharedCanonicalLeaf->HasUnresolvedTargets);
+  EXPECT_FALSE(SharedCanonicalLeaf->HasUnboundedIndirectEntries);
+
   // A separate finite call enters the add of the exact singleton call above,
   // bypassing its defining get-PC. The canonical callee frame remains valid,
   // but the exact closure must reject this alternate materialization entry
@@ -2302,8 +2320,7 @@ TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
   // collectDirectBranchTargets normally sees the complete .text decode. Keep
   // the synthetic production slice faithful to that contract by representing
   // the resolved local target as an instruction boundary.
-  llvm::SmallVector<uint8_t> TargetBytes =
-      assembleInstructions("s_endpgm", S);
+  llvm::SmallVector<uint8_t> TargetBytes = assembleInstructions("s_endpgm", S);
   std::vector<InternalDecodedInst> TargetDecoded;
   ASSERT_TRUE(decodeTextSection(TargetBytes.data(), TargetBytes.size(), S,
                                 TargetDecoded));
@@ -2469,8 +2486,8 @@ TEST(SourceTailSafety, IndexedRangeQueryMatchesOverlapBoundaries) {
 
   llvm::SmallVector<ElfView::FunctionTextRange, 2> SameBeginDifferentEnd{
       {0, 32, nullptr, nullptr}, {0, 24, nullptr, nullptr}};
-  EXPECT_FALSE(sourceHasUniqueFunctionRange(
-      T, SameBeginDifferentEnd, /*TextAddr=*/0));
+  EXPECT_FALSE(
+      sourceHasUniqueFunctionRange(T, SameBeginDifferentEnd, /*TextAddr=*/0));
   EXPECT_FALSE(sourceHasUniqueFunctionRangeIndexedForTest(
       T, SameBeginDifferentEnd, /*TextAddr=*/0));
 
@@ -2480,16 +2497,14 @@ TEST(SourceTailSafety, IndexedRangeQueryMatchesOverlapBoundaries) {
   T.FunctionEnd = 40;
   T.OriginalOffset = 16;
   T.OriginalSize = 8;
-  EXPECT_TRUE(
-      sourceHasUniqueFunctionRange(T, PartialOverlap, /*TextAddr=*/0));
-  EXPECT_TRUE(sourceHasUniqueFunctionRangeIndexedForTest(
-      T, PartialOverlap, /*TextAddr=*/0));
+  EXPECT_TRUE(sourceHasUniqueFunctionRange(T, PartialOverlap, /*TextAddr=*/0));
+  EXPECT_TRUE(sourceHasUniqueFunctionRangeIndexedForTest(T, PartialOverlap,
+                                                         /*TextAddr=*/0));
 
   T.OriginalSize = 4;
-  EXPECT_FALSE(
-      sourceHasUniqueFunctionRange(T, PartialOverlap, /*TextAddr=*/0));
-  EXPECT_FALSE(sourceHasUniqueFunctionRangeIndexedForTest(
-      T, PartialOverlap, /*TextAddr=*/0));
+  EXPECT_FALSE(sourceHasUniqueFunctionRange(T, PartialOverlap, /*TextAddr=*/0));
+  EXPECT_FALSE(sourceHasUniqueFunctionRangeIndexedForTest(T, PartialOverlap,
+                                                          /*TextAddr=*/0));
 }
 
 TEST(SourceTailSafety, IndexedRangeQueryMatchesRandomizedLinearOracle) {
@@ -2506,14 +2521,12 @@ TEST(SourceTailSafety, IndexedRangeQueryMatchesRandomizedLinearOracle) {
     for (unsigned I = 0; I != Count; ++I) {
       uint64_t Begin = (Next() % 64) * MinInstSize;
       uint64_t End = Begin + (1 + Next() % 24) * MinInstSize;
-      Ranges.push_back(
-          {TextAddr + Begin, TextAddr + End, nullptr, nullptr});
+      Ranges.push_back({TextAddr + Begin, TextAddr + End, nullptr, nullptr});
       if ((Next() & 3) == 0)
         Ranges.push_back(Ranges.back());
     }
 
-    const ElfView::FunctionTextRange &Selected =
-        Ranges[Next() % Ranges.size()];
+    const ElfView::FunctionTextRange &Selected = Ranges[Next() % Ranges.size()];
     Trampoline T;
     T.HasFunctionRange = (Next() & 15) != 0;
     T.FunctionStart = Selected.Begin - TextAddr;
@@ -4199,10 +4212,9 @@ TEST(BranchIslandAllocator, AcceptsExactPositiveReachBoundary) {
   std::vector<NopSled> Gateways = {
       {MaxSledDistance, MaxSledDistance + MinInstSize, MaxSledDistance,
        /*FunctionStart=*/0, /*FunctionEnd=*/3 * MaxSledDistance}};
-  BranchIslandAllocatorTestResult Result =
-      runBranchIslandAllocatorForTest(
-          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
-          /*TargetOffset=*/2 * MaxSledDistance, /*Backward=*/false);
+  BranchIslandAllocatorTestResult Result = runBranchIslandAllocatorForTest(
+      std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
+      /*TargetOffset=*/2 * MaxSledDistance, /*Backward=*/false);
   ASSERT_TRUE(Result.Success);
   ASSERT_EQ(Result.Islands.size(), 1u);
   EXPECT_EQ(Result.Islands.front(), MaxSledDistance);
@@ -4213,10 +4225,9 @@ TEST(BranchIslandAllocator, RollsBackPartialChainAndAliases) {
   std::vector<NopSled> Gateways = {
       {Head, Head + MinInstSize, Head, 0, 400000},
       {Head, Head + 2 * MinInstSize, Head, 0, 400000}};
-  BranchIslandAllocatorTestResult Result =
-      runBranchIslandAllocatorForTest(
-          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/300000,
-          /*TargetOffset=*/0, /*Backward=*/true);
+  BranchIslandAllocatorTestResult Result = runBranchIslandAllocatorForTest(
+      std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/300000,
+      /*TargetOffset=*/0, /*Backward=*/true);
   EXPECT_FALSE(Result.Success);
   ASSERT_EQ(Result.Gateways.size(), 2u);
   EXPECT_EQ(Result.Gateways[0].WritePos, Head);
@@ -4237,9 +4248,8 @@ TEST(BranchIslandAllocator, HoldsPartialChainAcrossMultiplePromotions) {
           std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/800000,
           /*TargetOffset=*/20000, /*Backward=*/true, Promotions);
   ASSERT_TRUE(Result.Success);
-  EXPECT_EQ(Result.Islands,
-            (llvm::SmallVector<uint64_t, 4>{670000, 540000, 410000, 280000,
-                                            150000}));
+  EXPECT_EQ(Result.Islands, (llvm::SmallVector<uint64_t, 4>{
+                                670000, 540000, 410000, 280000, 150000}));
   EXPECT_EQ(Result.HeldIslandCountsAtPromotion,
             (llvm::SmallVector<size_t, 4>{3, 4}));
 }
@@ -4274,10 +4284,9 @@ TEST(BranchIslandAllocator, SkipsGatewayFromDifferentFunction) {
        /*FunctionStart=*/0, /*FunctionEnd=*/300000},
       {260000, 260000 + MinInstSize, 260000,
        /*FunctionStart=*/0, /*FunctionEnd=*/300000}};
-  BranchIslandAllocatorTestResult Result =
-      runBranchIslandAllocatorForTest(
-          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
-          /*TargetOffset=*/262144, /*Backward=*/false);
+  BranchIslandAllocatorTestResult Result = runBranchIslandAllocatorForTest(
+      std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
+      /*TargetOffset=*/262144, /*Backward=*/false);
   ASSERT_TRUE(Result.Success);
   ASSERT_EQ(Result.Islands.size(), 2u);
   EXPECT_EQ(Result.Islands[0], 130000u);
@@ -4286,28 +4295,24 @@ TEST(BranchIslandAllocator, SkipsGatewayFromDifferentFunction) {
 
 TEST(BranchIslandAllocator, CoAdvancesEqualPhysicalAliases) {
   std::vector<NopSled> Gateways = {
-      {MaxSledDistance, MaxSledDistance + 2 * MinInstSize, MaxSledDistance,
-       0, 3 * MaxSledDistance},
-      {MaxSledDistance, MaxSledDistance + 3 * MinInstSize, MaxSledDistance,
-       0, 3 * MaxSledDistance}};
-  BranchIslandAllocatorTestResult Result =
-      runBranchIslandAllocatorForTest(
-          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
-          /*TargetOffset=*/2 * MaxSledDistance, /*Backward=*/false);
+      {MaxSledDistance, MaxSledDistance + 2 * MinInstSize, MaxSledDistance, 0,
+       3 * MaxSledDistance},
+      {MaxSledDistance, MaxSledDistance + 3 * MinInstSize, MaxSledDistance, 0,
+       3 * MaxSledDistance}};
+  BranchIslandAllocatorTestResult Result = runBranchIslandAllocatorForTest(
+      std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
+      /*TargetOffset=*/2 * MaxSledDistance, /*Backward=*/false);
   ASSERT_TRUE(Result.Success);
   ASSERT_EQ(Result.Gateways.size(), 2u);
-  EXPECT_EQ(Result.Gateways[0].WritePos,
-            MaxSledDistance + MinInstSize);
-  EXPECT_EQ(Result.Gateways[1].WritePos,
-            MaxSledDistance + MinInstSize);
+  EXPECT_EQ(Result.Gateways[0].WritePos, MaxSledDistance + MinInstSize);
+  EXPECT_EQ(Result.Gateways[1].WritePos, MaxSledDistance + MinInstSize);
   EXPECT_TRUE(Result.Occupied.contains(MaxSledDistance));
 }
 
 TEST(BranchIslandAllocator, SplitsPartialAliasAtOccupiedDword) {
   llvm::DenseSet<uint64_t> Occupied = {108};
-  std::vector<NopSled> Available =
-      subtractOccupiedBranchGatewaySlotsForTest(
-          {{100, 140, 100, 0, 200}}, Occupied);
+  std::vector<NopSled> Available = subtractOccupiedBranchGatewaySlotsForTest(
+      {{100, 140, 100, 0, 200}}, Occupied);
   ASSERT_EQ(Available.size(), 2u);
   EXPECT_EQ(Available[0].Start, 100u);
   EXPECT_EQ(Available[0].End, 108u);
@@ -4336,17 +4341,14 @@ TEST(BranchPromotionSearchRange, ClampsForwardCorridorToReachableBand) {
 
 TEST(BranchPromotionSearchRange, ClampsBackwardCorridorToReachableBand) {
   constexpr uint64_t Current = 1000000;
-  auto Far =
-      branchPromotionSearchRangeForTest(Current, /*CorridorOffset=*/1000,
-                                        /*Forward=*/false);
-  EXPECT_EQ(Far.first, Current - MaxSledDistance -
-                           SetPcForwardSequenceBytes);
+  auto Far = branchPromotionSearchRangeForTest(Current, /*CorridorOffset=*/1000,
+                                               /*Forward=*/false);
+  EXPECT_EQ(Far.first, Current - MaxSledDistance - SetPcForwardSequenceBytes);
   EXPECT_EQ(Far.second, Current);
 
   auto Near = branchPromotionSearchRangeForTest(
       Current, /*CorridorOffset=*/950000, /*Forward=*/false);
-  EXPECT_EQ(Near.first,
-            950000u - SetPcForwardSequenceBytes - MinInstSize);
+  EXPECT_EQ(Near.first, 950000u - SetPcForwardSequenceBytes - MinInstSize);
   EXPECT_EQ(Near.second, Current);
 
   auto Saturated = branchPromotionSearchRangeForTest(
@@ -4380,10 +4382,10 @@ TEST(BranchPromotionCandidateCursor, MatchesScalarDirectionalOrderAndBounds) {
                                            /*Forward=*/false),
             ScalarBackward);
 
-  EXPECT_TRUE(promotionCandidateOrderForTest(
-                  Count, Rejected, /*BeginIndex=*/Count,
-                  /*EndIndex=*/Count + 10, /*Forward=*/true)
-                  .empty());
+  EXPECT_TRUE(
+      promotionCandidateOrderForTest(Count, Rejected, /*BeginIndex=*/Count,
+                                     /*EndIndex=*/Count + 10, /*Forward=*/true)
+          .empty());
 }
 
 TEST(BranchPromotionCandidateCursor,
@@ -4395,17 +4397,15 @@ TEST(BranchPromotionCandidateCursor,
   EXPECT_EQ(Initial, (llvm::SmallVector<size_t, 8>{4, 3, 2, 1}));
 
   const size_t PermanentlyRejected[] = {4, 2};
-  llvm::SmallVector<size_t, 8> Retried =
-      promotionCandidateOrderForTest(
-          /*CandidateCount=*/6, PermanentlyRejected,
-          /*BeginIndex=*/1, /*EndIndex=*/5, /*Forward=*/true);
+  llvm::SmallVector<size_t, 8> Retried = promotionCandidateOrderForTest(
+      /*CandidateCount=*/6, PermanentlyRejected,
+      /*BeginIndex=*/1, /*EndIndex=*/5, /*Forward=*/true);
   EXPECT_EQ(Retried, (llvm::SmallVector<size_t, 8>{3, 1}));
 
   // The same persistent bits retain the opposite directional order.
-  llvm::SmallVector<size_t, 8> Backward =
-      promotionCandidateOrderForTest(
-          /*CandidateCount=*/6, PermanentlyRejected,
-          /*BeginIndex=*/1, /*EndIndex=*/5, /*Forward=*/false);
+  llvm::SmallVector<size_t, 8> Backward = promotionCandidateOrderForTest(
+      /*CandidateCount=*/6, PermanentlyRejected,
+      /*BeginIndex=*/1, /*EndIndex=*/5, /*Forward=*/false);
   EXPECT_EQ(Backward, (llvm::SmallVector<size_t, 8>{1, 3}));
 }
 
@@ -4476,14 +4476,14 @@ TEST(RegisterLiveness, PartialVccDefinitionDoesNotKillFullVcc) {
   EXPECT_TRUE(instructionFullyWritesRegister(Full.front(), S, VccLo));
   EXPECT_TRUE(instructionFullyWritesRegister(Full.front(), S, S.VCCRegister));
 
-  llvm::SmallVector<uint8_t> PartialThenHighUse = assembleInstructions(
-      "s_mov_b32 vcc_lo, s0\ns_mov_b32 s1, vcc_hi", S);
+  llvm::SmallVector<uint8_t> PartialThenHighUse =
+      assembleInstructions("s_mov_b32 vcc_lo, s0\ns_mov_b32 s1, vcc_hi", S);
   ASSERT_FALSE(PartialThenHighUse.empty());
-  EXPECT_TRUE(replacementNeedsIncomingRegister(PartialThenHighUse, S,
-                                               S.VCCRegister));
+  EXPECT_TRUE(
+      replacementNeedsIncomingRegister(PartialThenHighUse, S, S.VCCRegister));
 
-  llvm::SmallVector<uint8_t> FullThenHighUse = assembleInstructions(
-      "s_mov_b64 vcc, -1\ns_mov_b32 s1, vcc_hi", S);
+  llvm::SmallVector<uint8_t> FullThenHighUse =
+      assembleInstructions("s_mov_b64 vcc, -1\ns_mov_b32 s1, vcc_hi", S);
   ASSERT_FALSE(FullThenHighUse.empty());
   EXPECT_FALSE(
       replacementNeedsIncomingRegister(FullThenHighUse, S, S.VCCRegister));
@@ -4504,28 +4504,27 @@ TEST(RegisterLiveness, BatchedVccNeedsRespectControlFlowAndFullDefs) {
                                         S.VCCRegister);
   };
 
-  std::optional<llvm::DenseSet<uint64_t>> Partial = Compute(
-      llvm::ArrayRef<llvm::StringRef>({"s_mov_b32 vcc_lo, s0",
-                                      "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+  std::optional<llvm::DenseSet<uint64_t>> Partial =
+      Compute(llvm::ArrayRef<llvm::StringRef>(
+          {"s_mov_b32 vcc_lo, s0", "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
   ASSERT_TRUE(Partial);
   EXPECT_TRUE(Partial->contains(0));
 
-  std::optional<llvm::DenseSet<uint64_t>> Full = Compute(
-      llvm::ArrayRef<llvm::StringRef>({"s_mov_b64 vcc, -1",
-                                      "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+  std::optional<llvm::DenseSet<uint64_t>> Full =
+      Compute(llvm::ArrayRef<llvm::StringRef>(
+          {"s_mov_b64 vcc, -1", "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
   ASSERT_TRUE(Full);
   EXPECT_FALSE(Full->contains(0));
   EXPECT_TRUE(Full->contains(MinInstSize));
 
   std::optional<llvm::DenseSet<uint64_t>> BranchUnion = Compute(
-      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1",
-                                      "s_mov_b64 vcc, -1",
-                                      "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_mov_b64 vcc, -1",
+                                       "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
   ASSERT_TRUE(BranchUnion);
   EXPECT_TRUE(BranchUnion->contains(0));
 
-  std::optional<llvm::DenseSet<uint64_t>> Opaque = Compute(
-      llvm::ArrayRef<llvm::StringRef>({"s_set_pc_i64 s[0:1]"}));
+  std::optional<llvm::DenseSet<uint64_t>> Opaque =
+      Compute(llvm::ArrayRef<llvm::StringRef>({"s_set_pc_i64 s[0:1]"}));
   ASSERT_TRUE(Opaque);
   EXPECT_TRUE(Opaque->contains(0));
 
@@ -4536,23 +4535,25 @@ TEST(RegisterLiveness, BatchedVccNeedsRespectControlFlowAndFullDefs) {
 
   std::optional<llvm::DenseSet<uint64_t>> LoopWithUnsafeExit = Compute(
       llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_branch -2",
-                                      "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+                                       "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
   ASSERT_TRUE(LoopWithUnsafeExit);
   EXPECT_TRUE(LoopWithUnsafeExit->contains(0));
   EXPECT_TRUE(LoopWithUnsafeExit->contains(MinInstSize));
 
   expectBatchRegisterNeedsMatchesScalar(
-      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b32 vcc_lo, s0",
-                                         "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S,
+      llvm::ArrayRef<llvm::StringRef>(
+          {"s_mov_b32 vcc_lo, s0", "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
       S.VCCRegister);
   expectBatchRegisterNeedsMatchesScalar(
-      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b64 vcc, -1",
-                                         "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S,
+      llvm::ArrayRef<llvm::StringRef>(
+          {"s_mov_b64 vcc, -1", "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
       S.VCCRegister);
   expectBatchRegisterNeedsMatchesScalar(
-      S, llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1",
-                                         "s_mov_b64 vcc, -1",
-                                         "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S,
+      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_mov_b64 vcc, -1",
+                                       "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
       S.VCCRegister);
   expectBatchRegisterNeedsMatchesScalar(
       S, llvm::ArrayRef<llvm::StringRef>({"s_set_pc_i64 s[0:1]"}),
@@ -4560,8 +4561,9 @@ TEST(RegisterLiveness, BatchedVccNeedsRespectControlFlowAndFullDefs) {
   expectBatchRegisterNeedsMatchesScalar(
       S, llvm::ArrayRef<llvm::StringRef>({"s_branch -1"}), S.VCCRegister);
   expectBatchRegisterNeedsMatchesScalar(
-      S, llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_branch -2",
-                                         "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S,
+      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_branch -2",
+                                       "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
       S.VCCRegister);
 }
 
@@ -4585,9 +4587,9 @@ TEST(RegisterLiveness, BatchProofMatchesScalarAcrossControlFlow) {
                                              "s_mov_b32 s30, 0"};
   expectBatchSgprProofMatchesScalar(S, OpaqueBeforeDef);
 
-  const llvm::StringRef TiedAndTuple[] = {
-      "s_add_u32 s30, s30, 1", "s_mov_b64 s[30:31], s[0:1]",
-      "s_mov_b32 s2, s31", "s_endpgm"};
+  const llvm::StringRef TiedAndTuple[] = {"s_add_u32 s30, s30, 1",
+                                          "s_mov_b64 s[30:31], s[0:1]",
+                                          "s_mov_b32 s2, s31", "s_endpgm"};
   expectBatchSgprProofMatchesScalar(S, TiedAndTuple);
 
   const llvm::StringRef InvalidBranchEdge[] = {"s_cbranch_scc0 100",
@@ -4621,15 +4623,15 @@ TEST(RegisterLiveness, BatchedSgprProofMatchesRandomizedBranchLoops) {
         break;
       case 2: {
         size_t Target = Next() % InstructionCount;
-        int64_t Delta = static_cast<int64_t>(Target) -
-                        static_cast<int64_t>(I) - 1;
+        int64_t Delta =
+            static_cast<int64_t>(Target) - static_cast<int64_t>(I) - 1;
         Storage.push_back("s_cbranch_scc0 " + std::to_string(Delta));
         break;
       }
       case 3: {
         size_t Target = Next() % InstructionCount;
-        int64_t Delta = static_cast<int64_t>(Target) -
-                        static_cast<int64_t>(I) - 1;
+        int64_t Delta =
+            static_cast<int64_t>(Target) - static_cast<int64_t>(I) - 1;
         Storage.push_back("s_branch " + std::to_string(Delta));
         break;
       }
@@ -4651,9 +4653,9 @@ TEST(RegisterLiveness, BatchedSgprProofPreservesReplacementUnion) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(
-      S, llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1",
-                                         "s_mov_b32 s104, 0",
-                                         "s_mov_b32 s0, s103", "s_endpgm"}));
+      S,
+      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_mov_b32 s104, 0",
+                                       "s_mov_b32 s0, s103", "s_endpgm"}));
   ASSERT_FALSE(Decoded.empty());
   std::optional<llvm::SmallVector<llvm::MCRegister, 128>> NumberedSgprs =
       resolveNumberedSgprRegisters(*S.MRI, /*MaxSgprs=*/106);
@@ -4661,24 +4663,22 @@ TEST(RegisterLiveness, BatchedSgprProofPreservesReplacementUnion) {
   uint64_t FunctionEnd = Decoded.back().Offset + Decoded.back().Size;
   uint64_t Continuation = Decoded[1].Offset;
   BatchedSgprContinuationTestResult Batch =
-      runBatchedSgprContinuationAnalysisForTest(
-          Decoded, S, /*FunctionBegin=*/0, FunctionEnd, {Continuation},
-          *NumberedSgprs);
+      runBatchedSgprContinuationAnalysisForTest(Decoded, S, /*FunctionBegin=*/0,
+                                                FunctionEnd, {Continuation},
+                                                *NumberedSgprs);
   ASSERT_EQ(Batch.Analyses, 1u);
   ASSERT_EQ(Batch.Queries.size(), 1u);
   ASSERT_TRUE(Batch.Queries.front());
-  std::optional<llvm::BitVector> Scalar =
-      unsafeIncomingNumberedSgprsInRange(
-          Decoded, S, /*FunctionBegin=*/0, FunctionEnd, Continuation,
-          *NumberedSgprs);
+  std::optional<llvm::BitVector> Scalar = unsafeIncomingNumberedSgprsInRange(
+      Decoded, S, /*FunctionBegin=*/0, FunctionEnd, Continuation,
+      *NumberedSgprs);
   ASSERT_TRUE(Scalar);
 
   llvm::SmallVector<uint8_t> Replacement =
       assembleInstructions("s_mov_b32 s102, 0\ns_mov_b32 s1, s101", S);
   ASSERT_FALSE(Replacement.empty());
   llvm::BitVector ReplacementUnsafe =
-      unsafeIncomingNumberedSgprsInReplacement(Replacement, S,
-                                               *NumberedSgprs);
+      unsafeIncomingNumberedSgprsInReplacement(Replacement, S, *NumberedSgprs);
   llvm::BitVector BatchedUnion = *Batch.Queries.front();
   BatchedUnion |= ReplacementUnsafe;
   llvm::BitVector ScalarUnion = *Scalar;

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -23,7 +23,9 @@
 #include "llvm/Support/TargetSelect.h"
 #include "gtest/gtest.h"
 
+#include <algorithm>
 #include <cstring>
+#include <iterator>
 #include <limits>
 #include <mutex>
 #include <vector>
@@ -69,6 +71,207 @@ static TargetIdentifier makeGfx1250Ident() {
   TI.Environ = "";
   TI.Processor = "gfx1250";
   return TI;
+}
+
+static std::vector<InternalDecodedInst>
+decodeAsmSequence(const LLVMState &S, llvm::ArrayRef<llvm::StringRef> Lines) {
+  llvm::SmallVector<uint8_t, 32> Bytes;
+  for (llvm::StringRef Line : Lines) {
+    llvm::SmallVector<uint8_t> Encoded = assembleSingleInst(Line, S);
+    EXPECT_FALSE(Encoded.empty()) << Line.str();
+    Bytes.append(Encoded);
+  }
+  std::vector<InternalDecodedInst> Decoded;
+  EXPECT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  return Decoded;
+}
+
+static bool scalarIncomingSgprIsUnsafe(
+    llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &S,
+    uint64_t FunctionBegin, uint64_t FunctionEnd, uint64_t Continuation,
+    llvm::ArrayRef<llvm::MCRegister> NumberedSgprs, unsigned Sgpr) {
+  auto FindInstruction = [&](uint64_t Offset) -> std::optional<size_t> {
+    if (Offset < FunctionBegin || Offset >= FunctionEnd)
+      return std::nullopt;
+    auto It = llvm::lower_bound(
+        Decoded, Offset, [](const InternalDecodedInst &DI, uint64_t Target) {
+          return DI.Offset < Target;
+        });
+    if (It == Decoded.end() || It->Offset != Offset)
+      return std::nullopt;
+    return It - Decoded.begin();
+  };
+  std::optional<size_t> Start = FindInstruction(Continuation);
+  if (!Start)
+    return true;
+
+  llvm::SmallVector<size_t, 8> Worklist(1, *Start);
+  llvm::DenseSet<size_t> Visited;
+  while (!Worklist.empty()) {
+    size_t Index = Worklist.pop_back_val();
+    if (!Visited.insert(Index).second)
+      continue;
+    const InternalDecodedInst &DI = Decoded[Index];
+    if (!DI.DecodeSucceeded || !S.MIA || DI.Offset < FunctionBegin ||
+        DI.Offset >= FunctionEnd)
+      return true;
+
+    llvm::BitVector Uses(NumberedSgprs.size());
+    llvm::BitVector Defs(NumberedSgprs.size());
+    getNumberedSgprUsesAndDefs(DI, S, NumberedSgprs, Uses, Defs);
+    if (Uses.test(Sgpr))
+      return true;
+    if (Defs.test(Sgpr) || DI.Inst.getOpcode() == S.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == S.SEndPgmSavedOpcode)
+      continue;
+
+    auto AddSuccessor = [&](uint64_t Offset) {
+      std::optional<size_t> Successor = FindInstruction(Offset);
+      if (!Successor)
+        return false;
+      Worklist.push_back(*Successor);
+      return true;
+    };
+    if (S.MIA->isCall(DI.Inst) || S.MIA->isIndirectBranch(DI.Inst) ||
+        S.MIA->isReturn(DI.Inst))
+      return true;
+    if (S.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, S);
+      if (!Target || !AddSuccessor(*Target))
+        return true;
+      if (S.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (S.MIA->mayAffectControlFlow(DI.Inst, *S.MRI) &&
+               !S.MIA->isBarrier(DI.Inst)) {
+      return true;
+    }
+    std::optional<uint64_t> Fallthrough =
+        llvm::checkedAddUnsigned(DI.Offset, static_cast<uint64_t>(DI.Size));
+    if (!Fallthrough || !AddSuccessor(*Fallthrough))
+      return true;
+  }
+  return false;
+}
+
+static bool scalarIncomingRegisterIsNeeded(
+    llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &S,
+    uint64_t FunctionBegin, uint64_t FunctionEnd, uint64_t Continuation,
+    llvm::MCRegister Register) {
+  auto FindInstruction = [&](uint64_t Offset) -> std::optional<size_t> {
+    if (Offset < FunctionBegin || Offset >= FunctionEnd)
+      return std::nullopt;
+    auto It = llvm::lower_bound(
+        Decoded, Offset, [](const InternalDecodedInst &DI, uint64_t Target) {
+          return DI.Offset < Target;
+        });
+    if (It == Decoded.end() || It->Offset != Offset)
+      return std::nullopt;
+    return It - Decoded.begin();
+  };
+  std::optional<size_t> Start = FindInstruction(Continuation);
+  if (!Start)
+    return true;
+
+  llvm::SmallVector<size_t, 8> Worklist(1, *Start);
+  llvm::DenseSet<size_t> Visited;
+  while (!Worklist.empty()) {
+    size_t Index = Worklist.pop_back_val();
+    if (!Visited.insert(Index).second)
+      continue;
+    const InternalDecodedInst &DI = Decoded[Index];
+    if (!DI.DecodeSucceeded || !S.MIA || DI.Offset < FunctionBegin ||
+        DI.Offset >= FunctionEnd)
+      return true;
+    if (instructionReadsRegister(DI, S, Register))
+      return true;
+    if (instructionFullyWritesRegister(DI, S, Register) ||
+        DI.Inst.getOpcode() == S.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == S.SEndPgmSavedOpcode)
+      continue;
+
+    auto AddSuccessor = [&](uint64_t Offset) {
+      std::optional<size_t> Successor = FindInstruction(Offset);
+      if (!Successor)
+        return false;
+      Worklist.push_back(*Successor);
+      return true;
+    };
+    if (S.MIA->isCall(DI.Inst) || S.MIA->isIndirectBranch(DI.Inst) ||
+        S.MIA->isReturn(DI.Inst))
+      return true;
+    if (S.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, S);
+      if (!Target || !AddSuccessor(*Target))
+        return true;
+      if (S.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (S.MIA->mayAffectControlFlow(DI.Inst, *S.MRI) &&
+               !S.MIA->isBarrier(DI.Inst)) {
+      return true;
+    }
+    std::optional<uint64_t> Fallthrough =
+        llvm::checkedAddUnsigned(DI.Offset, static_cast<uint64_t>(DI.Size));
+    if (!Fallthrough || !AddSuccessor(*Fallthrough))
+      return true;
+  }
+  return false;
+}
+
+static void expectBatchRegisterNeedsMatchesScalar(
+    const LLVMState &S, llvm::ArrayRef<llvm::StringRef> Lines,
+    llvm::MCRegister Register) {
+  std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(S, Lines);
+  ASSERT_FALSE(Decoded.empty());
+  uint64_t FunctionEnd = Decoded.back().Offset + Decoded.back().Size;
+  std::optional<llvm::DenseSet<uint64_t>> Batch =
+      computeIncomingRegisterNeeds(Decoded, S, /*FunctionBegin=*/0,
+                                   FunctionEnd, Register);
+  ASSERT_TRUE(Batch);
+  for (const InternalDecodedInst &DI : Decoded)
+    EXPECT_EQ(Batch->contains(DI.Offset),
+              scalarIncomingRegisterIsNeeded(
+                  Decoded, S, /*FunctionBegin=*/0, FunctionEnd, DI.Offset,
+                  Register))
+        << "continuation 0x" << llvm::utohexstr(DI.Offset);
+}
+
+static void
+expectBatchSgprProofMatchesScalar(const LLVMState &S,
+                                  llvm::ArrayRef<llvm::StringRef> Lines) {
+  std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(S, Lines);
+  ASSERT_FALSE(Decoded.empty());
+  std::optional<llvm::SmallVector<llvm::MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*S.MRI, /*MaxSgprs=*/106);
+  ASSERT_TRUE(NumberedSgprs);
+  uint64_t FunctionEnd = Decoded.back().Offset + Decoded.back().Size;
+  llvm::SmallVector<uint64_t, 16> Continuations;
+  for (const InternalDecodedInst &DI : Decoded)
+    Continuations.push_back(DI.Offset);
+  Continuations.push_back(1);
+  BatchedSgprContinuationTestResult Batch =
+      runBatchedSgprContinuationAnalysisForTest(
+          Decoded, S, /*FunctionBegin=*/0, FunctionEnd, Continuations,
+          *NumberedSgprs);
+  EXPECT_EQ(Batch.Analyses, 1u);
+  ASSERT_EQ(Batch.Queries.size(), Continuations.size());
+  for (size_t Query = 0; Query != Decoded.size(); ++Query) {
+    std::optional<llvm::BitVector> Scalar =
+        unsafeIncomingNumberedSgprsInRange(
+            Decoded, S, /*FunctionBegin=*/0, FunctionEnd,
+            Continuations[Query], *NumberedSgprs);
+    ASSERT_TRUE(Scalar);
+    ASSERT_TRUE(Batch.Queries[Query]);
+    EXPECT_EQ(*Batch.Queries[Query], *Scalar)
+        << "continuation 0x" << llvm::utohexstr(Continuations[Query]);
+    for (unsigned I = 0; I != NumberedSgprs->size(); ++I)
+      EXPECT_EQ(Batch.Queries[Query]->test(I),
+                scalarIncomingSgprIsUnsafe(
+                    Decoded, S, /*FunctionBegin=*/0, FunctionEnd,
+                    Continuations[Query], *NumberedSgprs, I))
+          << "continuation 0x" << llvm::utohexstr(Continuations[Query])
+          << ", s" << I;
+  }
+  EXPECT_FALSE(Batch.Queries.back());
 }
 
 // Helper: decode the little-endian 32-bit dword at \p Bytes.
@@ -273,6 +476,269 @@ static std::vector<uint8_t> makeDisplacementTestElf(
   return Buf;
 }
 
+enum class FunctionTableElfMutation {
+  None,
+  NoRelro,
+  RelocationGap,
+  WrongRelocationKind,
+  RelocatedSentinel,
+  NonFunctionTarget,
+  NonBoundaryTarget,
+  NonZeroSlot,
+  MisalignedTableSymbol,
+  MalformedSymbolTable,
+  FunctionEndInterior,
+  FunctionSizeOutOfText,
+};
+
+struct FunctionTableTestElf {
+  std::vector<uint8_t> Bytes;
+  std::vector<InternalDecodedInst> Decoded;
+  uint64_t CallOffset = 0;
+};
+
+static FunctionTableTestElf makeFunctionTableTestElf(
+    const LLVMState &S, llvm::StringRef Load,
+    FunctionTableElfMutation Mutation = FunctionTableElfMutation::None,
+    uint64_t TableDelta = 0xFFC, llvm::StringRef CustomAsm = {},
+    size_t CallerBeginIndex = 0,
+    size_t CallerEndIndex = std::numeric_limits<size_t>::max(),
+    size_t Target1BeginIndex = std::numeric_limits<size_t>::max()) {
+  using namespace llvm::ELF;
+
+  static constexpr uint64_t ShOff = sizeof(Elf64_Ehdr);
+  static constexpr uint64_t PhOff = 0x200;
+  static constexpr uint64_t TextOff = 0x300;
+  static constexpr uint64_t TextAddr = 0x1000;
+  static constexpr uint64_t TableAddr = 0x2000;
+  static constexpr size_t TableSlots = 3;
+
+  std::string Asm = CustomAsm.empty()
+                        ? "s_get_pc_i64 s[4:5]\n"
+                          "s_add_nc_u64 s[4:5], s[4:5], " +
+                              std::to_string(TableDelta) + "\n" + Load.str() +
+                              "\n"
+                              "s_wait_kmcnt 0\n"
+                              "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                              "s_endpgm\n"
+                              "s_endpgm\n"
+                              "s_endpgm\n"
+                        : CustomAsm.str();
+  llvm::SmallVector<uint8_t> Text = assembleInstructions(Asm, S);
+  EXPECT_FALSE(Text.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  EXPECT_TRUE(decodeTextSection(Text.data(), Text.size(), S, Decoded));
+  EXPECT_GE(Decoded.size(), 3u);
+  bool HasCustomCallerEnd =
+      CallerEndIndex != std::numeric_limits<size_t>::max();
+  if (!HasCustomCallerEnd)
+    CallerEndIndex = Decoded.size() - 2;
+  if (Target1BeginIndex == std::numeric_limits<size_t>::max())
+    Target1BeginIndex = Decoded.size() - 1;
+  EXPECT_LT(CallerBeginIndex, CallerEndIndex);
+  EXPECT_LT(CallerEndIndex, Target1BeginIndex);
+  EXPECT_LT(Target1BeginIndex, Decoded.size());
+
+  const uint64_t CallerBegin = Decoded[CallerBeginIndex].Offset;
+  const uint64_t CallerEnd = Decoded[CallerEndIndex].Offset;
+  const uint64_t Target0 = TextAddr + CallerEnd;
+  const uint64_t Target1 = TextAddr + Decoded[Target1BeginIndex].Offset;
+  uint64_t CallOffset = 0;
+  bool FoundCall = false;
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (!S.MIA->isCall(DI.Inst))
+      continue;
+    CallOffset = DI.Offset;
+    FoundCall = true;
+    break;
+  }
+  EXPECT_TRUE(FoundCall);
+
+  const char StrTab[] = "\0caller\0target0\0target1\0table\0";
+  const char ShStrTab[] =
+      "\0.text\0.data.rel.ro\0.strtab\0.symtab\0.rela.dyn\0.shstrtab\0";
+  const uint64_t DataOff = alignTo8(TextOff + Text.size());
+  const uint64_t DataSize = TableSlots * sizeof(uint64_t);
+  const uint64_t StrTabOff = alignTo8(DataOff + DataSize);
+  const uint64_t SymTabOff = alignTo8(StrTabOff + sizeof(StrTab));
+  static constexpr size_t SymbolCount = 5;
+  const uint64_t RelaOff =
+      alignTo8(SymTabOff + SymbolCount * sizeof(Elf64_Sym));
+  const size_t RelaCount =
+      Mutation == FunctionTableElfMutation::RelocatedSentinel ? 3 : 2;
+  const uint64_t ShStrTabOff =
+      alignTo8(RelaOff + RelaCount * sizeof(Elf64_Rela));
+  const uint64_t BufSize = alignTo8(ShStrTabOff + sizeof(ShStrTab));
+  std::vector<uint8_t> Buf(BufSize, 0);
+  std::memcpy(Buf.data() + TextOff, Text.data(), Text.size());
+  std::memcpy(Buf.data() + StrTabOff, StrTab, sizeof(StrTab));
+  std::memcpy(Buf.data() + ShStrTabOff, ShStrTab, sizeof(ShStrTab));
+  if (Mutation == FunctionTableElfMutation::NonZeroSlot)
+    Buf[DataOff] = 1;
+
+  Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(EM_AMDGPU);
+  Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ET_DYN;
+  Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_phoff = PhOff;
+  Ehdr.e_shoff = ShOff;
+  Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  Ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  Ehdr.e_phnum = 3;
+  Ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  Ehdr.e_shnum = 7;
+  Ehdr.e_shstrndx = 6;
+  std::memcpy(Buf.data(), &Ehdr, sizeof(Ehdr));
+
+  Elf64_Phdr TextPh{};
+  TextPh.p_type = PT_LOAD;
+  TextPh.p_flags = PF_R | PF_X;
+  TextPh.p_offset = TextOff;
+  TextPh.p_vaddr = TextAddr;
+  TextPh.p_paddr = TextAddr;
+  TextPh.p_filesz = Text.size();
+  TextPh.p_memsz = Text.size();
+  TextPh.p_align = 8;
+  std::memcpy(Buf.data() + PhOff, &TextPh, sizeof(TextPh));
+
+  Elf64_Phdr DataPh{};
+  DataPh.p_type = PT_LOAD;
+  DataPh.p_flags = PF_R | PF_W;
+  DataPh.p_offset = DataOff;
+  DataPh.p_vaddr = TableAddr;
+  DataPh.p_paddr = TableAddr;
+  DataPh.p_filesz = DataSize;
+  DataPh.p_memsz = DataSize;
+  DataPh.p_align = 8;
+  std::memcpy(Buf.data() + PhOff + sizeof(Elf64_Phdr), &DataPh, sizeof(DataPh));
+
+  Elf64_Phdr RelroPh = DataPh;
+  RelroPh.p_type =
+      Mutation == FunctionTableElfMutation::NoRelro ? PT_NOTE : PT_GNU_RELRO;
+  RelroPh.p_flags = PF_R;
+  std::memcpy(Buf.data() + PhOff + 2 * sizeof(Elf64_Phdr), &RelroPh,
+              sizeof(RelroPh));
+
+  Elf64_Shdr TextSh{};
+  TextSh.sh_name = 1;
+  TextSh.sh_type = SHT_PROGBITS;
+  TextSh.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  TextSh.sh_offset = TextOff;
+  TextSh.sh_addr = TextAddr;
+  TextSh.sh_size = Text.size();
+  TextSh.sh_addralign = 4;
+  std::memcpy(Buf.data() + ShOff + sizeof(Elf64_Shdr), &TextSh, sizeof(TextSh));
+
+  Elf64_Shdr DataSh{};
+  DataSh.sh_name = 7;
+  DataSh.sh_type = SHT_PROGBITS;
+  DataSh.sh_flags = SHF_ALLOC | SHF_WRITE;
+  DataSh.sh_offset = DataOff;
+  DataSh.sh_addr = TableAddr;
+  DataSh.sh_size = DataSize;
+  DataSh.sh_addralign = 8;
+  std::memcpy(Buf.data() + ShOff + 2 * sizeof(Elf64_Shdr), &DataSh,
+              sizeof(DataSh));
+
+  Elf64_Shdr StrtabSh{};
+  StrtabSh.sh_name = 20;
+  StrtabSh.sh_type = SHT_STRTAB;
+  StrtabSh.sh_offset = StrTabOff;
+  StrtabSh.sh_size = sizeof(StrTab);
+  std::memcpy(Buf.data() + ShOff + 3 * sizeof(Elf64_Shdr), &StrtabSh,
+              sizeof(StrtabSh));
+
+  Elf64_Shdr SymtabSh{};
+  SymtabSh.sh_name = 28;
+  SymtabSh.sh_type = SHT_SYMTAB;
+  SymtabSh.sh_offset = SymTabOff;
+  SymtabSh.sh_size = SymbolCount * sizeof(Elf64_Sym);
+  SymtabSh.sh_link = 3;
+  SymtabSh.sh_info = SymbolCount;
+  SymtabSh.sh_entsize =
+      Mutation == FunctionTableElfMutation::MalformedSymbolTable
+          ? sizeof(Elf64_Sym) - 1
+          : sizeof(Elf64_Sym);
+  std::memcpy(Buf.data() + ShOff + 4 * sizeof(Elf64_Shdr), &SymtabSh,
+              sizeof(SymtabSh));
+
+  Elf64_Shdr RelaSh{};
+  RelaSh.sh_name = 36;
+  RelaSh.sh_type = SHT_RELA;
+  RelaSh.sh_offset = RelaOff;
+  RelaSh.sh_size = RelaCount * sizeof(Elf64_Rela);
+  RelaSh.sh_link = 4;
+  RelaSh.sh_info = 0;
+  RelaSh.sh_addralign = 8;
+  RelaSh.sh_entsize = sizeof(Elf64_Rela);
+  std::memcpy(Buf.data() + ShOff + 5 * sizeof(Elf64_Shdr), &RelaSh,
+              sizeof(RelaSh));
+
+  Elf64_Shdr ShstrSh{};
+  ShstrSh.sh_name = 46;
+  ShstrSh.sh_type = SHT_STRTAB;
+  ShstrSh.sh_offset = ShStrTabOff;
+  ShstrSh.sh_size = sizeof(ShStrTab);
+  std::memcpy(Buf.data() + ShOff + 6 * sizeof(Elf64_Shdr), &ShstrSh,
+              sizeof(ShstrSh));
+
+  auto writeSymbol = [&](size_t Index, uint32_t Name, uint8_t Type,
+                         uint16_t SectionIndex, uint64_t Value, uint64_t Size) {
+    Elf64_Sym Symbol{};
+    Symbol.st_name = Name;
+    Symbol.setBindingAndType(STB_LOCAL, Type);
+    Symbol.st_shndx = SectionIndex;
+    Symbol.st_value = Value;
+    Symbol.st_size = Size;
+    std::memcpy(Buf.data() + SymTabOff + Index * sizeof(Elf64_Sym), &Symbol,
+                sizeof(Symbol));
+  };
+  uint64_t CallerSize = CallerEnd - CallerBegin;
+  if (Mutation == FunctionTableElfMutation::FunctionEndInterior)
+    CallerSize += 2;
+  else if (Mutation == FunctionTableElfMutation::FunctionSizeOutOfText)
+    CallerSize = Text.size() * 2;
+  writeSymbol(1, 1, STT_FUNC, 1, TextAddr + CallerBegin, CallerSize);
+  writeSymbol(2, 8,
+              Mutation == FunctionTableElfMutation::NonFunctionTarget
+                  ? STT_OBJECT
+                  : STT_FUNC,
+              1, Target0, HasCustomCallerEnd ? Target1 - Target0 : MinInstSize);
+  writeSymbol(3, 16, STT_FUNC, 1, Target1, TextAddr + Text.size() - Target1);
+  writeSymbol(4, 24, STT_OBJECT, 2,
+              Mutation == FunctionTableElfMutation::MisalignedTableSymbol
+                  ? TableAddr + 1
+                  : TableAddr,
+              DataSize);
+
+  auto writeRela = [&](size_t Index, uint64_t Offset, uint32_t Type,
+                       uint64_t Addend) {
+    Elf64_Rela Rela{};
+    Rela.r_offset = Offset;
+    Rela.setSymbolAndType(/*Symbol=*/0, Type);
+    Rela.r_addend = static_cast<int64_t>(Addend);
+    std::memcpy(Buf.data() + RelaOff + Index * sizeof(Elf64_Rela), &Rela,
+                sizeof(Rela));
+  };
+  writeRela(0, TableAddr,
+            Mutation == FunctionTableElfMutation::WrongRelocationKind
+                ? R_AMDGPU_ABS64
+                : R_AMDGPU_RELATIVE64,
+            Mutation == FunctionTableElfMutation::NonBoundaryTarget
+                ? Target0 + 2
+                : Target0);
+  writeRela(1,
+            Mutation == FunctionTableElfMutation::RelocationGap
+                ? TableAddr
+                : TableAddr + sizeof(uint64_t),
+            R_AMDGPU_RELATIVE64, Target1);
+  if (Mutation == FunctionTableElfMutation::RelocatedSentinel)
+    writeRela(2, TableAddr + 2 * sizeof(uint64_t), R_AMDGPU_RELATIVE64,
+              Target0);
+
+  return {std::move(Buf), std::move(Decoded), CallOffset};
+}
+
 // -- initLLVM ----------------------------------------------------------------
 
 TEST(InitLLVM, ValidGfx1250) {
@@ -452,6 +918,26 @@ TEST(EncodeSetPCLongBranch, ForwardLandsOnTarget) {
   EXPECT_EQ(From + MinInstSize + Delta, To);
 }
 
+TEST(EncodeSetPCLongBranch, UsesVccWhenRequested) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::optional<llvm::SmallVector<uint8_t>> Out = encodeSetPCLongBranch(
+      S, /*FromOffset=*/0x1000, /*TargetOffset=*/0x81000, /*SgprBase=*/0,
+      /*UseVcc=*/true);
+  ASSERT_TRUE(Out);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  for (const InternalDecodedInst &DI : Decoded) {
+    ASSERT_NE(DI.Inst.getNumOperands(), 0u);
+    ASSERT_TRUE(DI.Inst.getOperand(0).isReg());
+    EXPECT_TRUE(S.MRI->regsOverlap(
+        llvm::MCRegister(DI.Inst.getOperand(0).getReg()), S.VCCRegister));
+  }
+}
+
 TEST(EncodeSetPCLongBranch, InlineDisplacementUsesTwelveBytes) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -488,6 +974,30 @@ TEST(FindNearestSetPcGateway, FitsActualSixteenByteEncoding) {
   EXPECT_EQ(Gateway->Sled, &Gateways[0]);
   EXPECT_EQ(Gateway->Bytes.size(), 16u);
   EXPECT_EQ(Gateways[0].WritePos, 0x100u);
+}
+
+TEST(FindNearestSetPcGateway, PrependsWave32VccSave) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x100, /*End=*/0x118, /*WritePos=*/0x100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000}};
+  llvm::Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
+      findNearestSetPcGateway(
+          Gateways, S, /*FromOffset=*/0, /*TargetOffset=*/0x81000,
+          /*SgprBase=*/105, /*UseVcc=*/true, /*PreserveVcc=*/true);
+  ASSERT_TRUE((bool)GatewayOrErr) << llvm::toString(GatewayOrErr.takeError());
+  std::optional<EncodedSetPcGateway> &Gateway = *GatewayOrErr;
+  ASSERT_TRUE(Gateway);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Gateway->Bytes.data(), Gateway->Bytes.size(), S,
+                                Decoded));
+  ASSERT_EQ(Decoded.size(), 4u);
+  EXPECT_EQ(Decoded.front().Mnemonic, "s_mov_b32");
+  EXPECT_EQ(Decoded[1].Mnemonic, "s_get_pc_i64");
+  EXPECT_EQ(Decoded.back().Mnemonic, "s_set_pc_i64");
 }
 
 TEST(FindNearestSetPcGateway, SkipsNearerUndersizedCandidate) {
@@ -586,6 +1096,97 @@ TEST(FindNearestSetPcGateway, AnalyticalWidthsMatchEncodedBoundaries) {
     ASSERT_TRUE(*GatewayOrErr);
     EXPECT_EQ((*GatewayOrErr)->Bytes.size(), Encoded->size());
   }
+}
+
+TEST(FindSplitVccGateway, UsesDisjointEightAndSixteenByteSleds) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x100, /*End=*/0x108, /*WritePos=*/0x100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000},
+      {/*Start=*/0x200, /*End=*/0x210, /*WritePos=*/0x200,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000,
+       /*GatewayOnly=*/true}};
+  std::optional<EncodedSplitVccGateway> Split =
+      findSplitVccGateway(Gateways, S, /*FromOffset=*/0,
+                          /*TargetOffset=*/0x81000, /*SaveSgpr=*/105);
+  ASSERT_TRUE(Split);
+  EXPECT_EQ(Split->PrimaryIndex, 0u);
+  EXPECT_EQ(Split->SecondaryIndex, 1u);
+  EXPECT_EQ(Split->PrimaryBytes.size(), 8u);
+  EXPECT_EQ(Split->SecondaryBytes.size(), 16u);
+  EXPECT_EQ(Gateways[0].WritePos, 0x100u);
+  EXPECT_EQ(Gateways[1].WritePos, 0x200u);
+
+  std::vector<InternalDecodedInst> Primary;
+  ASSERT_TRUE(decodeTextSection(Split->PrimaryBytes.data(),
+                                Split->PrimaryBytes.size(), S, Primary));
+  ASSERT_EQ(Primary.size(), 2u);
+  EXPECT_EQ(Primary[0].Mnemonic, "s_mov_b32");
+  ASSERT_GE(Primary[0].Inst.getNumOperands(), 2u);
+  ASSERT_TRUE(Primary[0].Inst.getOperand(0).isReg());
+  ASSERT_TRUE(Primary[0].Inst.getOperand(1).isReg());
+  EXPECT_STREQ(S.MRI->getName(Primary[0].Inst.getOperand(0).getReg()),
+               "SGPR105");
+  EXPECT_TRUE(S.MRI->regsOverlap(
+      llvm::MCRegister(Primary[0].Inst.getOperand(1).getReg()), S.VCCRegister));
+  EXPECT_EQ(Primary[1].Mnemonic, "s_branch");
+  EXPECT_EQ(static_cast<int16_t>(
+                readDword(Split->PrimaryBytes.data() + MinInstSize) & 0xFFFFu),
+            62);
+
+  std::vector<InternalDecodedInst> Secondary;
+  ASSERT_TRUE(decodeTextSection(Split->SecondaryBytes.data(),
+                                Split->SecondaryBytes.size(), S, Secondary));
+  ASSERT_EQ(Secondary.size(), 3u);
+  EXPECT_EQ(Secondary[0].Mnemonic, "s_get_pc_i64");
+  EXPECT_EQ(Secondary[1].Mnemonic, "s_add_nc_u64");
+  EXPECT_EQ(Secondary[2].Mnemonic, "s_set_pc_i64");
+  for (const InternalDecodedInst &DI : Secondary) {
+    ASSERT_NE(DI.Inst.getNumOperands(), 0u);
+    ASSERT_TRUE(DI.Inst.getOperand(0).isReg());
+    EXPECT_TRUE(S.MRI->regsOverlap(
+        llvm::MCRegister(DI.Inst.getOperand(0).getReg()), S.VCCRegister));
+  }
+  ASSERT_TRUE(Secondary[1].Inst.getOperand(2).isImm());
+  uint64_t Delta =
+      static_cast<uint64_t>(Secondary[1].Inst.getOperand(2).getImm());
+  EXPECT_EQ(0x200u + MinInstSize + Delta, 0x81000u);
+}
+
+TEST(FindSplitVccGateway, RejectsPhysicalOverlapWithoutMutation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x100, /*End=*/0x108, /*WritePos=*/0x100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000},
+      {/*Start=*/0x104, /*End=*/0x114, /*WritePos=*/0x104,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000,
+       /*GatewayOnly=*/true}};
+  EXPECT_FALSE(findSplitVccGateway(Gateways, S, /*FromOffset=*/0,
+                                   /*TargetOffset=*/0x81000,
+                                   /*SaveSgpr=*/105));
+  EXPECT_EQ(Gateways[0].WritePos, 0x100u);
+  EXPECT_EQ(Gateways[1].WritePos, 0x104u);
+}
+
+TEST(FindSplitVccGateway, RejectsGatewayOnlyPrimaryWithoutMutation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x100, /*End=*/0x108, /*WritePos=*/0x100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000,
+       /*GatewayOnly=*/true},
+      {/*Start=*/0x200, /*End=*/0x210, /*WritePos=*/0x200,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000}};
+  EXPECT_FALSE(findSplitVccGateway(Gateways, S, /*FromOffset=*/0,
+                                   /*TargetOffset=*/0x81000,
+                                   /*SaveSgpr=*/105));
+  EXPECT_EQ(Gateways[0].WritePos, 0x100u);
+  EXPECT_EQ(Gateways[1].WritePos, 0x200u);
 }
 
 TEST(CountReachableSetPcGatewaySlots, DistinguishesZeroFromEncodingFailure) {
@@ -918,6 +1519,42 @@ TEST(EvaluateDirectControlFlowTarget, EvaluatesGfx1250CallOperandFallback) {
             0x200u + Decoded[0].Size + 2 * MinInstSize);
 }
 
+TEST(CanonicalAbiFrame, RequiresExactWritelaneTiedInput) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>(
+             {"v_writelane_b32 v40, s30, 0", "v_writelane_b32 v41, s30, 0"}));
+  ASSERT_EQ(Decoded.size(), 2u);
+  InternalDecodedInst Write = Decoded[0];
+  ASSERT_EQ(Write.Inst.getNumOperands(), 4u);
+  llvm::MCRegister V40 = Write.Inst.getOperand(0).getReg();
+  llvm::MCRegister S30 = Write.Inst.getOperand(1).getReg();
+  EXPECT_TRUE(
+      matchesCanonicalLaneTransfer(Write, "v_writelane_b32", V40, S30, 0));
+
+  Write.Inst.erase(std::prev(Write.Inst.end()));
+  EXPECT_FALSE(
+      matchesCanonicalLaneTransfer(Write, "v_writelane_b32", V40, S30, 0));
+
+  Write = Decoded[0];
+  llvm::MCRegister V41 = Decoded[1].Inst.getOperand(0).getReg();
+  Write.Inst.getOperand(3).setReg(V41);
+  EXPECT_FALSE(
+      matchesCanonicalLaneTransfer(Write, "v_writelane_b32", V40, S30, 0));
+}
+
+TEST(CanonicalAbiFrame, DistinguishesSaveExecFromPcTransfer) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded =
+      decodeAsmSequence(S, llvm::ArrayRef<llvm::StringRef>(
+                               {"s_or_saveexec_b32 s0, s1", "s_branch 0"}));
+  ASSERT_EQ(Decoded.size(), 2u);
+  EXPECT_FALSE(isTruePcTransfer(Decoded[0], S));
+  EXPECT_TRUE(isTruePcTransfer(Decoded[1], S));
+}
+
 TEST(CollectDirectBranchTargets, MarksRegisterTargetCallUnresolved) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -938,10 +1575,585 @@ TEST(CollectDirectBranchTargets, MarksRegisterTargetCallUnresolved) {
                                  /*TextSize=*/0x1000, /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
-TEST(CollectDirectBranchTargets, IgnoresSetPcWithoutTreatingItAsCall) {
+TEST(CollectDirectBranchTargets,
+     LeavesDynamicallyIndexedRelocationBackedFunctionTableUnresolved) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  FunctionTableTestElf Obj = makeFunctionTableTestElf(
+      S, "s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv");
+  llvm::Expected<ElfView> View =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+
+  std::vector<ElfView::FunctionTextRange> Ranges = View->functionTextRanges();
+  llvm::SmallVector<uint64_t, 4> Entries;
+  for (const ElfView::FunctionTextRange &Range : Ranges)
+    Entries.push_back(Range.Begin - View->textAddr());
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Obj.Decoded, S, View->textAddr(), View->textSize(), Entries, Ranges,
+      /*ExternalEntries=*/{},
+      llvm::ArrayRef<uint8_t>(View->textData(), View->textSize()), &*View);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Obj.CallOffset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsMalformedRelocationBackedFunctionPointerTables) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  struct Case {
+    llvm::StringLiteral Load;
+    FunctionTableElfMutation Mutation;
+    uint64_t TableDelta;
+  };
+  const Case Cases[] = {
+      // Exact base provenance is mandatory.
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::None, 0xFF4},
+      // Only aligned, zero-immediate, b64 element-index scaling is accepted.
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 nv",
+       FunctionTableElfMutation::None, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:8 scale_offset nv",
+       FunctionTableElfMutation::None, 0xFFC},
+      // The symbol must describe immutable RELRO data with a complete,
+      // zero-filled RELATIVE64 layout and one unrelocated trailing sentinel.
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::NoRelro, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::RelocationGap, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::WrongRelocationKind, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::RelocatedSentinel, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::NonZeroSlot, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::MisalignedTableSymbol, 0xFFC},
+      // Every addend must name both a defined STT_FUNC and a decoded boundary.
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::NonFunctionTarget, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::NonBoundaryTarget, 0xFFC},
+  };
+
+  for (const Case &C : Cases) {
+    FunctionTableTestElf Obj =
+        makeFunctionTableTestElf(S, C.Load, C.Mutation, C.TableDelta);
+    llvm::Expected<ElfView> View =
+        ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+    ASSERT_TRUE((bool)View)
+        << C.Load.str() << ": " << llvm::toString(View.takeError());
+    std::vector<ElfView::FunctionTextRange> Ranges = View->functionTextRanges();
+    llvm::SmallVector<uint64_t, 4> Entries;
+    for (const ElfView::FunctionTextRange &Range : Ranges)
+      Entries.push_back(Range.Begin - View->textAddr());
+    std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+        Obj.Decoded, S, View->textAddr(), View->textSize(), Entries, Ranges,
+        /*ExternalEntries=*/{},
+        llvm::ArrayRef<uint8_t>(View->textData(), View->textSize()), &*View);
+    ASSERT_TRUE(Info) << C.Load.str();
+    EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Obj.CallOffset))
+        << C.Load.str();
+    EXPECT_TRUE(Info->HasUnboundedIndirectEntries) << C.Load.str();
+    EXPECT_TRUE(Info->HasUnresolvedTargets) << C.Load.str();
+  }
+}
+
+TEST(ElfView, MarksFunctionRangesIncompleteOnMalformedSymbolTable) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  FunctionTableTestElf Obj = makeFunctionTableTestElf(
+      S, "s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+      FunctionTableElfMutation::MalformedSymbolTable);
+  llvm::Expected<ElfView> View =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  EXPECT_TRUE(View->functionTextRanges().empty());
+  EXPECT_FALSE(View->functionTextRangesComplete());
+}
+
+TEST(CollectDirectBranchTargets,
+     BoundsSplitVgprCanonicalFrameWithLongEpilogue) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  auto MakeFrame =
+      [](llvm::StringRef BeforeSaves, llvm::StringRef AfterCall,
+         llvm::StringRef AfterRestores = {}, llvm::StringRef SavedLow = "v41",
+         llvm::StringRef SavedHigh = "v42", llvm::StringRef BeforeCall = {}) {
+        std::string Asm = BeforeSaves.str();
+        Asm += "s_or_saveexec_b32 s0, -1\n";
+        Asm += "v_writelane_b32 " + SavedLow.str() + ", s30, 31\n";
+        Asm += "v_writelane_b32 " + SavedHigh.str() + ", s31, 0\n";
+        Asm += BeforeCall.str();
+        Asm += "s_swap_pc_i64 s[30:31], s[2:3]\n";
+        Asm += AfterCall.str();
+        Asm += "v_readlane_b32 s30, " + SavedLow.str() + ", 31\n";
+        Asm += "v_readlane_b32 s31, " + SavedHigh.str() + ", 0\n";
+        for (unsigned I = 0; I != 70; ++I)
+          Asm += "s_nop 0\n";
+        Asm += AfterRestores.str();
+        Asm += "s_set_pc_i64 s[30:31]\n"
+               "s_endpgm\n"
+               "s_endpgm\n";
+        return Asm;
+      };
+
+  auto Audit =
+      [&](llvm::StringRef Asm,
+          llvm::ArrayRef<uint64_t> NonCallEntries = llvm::ArrayRef<uint64_t>{},
+          size_t CallerBeginIndex = 0,
+          FunctionTableElfMutation Mutation = FunctionTableElfMutation::None,
+          size_t CallerEndIndex = std::numeric_limits<size_t>::max(),
+          llvm::ArrayRef<uint64_t> ExternalEntries = llvm::ArrayRef<uint64_t>{},
+          size_t Target1BeginIndex = std::numeric_limits<size_t>::max()) {
+        FunctionTableTestElf Obj = makeFunctionTableTestElf(
+            S, /*Load=*/"", Mutation,
+            /*TableDelta=*/0xFFC, Asm, CallerBeginIndex, CallerEndIndex,
+            Target1BeginIndex);
+        llvm::Expected<ElfView> View =
+            ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+        EXPECT_TRUE((bool)View) << llvm::toString(View.takeError());
+        if (!View)
+          return std::optional<DirectControlFlowInfo>();
+        std::vector<ElfView::FunctionTextRange> Ranges =
+            View->functionTextRanges();
+        llvm::SmallVector<uint64_t, 4> Entries;
+        for (const ElfView::FunctionTextRange &Range : Ranges)
+          Entries.push_back(Range.Begin - View->textAddr());
+        return collectDirectBranchTargets(
+            Obj.Decoded, S, View->textAddr(), View->textSize(), Entries, Ranges,
+            ExternalEntries,
+            llvm::ArrayRef<uint8_t>(View->textData(), View->textSize()), &*View,
+            NonCallEntries);
+      };
+
+  std::optional<DirectControlFlowInfo> Valid = Audit(MakeFrame("", ""));
+  ASSERT_TRUE(Valid);
+  EXPECT_FALSE(Valid->HasUnresolvedTargets);
+  EXPECT_FALSE(Valid->HasUnboundedIndirectEntries);
+
+  // A compiler may place a call in the preceding local function immediately
+  // before a fallthrough entry. The call's s30 continuation is a valid
+  // incoming link only when no entry bypasses it and the gap preserves it.
+  std::string PrefixFrame = "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                            "s_nop 0\n" +
+                            MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> PrefixFallthrough =
+      Audit(PrefixFrame, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/2);
+  ASSERT_TRUE(PrefixFallthrough);
+  EXPECT_FALSE(PrefixFallthrough->HasUnresolvedTargets);
+  EXPECT_FALSE(PrefixFallthrough->HasUnboundedIndirectEntries);
+
+  const uint64_t PrefixGapEntry[] = {4};
+  std::optional<DirectControlFlowInfo> PrefixRootBypass =
+      Audit(PrefixFrame, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/2, PrefixGapEntry);
+  ASSERT_TRUE(PrefixRootBypass);
+  EXPECT_TRUE(PrefixRootBypass->HasUnresolvedTargets);
+  EXPECT_TRUE(PrefixRootBypass->HasUnboundedIndirectEntries);
+
+  std::string PrefixDirectBypass = "s_cbranch_vccnz 1\n"
+                                   "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                                   "s_nop 0\n" +
+                                   MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> PrefixDirect =
+      Audit(PrefixDirectBypass, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/3);
+  ASSERT_TRUE(PrefixDirect);
+  EXPECT_TRUE(PrefixDirect->HasUnresolvedTargets);
+  EXPECT_TRUE(PrefixDirect->HasUnboundedIndirectEntries);
+
+  std::string PrefixExactBypass = "s_cbranch_vccnz 3\n"
+                                  "s_get_pc_i64 s[4:5]\n"
+                                  "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                                  "s_set_pc_i64 s[4:5]\n"
+                                  "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                                  "s_nop 0\n" +
+                                  MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> PrefixExact =
+      Audit(PrefixExactBypass, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/6);
+  ASSERT_TRUE(PrefixExact);
+  EXPECT_TRUE(PrefixExact->HasUnresolvedTargets);
+  EXPECT_TRUE(PrefixExact->HasUnboundedIndirectEntries);
+
+  std::string PrefixForeignCall = "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                                  "s_swap_pc_i64 s[4:5], s[6:7]\n" +
+                                  MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> PrefixForeign =
+      Audit(PrefixForeignCall, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/2);
+  ASSERT_TRUE(PrefixForeign);
+  EXPECT_TRUE(PrefixForeign->HasUnresolvedTargets);
+  EXPECT_TRUE(PrefixForeign->HasUnboundedIndirectEntries);
+
+  std::string PrefixLinkClobber = "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                                  "s_mov_b32 s30, 0\n" +
+                                  MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> PrefixClobber =
+      Audit(PrefixLinkClobber, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/2);
+  ASSERT_TRUE(PrefixClobber);
+  EXPECT_TRUE(PrefixClobber->HasUnresolvedTargets);
+  EXPECT_TRUE(PrefixClobber->HasUnboundedIndirectEntries);
+
+  // A leaf can use the ABI link SGPRs as scratch after saving them even though
+  // it performs no nested call itself. Exercise that production frame as a
+  // second local STT_FUNC in an object whose first function has an opaque call.
+  std::string CallerFrame = MakeFrame("", "");
+  llvm::SmallVector<uint8_t> CallerBytes = assembleInstructions(CallerFrame, S);
+  std::vector<InternalDecodedInst> CallerDecoded;
+  ASSERT_TRUE(decodeTextSection(CallerBytes.data(), CallerBytes.size(), S,
+                                CallerDecoded));
+  std::string LeafFrame = "v_writelane_b32 v43, s30, 4\n"
+                          "v_writelane_b32 v44, s31, 5\n"
+                          "s_mov_b32 s30, 0\n"
+                          "s_mov_b32 s31, 0\n"
+                          "v_readlane_b32 s30, v43, 4\n"
+                          "v_readlane_b32 s31, v44, 5\n"
+                          "s_set_pc_i64 s[30:31]\n"
+                          "s_endpgm\n";
+  std::optional<DirectControlFlowInfo> LeafWithLinkScratch =
+      Audit(CallerFrame + LeafFrame, {}, 0, FunctionTableElfMutation::None,
+            CallerDecoded.size());
+  ASSERT_TRUE(LeafWithLinkScratch);
+  EXPECT_FALSE(LeafWithLinkScratch->HasUnresolvedTargets);
+  EXPECT_FALSE(LeafWithLinkScratch->HasUnboundedIndirectEntries);
+
+  // The same canonical leaf can be reached only by an exact materialized
+  // singleton call. This is a machine-level closure, not the opaque-call ABI
+  // fallback: the call target, canonical return, and continuation must be
+  // validated together.
+  std::string ExactCaller = "s_get_pc_i64 s[0:1]\n"
+                            "s_add_nc_u64 s[0:1], s[0:1], 12\n"
+                            "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                            "s_endpgm\n";
+  std::optional<DirectControlFlowInfo> ExactCanonicalLeaf =
+      Audit(ExactCaller + LeafFrame, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/4);
+  ASSERT_TRUE(ExactCanonicalLeaf);
+  EXPECT_FALSE(ExactCanonicalLeaf->HasUnresolvedTargets);
+  EXPECT_FALSE(ExactCanonicalLeaf->HasUnboundedIndirectEntries);
+
+  // A separate finite call enters the add of the exact singleton call above,
+  // bypassing its defining get-PC. The canonical callee frame remains valid,
+  // but the exact closure must reject this alternate materialization entry
+  // rather than using the fallback to publish both calls as bounded.
+  std::string InteriorCaller = "s_call_i64 s[4:5], 2\n"
+                               "s_endpgm\n" +
+                               ExactCaller + LeafFrame;
+  std::optional<DirectControlFlowInfo> InteriorCanonicalLeaf =
+      Audit(InteriorCaller, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/2, /*ExternalEntries=*/{},
+            /*Target1BeginIndex=*/6);
+  ASSERT_TRUE(InteriorCanonicalLeaf);
+  EXPECT_TRUE(InteriorCanonicalLeaf->HasUnresolvedTargets);
+  EXPECT_TRUE(InteriorCanonicalLeaf->HasUnboundedIndirectEntries);
+
+  // Canonical compiler tail thunk: save the incoming link, materialize a
+  // different STT_FUNC entry, restore the link, and jump without replacing
+  // s[30:31]. The target returns directly to the thunk's original caller.
+  std::string TailThunk = "v_writelane_b32 v43, s30, 4\n"
+                          "v_writelane_b32 v44, s31, 5\n"
+                          "s_get_pc_i64 s[0:1]\n"
+                          "s_add_nc_u64 s[0:1], s[0:1], 24\n"
+                          "v_readlane_b32 s30, v43, 4\n"
+                          "v_readlane_b32 s31, v44, 5\n"
+                          "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> CanonicalTail = Audit(
+      TailThunk + MakeFrame("", ""), {}, 0, FunctionTableElfMutation::None,
+      /*CallerEndIndex=*/7);
+  ASSERT_TRUE(CanonicalTail);
+  EXPECT_FALSE(CanonicalTail->HasUnresolvedTargets);
+  EXPECT_FALSE(CanonicalTail->HasUnboundedIndirectEntries);
+
+  // A finite exact jump to a defined noreturn function never needs permission
+  // to enter an s30-returning frame. Do not require its source to have a
+  // canonical save/restore frame merely because the destination is STT_FUNC.
+  std::string ExactNoreturnTarget = "s_cbranch_vccnz 3\n"
+                                    "s_get_pc_i64 s[0:1]\n"
+                                    "s_add_nc_u64 s[0:1], s[0:1], 12\n"
+                                    "s_set_pc_i64 s[0:1]\n"
+                                    "s_set_pc_i64 s[30:31]\n"
+                                    "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                                    "s_endpgm\n"
+                                    "s_endpgm\n";
+  std::optional<DirectControlFlowInfo> NoreturnExact =
+      Audit(ExactNoreturnTarget, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/5);
+  ASSERT_TRUE(NoreturnExact);
+  EXPECT_FALSE(NoreturnExact->HasUnresolvedTargets);
+  EXPECT_FALSE(NoreturnExact->HasUnboundedIndirectEntries);
+
+  // Tail-chain certification is intentionally strict: B cannot use A's
+  // not-yet-certified entry while Phase 1 proves B -> returning C.
+  std::optional<DirectControlFlowInfo> TailChain =
+      Audit(TailThunk + TailThunk + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/7, {},
+            /*Target1BeginIndex=*/14);
+  ASSERT_TRUE(TailChain);
+  EXPECT_TRUE(TailChain->HasUnresolvedTargets);
+  EXPECT_TRUE(TailChain->HasUnboundedIndirectEntries);
+
+  // Permissions are keyed by source instruction. One certified entrant must
+  // not authorize a second, noncanonical source that targets the same frame.
+  std::string SafeTailToThird = "v_writelane_b32 v43, s30, 4\n"
+                                "v_writelane_b32 v44, s31, 5\n"
+                                "s_get_pc_i64 s[0:1]\n"
+                                "s_add_nc_u64 s[0:1], s[0:1], 36\n"
+                                "v_readlane_b32 s30, v43, 4\n"
+                                "v_readlane_b32 s31, v44, 5\n"
+                                "s_set_pc_i64 s[0:1]\n";
+  std::string UnsafeTailToThird = "s_get_pc_i64 s[0:1]\n"
+                                  "s_add_nc_u64 s[0:1], s[0:1], 8\n"
+                                  "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> MixedTailSources =
+      Audit(SafeTailToThird + UnsafeTailToThird + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/7, {},
+            /*Target1BeginIndex=*/10);
+  ASSERT_TRUE(MixedTailSources);
+  EXPECT_TRUE(MixedTailSources->HasUnresolvedTargets);
+  EXPECT_TRUE(MixedTailSources->HasUnboundedIndirectEntries);
+
+  std::string ClobberedTail = "v_writelane_b32 v43, s30, 4\n"
+                              "v_writelane_b32 v44, s31, 5\n"
+                              "s_get_pc_i64 s[0:1]\n"
+                              "s_add_nc_u64 s[0:1], s[0:1], 28\n"
+                              "v_readlane_b32 s30, v43, 4\n"
+                              "v_readlane_b32 s31, v44, 5\n"
+                              "s_mov_b32 s30, 0\n"
+                              "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailLinkClobber = Audit(
+      ClobberedTail + MakeFrame("", ""), {}, 0, FunctionTableElfMutation::None,
+      /*CallerEndIndex=*/8);
+  ASSERT_TRUE(TailLinkClobber);
+  EXPECT_TRUE(TailLinkClobber->HasUnresolvedTargets);
+  EXPECT_TRUE(TailLinkClobber->HasUnboundedIndirectEntries);
+
+  std::string NonzeroModeTail = "v_writelane_b32 v43, s30, 4\n"
+                                "v_writelane_b32 v44, s31, 5\n"
+                                "s_get_pc_i64 s[0:1]\n"
+                                "s_add_nc_u64 s[0:1], s[0:1], 28\n"
+                                "v_readlane_b32 s30, v43, 4\n"
+                                "v_readlane_b32 s31, v44, 5\n"
+                                "s_set_vgpr_msb 1\n"
+                                "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailModeClobber =
+      Audit(NonzeroModeTail + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/8);
+  ASSERT_TRUE(TailModeClobber);
+  EXPECT_TRUE(TailModeClobber->HasUnresolvedTargets);
+  EXPECT_TRUE(TailModeClobber->HasUnboundedIndirectEntries);
+
+  std::string MissingTailRestore = "v_writelane_b32 v43, s30, 4\n"
+                                   "v_writelane_b32 v44, s31, 5\n"
+                                   "s_get_pc_i64 s[0:1]\n"
+                                   "s_add_nc_u64 s[0:1], s[0:1], 16\n"
+                                   "v_readlane_b32 s30, v43, 4\n"
+                                   "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailMissingRestore =
+      Audit(MissingTailRestore + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/6);
+  ASSERT_TRUE(TailMissingRestore);
+  EXPECT_TRUE(TailMissingRestore->HasUnresolvedTargets);
+  EXPECT_TRUE(TailMissingRestore->HasUnboundedIndirectEntries);
+
+  std::string NonCsrTail = "v_writelane_b32 v0, s30, 4\n"
+                           "v_writelane_b32 v1, s31, 5\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 24\n"
+                           "v_readlane_b32 s30, v0, 4\n"
+                           "v_readlane_b32 s31, v1, 5\n"
+                           "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailNonCsr = Audit(
+      NonCsrTail + MakeFrame("", ""), {}, 0, FunctionTableElfMutation::None,
+      /*CallerEndIndex=*/7);
+  ASSERT_TRUE(TailNonCsr);
+  EXPECT_TRUE(TailNonCsr->HasUnresolvedTargets);
+  EXPECT_TRUE(TailNonCsr->HasUnboundedIndirectEntries);
+
+  std::string SavedLaneClobberTail = "v_writelane_b32 v43, s30, 4\n"
+                                     "v_writelane_b32 v44, s31, 5\n"
+                                     "s_get_pc_i64 s[0:1]\n"
+                                     "s_add_nc_u64 s[0:1], s[0:1], 32\n"
+                                     "v_writelane_b32 v43, s0, 4\n"
+                                     "v_readlane_b32 s30, v43, 4\n"
+                                     "v_readlane_b32 s31, v44, 5\n"
+                                     "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailSavedLaneClobber =
+      Audit(SavedLaneClobberTail + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/8);
+  ASSERT_TRUE(TailSavedLaneClobber);
+  EXPECT_TRUE(TailSavedLaneClobber->HasUnresolvedTargets);
+  EXPECT_TRUE(TailSavedLaneClobber->HasUnboundedIndirectEntries);
+
+  std::string InteriorTargetTail = "v_writelane_b32 v43, s30, 4\n"
+                                   "v_writelane_b32 v44, s31, 5\n"
+                                   "s_get_pc_i64 s[0:1]\n"
+                                   "s_add_nc_u64 s[0:1], s[0:1], 28\n"
+                                   "v_readlane_b32 s30, v43, 4\n"
+                                   "v_readlane_b32 s31, v44, 5\n"
+                                   "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailInteriorTarget =
+      Audit(InteriorTargetTail + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/7);
+  ASSERT_TRUE(TailInteriorTarget);
+  EXPECT_TRUE(TailInteriorTarget->HasUnresolvedTargets);
+  EXPECT_TRUE(TailInteriorTarget->HasUnboundedIndirectEntries);
+
+  const uint64_t TailSaveBypassEntry[] = {16};
+  std::optional<DirectControlFlowInfo> TailSaveBypass = Audit(
+      TailThunk + MakeFrame("", ""), {}, 0, FunctionTableElfMutation::None,
+      /*CallerEndIndex=*/7, TailSaveBypassEntry);
+  ASSERT_TRUE(TailSaveBypass);
+  EXPECT_TRUE(TailSaveBypass->HasUnresolvedTargets);
+  EXPECT_TRUE(TailSaveBypass->HasUnboundedIndirectEntries);
+
+  const uint64_t TailNonCallEntry[] = {0};
+  std::optional<DirectControlFlowInfo> TailNonCallRoot =
+      Audit(TailThunk + MakeFrame("", ""), TailNonCallEntry, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/7);
+  ASSERT_TRUE(TailNonCallRoot);
+  EXPECT_TRUE(TailNonCallRoot->HasUnresolvedTargets);
+  EXPECT_TRUE(TailNonCallRoot->HasUnboundedIndirectEntries);
+
+  // A loop wholly inside the function is not a new entry, including when its
+  // backedge targets the function's first instruction.  The two saves still
+  // dominate the nested call.
+  std::optional<DirectControlFlowInfo> InternalBackedge =
+      Audit(MakeFrame("", "", "", "v41", "v42", "s_cbranch_vccnz -6\n"));
+  ASSERT_TRUE(InternalBackedge);
+  EXPECT_FALSE(InternalBackedge->HasUnresolvedTargets);
+  EXPECT_FALSE(InternalBackedge->HasUnboundedIndirectEntries);
+
+  // Re-entering the prologue after a nested call would overwrite the
+  // originally saved incoming link with the call's continuation.
+  std::optional<DirectControlFlowInfo> PostCallBackedge =
+      Audit(MakeFrame("", "s_branch -8\n"));
+  ASSERT_TRUE(PostCallBackedge);
+  EXPECT_TRUE(PostCallBackedge->HasUnresolvedTargets);
+  EXPECT_TRUE(PostCallBackedge->HasUnboundedIndirectEntries);
+
+  // The must-link fact has to converge around cycles: the lexically early
+  // Begin backedge is unsafe when a second edge revisits it after the call.
+  std::optional<DirectControlFlowInfo> CyclicPostCallBackedge = Audit(
+      MakeFrame("", "s_branch -3\n", "", "v41", "v42", "s_cbranch_vccnz -6\n"));
+  ASSERT_TRUE(CyclicPostCallBackedge);
+  EXPECT_TRUE(CyclicPostCallBackedge->HasUnresolvedTargets);
+  EXPECT_TRUE(CyclicPostCallBackedge->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> BodyLinkScratch =
+      Audit(MakeFrame("", "s_add_u32 s30, s0, s1\n"));
+  ASSERT_TRUE(BodyLinkScratch);
+  EXPECT_FALSE(BodyLinkScratch->HasUnresolvedTargets);
+  EXPECT_FALSE(BodyLinkScratch->HasUnboundedIndirectEntries);
+
+  // A write to the exact protected lane after the call destroys the saved
+  // low link half. A genuine branch before the saves also prevents the
+  // prologue from dominating the frame, unlike the save-exec instruction.
+  std::optional<DirectControlFlowInfo> Clobbered =
+      Audit(MakeFrame("", "v_writelane_b32 v41, s0, 31\n"));
+  ASSERT_TRUE(Clobbered);
+  EXPECT_TRUE(Clobbered->HasUnresolvedTargets);
+  EXPECT_TRUE(Clobbered->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> Branched =
+      Audit(MakeFrame("s_branch 0\n", ""));
+  ASSERT_TRUE(Branched);
+  EXPECT_TRUE(Branched->HasUnresolvedTargets);
+  EXPECT_TRUE(Branched->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> OutsideBranch =
+      Audit(MakeFrame("s_branch 0\n", ""), {}, /*CallerBeginIndex=*/1);
+  ASSERT_TRUE(OutsideBranch);
+  EXPECT_TRUE(OutsideBranch->HasUnresolvedTargets);
+  EXPECT_TRUE(OutsideBranch->HasUnboundedIndirectEntries);
+
+  std::string ExternalExactSetPc = "s_get_pc_i64 s[4:5]\n"
+                                   "s_add_nc_u64 s[4:5], s[4:5], 28\n"
+                                   "s_set_pc_i64 s[4:5]\n" +
+                                   MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> OutsideExactSetPc =
+      Audit(ExternalExactSetPc, {}, /*CallerBeginIndex=*/3);
+  ASSERT_TRUE(OutsideExactSetPc);
+  EXPECT_TRUE(OutsideExactSetPc->HasUnresolvedTargets);
+  EXPECT_TRUE(OutsideExactSetPc->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> InteriorFunctionEnd = Audit(
+      MakeFrame("", ""), {}, 0, FunctionTableElfMutation::FunctionEndInterior);
+  ASSERT_TRUE(InteriorFunctionEnd);
+  EXPECT_TRUE(InteriorFunctionEnd->HasUnresolvedTargets);
+  EXPECT_TRUE(InteriorFunctionEnd->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> OutOfTextFunctionSize =
+      Audit(MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::FunctionSizeOutOfText);
+  ASSERT_TRUE(OutOfTextFunctionSize);
+  EXPECT_TRUE(OutOfTextFunctionSize->HasUnresolvedTargets);
+  EXPECT_TRUE(OutOfTextFunctionSize->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> MalformedSymbolTable = Audit(
+      MakeFrame("", ""), {}, 0, FunctionTableElfMutation::MalformedSymbolTable);
+  ASSERT_TRUE(MalformedSymbolTable);
+  EXPECT_TRUE(MalformedSymbolTable->HasUnresolvedTargets);
+  EXPECT_TRUE(MalformedSymbolTable->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> ClobberedBeforeSave =
+      Audit(MakeFrame("s_mov_b32 s30, 0\n", ""));
+  ASSERT_TRUE(ClobberedBeforeSave);
+  EXPECT_TRUE(ClobberedBeforeSave->HasUnresolvedTargets);
+  EXPECT_TRUE(ClobberedBeforeSave->HasUnboundedIndirectEntries);
+
+  const uint64_t NonCallBegin[] = {0};
+  std::optional<DirectControlFlowInfo> NonCallRoot =
+      Audit(MakeFrame("", ""), NonCallBegin);
+  ASSERT_TRUE(NonCallRoot);
+  EXPECT_TRUE(NonCallRoot->HasUnresolvedTargets);
+  EXPECT_TRUE(NonCallRoot->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> CallerMode =
+      Audit(MakeFrame("s_set_vgpr_msb 1\n", ""));
+  ASSERT_TRUE(CallerMode);
+  EXPECT_TRUE(CallerMode->HasUnresolvedTargets);
+  EXPECT_TRUE(CallerMode->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> ReturnMode =
+      Audit(MakeFrame("", "", "s_set_vgpr_msb 1\n"));
+  ASSERT_TRUE(ReturnMode);
+  EXPECT_TRUE(ReturnMode->HasUnresolvedTargets);
+  EXPECT_TRUE(ReturnMode->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> ClobberedAfterRestore =
+      Audit(MakeFrame("", "", "s_mov_b32 s30, 0\n"));
+  ASSERT_TRUE(ClobberedAfterRestore);
+  EXPECT_TRUE(ClobberedAfterRestore->HasUnresolvedTargets);
+  EXPECT_TRUE(ClobberedAfterRestore->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> NonCsr =
+      Audit(MakeFrame("", "", "", "v0", "v1"));
+  ASSERT_TRUE(NonCsr);
+  EXPECT_TRUE(NonCsr->HasUnresolvedTargets);
+  EXPECT_TRUE(NonCsr->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     MarksUnboundedSetPcEntryWithoutTreatingItAsUnresolvedCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
@@ -961,6 +2173,112 @@ TEST(CollectDirectBranchTargets, IgnoresSetPcWithoutTreatingItAsCall) {
                                  /*TextSize=*/0x1000, /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     HandlesSparseSetPcAndFunctionRangesWithoutCartesianScan) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_set_pc_i64 s[8:9]", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Prototype;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Prototype));
+  ASSERT_EQ(Prototype.size(), 1u);
+
+  constexpr size_t Count = 16384;
+  constexpr uint64_t TextSize = 1 << 20;
+  std::vector<InternalDecodedInst> Decoded;
+  Decoded.reserve(Count);
+  llvm::SmallVector<ElfView::FunctionTextRange, 16> FunctionRanges;
+  FunctionRanges.reserve(Count);
+  for (size_t I = 0; I != Count; ++I) {
+    Decoded.push_back(Prototype[0]);
+    Decoded.back().Offset = I * MinInstSize;
+    // These validly ordered ranges do not cover any instruction. This pins
+    // the sparse return-to-range index: a full range scan for every set-PC
+    // would perform Count squared containment checks.
+    uint64_t Begin = TextSize + I * MinInstSize;
+    FunctionRanges.push_back({Begin, Begin + MinInstSize});
+  }
+
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, TextSize,
+                                 /*DeclaredEntries=*/{}, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, HandlesManyCallsWithoutCartesianGrouping) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_call_i64 s[30:31], 0", S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Prototype;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Prototype));
+  ASSERT_EQ(Prototype.size(), 1u);
+
+  constexpr size_t Count = 8192;
+  std::vector<InternalDecodedInst> Decoded(Count, Prototype.front());
+  for (size_t I = 0; I != Count; ++I)
+    Decoded[I].Offset = I * MinInstSize;
+  const uint64_t TextSize = Count * MinInstSize;
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, TextSize, DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(MinInstSize));
+  EXPECT_TRUE(Info->Targets.contains(TextSize));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     IndexesManyBoundedReturnsAndKnownCallsWithoutCartesianScan) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Prototype;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Prototype));
+  ASSERT_EQ(Prototype.size(), 2u);
+
+  constexpr size_t Count = 16384;
+  std::vector<InternalDecodedInst> Decoded;
+  Decoded.reserve(Count * 2);
+  llvm::SmallVector<uint64_t, 16> DeclaredEntries;
+  DeclaredEntries.reserve(Count);
+  llvm::SmallVector<ElfView::FunctionTextRange, 16> FunctionRanges;
+  FunctionRanges.reserve(Count);
+  for (size_t I = 0; I != Count; ++I) {
+    uint64_t CallOffset = I * 2 * MinInstSize;
+    uint64_t FunctionBegin = CallOffset + MinInstSize;
+    Decoded.push_back(Prototype[0]);
+    Decoded.back().Offset = CallOffset;
+    Decoded.push_back(Prototype[1]);
+    Decoded.back().Offset = FunctionBegin;
+    DeclaredEntries.push_back(FunctionBegin);
+    FunctionRanges.push_back({FunctionBegin, FunctionBegin + MinInstSize});
+  }
+
+  // Each call targets the following one-instruction return function. This
+  // simultaneously pins target/continuation range queries and direct-call
+  // source membership: scanning all calls for every return is quadratic.
+  uint64_t TextSize = Count * 2 * MinInstSize;
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, TextSize, DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_EQ(Info->Targets.size(), Count);
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
@@ -981,6 +2299,17 @@ TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
   for (InternalDecodedInst &DI : Decoded)
     DI.Offset += 0x12EDCC;
 
+  // collectDirectBranchTargets normally sees the complete .text decode. Keep
+  // the synthetic production slice faithful to that contract by representing
+  // the resolved local target as an instruction boundary.
+  llvm::SmallVector<uint8_t> TargetBytes =
+      assembleInstructions("s_endpgm", S);
+  std::vector<InternalDecodedInst> TargetDecoded;
+  ASSERT_TRUE(decodeTextSection(TargetBytes.data(), TargetBytes.size(), S,
+                                TargetDecoded));
+  ASSERT_EQ(TargetDecoded.size(), 1u);
+  Decoded.insert(Decoded.begin(), TargetDecoded.front());
+
   // This is the exact address calculation from the production reproducer:
   // 0x1a000 + 0x12edcc + 4 - 0x12edd0 = 0x1a000.
   std::optional<DirectControlFlowInfo> Info =
@@ -991,6 +2320,80 @@ TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
   ASSERT_EQ(Info->Targets.size(), 1u);
   EXPECT_TRUE(Info->Targets.contains(0));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, BoundsFiniteExternalPcMaterializedCall) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 0x100\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 4u);
+
+  // The exact target is outside this deliberately short .text range. The
+  // external callee may return through the link pair, so the local
+  // continuation remains a protected entry even though the external target
+  // contributes no local offset.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x20,
+                                 /*DeclaredEntries=*/{});
+  ASSERT_TRUE(Info);
+  ASSERT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[3].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsExternalCallContinuationIntoReturnFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_endpgm\n"
+                           "s_get_pc_i64 s[2:3]\n"
+                           "s_add_co_i32 s4, 0x1000, 4\n"
+                           "s_add_co_u32 s2, s2, s4\n"
+                           "s_add_co_ci_u32 s3, s3, 0\n"
+                           "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_endpgm\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -16\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 13u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{Decoded[7].Offset,
+                                                 Decoded[10].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 3> FunctionRanges{
+      {Decoded[1].Offset, Decoded[7].Offset},
+      {Decoded[7].Offset, Decoded[9].Offset},
+      {Decoded[10].Offset, Decoded.back().Offset + Decoded.back().Size}};
+
+  // The first call has one finite target outside this .text, and returns to
+  // the padding that falls through into the local helper. The later local
+  // call alone would appear to justify the helper's s_set_pc_i64, but the
+  // external continuation is a second link-register provenance and must keep
+  // that return unbounded.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/Bytes.size(), DeclaredEntries,
+      FunctionRanges, /*ExternalEntries=*/{}, Bytes);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[5].Offset + Decoded[5].Size));
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
 TEST(CollectDirectBranchTargets, RejectsClobberedPcMaterializedCall) {
@@ -1014,6 +2417,150 @@ TEST(CollectDirectBranchTargets, RejectsClobberedPcMaterializedCall) {
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.empty());
   EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(SourceTailSafety, RejectsProtectedEntriesAndOverlappingRanges) {
+  Trampoline T;
+  T.OriginalOffset = 8;
+  T.OriginalSize = 12;
+  T.HasFunctionRange = true;
+  T.FunctionStart = 0;
+  T.FunctionEnd = 32;
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> OneRange{
+      {0, 32, nullptr, nullptr}};
+  EXPECT_TRUE(sourceHasUniqueFunctionRange(T, OneRange, /*TextAddr=*/0));
+
+  DirectControlFlowInfo ControlFlow;
+  EXPECT_TRUE(isSafeSourceTailRange(T, ControlFlow,
+                                    /*HasUniqueFunctionRange=*/true,
+                                    /*Begin=*/12, /*End=*/20));
+  ControlFlow.Targets.insert(16);
+  EXPECT_FALSE(isSafeSourceTailRange(T, ControlFlow,
+                                     /*HasUniqueFunctionRange=*/true,
+                                     /*Begin=*/12, /*End=*/20));
+  ControlFlow.Targets.clear();
+  ControlFlow.HasUnboundedIndirectEntries = true;
+  EXPECT_FALSE(isSafeSourceTailRange(T, ControlFlow,
+                                     /*HasUniqueFunctionRange=*/true,
+                                     /*Begin=*/12, /*End=*/20));
+
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> AliasedRanges{
+      {0, 32, nullptr, nullptr}, {0, 32, nullptr, nullptr}};
+  // The same logical global function can appear in both .symtab and .dynsym.
+  // Equal bounds add no new interior ownership ambiguity.
+  EXPECT_TRUE(sourceHasUniqueFunctionRange(T, AliasedRanges, /*TextAddr=*/0));
+
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> NestedRanges{
+      {0, 64, nullptr, nullptr}, {32, 48, nullptr, nullptr}};
+  T.FunctionEnd = 64;
+  T.OriginalOffset = 8;
+  EXPECT_TRUE(sourceHasUniqueFunctionRange(T, NestedRanges, /*TextAddr=*/0));
+  T.OriginalOffset = 36;
+  EXPECT_FALSE(sourceHasUniqueFunctionRange(T, NestedRanges, /*TextAddr=*/0));
+}
+
+TEST(SourceTailSafety, IndexedRangeQueryMatchesOverlapBoundaries) {
+  Trampoline T;
+  T.OriginalOffset = 8;
+  T.OriginalSize = 12;
+  T.HasFunctionRange = true;
+  T.FunctionStart = 0;
+  T.FunctionEnd = 32;
+
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> SameBeginDifferentEnd{
+      {0, 32, nullptr, nullptr}, {0, 24, nullptr, nullptr}};
+  EXPECT_FALSE(sourceHasUniqueFunctionRange(
+      T, SameBeginDifferentEnd, /*TextAddr=*/0));
+  EXPECT_FALSE(sourceHasUniqueFunctionRangeIndexedForTest(
+      T, SameBeginDifferentEnd, /*TextAddr=*/0));
+
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> PartialOverlap{
+      {8, 40, nullptr, nullptr}, {0, 20, nullptr, nullptr}};
+  T.FunctionStart = 8;
+  T.FunctionEnd = 40;
+  T.OriginalOffset = 16;
+  T.OriginalSize = 8;
+  EXPECT_TRUE(
+      sourceHasUniqueFunctionRange(T, PartialOverlap, /*TextAddr=*/0));
+  EXPECT_TRUE(sourceHasUniqueFunctionRangeIndexedForTest(
+      T, PartialOverlap, /*TextAddr=*/0));
+
+  T.OriginalSize = 4;
+  EXPECT_FALSE(
+      sourceHasUniqueFunctionRange(T, PartialOverlap, /*TextAddr=*/0));
+  EXPECT_FALSE(sourceHasUniqueFunctionRangeIndexedForTest(
+      T, PartialOverlap, /*TextAddr=*/0));
+}
+
+TEST(SourceTailSafety, IndexedRangeQueryMatchesRandomizedLinearOracle) {
+  uint64_t State = 0xC0FFEE1234567890ULL;
+  auto Next = [&]() {
+    State = State * 6364136223846793005ULL + 1442695040888963407ULL;
+    return State;
+  };
+
+  constexpr uint64_t TextAddr = 0x100000;
+  for (unsigned Trial = 0; Trial != 500; ++Trial) {
+    llvm::SmallVector<ElfView::FunctionTextRange, 32> Ranges;
+    unsigned Count = 1 + Next() % 16;
+    for (unsigned I = 0; I != Count; ++I) {
+      uint64_t Begin = (Next() % 64) * MinInstSize;
+      uint64_t End = Begin + (1 + Next() % 24) * MinInstSize;
+      Ranges.push_back(
+          {TextAddr + Begin, TextAddr + End, nullptr, nullptr});
+      if ((Next() & 3) == 0)
+        Ranges.push_back(Ranges.back());
+    }
+
+    const ElfView::FunctionTextRange &Selected =
+        Ranges[Next() % Ranges.size()];
+    Trampoline T;
+    T.HasFunctionRange = (Next() & 15) != 0;
+    T.FunctionStart = Selected.Begin - TextAddr;
+    T.FunctionEnd = Selected.End - TextAddr;
+    uint64_t Width = T.FunctionEnd - T.FunctionStart;
+    T.OriginalOffset = T.FunctionStart + Next() % Width;
+    T.OriginalSize = 1 + Next() % (T.FunctionEnd - T.OriginalOffset);
+    if (Trial % 17 == 0)
+      ++T.FunctionEnd;
+
+    bool Linear = sourceHasUniqueFunctionRange(T, Ranges, TextAddr);
+    bool Indexed =
+        sourceHasUniqueFunctionRangeIndexedForTest(T, Ranges, TextAddr);
+    EXPECT_EQ(Indexed, Linear) << "trial " << Trial;
+  }
+}
+
+TEST(SourceTailSafety, ReservesRegisterlessReturnTailBeforeAffinePlanning) {
+  Trampoline T;
+  T.OriginalOffset = 0x100;
+  T.Long = true;
+  T.OriginalSize = 2 * MinInstSize;
+  EXPECT_TRUE(mustReserveSourceTailForRegisterlessReturn(T));
+  EXPECT_FALSE(registerlessSourceAffineGatewayRange(T));
+
+  T.OriginalSize = 7 * MinInstSize;
+  std::optional<std::pair<uint64_t, uint64_t>> Gateway =
+      registerlessSourceAffineGatewayRange(T);
+  ASSERT_TRUE(Gateway);
+  EXPECT_EQ(Gateway->first, T.OriginalOffset + 2 * MinInstSize);
+  EXPECT_EQ(Gateway->second, T.OriginalOffset + 7 * MinInstSize);
+  EXPECT_GT(Gateway->first, T.OriginalOffset + MinInstSize);
+
+  T.UsesSetPCBack = true;
+  EXPECT_FALSE(mustReserveSourceTailForRegisterlessReturn(T));
+  T.UsesSetPCBack = false;
+  T.LongBranchPreservesVcc = true;
+  EXPECT_FALSE(mustReserveSourceTailForRegisterlessReturn(T));
+  T.LongBranchPreservesVcc = false;
+  T.UsesSharedDispatcherForward = true;
+  EXPECT_FALSE(mustReserveSourceTailForRegisterlessReturn(T));
+  T.UsesSharedDispatcherForward = false;
+  T.OriginalSize = MinInstSize;
+  EXPECT_FALSE(mustReserveSourceTailForRegisterlessReturn(T));
+  T.OriginalSize = 2 * MinInstSize;
+  T.Long = false;
+  EXPECT_FALSE(mustReserveSourceTailForRegisterlessReturn(T));
 }
 
 TEST(CollectDirectBranchTargets, RejectsAlternateEntryIntoMaterialization) {
@@ -1061,7 +2608,8 @@ TEST(CollectDirectBranchTargets, RejectsDeclaredEntryIntoMaterialization) {
   std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries);
   ASSERT_TRUE(Info);
-  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries.front()));
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
@@ -1144,13 +2692,87 @@ TEST(CollectDirectBranchTargets, BoundsCanonicalSetPcReturn) {
   // matching the production CFG, but it preserves the pair as well. The
   // materialized call is therefore the return's sole possible source.
   std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
-      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/Bytes.size(), DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
-  ASSERT_EQ(Info->Targets.size(), 2u);
+  ASSERT_EQ(Info->Targets.size(), 3u);
   EXPECT_TRUE(Info->Targets.contains(0));
   EXPECT_TRUE(Info->Targets.contains(Decoded[1].Offset));
+  EXPECT_TRUE(
+      Info->Targets.contains(Decoded.back().Offset + Decoded.back().Size));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     ClosesMaterializedCallExactJumpAndCanonicalReturnTogether) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 12\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                           "s_endpgm\n"
+                           "s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_endpgm\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 9u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[4].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> FunctionRanges{
+      {0, Decoded[4].Offset}, {Decoded[4].Offset, Bytes.size()}};
+
+  // No edge is independently sufficient: the materialized call defines the
+  // helper's s30 link, its exact set-PC reaches the return, and that return
+  // reaches only the call continuation. The joint finite-control-flow audit
+  // must close all three edges without treating the register call's generic
+  // indirect-branch classification as a second unbounded edge.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries, FunctionRanges,
+      /*ExternalEntries=*/{}, Bytes);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[6].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[8].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[4].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[2].Offset + Decoded[2].Size));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsFiniteCallEntryIntoAnotherCallMaterialization) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_swap_pc_i64 s[30:31], s[4:5]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 0x100\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+
+  // The first exact call targets the add in the second call's get-PC/add
+  // materialization. Both targets are finite instruction boundaries, but the
+  // first call can bypass the second call's defining get-PC. Joint closure
+  // must therefore leave the second call unresolved.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[4].Offset));
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
 TEST(CollectDirectBranchTargets, RejectsClobberedSetPcReturn) {
@@ -1178,7 +2800,8 @@ TEST(CollectDirectBranchTargets, RejectsClobberedSetPcReturn) {
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
-  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries.front()));
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
@@ -1309,7 +2932,8 @@ TEST(CollectDirectBranchTargets,
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
-  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries.front()));
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
@@ -1339,11 +2963,13 @@ TEST(CollectDirectBranchTargets, RejectsExternalAliasAtLocalFunctionEntry) {
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges, ExternalEntries);
   ASSERT_TRUE(Info);
-  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries.front()));
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
-TEST(CollectDirectBranchTargets, RejectsFallthroughIntoReturnFunction) {
+TEST(CollectDirectBranchTargets,
+     RejectsUnsortedDeclaredFallthroughIntoReturnFunction) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
@@ -1359,18 +2985,177 @@ TEST(CollectDirectBranchTargets, RejectsFallthroughIntoReturnFunction) {
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
   ASSERT_EQ(Decoded.size(), 6u);
-  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[1].Offset};
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{Decoded[1].Offset, 0};
   llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
       {Decoded[1].Offset, Decoded[3].Offset}};
 
-  // The declared entry at zero reaches the local helper by fallthrough and
-  // does not define s[30:31], so the helper's return cannot be bounded.
+  // The deliberately unsorted declared entry at zero reaches the local helper
+  // by fallthrough and does not define s[30:31], so the helper's return cannot
+  // be bounded.
   std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
-  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_EQ(Info->Targets.size(), 2u);
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries[0]));
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries[1]));
   EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsExactSetPcEntryIntoCallDefinedReturnFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                           "s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], -24\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 9u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[2].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> FunctionRanges{
+      {0, Decoded[2].Offset}, {Decoded[2].Offset, Bytes.size()}};
+
+  // The first call would otherwise prove the helper's link pair. The exact
+  // jump later in the caller reaches the helper without defining s[30:31].
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[1].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsCallReachedExactEntryIntoReturnFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_call_i64 s[4:5], 3\n"
+                           "s_call_i64 s[30:31], -4\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_get_pc_i64 s[6:7]\n"
+                           "s_add_nc_u64 s[6:7], s[6:7], -28\n"
+                           "s_set_pc_i64 s[6:7]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 9u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[2].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> FunctionRanges{
+      {0, Decoded[2].Offset}, {Decoded[2].Offset, Bytes.size()}};
+
+  // The endpgm at 16 blocks layout reachability to the materialization. Only
+  // the finite call at 8 reaches it; that edge must still participate in the
+  // exact-jump alternate-entry proof for the helper at zero.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[1].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     DoesNotPublishBoundedReturnsAfterNonClosedAudit) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                           "s_set_pc_i64 s[8:9]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[2].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> FunctionRanges{
+      {0, Decoded[2].Offset}, {Decoded[2].Offset, Bytes.size()}};
+
+  // The local call initially proves the helper return, but its continuation
+  // reaches an open indirect transfer. A non-closed object-wide audit must
+  // retract every bounded-return fact before publishing the final result.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[1].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsLocalCallContinuationAtReturnFunctionEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_nop 0\n"
+                           "s_call_i64 s[4:5], 3\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_call_i64 s[30:31], -5\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 8u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[6].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {Decoded[2].Offset, Decoded[4].Offset}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[3].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsFiniteExternalCallContinuationAtReturnFunctionEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 0x100\n"
+                           "s_swap_pc_i64 s[4:5], s[0:1]\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_call_i64 s[30:31], -3\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 7u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[5].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {Decoded[3].Offset, Decoded[5].Offset}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[4].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
 }
 
 TEST(CollectDirectBranchTargets, AllowsUnreachablePaddingBeforeReturnFunction) {
@@ -1399,7 +3184,7 @@ TEST(CollectDirectBranchTargets, AllowsUnreachablePaddingBeforeReturnFunction) {
   // fallthrough chain terminates at an unconditional branch. This mirrors the
   // padding before the production HSACO's second helper.
   std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
-      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/Bytes.size(), DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.contains(Decoded[3].Offset));
@@ -1431,7 +3216,9 @@ TEST(CollectDirectBranchTargets, HandlesImmediateAbsoluteTargetCall) {
       collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x220,
                                  /*TextSize=*/0x40, /*DeclaredEntries=*/{});
   ASSERT_TRUE(OutsideInfo);
-  EXPECT_TRUE(OutsideInfo->Targets.empty());
+  ASSERT_EQ(OutsideInfo->Targets.size(), 1u);
+  EXPECT_TRUE(
+      OutsideInfo->Targets.contains(Decoded[0].Offset + Decoded[0].Size));
   EXPECT_FALSE(OutsideInfo->HasUnresolvedTargets);
 
   std::optional<DirectControlFlowInfo> OverflowInfo =
@@ -1462,6 +3249,797 @@ TEST(CollectDirectBranchTargets, CollectsPcRelativeCall) {
   EXPECT_TRUE(
       Info->Targets.contains(0x200u + Decoded[0].Size + 2 * MinInstSize));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, ProtectsExternalPcRelativeCallContinuation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_call_i64 s[30:31], 2", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+
+  // The encoded target is beyond this deliberately short .text, while the
+  // instruction after the call remains inside .text. The target must not
+  // become a local protection offset, while the return continuation remains
+  // protected.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/2 * Decoded[0].Size,
+                                 /*DeclaredEntries=*/{});
+  ASSERT_TRUE(Info);
+  ASSERT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[0].Offset + Decoded[0].Size));
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     BoundsExactSetPcEdgeThatEnablesDifferentPairSelector) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_endpgm\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_co_i32 s2, 0xfe8, 4\n"
+                           "s_add_co_u32 s0, s0, s2\n"
+                           "s_add_co_ci_u32 s1, s1, 0\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 9u);
+  ASSERT_EQ(Decoded[4].Offset, 16u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+
+  // The exact s[4:5] jump reaches a selector built in s[0:1]. Its call target
+  // is the finite external address 0x1000 and its local continuation must be
+  // retained.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries, FunctionRanges,
+      /*ExternalEntries=*/{}, Bytes);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[8].Offset));
+  EXPECT_TRUE(Info->Targets.contains(0));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[4].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[8].Offset + Decoded[8].Size));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RebuildsLeastSetPcFixedPointAfterUpstreamRejection) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_endpgm\n"
+                           "s_get_pc_i64 s[6:7]\n"
+                           "s_add_nc_u64 s[6:7], s[6:7], 0x100\n"
+                           "s_set_pc_i64 s[6:7]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 7u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[1].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+
+  // The alternate entry invalidates A. B was reachable only through A, so a
+  // fresh least-fixed-point rebuild must not retain B as a sticky proof.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries, FunctionRanges,
+      /*ExternalEntries=*/{}, Bytes);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[6].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsGappedExactSetPcSequence) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 0x100\n"
+                           "s_set_pc_i64 s[4:5]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  Decoded[1].Offset += MinInstSize;
+  Decoded[2].Offset += MinInstSize;
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size() + MinInstSize}};
+
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size() + MinInstSize, DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  // The set-PC itself is unreachable across the decode gap.
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsExactSetPcTargetInInstructionInterior) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_add_co_i32 s6, 0x100, 4\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 5u);
+  ASSERT_EQ(Decoded[3].Size, 2 * MinInstSize);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+
+  // PC=4 plus 12 targets offset 16, the second dword of Decoded[3].
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsOverlappingSetPcDeltaRegister) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_co_i32 s0, 0x100, 4\n"
+                           "s_add_co_u32 s0, s0, s0\n"
+                           "s_add_co_ci_u32 s1, s1, 0\n"
+                           "s_set_pc_i64 s[0:1]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 5u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsSecondDwordEntryIntoExactSetPcMaterialization) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_co_i32 s2, 0xfc, 4\n"
+                           "s_add_co_u32 s0, s0, s2\n"
+                           "s_add_co_ci_u32 s1, s1, 0\n"
+                           "s_set_pc_i64 s[0:1]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 5u);
+  ASSERT_EQ(Decoded[1].Size, 2 * MinInstSize);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[1].Offset +
+                                                        MinInstSize};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets, BoundsExactSetPcTargetOutsideText) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 0x100\n"
+                           "s_set_pc_i64 s[4:5]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(0));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     BoundsBothSignedSetPcDirectionsAndWrappedExternalTarget) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  for (llvm::StringRef Literal : {"0x24", "0xfc", "0xfffffff8", "0x7fffffff"}) {
+    SCOPED_TRACE(Literal);
+    llvm::SmallString<512> Assembly;
+    Assembly += "s_get_pc_i64 s[4:5]\ns_add_co_i32 s6, ";
+    Assembly += Literal;
+    Assembly += ", 4\n"
+                "s_cmp_ge_i32 s6, 0\n"
+                "s_cbranch_scc1 4\n"
+                "s_abs_i32 s6, s6\n"
+                "s_sub_co_u32 s4, s4, s6\n"
+                "s_sub_co_ci_u32 s5, s5, 0\n"
+                "s_set_pc_i64 s[4:5]\n"
+                "s_add_co_u32 s4, s4, s6\n"
+                "s_add_co_ci_u32 s5, s5, 0\n"
+                "s_set_pc_i64 s[4:5]\n"
+                "s_endpgm";
+    llvm::SmallVector<uint8_t> Bytes = assembleInstructions(Assembly, S);
+    ASSERT_FALSE(Bytes.empty());
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+    ASSERT_EQ(Decoded.size(), 12u);
+    llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+    llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+        {0, Bytes.size()}};
+    std::optional<DirectControlFlowInfo> Info =
+        collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                   DeclaredEntries, FunctionRanges);
+    ASSERT_TRUE(Info);
+    EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[7].Offset));
+    EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[10].Offset));
+    if (Literal == "0x24") {
+      // PC=4 plus (0x24+4) lands just after the complete two-arm sequence.
+      EXPECT_TRUE(Info->Targets.contains(Decoded[11].Offset));
+    }
+    EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+    EXPECT_FALSE(Info->HasUnresolvedTargets);
+  }
+}
+
+TEST(CollectDirectBranchTargets, RejectsExactSetPcSelfInteriorTarget) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_co_i32 s6, 4, 4\n"
+                           "s_cmp_ge_i32 s6, 0\n"
+                           "s_cbranch_scc1 4\n"
+                           "s_abs_i32 s6, s6\n"
+                           "s_sub_co_u32 s4, s4, s6\n"
+                           "s_sub_co_ci_u32 s5, s5, 0\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_add_co_u32 s4, s4, s6\n"
+                           "s_add_co_ci_u32 s5, s5, 0\n"
+                           "s_set_pc_i64 s[4:5]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 11u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[7].Offset));
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[10].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     DoesNotSelfAuthorizeDisconnectedExactCycleAndHonorsExternalRoot) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_endpgm\n"
+                           "s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 8\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_get_pc_i64 s[6:7]\n"
+                           "s_add_nc_u64 s[6:7], s[6:7], -16\n"
+                           "s_set_pc_i64 s[6:7]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 7u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+
+  std::optional<DirectControlFlowInfo> DeadInfo =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(DeadInfo);
+  EXPECT_FALSE(DeadInfo->BoundedIndirectTransfers.contains(Decoded[3].Offset));
+  EXPECT_FALSE(DeadInfo->BoundedIndirectTransfers.contains(Decoded[6].Offset));
+  EXPECT_FALSE(DeadInfo->HasUnboundedIndirectEntries);
+
+  llvm::SmallVector<uint64_t, 1> ExternalEntries{Decoded[1].Offset};
+  std::optional<DirectControlFlowInfo> RootedInfo = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries, FunctionRanges,
+      ExternalEntries);
+  ASSERT_TRUE(RootedInfo);
+  EXPECT_TRUE(RootedInfo->BoundedIndirectTransfers.contains(Decoded[3].Offset));
+  EXPECT_TRUE(RootedInfo->BoundedIndirectTransfers.contains(Decoded[6].Offset));
+  EXPECT_TRUE(RootedInfo->Targets.contains(Decoded[1].Offset));
+  EXPECT_TRUE(RootedInfo->Targets.contains(Decoded[4].Offset));
+  EXPECT_FALSE(RootedInfo->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(RootedInfo->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsNonBoundaryExternalEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_endpgm\n"
+                           "s_add_co_i32 s2, 0x100, 4\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  ASSERT_EQ(Decoded[1].Size, 2 * MinInstSize);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<uint64_t, 1> ExternalEntries{Decoded[1].Offset +
+                                                 MinInstSize};
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries,
+      /*FunctionRanges=*/{}, ExternalEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(ExternalEntries.front()));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsNonBoundaryDirectAndCallTargets) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  for (llvm::StringRef Transfer :
+       {"s_branch 1\n", "s_call_i64 s[30:31], 1\n"}) {
+    SCOPED_TRACE(Transfer);
+    llvm::SmallString<128> Assembly(Transfer);
+    Assembly += "s_add_co_i32 s2, 0x100, 4\ns_endpgm";
+    llvm::SmallVector<uint8_t> Bytes = assembleInstructions(Assembly, S);
+    ASSERT_FALSE(Bytes.empty());
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+    ASSERT_EQ(Decoded.size(), 3u);
+    ASSERT_EQ(Decoded[1].Size, 2 * MinInstSize);
+    llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+    std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+        Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+    ASSERT_TRUE(Info);
+    EXPECT_TRUE(Info->Targets.contains(2 * MinInstSize));
+    EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+    EXPECT_FALSE(Info->HasUnresolvedTargets);
+  }
+}
+
+TEST(CollectDirectBranchTargets,
+     BoundsSymbolLessReturnAndUnionsAllContinuations) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_call_i64 s[30:31], 1\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 5u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[0].Offset + Decoded[0].Size));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[1].Offset + Decoded[1].Size));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[3].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[4].Offset));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, BoundsTwoIndependentSymbolLessReturnRegions) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 5\n"
+                           "s_endpgm\n"
+                           "s_call_i64 s[28:29], 5\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[28:29]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 10u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[2].Offset};
+
+  // Both regions are independently call-defined and neither may cause the
+  // other's still-provisional return to be treated as an open indirect entry.
+  // They must be inferred together and accepted by the joint closed audit.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[7].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[9].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[6].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[8].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[0].Offset + Decoded[0].Size));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[2].Offset + Decoded[2].Size));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsJointSymbolLessReturnEntryBetweenRegions) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 4\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[28:29]\n"
+                           "s_call_i64 s[28:29], -3\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 7u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[3].Offset};
+
+  // The first region's return continuation is the second region's entry, but
+  // it does not define that region's s[28:29] link pair. Provisional returns
+  // inferred in one pass must not mutually authorize this alternate entry.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[6].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsOverlappingSymbolLessReturnRegions) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 5\n"
+                           "s_endpgm\n"
+                           "s_call_i64 s[30:31], 5\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_branch 2\n"
+                           "s_endpgm\n"
+                           "s_branch 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 11u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[2].Offset};
+
+  // The two distinct call entries use the same link pair but converge on one
+  // return tail. Neither provisional region owns that shared body uniquely,
+  // so the streaming overlap audit must reject both.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[10].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsWrongPairAndClobberedSymbolLessReturns) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  for (llvm::StringRef Body : {"s_nop 0\ns_set_pc_i64 s[28:29]",
+                               "s_mov_b32 s30, 0\ns_set_pc_i64 s[30:31]"}) {
+    SCOPED_TRACE(Body);
+    llvm::SmallString<128> Assembly(
+        "s_call_i64 s[30:31], 2\ns_endpgm\ns_endpgm\n");
+    Assembly += Body;
+    llvm::SmallVector<uint8_t> Bytes = assembleInstructions(Assembly, S);
+    ASSERT_FALSE(Bytes.empty());
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+    ASSERT_EQ(Decoded.size(), 5u);
+    llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+    std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+        Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+    ASSERT_TRUE(Info);
+    EXPECT_FALSE(
+        Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+    EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+    EXPECT_FALSE(Info->HasUnresolvedTargets);
+  }
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsNestedCallAndFallthroughSymbolLessReturns) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> NestedBytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_call_i64 s[4:5], 1\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(NestedBytes.empty());
+  std::vector<InternalDecodedInst> Nested;
+  ASSERT_TRUE(
+      decodeTextSection(NestedBytes.data(), NestedBytes.size(), S, Nested));
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  std::optional<DirectControlFlowInfo> NestedInfo = collectDirectBranchTargets(
+      Nested, S, /*TextAddr=*/0, NestedBytes.size(), DeclaredEntries);
+  ASSERT_TRUE(NestedInfo);
+  EXPECT_FALSE(NestedInfo->BoundedIndirectTransfers.contains(Nested[4].Offset));
+  EXPECT_TRUE(NestedInfo->HasUnboundedIndirectEntries);
+
+  llvm::SmallVector<uint8_t> FallthroughBytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(FallthroughBytes.empty());
+  std::vector<InternalDecodedInst> Fallthrough;
+  ASSERT_TRUE(decodeTextSection(FallthroughBytes.data(),
+                                FallthroughBytes.size(), S, Fallthrough));
+  std::optional<DirectControlFlowInfo> FallthroughInfo =
+      collectDirectBranchTargets(Fallthrough, S, /*TextAddr=*/0,
+                                 FallthroughBytes.size(), DeclaredEntries);
+  ASSERT_TRUE(FallthroughInfo);
+  EXPECT_FALSE(FallthroughInfo->BoundedIndirectTransfers.contains(
+      Fallthrough.back().Offset));
+  EXPECT_TRUE(FallthroughInfo->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsUnknownAndExternalEntriesIntoSymbolLessReturn) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_set_pc_i64 s[8:9]\n"
+                           "s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[1].Offset};
+  std::optional<DirectControlFlowInfo> UnknownInfo = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(UnknownInfo);
+  EXPECT_FALSE(
+      UnknownInfo->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_TRUE(UnknownInfo->HasUnboundedIndirectEntries);
+
+  llvm::SmallVector<uint64_t, 1> ExternalEntries{Decoded[4].Offset};
+  std::optional<DirectControlFlowInfo> ExternalInfo =
+      collectDirectBranchTargets(
+          llvm::ArrayRef<InternalDecodedInst>(Decoded).drop_front(), S,
+          /*TextAddr=*/0, Bytes.size(),
+          /*DeclaredEntries=*/{Decoded[1].Offset},
+          /*FunctionRanges=*/{}, ExternalEntries);
+  ASSERT_TRUE(ExternalInfo);
+  EXPECT_FALSE(
+      ExternalInfo->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_TRUE(ExternalInfo->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsGapAndSecondDwordEntryIntoSymbolLessReturn) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> GapBytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(GapBytes.empty());
+  std::vector<InternalDecodedInst> Gap;
+  ASSERT_TRUE(decodeTextSection(GapBytes.data(), GapBytes.size(), S, Gap));
+  ASSERT_EQ(Gap.size(), 5u);
+  Gap.back().Offset += MinInstSize;
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  std::optional<DirectControlFlowInfo> GapInfo = collectDirectBranchTargets(
+      Gap, S, /*TextAddr=*/0, GapBytes.size() + MinInstSize, DeclaredEntries);
+  ASSERT_TRUE(GapInfo);
+  EXPECT_FALSE(GapInfo->BoundedIndirectTransfers.contains(Gap.back().Offset));
+
+  llvm::SmallVector<uint8_t> MidBytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_add_co_i32 s2, 0x100, 4\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(MidBytes.empty());
+  std::vector<InternalDecodedInst> Mid;
+  ASSERT_TRUE(decodeTextSection(MidBytes.data(), MidBytes.size(), S, Mid));
+  ASSERT_EQ(Mid.size(), 5u);
+  ASSERT_EQ(Mid[3].Size, 2 * MinInstSize);
+  llvm::SmallVector<uint64_t, 2> MidEntries{0, Mid[3].Offset + MinInstSize};
+  std::optional<DirectControlFlowInfo> MidInfo = collectDirectBranchTargets(
+      Mid, S, /*TextAddr=*/0, MidBytes.size(), MidEntries);
+  ASSERT_TRUE(MidInfo);
+  EXPECT_FALSE(MidInfo->BoundedIndirectTransfers.contains(Mid.back().Offset));
+  EXPECT_TRUE(MidInfo->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsDirectAndDeclaredBypassIntoSymbolLessReturn) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 4\n"
+                           "s_endpgm\n"
+                           "s_branch 3\n"
+                           "s_call_i64 s[4:5], 2\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 8u);
+  llvm::SmallVector<uint64_t, 3> DirectRoots{0, Decoded[2].Offset,
+                                             Decoded[3].Offset};
+  std::optional<DirectControlFlowInfo> DirectInfo = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DirectRoots);
+  ASSERT_TRUE(DirectInfo);
+  EXPECT_FALSE(
+      DirectInfo->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_TRUE(DirectInfo->HasUnboundedIndirectEntries);
+
+  llvm::SmallVector<uint8_t> DeclaredBytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(DeclaredBytes.empty());
+  std::vector<InternalDecodedInst> Declared;
+  ASSERT_TRUE(decodeTextSection(DeclaredBytes.data(), DeclaredBytes.size(), S,
+                                Declared));
+  llvm::SmallVector<uint64_t, 2> DeclaredBypass{0, Declared[3].Offset};
+  std::optional<DirectControlFlowInfo> DeclaredInfo =
+      collectDirectBranchTargets(Declared, S, /*TextAddr=*/0,
+                                 DeclaredBytes.size(), DeclaredBypass);
+  ASSERT_TRUE(DeclaredInfo);
+  EXPECT_FALSE(
+      DeclaredInfo->BoundedIndirectTransfers.contains(Declared.back().Offset));
+  EXPECT_TRUE(DeclaredInfo->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsFunctionRangeEntryInsideExactSetPcMaterialization) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 4u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> FunctionRanges{
+      {0, Bytes.size()}, {Decoded[1].Offset, Bytes.size()}};
+
+  // Exercise the internal API defensively without duplicating the second
+  // range start in DeclaredEntries. It is still an alternate root into the
+  // exact materialization and must invalidate that bounded transfer.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsFunctionRangeEntryInsideSymbolLessReturnRegion) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {Decoded[4].Offset, Bytes.size()}};
+
+  // The function-range start is a second root into the inferred region after
+  // its call entry. It bypasses the call-defined link pair even when callers
+  // of this internal API omit that begin from DeclaredEntries.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[5].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
 }
 
 TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
@@ -1617,6 +4195,220 @@ TEST(FindNearestSled, HandlesLargeUnsignedOffsets) {
   EXPECT_EQ(Sled, &Sleds[1]);
 }
 
+TEST(BranchIslandAllocator, AcceptsExactPositiveReachBoundary) {
+  std::vector<NopSled> Gateways = {
+      {MaxSledDistance, MaxSledDistance + MinInstSize, MaxSledDistance,
+       /*FunctionStart=*/0, /*FunctionEnd=*/3 * MaxSledDistance}};
+  BranchIslandAllocatorTestResult Result =
+      runBranchIslandAllocatorForTest(
+          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
+          /*TargetOffset=*/2 * MaxSledDistance, /*Backward=*/false);
+  ASSERT_TRUE(Result.Success);
+  ASSERT_EQ(Result.Islands.size(), 1u);
+  EXPECT_EQ(Result.Islands.front(), MaxSledDistance);
+}
+
+TEST(BranchIslandAllocator, RollsBackPartialChainAndAliases) {
+  constexpr uint64_t Head = 170000;
+  std::vector<NopSled> Gateways = {
+      {Head, Head + MinInstSize, Head, 0, 400000},
+      {Head, Head + 2 * MinInstSize, Head, 0, 400000}};
+  BranchIslandAllocatorTestResult Result =
+      runBranchIslandAllocatorForTest(
+          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/300000,
+          /*TargetOffset=*/0, /*Backward=*/true);
+  EXPECT_FALSE(Result.Success);
+  ASSERT_EQ(Result.Gateways.size(), 2u);
+  EXPECT_EQ(Result.Gateways[0].WritePos, Head);
+  EXPECT_EQ(Result.Gateways[1].WritePos, Head);
+  EXPECT_TRUE(Result.Occupied.empty());
+}
+
+TEST(BranchIslandAllocator, HoldsPartialChainAcrossMultiplePromotions) {
+  std::vector<NopSled> Gateways = {
+      {670000, 670000 + MinInstSize, 670000, 0, 900000},
+      {540000, 540000 + MinInstSize, 540000, 0, 900000},
+      {410000, 410000 + MinInstSize, 410000, 0, 900000}};
+  const NopSled Promotions[] = {
+      {280000, 280000 + MinInstSize, 280000, 0, 900000},
+      {150000, 150000 + MinInstSize, 150000, 0, 900000}};
+  BranchIslandAllocatorTestResult Result =
+      runBranchIslandAllocatorWithPromotionsForTest(
+          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/800000,
+          /*TargetOffset=*/20000, /*Backward=*/true, Promotions);
+  ASSERT_TRUE(Result.Success);
+  EXPECT_EQ(Result.Islands,
+            (llvm::SmallVector<uint64_t, 4>{670000, 540000, 410000, 280000,
+                                            150000}));
+  EXPECT_EQ(Result.HeldIslandCountsAtPromotion,
+            (llvm::SmallVector<size_t, 4>{3, 4}));
+}
+
+TEST(BranchIslandAllocator, TerminalFailureRollsBackPromotedPartialChain) {
+  std::vector<NopSled> Gateways = {
+      {670000, 670000 + MinInstSize, 670000, 0, 900000},
+      {540000, 540000 + MinInstSize, 540000, 0, 900000},
+      {410000, 410000 + MinInstSize, 410000, 0, 900000}};
+  const NopSled Promotions[] = {
+      {280000, 280000 + MinInstSize, 280000, 0, 900000}};
+  BranchIslandAllocatorTestResult Result =
+      runBranchIslandAllocatorWithPromotionsForTest(
+          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/800000,
+          /*TargetOffset=*/20000, /*Backward=*/true, Promotions);
+  ASSERT_FALSE(Result.Success);
+  ASSERT_EQ(Result.Gateways.size(), 4u);
+  EXPECT_EQ(Result.Gateways[0].WritePos, 670000u);
+  EXPECT_EQ(Result.Gateways[1].WritePos, 540000u);
+  EXPECT_EQ(Result.Gateways[2].WritePos, 410000u);
+  EXPECT_EQ(Result.Gateways[3].WritePos, 280000u);
+  EXPECT_TRUE(Result.Occupied.empty());
+  EXPECT_EQ(Result.HeldIslandCountsAtPromotion,
+            (llvm::SmallVector<size_t, 4>{3}));
+}
+
+TEST(BranchIslandAllocator, SkipsGatewayFromDifferentFunction) {
+  std::vector<NopSled> Gateways = {
+      {MaxSledDistance, MaxSledDistance + MinInstSize, MaxSledDistance,
+       /*FunctionStart=*/1, /*FunctionEnd=*/300000},
+      {130000, 130000 + MinInstSize, 130000,
+       /*FunctionStart=*/0, /*FunctionEnd=*/300000},
+      {260000, 260000 + MinInstSize, 260000,
+       /*FunctionStart=*/0, /*FunctionEnd=*/300000}};
+  BranchIslandAllocatorTestResult Result =
+      runBranchIslandAllocatorForTest(
+          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
+          /*TargetOffset=*/262144, /*Backward=*/false);
+  ASSERT_TRUE(Result.Success);
+  ASSERT_EQ(Result.Islands.size(), 2u);
+  EXPECT_EQ(Result.Islands[0], 130000u);
+  EXPECT_EQ(Result.Islands[1], 260000u);
+}
+
+TEST(BranchIslandAllocator, CoAdvancesEqualPhysicalAliases) {
+  std::vector<NopSled> Gateways = {
+      {MaxSledDistance, MaxSledDistance + 2 * MinInstSize, MaxSledDistance,
+       0, 3 * MaxSledDistance},
+      {MaxSledDistance, MaxSledDistance + 3 * MinInstSize, MaxSledDistance,
+       0, 3 * MaxSledDistance}};
+  BranchIslandAllocatorTestResult Result =
+      runBranchIslandAllocatorForTest(
+          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
+          /*TargetOffset=*/2 * MaxSledDistance, /*Backward=*/false);
+  ASSERT_TRUE(Result.Success);
+  ASSERT_EQ(Result.Gateways.size(), 2u);
+  EXPECT_EQ(Result.Gateways[0].WritePos,
+            MaxSledDistance + MinInstSize);
+  EXPECT_EQ(Result.Gateways[1].WritePos,
+            MaxSledDistance + MinInstSize);
+  EXPECT_TRUE(Result.Occupied.contains(MaxSledDistance));
+}
+
+TEST(BranchIslandAllocator, SplitsPartialAliasAtOccupiedDword) {
+  llvm::DenseSet<uint64_t> Occupied = {108};
+  std::vector<NopSled> Available =
+      subtractOccupiedBranchGatewaySlotsForTest(
+          {{100, 140, 100, 0, 200}}, Occupied);
+  ASSERT_EQ(Available.size(), 2u);
+  EXPECT_EQ(Available[0].Start, 100u);
+  EXPECT_EQ(Available[0].End, 108u);
+  EXPECT_EQ(Available[1].Start, 112u);
+  EXPECT_EQ(Available[1].End, 140u);
+}
+
+TEST(BranchPromotionSearchRange, ClampsForwardCorridorToReachableBand) {
+  constexpr uint64_t Current = 100000;
+  auto Far =
+      branchPromotionSearchRangeForTest(Current, /*CorridorOffset=*/900000,
+                                        /*Forward=*/true);
+  EXPECT_EQ(Far.first, Current);
+  EXPECT_EQ(Far.second, Current + MaxSledDistance);
+
+  auto Near =
+      branchPromotionSearchRangeForTest(Current, /*CorridorOffset=*/120000,
+                                        /*Forward=*/true);
+  EXPECT_EQ(Near, (std::pair<uint64_t, uint64_t>{Current, 120000}));
+
+  auto Saturated = branchPromotionSearchRangeForTest(
+      std::numeric_limits<uint64_t>::max() - 8,
+      std::numeric_limits<uint64_t>::max(), /*Forward=*/true);
+  EXPECT_EQ(Saturated.second, std::numeric_limits<uint64_t>::max());
+}
+
+TEST(BranchPromotionSearchRange, ClampsBackwardCorridorToReachableBand) {
+  constexpr uint64_t Current = 1000000;
+  auto Far =
+      branchPromotionSearchRangeForTest(Current, /*CorridorOffset=*/1000,
+                                        /*Forward=*/false);
+  EXPECT_EQ(Far.first, Current - MaxSledDistance -
+                           SetPcForwardSequenceBytes);
+  EXPECT_EQ(Far.second, Current);
+
+  auto Near = branchPromotionSearchRangeForTest(
+      Current, /*CorridorOffset=*/950000, /*Forward=*/false);
+  EXPECT_EQ(Near.first,
+            950000u - SetPcForwardSequenceBytes - MinInstSize);
+  EXPECT_EQ(Near.second, Current);
+
+  auto Saturated = branchPromotionSearchRangeForTest(
+      /*CurrentOffset=*/8, /*CorridorOffset=*/0, /*Forward=*/false);
+  EXPECT_EQ(Saturated.first, 0u);
+}
+
+TEST(BranchPromotionCandidateCursor, MatchesScalarDirectionalOrderAndBounds) {
+  constexpr size_t Count = 9;
+  constexpr size_t Begin = 2;
+  constexpr size_t End = 7;
+  const size_t Rejected[] = {3, 5, 99};
+  auto IsRejected = [&](size_t Index) {
+    return std::find(std::begin(Rejected), std::end(Rejected), Index) !=
+           std::end(Rejected);
+  };
+
+  llvm::SmallVector<size_t, 8> ScalarForward;
+  for (size_t Index = End; Index-- > Begin;)
+    if (!IsRejected(Index))
+      ScalarForward.push_back(Index);
+  EXPECT_EQ(promotionCandidateOrderForTest(Count, Rejected, Begin, End,
+                                           /*Forward=*/true),
+            ScalarForward);
+
+  llvm::SmallVector<size_t, 8> ScalarBackward;
+  for (size_t Index = Begin; Index != End; ++Index)
+    if (!IsRejected(Index))
+      ScalarBackward.push_back(Index);
+  EXPECT_EQ(promotionCandidateOrderForTest(Count, Rejected, Begin, End,
+                                           /*Forward=*/false),
+            ScalarBackward);
+
+  EXPECT_TRUE(promotionCandidateOrderForTest(
+                  Count, Rejected, /*BeginIndex=*/Count,
+                  /*EndIndex=*/Count + 10, /*Forward=*/true)
+                  .empty());
+}
+
+TEST(BranchPromotionCandidateCursor,
+     RepeatedScanSkipsOnlyPermanentlyRejectedStarts) {
+  llvm::SmallVector<size_t, 8> Initial =
+      promotionCandidateOrderForTest(/*CandidateCount=*/6, {},
+                                     /*BeginIndex=*/1, /*EndIndex=*/5,
+                                     /*Forward=*/true);
+  EXPECT_EQ(Initial, (llvm::SmallVector<size_t, 8>{4, 3, 2, 1}));
+
+  const size_t PermanentlyRejected[] = {4, 2};
+  llvm::SmallVector<size_t, 8> Retried =
+      promotionCandidateOrderForTest(
+          /*CandidateCount=*/6, PermanentlyRejected,
+          /*BeginIndex=*/1, /*EndIndex=*/5, /*Forward=*/true);
+  EXPECT_EQ(Retried, (llvm::SmallVector<size_t, 8>{3, 1}));
+
+  // The same persistent bits retain the opposite directional order.
+  llvm::SmallVector<size_t, 8> Backward =
+      promotionCandidateOrderForTest(
+          /*CandidateCount=*/6, PermanentlyRejected,
+          /*BeginIndex=*/1, /*EndIndex=*/5, /*Forward=*/false);
+  EXPECT_EQ(Backward, (llvm::SmallVector<size_t, 8>{1, 3}));
+}
+
 // -- assembleSingleInst / decodeTextSection round-trip ------------------------
 
 TEST(AssembleDecode, SNopRoundTrip) {
@@ -1635,6 +4427,350 @@ TEST(AssembleDecode, SNopRoundTrip) {
   EXPECT_TRUE(Decoded[0].DecodeSucceeded);
   EXPECT_EQ(Decoded[0].Size, MinInstSize);
   EXPECT_EQ(Decoded[0].Mnemonic, "s_nop");
+}
+
+TEST(RegisterLiveness, TiedAccumulatorDefCountsAsIncomingRead) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("v_fmac_f32_e32 v5, v1, v2", S);
+  ASSERT_EQ(Bytes.size(), MinInstSize);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  const InternalDecodedInst &DI = Decoded[0];
+  const llvm::MCInstrDesc &Desc = S.MCII->get(DI.Inst.getOpcode());
+  ASSERT_GE(Desc.getNumDefs(), 1u);
+  ASSERT_GE(DI.Inst.getNumOperands(), 1u);
+  ASSERT_TRUE(DI.Inst.getOperand(0).isReg());
+
+  bool HasTiedAccumulatorUse = false;
+  for (unsigned I = Desc.getNumDefs(); I != Desc.getNumOperands(); ++I)
+    HasTiedAccumulatorUse |=
+        Desc.getOperandConstraint(I, llvm::MCOI::TIED_TO) == 0;
+  ASSERT_TRUE(HasTiedAccumulatorUse);
+
+  llvm::MCRegister Accumulator(DI.Inst.getOperand(0).getReg());
+  EXPECT_TRUE(instructionReadsRegister(DI, S, Accumulator));
+}
+
+TEST(RegisterLiveness, PartialVccDefinitionDoesNotKillFullVcc) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  ASSERT_TRUE(S.VCCRegister.isValid());
+
+  std::vector<InternalDecodedInst> Partial = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b32 vcc_lo, s0"}));
+  ASSERT_EQ(Partial.size(), 1u);
+  ASSERT_TRUE(Partial.front().Inst.getOperand(0).isReg());
+  llvm::MCRegister VccLo(Partial.front().Inst.getOperand(0).getReg());
+  EXPECT_TRUE(instructionFullyWritesRegister(Partial.front(), S, VccLo));
+  EXPECT_FALSE(
+      instructionFullyWritesRegister(Partial.front(), S, S.VCCRegister));
+
+  std::vector<InternalDecodedInst> Full = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b64 vcc, -1"}));
+  ASSERT_EQ(Full.size(), 1u);
+  EXPECT_TRUE(instructionFullyWritesRegister(Full.front(), S, VccLo));
+  EXPECT_TRUE(instructionFullyWritesRegister(Full.front(), S, S.VCCRegister));
+
+  llvm::SmallVector<uint8_t> PartialThenHighUse = assembleInstructions(
+      "s_mov_b32 vcc_lo, s0\ns_mov_b32 s1, vcc_hi", S);
+  ASSERT_FALSE(PartialThenHighUse.empty());
+  EXPECT_TRUE(replacementNeedsIncomingRegister(PartialThenHighUse, S,
+                                               S.VCCRegister));
+
+  llvm::SmallVector<uint8_t> FullThenHighUse = assembleInstructions(
+      "s_mov_b64 vcc, -1\ns_mov_b32 s1, vcc_hi", S);
+  ASSERT_FALSE(FullThenHighUse.empty());
+  EXPECT_FALSE(
+      replacementNeedsIncomingRegister(FullThenHighUse, S, S.VCCRegister));
+}
+
+TEST(RegisterLiveness, BatchedVccNeedsRespectControlFlowAndFullDefs) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  ASSERT_TRUE(S.VCCRegister.isValid());
+
+  auto Compute = [&](llvm::ArrayRef<llvm::StringRef> Lines) {
+    std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(S, Lines);
+    EXPECT_FALSE(Decoded.empty());
+    if (Decoded.empty())
+      return std::optional<llvm::DenseSet<uint64_t>>();
+    uint64_t End = Decoded.back().Offset + Decoded.back().Size;
+    return computeIncomingRegisterNeeds(Decoded, S, /*FunctionBegin=*/0, End,
+                                        S.VCCRegister);
+  };
+
+  std::optional<llvm::DenseSet<uint64_t>> Partial = Compute(
+      llvm::ArrayRef<llvm::StringRef>({"s_mov_b32 vcc_lo, s0",
+                                      "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+  ASSERT_TRUE(Partial);
+  EXPECT_TRUE(Partial->contains(0));
+
+  std::optional<llvm::DenseSet<uint64_t>> Full = Compute(
+      llvm::ArrayRef<llvm::StringRef>({"s_mov_b64 vcc, -1",
+                                      "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+  ASSERT_TRUE(Full);
+  EXPECT_FALSE(Full->contains(0));
+  EXPECT_TRUE(Full->contains(MinInstSize));
+
+  std::optional<llvm::DenseSet<uint64_t>> BranchUnion = Compute(
+      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1",
+                                      "s_mov_b64 vcc, -1",
+                                      "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+  ASSERT_TRUE(BranchUnion);
+  EXPECT_TRUE(BranchUnion->contains(0));
+
+  std::optional<llvm::DenseSet<uint64_t>> Opaque = Compute(
+      llvm::ArrayRef<llvm::StringRef>({"s_set_pc_i64 s[0:1]"}));
+  ASSERT_TRUE(Opaque);
+  EXPECT_TRUE(Opaque->contains(0));
+
+  std::optional<llvm::DenseSet<uint64_t>> PureLoop =
+      Compute(llvm::ArrayRef<llvm::StringRef>({"s_branch -1"}));
+  ASSERT_TRUE(PureLoop);
+  EXPECT_FALSE(PureLoop->contains(0));
+
+  std::optional<llvm::DenseSet<uint64_t>> LoopWithUnsafeExit = Compute(
+      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_branch -2",
+                                      "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+  ASSERT_TRUE(LoopWithUnsafeExit);
+  EXPECT_TRUE(LoopWithUnsafeExit->contains(0));
+  EXPECT_TRUE(LoopWithUnsafeExit->contains(MinInstSize));
+
+  expectBatchRegisterNeedsMatchesScalar(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b32 vcc_lo, s0",
+                                         "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S.VCCRegister);
+  expectBatchRegisterNeedsMatchesScalar(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b64 vcc, -1",
+                                         "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S.VCCRegister);
+  expectBatchRegisterNeedsMatchesScalar(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1",
+                                         "s_mov_b64 vcc, -1",
+                                         "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S.VCCRegister);
+  expectBatchRegisterNeedsMatchesScalar(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_set_pc_i64 s[0:1]"}),
+      S.VCCRegister);
+  expectBatchRegisterNeedsMatchesScalar(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_branch -1"}), S.VCCRegister);
+  expectBatchRegisterNeedsMatchesScalar(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_branch -2",
+                                         "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S.VCCRegister);
+}
+
+TEST(RegisterLiveness, BatchProofMatchesScalarAcrossControlFlow) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  const llvm::StringRef BranchJoin[] = {"s_cbranch_scc0 1", "s_mov_b32 s30, 0",
+                                        "s_mov_b32 s0, s30", "s_endpgm"};
+  expectBatchSgprProofMatchesScalar(S, BranchJoin);
+
+  const llvm::StringRef Loop[] = {"s_mov_b32 s30, 0", "s_cbranch_scc0 -2",
+                                  "s_endpgm"};
+  expectBatchSgprProofMatchesScalar(S, Loop);
+
+  const llvm::StringRef DefBeforeOpaque[] = {"s_mov_b32 s30, 0",
+                                             "s_set_pc_i64 s[0:1]"};
+  expectBatchSgprProofMatchesScalar(S, DefBeforeOpaque);
+
+  const llvm::StringRef OpaqueBeforeDef[] = {"s_set_pc_i64 s[0:1]",
+                                             "s_mov_b32 s30, 0"};
+  expectBatchSgprProofMatchesScalar(S, OpaqueBeforeDef);
+
+  const llvm::StringRef TiedAndTuple[] = {
+      "s_add_u32 s30, s30, 1", "s_mov_b64 s[30:31], s[0:1]",
+      "s_mov_b32 s2, s31", "s_endpgm"};
+  expectBatchSgprProofMatchesScalar(S, TiedAndTuple);
+
+  const llvm::StringRef InvalidBranchEdge[] = {"s_cbranch_scc0 100",
+                                               "s_endpgm"};
+  expectBatchSgprProofMatchesScalar(S, InvalidBranchEdge);
+}
+
+TEST(RegisterLiveness, BatchedSgprProofMatchesRandomizedBranchLoops) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  uint64_t State = 0x9E3779B97F4A7C15ULL;
+  auto Next = [&]() {
+    State = State * 2862933555777941757ULL + 3037000493ULL;
+    return State;
+  };
+
+  constexpr size_t InstructionCount = 10;
+  for (unsigned Trial = 0; Trial != 20; ++Trial) {
+    std::vector<std::string> Storage;
+    Storage.reserve(InstructionCount);
+    for (size_t I = 0; I + 1 < InstructionCount; ++I) {
+      unsigned Dst = Next() % 16;
+      unsigned Src = Next() % 16;
+      switch (Next() % 5) {
+      case 0:
+        Storage.push_back("s_mov_b32 s" + std::to_string(Dst) + ", s" +
+                          std::to_string(Src));
+        break;
+      case 1:
+        Storage.push_back("s_mov_b32 s" + std::to_string(Dst) + ", 0");
+        break;
+      case 2: {
+        size_t Target = Next() % InstructionCount;
+        int64_t Delta = static_cast<int64_t>(Target) -
+                        static_cast<int64_t>(I) - 1;
+        Storage.push_back("s_cbranch_scc0 " + std::to_string(Delta));
+        break;
+      }
+      case 3: {
+        size_t Target = Next() % InstructionCount;
+        int64_t Delta = static_cast<int64_t>(Target) -
+                        static_cast<int64_t>(I) - 1;
+        Storage.push_back("s_branch " + std::to_string(Delta));
+        break;
+      }
+      default:
+        Storage.push_back("s_add_u32 s" + std::to_string(Dst) + ", s" +
+                          std::to_string(Dst) + ", 1");
+        break;
+      }
+    }
+    Storage.push_back("s_endpgm");
+    llvm::SmallVector<llvm::StringRef, InstructionCount> Lines;
+    for (const std::string &Line : Storage)
+      Lines.push_back(Line);
+    expectBatchSgprProofMatchesScalar(S, Lines);
+  }
+}
+
+TEST(RegisterLiveness, BatchedSgprProofPreservesReplacementUnion) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1",
+                                         "s_mov_b32 s104, 0",
+                                         "s_mov_b32 s0, s103", "s_endpgm"}));
+  ASSERT_FALSE(Decoded.empty());
+  std::optional<llvm::SmallVector<llvm::MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*S.MRI, /*MaxSgprs=*/106);
+  ASSERT_TRUE(NumberedSgprs);
+  uint64_t FunctionEnd = Decoded.back().Offset + Decoded.back().Size;
+  uint64_t Continuation = Decoded[1].Offset;
+  BatchedSgprContinuationTestResult Batch =
+      runBatchedSgprContinuationAnalysisForTest(
+          Decoded, S, /*FunctionBegin=*/0, FunctionEnd, {Continuation},
+          *NumberedSgprs);
+  ASSERT_EQ(Batch.Analyses, 1u);
+  ASSERT_EQ(Batch.Queries.size(), 1u);
+  ASSERT_TRUE(Batch.Queries.front());
+  std::optional<llvm::BitVector> Scalar =
+      unsafeIncomingNumberedSgprsInRange(
+          Decoded, S, /*FunctionBegin=*/0, FunctionEnd, Continuation,
+          *NumberedSgprs);
+  ASSERT_TRUE(Scalar);
+
+  llvm::SmallVector<uint8_t> Replacement =
+      assembleInstructions("s_mov_b32 s102, 0\ns_mov_b32 s1, s101", S);
+  ASSERT_FALSE(Replacement.empty());
+  llvm::BitVector ReplacementUnsafe =
+      unsafeIncomingNumberedSgprsInReplacement(Replacement, S,
+                                               *NumberedSgprs);
+  llvm::BitVector BatchedUnion = *Batch.Queries.front();
+  BatchedUnion |= ReplacementUnsafe;
+  llvm::BitVector ScalarUnion = *Scalar;
+  ScalarUnion |= ReplacementUnsafe;
+  EXPECT_EQ(BatchedUnion, ScalarUnion);
+}
+
+TEST(RegisterLiveness, NumberedSgprExtractionCoversAliasesAndTiedRmw) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::optional<llvm::SmallVector<llvm::MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*S.MRI, /*MaxSgprs=*/106);
+  ASSERT_TRUE(NumberedSgprs);
+
+  auto GetUseDef = [&](const InternalDecodedInst &DI) {
+    std::pair<llvm::BitVector, llvm::BitVector> Result{
+        llvm::BitVector(NumberedSgprs->size()),
+        llvm::BitVector(NumberedSgprs->size())};
+    getNumberedSgprUsesAndDefs(DI, S, *NumberedSgprs, Result.first,
+                               Result.second);
+    return Result;
+  };
+
+  std::vector<InternalDecodedInst> Tuple = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b64 s[0:1], s[30:31]"}));
+  ASSERT_EQ(Tuple.size(), 1u);
+  auto [TupleUses, TupleDefs] = GetUseDef(Tuple.front());
+  EXPECT_TRUE(TupleUses.test(30));
+  EXPECT_TRUE(TupleUses.test(31));
+  EXPECT_TRUE(TupleDefs.test(0));
+  EXPECT_TRUE(TupleDefs.test(1));
+
+  std::vector<InternalDecodedInst> Rmw = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_add_u32 s30, s30, 1"}));
+  ASSERT_EQ(Rmw.size(), 1u);
+  auto [RmwUses, RmwDefs] = GetUseDef(Rmw.front());
+  EXPECT_TRUE(RmwUses.test(30));
+  EXPECT_TRUE(RmwDefs.test(30));
+
+  llvm::MCRegister Low16;
+  for (unsigned I = 1; I != S.MRI->getNumRegs(); ++I) {
+    llvm::MCRegister Candidate(I);
+    if (llvm::StringRef(S.MRI->getName(Candidate)) == "SGPR30_LO16") {
+      Low16 = Candidate;
+      break;
+    }
+  }
+  ASSERT_TRUE(Low16.isValid());
+
+  std::vector<InternalDecodedInst> Half = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b32 s0, s1"}));
+  ASSERT_EQ(Half.size(), 1u);
+  ASSERT_GE(Half.front().Inst.getNumOperands(), 2u);
+  Half.front().Inst.getOperand(1).setReg(Low16);
+  auto [HalfUses, HalfDefs] = GetUseDef(Half.front());
+  EXPECT_TRUE(HalfUses.test(30));
+  EXPECT_FALSE(HalfUses.test(1));
+  EXPECT_TRUE(HalfDefs.test(0));
+
+  Half.front().Inst.getOperand(0).setReg(Low16);
+  auto [HalfDefUses, HalfDefDefs] = GetUseDef(Half.front());
+  EXPECT_TRUE(HalfDefUses.test(30));
+  EXPECT_TRUE(HalfDefDefs.test(30));
+}
+
+TEST(RegisterLiveness, ReplacementTracksOnlyIncomingValues) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::optional<llvm::SmallVector<llvm::MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*S.MRI, /*MaxSgprs=*/106);
+  ASSERT_TRUE(NumberedSgprs);
+
+  llvm::SmallVector<uint8_t> UseBeforeDef =
+      assembleInstructions("s_mov_b32 s0, s30\ns_mov_b32 s30, 0", S);
+  ASSERT_FALSE(UseBeforeDef.empty());
+  llvm::BitVector UseBeforeDefUnsafe =
+      unsafeIncomingNumberedSgprsInReplacement(UseBeforeDef, S, *NumberedSgprs);
+  EXPECT_TRUE(UseBeforeDefUnsafe.test(30));
+
+  llvm::SmallVector<uint8_t> DefBeforeUse =
+      assembleInstructions("s_mov_b32 s30, 0\ns_mov_b32 s0, s30", S);
+  ASSERT_FALSE(DefBeforeUse.empty());
+  llvm::BitVector DefBeforeUseUnsafe =
+      unsafeIncomingNumberedSgprsInReplacement(DefBeforeUse, S, *NumberedSgprs);
+  EXPECT_FALSE(DefBeforeUseUnsafe.test(30));
+
+  llvm::SmallVector<uint8_t> Opaque =
+      assembleSingleInst("s_set_pc_i64 s[0:1]", S);
+  ASSERT_FALSE(Opaque.empty());
+  llvm::BitVector OpaqueUnsafe =
+      unsafeIncomingNumberedSgprsInReplacement(Opaque, S, *NumberedSgprs);
+  EXPECT_TRUE(OpaqueUnsafe.test(30));
 }
 
 TEST(AssembleDecode, SingleInstructionRejectsSequence) {
@@ -1955,6 +5091,123 @@ TEST(ExpandDs2Addr, RejectsCyclicExchangeDependency) {
 
   EXPECT_FALSE(expandDs2Addr(Decoded[0].Inst, Decoded[0].Mnemonic,
                              "ds_storexchg_rtn_b64", S));
+}
+
+TEST(RewriteDs2AddrOffsetsInPlace,
+     RewritesEveryNonStrideFamilyAndPreservesNonOffsetBytes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  struct Case {
+    llvm::StringLiteral Source;
+    llvm::StringLiteral Expected;
+    uint8_t Off0;
+    uint8_t Off1;
+  };
+  const Case Cases[] = {
+      {"ds_load_2addr_b32 v[0:1], v2 offset0:62 offset1:63",
+       "ds_load_2addr_b32 v[0:1], v2 offset0:248 offset1:252", 248, 252},
+      {"ds_load_2addr_b64 v[0:3], v4 offset0:30 offset1:31",
+       "ds_load_2addr_b64 v[0:3], v4 offset0:240 offset1:248", 240, 248},
+      {"ds_store_2addr_b32 v2, v0, v1 offset0:62 offset1:63",
+       "ds_store_2addr_b32 v2, v0, v1 offset0:248 offset1:252", 248, 252},
+      {"ds_store_2addr_b64 v19, v[14:15], v[20:21] "
+       "offset0:30 offset1:31",
+       "ds_store_2addr_b64 v19, v[14:15], v[20:21] "
+       "offset0:240 offset1:248",
+       240, 248},
+      {"ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 "
+       "offset0:62 offset1:63",
+       "ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 "
+       "offset0:248 offset1:252",
+       248, 252},
+      {"ds_storexchg_2addr_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
+       "offset0:30 offset1:31",
+       "ds_storexchg_2addr_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
+       "offset0:240 offset1:248",
+       240, 248},
+  };
+
+  for (const Case &C : Cases) {
+    llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(C.Source, S);
+    ASSERT_EQ(Bytes.size(), 2u * MinInstSize) << C.Source.str();
+    llvm::SmallVector<uint8_t> Original = Bytes;
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded))
+        << C.Source.str();
+    ASSERT_EQ(Decoded.size(), 1u) << C.Source.str();
+
+    EXPECT_TRUE(rewriteDs2AddrOffsetsInPlace(Bytes, Decoded[0].Inst,
+                                             Decoded[0].Mnemonic, S))
+        << C.Source.str();
+    EXPECT_EQ(Bytes[0], C.Off0) << C.Source.str();
+    EXPECT_EQ(Bytes[1], C.Off1) << C.Source.str();
+    EXPECT_TRUE(
+        std::equal(Bytes.begin() + 2, Bytes.end(), Original.begin() + 2))
+        << C.Source.str();
+
+    llvm::SmallVector<uint8_t> Expected = assembleSingleInst(C.Expected, S);
+    EXPECT_EQ(Bytes, Expected) << C.Source.str();
+  }
+}
+
+TEST(RewriteDs2AddrOffsetsInPlace,
+     RejectsUnrepresentableOffsetInEveryFamilyWithoutMutation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  for (llvm::StringRef Asm :
+       {"ds_load_2addr_b32 v[0:1], v2 offset0:63 offset1:64",
+        "ds_load_2addr_b64 v[0:3], v4 offset0:31 offset1:32",
+        "ds_store_2addr_b32 v2, v0, v1 offset0:63 offset1:64",
+        "ds_store_2addr_b64 v19, v[14:15], v[20:21] "
+        "offset0:31 offset1:32",
+        "ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 "
+        "offset0:63 offset1:64",
+        "ds_storexchg_2addr_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
+        "offset0:31 offset1:32"}) {
+    llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
+    ASSERT_EQ(Bytes.size(), 2u * MinInstSize) << Asm.str();
+    llvm::SmallVector<uint8_t> Original = Bytes;
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded))
+        << Asm.str();
+    ASSERT_EQ(Decoded.size(), 1u) << Asm.str();
+
+    EXPECT_FALSE(rewriteDs2AddrOffsetsInPlace(Bytes, Decoded[0].Inst,
+                                              Decoded[0].Mnemonic, S))
+        << Asm.str();
+    EXPECT_EQ(Bytes, Original) << Asm.str();
+  }
+}
+
+TEST(RewriteDs2AddrOffsetsInPlace, LeavesStride64FamiliesOnSplitPath) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  for (llvm::StringRef Asm :
+       {"ds_load_2addr_stride64_b32 v[0:1], v4 offset0:0 offset1:0",
+        "ds_load_2addr_stride64_b64 v[0:3], v4 offset0:0 offset1:0",
+        "ds_store_2addr_stride64_b32 v4, v0, v1 offset0:0 offset1:0",
+        "ds_store_2addr_stride64_b64 v4, v[0:1], v[2:3] "
+        "offset0:0 offset1:0",
+        "ds_storexchg_2addr_stride64_rtn_b32 v[0:1], v2, v3, v4 "
+        "offset0:0 offset1:0",
+        "ds_storexchg_2addr_stride64_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
+        "offset0:0 offset1:0"}) {
+    llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
+    ASSERT_EQ(Bytes.size(), 2u * MinInstSize) << Asm.str();
+    llvm::SmallVector<uint8_t> Original = Bytes;
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded))
+        << Asm.str();
+    ASSERT_EQ(Decoded.size(), 1u) << Asm.str();
+
+    EXPECT_FALSE(rewriteDs2AddrOffsetsInPlace(Bytes, Decoded[0].Inst,
+                                              Decoded[0].Mnemonic, S))
+        << Asm.str();
+    EXPECT_EQ(Bytes, Original) << Asm.str();
+  }
 }
 
 // -- buildKernelEntryTrampoline -----------------------------------------------

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -3527,7 +3527,7 @@ TEST(CollectDirectBranchTargets,
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   for (llvm::StringRef Literal : {"0x24", "0xfc", "0xfffffff8", "0x7fffffff"}) {
-    SCOPED_TRACE(Literal);
+    SCOPED_TRACE(Literal.str());
     llvm::SmallString<512> Assembly;
     Assembly += "s_get_pc_i64 s[4:5]\ns_add_co_i32 s6, ";
     Assembly += Literal;
@@ -3670,7 +3670,7 @@ TEST(CollectDirectBranchTargets, RejectsNonBoundaryDirectAndCallTargets) {
   ASSERT_TRUE(S.Valid);
   for (llvm::StringRef Transfer :
        {"s_branch 1\n", "s_call_i64 s[30:31], 1\n"}) {
-    SCOPED_TRACE(Transfer);
+    SCOPED_TRACE(Transfer.str());
     llvm::SmallString<128> Assembly(Transfer);
     Assembly += "s_add_co_i32 s2, 0x100, 4\ns_endpgm";
     llvm::SmallVector<uint8_t> Bytes = assembleInstructions(Assembly, S);
@@ -3824,7 +3824,7 @@ TEST(CollectDirectBranchTargets,
   ASSERT_TRUE(S.Valid);
   for (llvm::StringRef Body : {"s_nop 0\ns_set_pc_i64 s[28:29]",
                                "s_mov_b32 s30, 0\ns_set_pc_i64 s[30:31]"}) {
-    SCOPED_TRACE(Body);
+    SCOPED_TRACE(Body.str());
     llvm::SmallString<128> Assembly(
         "s_call_i64 s[30:31], 2\ns_endpgm\ns_endpgm\n");
     Assembly += Body;


### PR DESCRIPTION
## Scope

Close finite materialized-call components jointly and reject alternate entries into exact call materializations.

## Clean review range

- Clean fork PR: https://github.com/harsh-amd/llvm-project/pull/12
- Exact #3598 source commit(s): 1ed26ffc, b41cc057
- Depends on finite control flow and robust routing.

## Review status

Draft for early review. GitHub cannot base an upstream ROCm PR on a branch in the fork, so the Files changed view is temporarily cumulative with unmerged prerequisites. Review the clean fork PR and exact source commits linked above. This branch will be rebased and reduced after dependencies land; do not merge the cumulative snapshot.

ROCm/llvm-project#3598 remains unchanged as the immutable 2,685/2,685 integration reference.

## Validation provenance

The source commits are exact ancestors of corpus-tested ab3cdd61. The cumulative integration passed 2,685/2,685 corpus paths, 213/213 HotswapMCTests, and COMGR lit with 168 passed, 14 unsupported, and 0 failed. Standalone current-staging formatting, focused tests, CI, and the appropriate corpus transition gate are required before this draft becomes ready.