### PR TITLE
[comgr][hotswap] Prove scratch liveness from current text

### DIFF
--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -1153,8 +1153,13 @@ std::optional<BitVector> getLiveSgprsAtContinuation(PatchContext &Ctx,
                                                     uint32_t InstSize) {
   std::optional<ElfView::FunctionTextRange> FunctionRange =
       Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
-  if (!FunctionRange)
+  if (!FunctionRange) {
+    log() << "hotswap: SGPR continuation liveness failed closed for source at "
+             "0x"
+          << utohexstr(InstOffset) << " with size 0x" << utohexstr(InstSize)
+          << ": no containing function range\n";
     return std::nullopt;
+  }
   using FunctionKey = std::pair<uint64_t, uint64_t>;
   FunctionKey Key{FunctionRange->Begin, FunctionRange->End};
   DenseMap<FunctionKey, CurrentFunctionSgprLiveness>::iterator Cached =
@@ -1168,17 +1173,45 @@ std::optional<BitVector> getLiveSgprsAtContinuation(PatchContext &Ctx,
                  .insert_or_assign(Key, std::move(Current))
                  .first;
   }
-  if (!Cached->second.Valid)
+  if (!Cached->second.Valid) {
+    log() << "hotswap: SGPR continuation liveness failed closed for source at "
+             "0x"
+          << utohexstr(InstOffset) << " with size 0x" << utohexstr(InstSize)
+          << ": current function [0x" << utohexstr(FunctionRange->Begin)
+          << ", 0x" << utohexstr(FunctionRange->End)
+          << ") does not have a complete decoded liveness map\n";
     return std::nullopt;
+  }
 
-  std::optional<uint64_t> Continuation =
-      checkedAddUint64(InstOffset, InstSize, "SGPR liveness continuation");
-  if (!Continuation)
+  if (!Cached->second.InstructionIndices.contains(InstOffset)) {
+    log() << "hotswap: SGPR continuation liveness failed closed for source at "
+             "0x"
+          << utohexstr(InstOffset) << " with size 0x" << utohexstr(InstSize)
+          << ": source is not a decoded instruction boundary in function [0x"
+          << utohexstr(FunctionRange->Begin) << ", 0x"
+          << utohexstr(FunctionRange->End) << ")\n";
     return std::nullopt;
+  }
+  if (InstOffset > std::numeric_limits<uint64_t>::max() - InstSize) {
+    log() << "hotswap: SGPR continuation liveness failed closed for source at "
+             "0x"
+          << utohexstr(InstOffset) << " with size 0x" << utohexstr(InstSize)
+          << ": continuation overflows uint64_t\n";
+    return std::nullopt;
+  }
+  uint64_t Continuation = InstOffset + InstSize;
   DenseMap<uint64_t, size_t>::const_iterator Index =
-      Cached->second.InstructionIndices.find(*Continuation);
-  if (Index == Cached->second.InstructionIndices.end())
+      Cached->second.InstructionIndices.find(Continuation);
+  if (Index == Cached->second.InstructionIndices.end()) {
+    log() << "hotswap: SGPR continuation liveness failed closed for source at "
+             "0x"
+          << utohexstr(InstOffset) << " with size 0x" << utohexstr(InstSize)
+          << ": continuation 0x" << utohexstr(Continuation)
+          << " is not a decoded instruction boundary in function [0x"
+          << utohexstr(FunctionRange->Begin) << ", 0x"
+          << utohexstr(FunctionRange->End) << ")\n";
     return std::nullopt;
+  }
   return Cached->second.LiveBefore[Index->second];
 }
 

--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -894,8 +894,8 @@ bool instructionReadsRegister(const InternalDecodedInst &DI,
 }
 
 static void addTrackedSgprBits(const LLVMState &LS, MCRegister Register,
-                               unsigned MaxSgprs, BitVector &Bits,
-                               bool &Valid) {
+                               unsigned MaxSgprs, BitVector &Bits, bool &Valid,
+                               bool IsDefinition) {
   if (!Register.isValid())
     return;
   SmallVector<MCRegister, 8> Candidates;
@@ -917,7 +917,13 @@ static void addTrackedSgprBits(const LLVMState &LS, MCRegister Register,
     }
     Bits.set(*Index);
   }
-  if (isVccRegister(LS, Register))
+  // Any overlapping use consumes aggregate VCC. A definition kills that bit
+  // only when it covers both VCC subregisters.
+  bool TracksVcc = isVccRegister(LS, Register);
+  if (IsDefinition)
+    TracksVcc = LS.VCCRegister.isValid() &&
+                LS.MRI->isSubRegisterEq(Register, LS.VCCRegister);
+  if (TracksVcc)
     Bits.set(MaxSgprs);
 }
 
@@ -931,9 +937,11 @@ static bool collectTrackedSgprUsesAndDefs(const InternalDecodedInst &DI,
     return false;
   bool Valid = true;
   for (MCRegister Register : Effects->Uses)
-    addTrackedSgprBits(LS, Register, MaxSgprs, Uses, Valid);
+    addTrackedSgprBits(LS, Register, MaxSgprs, Uses, Valid,
+                       /*IsDefinition=*/false);
   for (MCRegister Register : Effects->Defs)
-    addTrackedSgprBits(LS, Register, MaxSgprs, Defs, Valid);
+    addTrackedSgprBits(LS, Register, MaxSgprs, Defs, Valid,
+                       /*IsDefinition=*/true);
   return Valid;
 }
 
@@ -978,7 +986,8 @@ bool replacementNeedsIncomingRegister(ArrayRef<uint8_t> Replacement,
     return true;
   BitVector RegisterBits(MaxTrackedSgprs + 1);
   bool Valid = true;
-  addTrackedSgprBits(LS, Register, MaxTrackedSgprs, RegisterBits, Valid);
+  addTrackedSgprBits(LS, Register, MaxTrackedSgprs, RegisterBits, Valid,
+                     /*IsDefinition=*/false);
   return !Valid || RegisterBits.none() || Incoming->anyCommon(RegisterBits);
 }
 
@@ -1195,8 +1204,8 @@ bool isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx,
     return false;
   BitVector RegisterBits(Ctx.Config.MaxSgprs + 1);
   bool Valid = true;
-  addTrackedSgprBits(Ctx.LS, Register, Ctx.Config.MaxSgprs, RegisterBits,
-                     Valid);
+  addTrackedSgprBits(Ctx.LS, Register, Ctx.Config.MaxSgprs, RegisterBits, Valid,
+                     /*IsDefinition=*/false);
   return Valid && RegisterBits.any() && !Live->anyCommon(RegisterBits);
 }
 

--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -898,11 +898,11 @@ bool instructionReadsRegister(const InternalDecodedInst &DI,
   return false;
 }
 
-static void addTrackedSgprBits(const LLVMState &LS, MCRegister Register,
-                               unsigned MaxSgprs, BitVector &Bits, bool &Valid,
+static bool addTrackedSgprBits(const LLVMState &LS, MCRegister Register,
+                               unsigned MaxSgprs, BitVector &Bits,
                                bool IsDefinition) {
   if (!Register.isValid())
-    return;
+    return true;
   SmallVector<MCRegister, 8> Candidates;
   Candidates.push_back(Register);
   for (MCPhysReg Subregister : LS.MRI->subregs(Register))
@@ -917,12 +917,10 @@ static void addTrackedSgprBits(const LLVMState &LS, MCRegister Register,
     if (!Index)
       continue;
     if (*Index >= MaxSgprs) {
-      if (Valid)
-        log() << "hotswap: tracked SGPR analysis failed: decoded register s"
-              << *Index << " exceeds configured numbered-SGPR count "
-              << MaxSgprs << "\n";
-      Valid = false;
-      continue;
+      log() << "hotswap: tracked SGPR analysis failed: decoded register s"
+            << *Index << " exceeds configured numbered-SGPR count " << MaxSgprs
+            << "\n";
+      return false;
     }
     Bits.set(*Index);
   }
@@ -934,6 +932,7 @@ static void addTrackedSgprBits(const LLVMState &LS, MCRegister Register,
                 LS.MRI->isSubRegisterEq(Register, LS.VCCRegister);
   if (TracksVcc)
     Bits.set(MaxSgprs);
+  return true;
 }
 
 static bool collectTrackedSgprUsesAndDefs(const InternalDecodedInst &DI,
@@ -944,14 +943,15 @@ static bool collectTrackedSgprUsesAndDefs(const InternalDecodedInst &DI,
       getInstructionRegisterEffects(DI, LS);
   if (!Effects)
     return false;
-  bool Valid = true;
   for (MCRegister Register : Effects->Uses)
-    addTrackedSgprBits(LS, Register, MaxSgprs, Uses, Valid,
-                       /*IsDefinition=*/false);
+    if (!addTrackedSgprBits(LS, Register, MaxSgprs, Uses,
+                            /*IsDefinition=*/false))
+      return false;
   for (MCRegister Register : Effects->Defs)
-    addTrackedSgprBits(LS, Register, MaxSgprs, Defs, Valid,
-                       /*IsDefinition=*/true);
-  return Valid;
+    if (!addTrackedSgprBits(LS, Register, MaxSgprs, Defs,
+                            /*IsDefinition=*/true))
+      return false;
+  return true;
 }
 
 std::optional<BitVector>
@@ -1024,10 +1024,10 @@ bool replacementNeedsIncomingRegister(ArrayRef<uint8_t> Replacement,
   if (!Incoming)
     return true;
   BitVector RegisterBits(Gfx1250MaxSgprs + 1);
-  bool Valid = true;
-  addTrackedSgprBits(LS, Register, Gfx1250MaxSgprs, RegisterBits, Valid,
-                     /*IsDefinition=*/false);
-  return !Valid || RegisterBits.none() || Incoming->anyCommon(RegisterBits);
+  if (!addTrackedSgprBits(LS, Register, Gfx1250MaxSgprs, RegisterBits,
+                          /*IsDefinition=*/false))
+    return true;
+  return RegisterBits.none() || Incoming->anyCommon(RegisterBits);
 }
 
 static bool addCurrentFunctionLivenessSuccessor(
@@ -1365,10 +1365,10 @@ bool isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx,
   if (!Live)
     return false;
   BitVector RegisterBits(Ctx.Config.MaxSgprs + 1);
-  bool Valid = true;
-  addTrackedSgprBits(Ctx.LS, Register, Ctx.Config.MaxSgprs, RegisterBits, Valid,
-                     /*IsDefinition=*/false);
-  return Valid && RegisterBits.any() && !Live->anyCommon(RegisterBits);
+  if (!addTrackedSgprBits(Ctx.LS, Register, Ctx.Config.MaxSgprs, RegisterBits,
+                          /*IsDefinition=*/false))
+    return false;
+  return RegisterBits.any() && !Live->anyCommon(RegisterBits);
 }
 
 static std::optional<SafeSgprScratchBlock>

--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -835,7 +835,7 @@ struct InstructionRegisterEffects {
 static std::optional<InstructionRegisterEffects>
 getInstructionRegisterEffects(const InternalDecodedInst &DI,
                               const LLVMState &LS) {
-  if (!DI.DecodeSucceeded || !LS.MCII || !LS.MRI)
+  if (!DI.DecodeSucceeded || DI.DecodeSoftFailed || !LS.MCII || !LS.MRI)
     return std::nullopt;
 
   InstructionRegisterEffects Effects;
@@ -885,8 +885,13 @@ bool instructionReadsRegister(const InternalDecodedInst &DI,
                               const LLVMState &LS, MCRegister Register) {
   std::optional<InstructionRegisterEffects> Effects =
       getInstructionRegisterEffects(DI, LS);
-  if (!Effects)
+  if (!Effects) {
+    log() << "hotswap: register-read analysis failed closed at instruction "
+             "offset 0x"
+          << utohexstr(DI.Offset)
+          << ": decode status or LLVM register metadata is not proof-safe\n";
     return true;
+  }
   for (MCRegister Use : Effects->Uses)
     if (LS.MRI->regsOverlap(Use, Register))
       return true;
@@ -912,6 +917,10 @@ static void addTrackedSgprBits(const LLVMState &LS, MCRegister Register,
     if (!Index)
       continue;
     if (*Index >= MaxSgprs) {
+      if (Valid)
+        log() << "hotswap: tracked SGPR analysis failed: decoded register s"
+              << *Index << " exceeds configured numbered-SGPR count "
+              << MaxSgprs << "\n";
       Valid = false;
       continue;
     }
@@ -948,27 +957,58 @@ static bool collectTrackedSgprUsesAndDefs(const InternalDecodedInst &DI,
 std::optional<BitVector>
 getReplacementIncomingSgprs(ArrayRef<uint8_t> Replacement, const LLVMState &LS,
                             unsigned MaxSgprs) {
-  if (MaxSgprs > Gfx1250MaxSgprs)
+  if (MaxSgprs > Gfx1250MaxSgprs) {
+    log() << "hotswap: replacement SGPR input analysis failed: configured "
+             "maximum "
+          << MaxSgprs << " exceeds gfx1250 limit " << Gfx1250MaxSgprs << "\n";
     return std::nullopt;
+  }
   const unsigned TrackedSgprs = MaxSgprs + 1;
   BitVector Incoming(TrackedSgprs);
   BitVector Defined(TrackedSgprs);
   std::vector<InternalDecodedInst> Decoded;
-  if (!decodeTextSection(Replacement.data(), Replacement.size(), LS, Decoded))
+  if (!decodeTextSection(Replacement.data(), Replacement.size(), LS, Decoded)) {
+    log() << "hotswap: replacement SGPR input analysis failed: MC decode "
+             "could not scan "
+          << Replacement.size() << " replacement bytes\n";
     return std::nullopt;
+  }
 
   for (const InternalDecodedInst &DI : Decoded) {
-    if (!DI.DecodeSucceeded || !LS.MIA)
+    if (!DI.DecodeSucceeded) {
+      log() << "hotswap: replacement SGPR input analysis failed at byte 0x"
+            << utohexstr(DI.Offset) << ": undecodable instruction\n";
       return std::nullopt;
+    }
+    if (DI.DecodeSoftFailed) {
+      log() << "hotswap: replacement SGPR input analysis failed at byte 0x"
+            << utohexstr(DI.Offset)
+            << ": potentially undefined instruction encoding\n";
+      return std::nullopt;
+    }
+    if (!LS.MIA) {
+      log() << "hotswap: replacement SGPR input analysis failed: LLVM control-"
+               "flow analysis is unavailable\n";
+      return std::nullopt;
+    }
     const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
     if (Desc.isTrap() || DI.Inst.getOpcode() == LS.STrapOpcode ||
-        LS.MIA->isBarrier(DI.Inst) ||
-        LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
+        DI.Inst.getOpcode() == LS.SRfeI64Opcode || LS.MIA->isBarrier(DI.Inst) ||
+        LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+      log() << "hotswap: replacement SGPR input analysis failed at byte 0x"
+            << utohexstr(DI.Offset) << ": control-flow instruction "
+            << DI.Mnemonic
+            << " is not allowed in a straight-line replacement\n";
       return std::nullopt;
+    }
     BitVector Uses(TrackedSgprs);
     BitVector Defs(TrackedSgprs);
-    if (!collectTrackedSgprUsesAndDefs(DI, LS, MaxSgprs, Uses, Defs))
+    if (!collectTrackedSgprUsesAndDefs(DI, LS, MaxSgprs, Uses, Defs)) {
+      log() << "hotswap: replacement SGPR input analysis failed at byte 0x"
+            << utohexstr(DI.Offset)
+            << ": register effects are not proof-safe\n";
       return std::nullopt;
+    }
     Uses.reset(Defined);
     Incoming |= Uses;
     Defined |= Defs;
@@ -979,14 +1019,13 @@ getReplacementIncomingSgprs(ArrayRef<uint8_t> Replacement, const LLVMState &LS,
 bool replacementNeedsIncomingRegister(ArrayRef<uint8_t> Replacement,
                                       const LLVMState &LS,
                                       MCRegister Register) {
-  constexpr unsigned MaxTrackedSgprs = 106;
   std::optional<BitVector> Incoming =
-      getReplacementIncomingSgprs(Replacement, LS, MaxTrackedSgprs);
+      getReplacementIncomingSgprs(Replacement, LS, Gfx1250MaxSgprs);
   if (!Incoming)
     return true;
-  BitVector RegisterBits(MaxTrackedSgprs + 1);
+  BitVector RegisterBits(Gfx1250MaxSgprs + 1);
   bool Valid = true;
-  addTrackedSgprBits(LS, Register, MaxTrackedSgprs, RegisterBits, Valid,
+  addTrackedSgprBits(LS, Register, Gfx1250MaxSgprs, RegisterBits, Valid,
                      /*IsDefinition=*/false);
   return !Valid || RegisterBits.none() || Incoming->anyCommon(RegisterBits);
 }
@@ -1010,32 +1049,92 @@ static CurrentFunctionSgprLiveness buildCurrentFunctionSgprLiveness(
   CurrentFunctionSgprLiveness Result;
   Result.Generation = Ctx.TextMutationGeneration;
   Result.MaxSgprs = Ctx.Config.MaxSgprs;
-  if (!Ctx.LS.MIA || FunctionRange.End < FunctionRange.Begin ||
+  if (!Ctx.LS.MIA) {
+    log() << "hotswap: current-function SGPR liveness failed for [0x"
+          << utohexstr(FunctionRange.Begin) << ", 0x"
+          << utohexstr(FunctionRange.End)
+          << "): LLVM control-flow analysis is unavailable\n";
+    return Result;
+  }
+  if (FunctionRange.End < FunctionRange.Begin ||
       FunctionRange.Begin > Ctx.TextSize ||
       FunctionRange.End - FunctionRange.Begin >
-          Ctx.TextSize - FunctionRange.Begin ||
-      Ctx.Config.MaxSgprs > Gfx1250MaxSgprs)
+          Ctx.TextSize - FunctionRange.Begin) {
+    log() << "hotswap: current-function SGPR liveness failed for [0x"
+          << utohexstr(FunctionRange.Begin) << ", 0x"
+          << utohexstr(FunctionRange.End)
+          << "): function range is outside current .text\n";
     return Result;
+  }
+  if (Ctx.Config.MaxSgprs > Gfx1250MaxSgprs) {
+    log() << "hotswap: current-function SGPR liveness failed for [0x"
+          << utohexstr(FunctionRange.Begin) << ", 0x"
+          << utohexstr(FunctionRange.End) << "): configured maximum "
+          << Ctx.Config.MaxSgprs << " exceeds gfx1250 limit " << Gfx1250MaxSgprs
+          << "\n";
+    return Result;
+  }
 
   std::vector<InternalDecodedInst> Decoded;
   uint64_t FunctionSize = FunctionRange.End - FunctionRange.Begin;
   if (!decodeTextSection(Ctx.Text + FunctionRange.Begin, FunctionSize, Ctx.LS,
-                         Decoded))
+                         Decoded)) {
+    log() << "hotswap: current-function SGPR liveness failed for [0x"
+          << utohexstr(FunctionRange.Begin) << ", 0x"
+          << utohexstr(FunctionRange.End)
+          << "): MC decode could not scan the function\n";
     return Result;
+  }
 
   uint64_t ExpectedOffset = FunctionRange.Begin;
   for (InternalDecodedInst &DI : Decoded) {
     DI.Offset += FunctionRange.Begin;
-    if (!DI.DecodeSucceeded || DI.Size == 0 || DI.Offset != ExpectedOffset)
+    if (!DI.DecodeSucceeded) {
+      log() << "hotswap: current-function SGPR liveness failed at 0x"
+            << utohexstr(DI.Offset) << ": undecodable instruction\n";
       return Result;
+    }
+    if (DI.DecodeSoftFailed) {
+      log() << "hotswap: current-function SGPR liveness failed at 0x"
+            << utohexstr(DI.Offset)
+            << ": potentially undefined instruction encoding\n";
+      return Result;
+    }
+    if (DI.Size == 0) {
+      log() << "hotswap: current-function SGPR liveness failed at 0x"
+            << utohexstr(DI.Offset) << ": decoded instruction has zero size\n";
+      return Result;
+    }
+    if (DI.Offset != ExpectedOffset) {
+      log() << "hotswap: current-function SGPR liveness failed at 0x"
+            << utohexstr(DI.Offset) << ": expected instruction boundary 0x"
+            << utohexstr(ExpectedOffset) << "\n";
+      return Result;
+    }
     std::optional<uint64_t> Next = checkedAddUint64(
         DI.Offset, DI.Size, "current-function SGPR liveness decode");
-    if (!Next || *Next > FunctionRange.End)
+    if (!Next || *Next > FunctionRange.End) {
+      log() << "hotswap: current-function SGPR liveness failed at 0x"
+            << utohexstr(DI.Offset)
+            << ": decoded instruction extends beyond the function\n";
       return Result;
+    }
     ExpectedOffset = *Next;
   }
-  if (ExpectedOffset != FunctionRange.End || Decoded.empty())
+  if (Decoded.empty()) {
+    log() << "hotswap: current-function SGPR liveness failed for [0x"
+          << utohexstr(FunctionRange.Begin) << ", 0x"
+          << utohexstr(FunctionRange.End)
+          << "): function has no instructions\n";
     return Result;
+  }
+  if (ExpectedOffset != FunctionRange.End) {
+    log() << "hotswap: current-function SGPR liveness failed for [0x"
+          << utohexstr(FunctionRange.Begin) << ", 0x"
+          << utohexstr(FunctionRange.End)
+          << "): decoded instructions do not cover the complete function\n";
+    return Result;
+  }
 
   const unsigned TrackedSgprs = Ctx.Config.MaxSgprs + 1;
   const size_t InstructionCount = Decoded.size();
@@ -1050,11 +1149,18 @@ static CurrentFunctionSgprLiveness buildCurrentFunctionSgprLiveness(
     const InternalDecodedInst &DI = Decoded[I];
     std::pair<DenseMap<uint64_t, size_t>::iterator, bool> Inserted =
         Result.InstructionIndices.try_emplace(DI.Offset, I);
-    if (!Inserted.second)
+    if (!Inserted.second) {
+      log() << "hotswap: current-function SGPR liveness failed at 0x"
+            << utohexstr(DI.Offset) << ": duplicate instruction offset\n";
       return Result;
+    }
     if (!collectTrackedSgprUsesAndDefs(DI, Ctx.LS, Ctx.Config.MaxSgprs, Uses[I],
-                                       Defs[I]))
+                                       Defs[I])) {
+      log() << "hotswap: current-function SGPR liveness failed at 0x"
+            << utohexstr(DI.Offset)
+            << ": register effects are not proof-safe\n";
       return Result;
+    }
   }
 
   for (size_t I = 0; I != InstructionCount; ++I) {
@@ -1162,6 +1268,21 @@ std::optional<BitVector> getLiveSgprsAtContinuation(PatchContext &Ctx,
   }
   using FunctionKey = std::pair<uint64_t, uint64_t>;
   FunctionKey Key{FunctionRange->Begin, FunctionRange->End};
+  // Deferred trampolines are logical mutations of their source functions, but
+  // their source branches are not written into Ctx.Text until final fixup.
+  // Decoding the current bytes after one is queued would therefore omit the
+  // replacement's effects and its new control-flow edges. Fail closed for the
+  // affected function until finalization rather than prove liveness from an
+  // incomplete program image. A trampoline without a resolved function range
+  // may affect any queried function and also forces the conservative result.
+  if (Ctx.HasUnresolvedPendingTrampoline ||
+      Ctx.PendingTrampolineFunctions.contains(Key)) {
+    log() << "hotswap: SGPR continuation liveness failed closed for source at "
+             "0x"
+          << utohexstr(InstOffset)
+          << ": pending trampoline source bytes are not finalized\n";
+    return std::nullopt;
+  }
   DenseMap<FunctionKey, CurrentFunctionSgprLiveness>::iterator Cached =
       Ctx.CurrentFunctionSgprLivenessCache.find(Key);
   if (Cached == Ctx.CurrentFunctionSgprLivenessCache.end() ||
@@ -1225,6 +1346,14 @@ void noteCurrentTextMutation(PatchContext &Ctx) {
     return;
   }
   ++Ctx.TextMutationGeneration;
+}
+
+void notePendingTrampolineMutation(PatchContext &Ctx, const Trampoline &T) {
+  if (!T.HasFunctionRange) {
+    Ctx.HasUnresolvedPendingTrampoline = true;
+    return;
+  }
+  Ctx.PendingTrampolineFunctions.insert({T.FunctionStart, T.FunctionEnd});
 }
 
 bool isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx,
@@ -1345,6 +1474,7 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
     T.UsesSetPCBack = true;
     T.LongBranchSgprBase = Scratch->Base;
     Ctx.Profile.count(HotswapMetric::JumpLong);
+    notePendingTrampolineMutation(Ctx, T);
     Ctx.OutTrampolines.emplace_back(std::move(T));
     Ctx.QueuedTrampolineBytes = *QueuedBytes;
     return true;
@@ -1354,6 +1484,7 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
     // Reserve the short branch-back slot; fixupTrampolineBranches fills it in.
     T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
   }
+  notePendingTrampolineMutation(Ctx, T);
   Ctx.OutTrampolines.emplace_back(std::move(T));
   Ctx.QueuedTrampolineBytes = *QueuedBytes;
   return true;

--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -361,6 +361,21 @@ truncateNopSledsAtDirectTargets(std::vector<NopSled> &Sleds,
 
 // -- Sled-or-trampoline code emission -----------------------------------------
 
+bool writeCurrentText(PatchContext &Ctx, uint64_t Offset,
+                      ArrayRef<uint8_t> Bytes, StringRef Context) {
+  if (Offset > Ctx.TextSize || Bytes.size() > Ctx.TextSize - Offset) {
+    log() << "hotswap: error: " << Context << ": current .text write [0x"
+          << utohexstr(Offset) << ", +0x" << utohexstr(Bytes.size())
+          << ") exceeds size 0x" << utohexstr(Ctx.TextSize) << "\n";
+    return false;
+  }
+  if (Bytes.empty())
+    return true;
+  std::memcpy(Ctx.Text + Offset, Bytes.data(), Bytes.size());
+  noteCurrentTextMutation(Ctx);
+  return true;
+}
+
 /// Emit the replacement code for the instruction at [\p InstOffset,
 /// \p InstOffset + \p InstSize) into a nearby NOP sled: writes \p Replacement
 /// into the sled, appends a branch-back to the next instruction after the
@@ -373,35 +388,55 @@ truncateNopSledsAtDirectTargets(std::vector<NopSled> &Sleds,
                                  uint64_t InstOffset, uint32_t InstSize,
                                  ArrayRef<uint8_t> Replacement) {
   const LLVMState &LS = Ctx.LS;
-  SmallVector<uint8_t> BrBack = LS.encodeSBranch(
-      Sled.WritePos + Replacement.size(), InstOffset + InstSize);
-  if (BrBack.empty()) {
+  std::optional<uint64_t> BackOffset = checkedAddUint64(
+      Sled.WritePos, Replacement.size(), "NOP-sled branch-back offset");
+  std::optional<uint64_t> SledWriteEnd =
+      BackOffset
+          ? checkedAddUint64(*BackOffset, MinInstSize, "NOP-sled write end")
+          : std::nullopt;
+  std::optional<uint64_t> InstEnd =
+      checkedAddUint64(InstOffset, InstSize, "NOP-sled source end");
+  if (!BackOffset || !SledWriteEnd || !InstEnd ||
+      Sled.WritePos > Ctx.TextSize || *SledWriteEnd > Ctx.TextSize ||
+      *SledWriteEnd > Sled.End || InstOffset > Ctx.TextSize ||
+      *InstEnd > Ctx.TextSize || InstSize < MinInstSize ||
+      InstSize % MinInstSize != 0) {
+    log() << "hotswap: error: emitToNopSled: invalid source or sled bounds\n";
+    return false;
+  }
+
+  SmallVector<uint8_t> BrBack = LS.encodeSBranch(*BackOffset, *InstEnd);
+  if (BrBack.size() != MinInstSize) {
     log() << "hotswap: error: emitToNopSled: encodeSBranch for branch-back "
-          << "at sled offset 0x"
-          << utohexstr(Sled.WritePos + Replacement.size()) << " -> 0x"
-          << utohexstr(InstOffset + InstSize) << " failed.\n";
+          << "at sled offset 0x" << utohexstr(*BackOffset) << " -> 0x"
+          << utohexstr(*InstEnd) << " failed.\n";
     return false;
   }
 
   SmallVector<uint8_t> BrFwd = LS.encodeSBranch(InstOffset, Sled.WritePos);
-  if (BrFwd.empty()) {
+  if (BrFwd.size() != MinInstSize) {
     log() << "hotswap: error: emitToNopSled: encodeSBranch for branch-fwd "
           << "at original offset 0x" << utohexstr(InstOffset) << " -> sled 0x"
           << utohexstr(Sled.WritePos) << " failed.\n";
     return false;
   }
 
-  std::memcpy(Ctx.Text + Sled.WritePos, Replacement.data(), Replacement.size());
-  std::memcpy(Ctx.Text + Sled.WritePos + Replacement.size(), BrBack.data(),
-              BrBack.size());
-  std::memcpy(Ctx.Text + InstOffset, BrFwd.data(), BrFwd.size());
+  if (!writeCurrentText(Ctx, Sled.WritePos, Replacement,
+                        "NOP-sled replacement") ||
+      !writeCurrentText(Ctx, *BackOffset, BrBack, "NOP-sled branch-back") ||
+      !writeCurrentText(Ctx, InstOffset, BrFwd, "NOP-sled branch-forward"))
+    return false;
 
   // Pad the tail of the replaced instruction slot with cached s_nop bytes
   // (pre-encoded in LLVMState at initLLVM() time).
   for (uint32_t I = MinInstSize; I < InstSize; I += MinInstSize)
-    std::memcpy(Ctx.Text + InstOffset + I, LS.SNopBytes.data(), MinInstSize);
+    if (!writeCurrentText(
+            Ctx, InstOffset + I,
+            ArrayRef<uint8_t>(LS.SNopBytes).take_front(MinInstSize),
+            "NOP-sled source padding"))
+      return false;
 
-  Sled.WritePos += Replacement.size() + MinInstSize;
+  Sled.WritePos = *SledWriteEnd;
   // Count-only row: patch placed in-line via a nearby NOP sled, no trampoline.
   Ctx.Profile.count(HotswapMetric::JumpNopSled);
   return true;
@@ -790,6 +825,379 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
     return false;
   }
   return true;
+}
+
+struct InstructionRegisterEffects {
+  SmallVector<MCRegister, 8> Uses;
+  SmallVector<MCRegister, 8> Defs;
+};
+
+static std::optional<InstructionRegisterEffects>
+getInstructionRegisterEffects(const InternalDecodedInst &DI,
+                              const LLVMState &LS) {
+  if (!DI.DecodeSucceeded || !LS.MCII || !LS.MRI)
+    return std::nullopt;
+
+  InstructionRegisterEffects Effects;
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned Def = 0; Def != DefCount; ++Def) {
+    const MCOperand &Operand = DI.Inst.getOperand(Def);
+    if (!Operand.isReg() || !Operand.getReg())
+      continue;
+    MCRegister Register(Operand.getReg());
+    Effects.Defs.push_back(Register);
+    // A tied use makes its explicit def a read/modify/write operand. Some
+    // MCInst producers retain only the destination operand, so derive this use
+    // from the descriptor instead of requiring a duplicate decoded operand.
+    for (unsigned Use = Desc.getNumDefs(); Use != Desc.getNumOperands();
+         ++Use) {
+      if (Desc.getOperandConstraint(Use, MCOI::TIED_TO) ==
+          static_cast<int>(Def)) {
+        Effects.Uses.push_back(Register);
+        break;
+      }
+    }
+  }
+
+  unsigned FixedOperandCount =
+      std::min(Desc.getNumOperands(), DI.Inst.getNumOperands());
+  for (unsigned I = DefCount; I != FixedOperandCount; ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (Operand.isReg() && Operand.getReg())
+      Effects.Uses.push_back(MCRegister(Operand.getReg()));
+  }
+  for (unsigned I = FixedOperandCount; I != DI.Inst.getNumOperands(); ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (!Operand.isReg() || !Operand.getReg())
+      continue;
+    (Desc.variadicOpsAreDefs() ? Effects.Defs : Effects.Uses)
+        .push_back(MCRegister(Operand.getReg()));
+  }
+  for (MCPhysReg ImplicitUse : Desc.implicit_uses())
+    Effects.Uses.push_back(MCRegister(ImplicitUse));
+  for (MCPhysReg ImplicitDef : Desc.implicit_defs())
+    Effects.Defs.push_back(MCRegister(ImplicitDef));
+  return Effects;
+}
+
+bool instructionReadsRegister(const InternalDecodedInst &DI,
+                              const LLVMState &LS, MCRegister Register) {
+  std::optional<InstructionRegisterEffects> Effects =
+      getInstructionRegisterEffects(DI, LS);
+  if (!Effects)
+    return true;
+  for (MCRegister Use : Effects->Uses)
+    if (LS.MRI->regsOverlap(Use, Register))
+      return true;
+  return false;
+}
+
+static void addTrackedSgprBits(const LLVMState &LS, MCRegister Register,
+                               unsigned MaxSgprs, BitVector &Bits,
+                               bool &Valid) {
+  if (!Register.isValid())
+    return;
+  SmallVector<MCRegister, 8> Candidates;
+  Candidates.push_back(Register);
+  for (MCPhysReg Subregister : LS.MRI->subregs(Register))
+    Candidates.push_back(MCRegister(Subregister));
+  // A decoded operand can name a low/high subregister directly. Its scalar
+  // numbered SGPR then appears among its super-registers rather than subregs.
+  for (MCPhysReg Superregister : LS.MRI->superregs(Register))
+    Candidates.push_back(MCRegister(Superregister));
+
+  for (MCRegister Candidate : Candidates) {
+    std::optional<unsigned> Index = numberedSgprIndex(*LS.MRI, Candidate);
+    if (!Index)
+      continue;
+    if (*Index >= MaxSgprs) {
+      Valid = false;
+      continue;
+    }
+    Bits.set(*Index);
+  }
+  if (isVccRegister(LS, Register))
+    Bits.set(MaxSgprs);
+}
+
+static bool collectTrackedSgprUsesAndDefs(const InternalDecodedInst &DI,
+                                          const LLVMState &LS,
+                                          unsigned MaxSgprs, BitVector &Uses,
+                                          BitVector &Defs) {
+  std::optional<InstructionRegisterEffects> Effects =
+      getInstructionRegisterEffects(DI, LS);
+  if (!Effects)
+    return false;
+  bool Valid = true;
+  for (MCRegister Register : Effects->Uses)
+    addTrackedSgprBits(LS, Register, MaxSgprs, Uses, Valid);
+  for (MCRegister Register : Effects->Defs)
+    addTrackedSgprBits(LS, Register, MaxSgprs, Defs, Valid);
+  return Valid;
+}
+
+std::optional<BitVector>
+getReplacementIncomingSgprs(ArrayRef<uint8_t> Replacement, const LLVMState &LS,
+                            unsigned MaxSgprs) {
+  if (MaxSgprs > Gfx1250MaxSgprs)
+    return std::nullopt;
+  const unsigned TrackedSgprs = MaxSgprs + 1;
+  BitVector Incoming(TrackedSgprs);
+  BitVector Defined(TrackedSgprs);
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Replacement.data(), Replacement.size(), LS, Decoded))
+    return std::nullopt;
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (!DI.DecodeSucceeded || !LS.MIA)
+      return std::nullopt;
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    if (Desc.isTrap() || DI.Inst.getOpcode() == LS.STrapOpcode ||
+        LS.MIA->isBarrier(DI.Inst) ||
+        LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
+      return std::nullopt;
+    BitVector Uses(TrackedSgprs);
+    BitVector Defs(TrackedSgprs);
+    if (!collectTrackedSgprUsesAndDefs(DI, LS, MaxSgprs, Uses, Defs))
+      return std::nullopt;
+    Uses.reset(Defined);
+    Incoming |= Uses;
+    Defined |= Defs;
+  }
+  return Incoming;
+}
+
+bool replacementNeedsIncomingRegister(ArrayRef<uint8_t> Replacement,
+                                      const LLVMState &LS,
+                                      MCRegister Register) {
+  constexpr unsigned MaxTrackedSgprs = 106;
+  std::optional<BitVector> Incoming =
+      getReplacementIncomingSgprs(Replacement, LS, MaxTrackedSgprs);
+  if (!Incoming)
+    return true;
+  BitVector RegisterBits(MaxTrackedSgprs + 1);
+  bool Valid = true;
+  addTrackedSgprBits(LS, Register, MaxTrackedSgprs, RegisterBits, Valid);
+  return !Valid || RegisterBits.none() || Incoming->anyCommon(RegisterBits);
+}
+
+static bool addCurrentFunctionLivenessSuccessor(
+    size_t From, uint64_t Offset,
+    const DenseMap<uint64_t, size_t> &InstructionIndices,
+    std::vector<SmallVector<size_t, 2>> &Successors,
+    std::vector<SmallVector<size_t, 2>> &Predecessors) {
+  DenseMap<uint64_t, size_t>::const_iterator Target =
+      InstructionIndices.find(Offset);
+  if (Target == InstructionIndices.end())
+    return false;
+  Successors[From].push_back(Target->second);
+  Predecessors[Target->second].push_back(From);
+  return true;
+}
+
+static CurrentFunctionSgprLiveness buildCurrentFunctionSgprLiveness(
+    PatchContext &Ctx, const ElfView::FunctionTextRange &FunctionRange) {
+  CurrentFunctionSgprLiveness Result;
+  Result.Generation = Ctx.TextMutationGeneration;
+  Result.MaxSgprs = Ctx.Config.MaxSgprs;
+  if (!Ctx.LS.MIA || FunctionRange.End < FunctionRange.Begin ||
+      FunctionRange.Begin > Ctx.TextSize ||
+      FunctionRange.End - FunctionRange.Begin >
+          Ctx.TextSize - FunctionRange.Begin ||
+      Ctx.Config.MaxSgprs > Gfx1250MaxSgprs)
+    return Result;
+
+  std::vector<InternalDecodedInst> Decoded;
+  uint64_t FunctionSize = FunctionRange.End - FunctionRange.Begin;
+  if (!decodeTextSection(Ctx.Text + FunctionRange.Begin, FunctionSize, Ctx.LS,
+                         Decoded))
+    return Result;
+
+  uint64_t ExpectedOffset = FunctionRange.Begin;
+  for (InternalDecodedInst &DI : Decoded) {
+    DI.Offset += FunctionRange.Begin;
+    if (!DI.DecodeSucceeded || DI.Size == 0 || DI.Offset != ExpectedOffset)
+      return Result;
+    std::optional<uint64_t> Next = checkedAddUint64(
+        DI.Offset, DI.Size, "current-function SGPR liveness decode");
+    if (!Next || *Next > FunctionRange.End)
+      return Result;
+    ExpectedOffset = *Next;
+  }
+  if (ExpectedOffset != FunctionRange.End || Decoded.empty())
+    return Result;
+
+  const unsigned TrackedSgprs = Ctx.Config.MaxSgprs + 1;
+  const size_t InstructionCount = Decoded.size();
+  std::vector<BitVector> Uses(InstructionCount, BitVector(TrackedSgprs));
+  std::vector<BitVector> Defs(InstructionCount, BitVector(TrackedSgprs));
+  std::vector<SmallVector<size_t, 2>> Successors(InstructionCount);
+  std::vector<SmallVector<size_t, 2>> Predecessors(InstructionCount);
+  BitVector HasUnknownSuccessor(InstructionCount);
+  BitVector HasUnknownRegisterEffects(InstructionCount);
+
+  for (size_t I = 0; I != InstructionCount; ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    std::pair<DenseMap<uint64_t, size_t>::iterator, bool> Inserted =
+        Result.InstructionIndices.try_emplace(DI.Offset, I);
+    if (!Inserted.second)
+      return Result;
+    if (!collectTrackedSgprUsesAndDefs(DI, Ctx.LS, Ctx.Config.MaxSgprs, Uses[I],
+                                       Defs[I]))
+      return Result;
+  }
+
+  for (size_t I = 0; I != InstructionCount; ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+    if (DI.Inst.getOpcode() == Ctx.LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == Ctx.LS.SEndPgmSavedOpcode)
+      continue;
+    if (Desc.isTrap() || DI.Inst.getOpcode() == Ctx.LS.STrapOpcode) {
+      HasUnknownSuccessor.set(I);
+      HasUnknownRegisterEffects.set(I);
+      continue;
+    }
+    if (Ctx.LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target =
+          evaluateDirectControlFlowTarget(DI, Ctx.LS);
+      if (!Target)
+        HasUnknownSuccessor.set(I);
+      else if (!addCurrentFunctionLivenessSuccessor(I, *Target,
+                                                    Result.InstructionIndices,
+                                                    Successors, Predecessors))
+        HasUnknownSuccessor.set(I);
+      if (Ctx.LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (Ctx.LS.MIA->isBarrier(DI.Inst)) {
+      HasUnknownSuccessor.set(I);
+      HasUnknownRegisterEffects.set(I);
+      continue;
+    } else if (Ctx.LS.MIA->isCall(DI.Inst) ||
+               Ctx.LS.MIA->isIndirectBranch(DI.Inst) ||
+               Ctx.LS.MIA->isReturn(DI.Inst) ||
+               DI.Inst.getOpcode() == Ctx.LS.SRfeI64Opcode) {
+      HasUnknownSuccessor.set(I);
+      continue;
+    } else if (Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI)) {
+      HasUnknownSuccessor.set(I);
+      HasUnknownRegisterEffects.set(I);
+      continue;
+    }
+
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "current-function SGPR liveness fallthrough");
+    if (!Fallthrough)
+      HasUnknownSuccessor.set(I);
+    else if (!addCurrentFunctionLivenessSuccessor(I, *Fallthrough,
+                                                  Result.InstructionIndices,
+                                                  Successors, Predecessors))
+      HasUnknownSuccessor.set(I);
+  }
+
+  // Each worklist transfer and successor union costs
+  // O(ceil(R / word-size)), where R is the configured tracked SGPR count.
+  // Computing all registers together avoids rebuilding and walking this CFG
+  // once per scratch-register candidate.
+  Result.LiveBefore.assign(InstructionCount, BitVector(TrackedSgprs));
+  std::vector<BitVector> LiveAfter(InstructionCount, BitVector(TrackedSgprs));
+  BitVector AllLive(TrackedSgprs, true);
+  SmallVector<size_t, 32> Worklist;
+  BitVector InWorklist(InstructionCount, true);
+  for (size_t I = 0; I != InstructionCount; ++I)
+    Worklist.push_back(I);
+
+  while (!Worklist.empty()) {
+    size_t I = Worklist.pop_back_val();
+    InWorklist.reset(I);
+    BitVector NewAfter(TrackedSgprs);
+    if (HasUnknownSuccessor.test(I))
+      NewAfter = AllLive;
+    for (size_t Successor : Successors[I])
+      NewAfter |= Result.LiveBefore[Successor];
+
+    BitVector NewBefore = NewAfter;
+    if (HasUnknownRegisterEffects.test(I)) {
+      NewBefore = AllLive;
+    } else {
+      NewBefore.reset(Defs[I]);
+      NewBefore |= Uses[I];
+    }
+    if (NewAfter == LiveAfter[I] && NewBefore == Result.LiveBefore[I])
+      continue;
+    LiveAfter[I] = std::move(NewAfter);
+    Result.LiveBefore[I] = std::move(NewBefore);
+    for (size_t Predecessor : Predecessors[I]) {
+      if (InWorklist.test(Predecessor))
+        continue;
+      InWorklist.set(Predecessor);
+      Worklist.push_back(Predecessor);
+    }
+  }
+  Result.Valid = true;
+  return Result;
+}
+
+std::optional<BitVector> getLiveSgprsAtContinuation(PatchContext &Ctx,
+                                                    uint64_t InstOffset,
+                                                    uint32_t InstSize) {
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!FunctionRange)
+    return std::nullopt;
+  using FunctionKey = std::pair<uint64_t, uint64_t>;
+  FunctionKey Key{FunctionRange->Begin, FunctionRange->End};
+  DenseMap<FunctionKey, CurrentFunctionSgprLiveness>::iterator Cached =
+      Ctx.CurrentFunctionSgprLivenessCache.find(Key);
+  if (Cached == Ctx.CurrentFunctionSgprLivenessCache.end() ||
+      Cached->second.Generation != Ctx.TextMutationGeneration ||
+      Cached->second.MaxSgprs != Ctx.Config.MaxSgprs) {
+    CurrentFunctionSgprLiveness Current =
+        buildCurrentFunctionSgprLiveness(Ctx, *FunctionRange);
+    Cached = Ctx.CurrentFunctionSgprLivenessCache
+                 .insert_or_assign(Key, std::move(Current))
+                 .first;
+  }
+  if (!Cached->second.Valid)
+    return std::nullopt;
+
+  std::optional<uint64_t> Continuation =
+      checkedAddUint64(InstOffset, InstSize, "SGPR liveness continuation");
+  if (!Continuation)
+    return std::nullopt;
+  DenseMap<uint64_t, size_t>::const_iterator Index =
+      Cached->second.InstructionIndices.find(*Continuation);
+  if (Index == Cached->second.InstructionIndices.end())
+    return std::nullopt;
+  return Cached->second.LiveBefore[Index->second];
+}
+
+void noteCurrentTextMutation(PatchContext &Ctx) {
+  // Every cached function was decoded from the previous text generation.
+  // Retaining those maps and bit vectors cannot produce a cache hit and lets
+  // many patch generations accumulate stale whole-function allocations.
+  Ctx.CurrentFunctionSgprLivenessCache.clear();
+  if (Ctx.TextMutationGeneration == std::numeric_limits<uint64_t>::max()) {
+    Ctx.TextMutationGeneration = 0;
+    return;
+  }
+  ++Ctx.TextMutationGeneration;
+}
+
+bool isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx,
+                                            uint64_t InstOffset,
+                                            uint32_t InstSize,
+                                            MCRegister Register) {
+  std::optional<BitVector> Live =
+      getLiveSgprsAtContinuation(Ctx, InstOffset, InstSize);
+  if (!Live)
+    return false;
+  BitVector RegisterBits(Ctx.Config.MaxSgprs + 1);
+  bool Valid = true;
+  addTrackedSgprBits(Ctx.LS, Register, Ctx.Config.MaxSgprs, RegisterBits,
+                     Valid);
+  return Valid && RegisterBits.any() && !Live->anyCommon(RegisterBits);
 }
 
 static std::optional<SafeSgprScratchBlock>
@@ -3327,18 +3735,14 @@ assignLongBranchGateways(PatchContext &Ctx,
               << utohexstr(T.ForwardGatewayOffset) << " extends past .text.\n";
         return false;
       }
-      std::memcpy(Ctx.Text + T.ForwardGatewayOffset,
-                  T.ForwardGatewayBytes.data(), T.ForwardGatewayBytes.size());
+      if (!writeCurrentText(Ctx, T.ForwardGatewayOffset, T.ForwardGatewayBytes,
+                            "forward set-PC gateway"))
+        return false;
       if (!T.SecondaryForwardGatewayBytes.empty()) {
         uint64_t Offset = T.SharedDispatcherSecondaryGatewayOffset;
-        if (Offset > Ctx.TextSize ||
-            T.SecondaryForwardGatewayBytes.size() > Ctx.TextSize - Offset) {
-          log() << "hotswap: error: secondary forward gateway at 0x"
-                << utohexstr(Offset) << " extends past .text.\n";
+        if (!writeCurrentText(Ctx, Offset, T.SecondaryForwardGatewayBytes,
+                              "secondary forward set-PC gateway"))
           return false;
-        }
-        std::memcpy(Ctx.Text + Offset, T.SecondaryForwardGatewayBytes.data(),
-                    T.SecondaryForwardGatewayBytes.size());
       }
     }
     for (size_t I = 0; I != T.ForwardBranchIslands.size(); ++I) {
@@ -3366,7 +3770,8 @@ assignLongBranchGateways(PatchContext &Ctx,
                 << utohexstr(From) << " is outside .text and trampoline pool\n";
           return false;
         }
-        std::memcpy(Ctx.Text + From, Branch.data(), Branch.size());
+        if (!writeCurrentText(Ctx, From, Branch, "forward branch island"))
+          return false;
       }
     }
   }

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -921,6 +921,11 @@ struct InternalDecodedInst {
   llvm::MCInst Inst;
   std::string Mnemonic;
   bool DecodeSucceeded = false;
+  // The disassembler recovered an instruction but diagnosed its encoding as
+  // potentially undefined. Ordinary matching may still inspect the MCInst,
+  // but safety proofs must fail closed because its modeled effects need not
+  // match the malformed encoded operands.
+  bool DecodeSoftFailed = false;
 };
 
 // -- Function declarations (LLVM MC layer) ------------------------------------
@@ -1313,6 +1318,11 @@ struct PatchContext {
   uint64_t TextMutationGeneration = 0;
   llvm::DenseMap<std::pair<uint64_t, uint64_t>, CurrentFunctionSgprLiveness>
       CurrentFunctionSgprLivenessCache{0};
+  // Deferred trampoline source branches are logical mutations that do not
+  // reach Text until final fixup. Index their owning functions so current-text
+  // liveness can reject incomplete program images in O(1) per query.
+  llvm::DenseSet<std::pair<uint64_t, uint64_t>> PendingTrampolineFunctions{0};
+  bool HasUnresolvedPendingTrampoline = false;
 };
 
 /// Return occupancy limits for \p Processor from COMGR's ISA metadata table.
@@ -1410,6 +1420,12 @@ void noteCurrentTextMutation(PatchContext &Ctx);
 [[nodiscard]] bool writeCurrentText(PatchContext &Ctx, uint64_t Offset,
                                     llvm::ArrayRef<uint8_t> Bytes,
                                     llvm::StringRef Context);
+
+/// Record the source function affected by a newly queued deferred trampoline.
+/// Call this before appending \p T to PatchContext::OutTrampolines. A
+/// trampoline without a resolved function range conservatively affects every
+/// later current-text liveness query.
+void notePendingTrampolineMutation(PatchContext &Ctx, const Trampoline &T);
 
 /// Prove that \p Register's incoming value is not read on any path from the
 /// instruction after [\p InstOffset, +\p InstSize) to the owning function's

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -866,6 +866,8 @@ struct LLVMState {
   unsigned SDelayAluOpcode = 0;
   unsigned SEndPgmOpcode = 0;
   unsigned SEndPgmSavedOpcode = 0;
+  unsigned SRfeI64Opcode = 0;
+  unsigned STrapOpcode = 0;
   unsigned SAddPcI64Opcode = 0;
   unsigned SCallI64Opcode = 0;
   unsigned SSwapPcI64Opcode = 0;
@@ -1221,6 +1223,16 @@ struct SafeSgprUsageSummary {
   unsigned HighWatermark = 0;
 };
 
+/// Current-text, per-function SGPR liveness cached for one mutation
+/// generation. Bits [0, MaxSgprs) name numbered SGPRs; bit MaxSgprs names VCC.
+struct CurrentFunctionSgprLiveness {
+  uint64_t Generation = 0;
+  unsigned MaxSgprs = 0;
+  bool Valid = false;
+  llvm::DenseMap<uint64_t, size_t> InstructionIndices{0};
+  std::vector<llvm::BitVector> LiveBefore;
+};
+
 struct DirectControlFlowInfo {
   llvm::DenseSet<uint64_t> Targets;
   // Register-based transfers whose complete finite target set was proven.
@@ -1295,6 +1307,12 @@ struct PatchContext {
   llvm::StringMap<std::optional<KernelWorkgroupMetadata>>
       WorkgroupMetadataCache;
   llvm::StringMap<unsigned> KernelVgprGranuleCache;
+  // Immediate .text writes advance this generation. Scratch liveness is
+  // rebuilt from current bytes when a cached function belongs to an older
+  // generation, so earlier patches can never leave the proof stale.
+  uint64_t TextMutationGeneration = 0;
+  llvm::DenseMap<std::pair<uint64_t, uint64_t>, CurrentFunctionSgprLiveness>
+      CurrentFunctionSgprLivenessCache{0};
 };
 
 /// Return occupancy limits for \p Processor from COMGR's ISA metadata table.
@@ -1347,6 +1365,59 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
 bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                 const SafeSgprScratchBlock &Block,
                                 llvm::StringRef Context);
+
+/// Return whether \p DI consumes the incoming value of \p Register, including
+/// explicit read/modify/write destinations represented by MC tied-operand
+/// constraints. This conservative query underpins scratch-register liveness.
+[[nodiscard]] bool instructionReadsRegister(const InternalDecodedInst &DI,
+                                            const LLVMState &LS,
+                                            llvm::MCRegister Register);
+
+/// Return whether \p Replacement may consume the incoming value of \p Register
+/// before overwriting it. Undecodable or control-flow-bearing replacements are
+/// conservatively treated as reads.
+[[nodiscard]] bool
+replacementNeedsIncomingRegister(llvm::ArrayRef<uint8_t> Replacement,
+                                 const LLVMState &LS,
+                                 llvm::MCRegister Register);
+
+/// Return the numbered-SGPR/VCC values consumed by \p Replacement before an
+/// overwrite. Returns nullopt for undecodable or control-flow-bearing bytes.
+/// The result uses the bit numbering documented by
+/// CurrentFunctionSgprLiveness.
+[[nodiscard]] std::optional<llvm::BitVector>
+getReplacementIncomingSgprs(llvm::ArrayRef<uint8_t> Replacement,
+                            const LLVMState &LS, unsigned MaxSgprs);
+
+/// Return the complete numbered-SGPR/VCC live set immediately after
+/// [\p InstOffset, +\p InstSize). One current-function decode and bit-vector
+/// dataflow serves every candidate scratch register. Results are cached for
+/// PatchContext::TextMutationGeneration and fail closed with nullopt.
+[[nodiscard]] std::optional<llvm::BitVector>
+getLiveSgprsAtContinuation(PatchContext &Ctx, uint64_t InstOffset,
+                           uint32_t InstSize);
+
+/// Record an immediate write to PatchContext::Text. writeCurrentText calls this
+/// for byte-range writes; specialized in-place bit writers must call it before
+/// they can perform another liveness query.
+void noteCurrentTextMutation(PatchContext &Ctx);
+
+/// Bounds-check and immediately write \p Bytes into the current .text image.
+/// Every nonempty successful write advances TextMutationGeneration before the
+/// caller can perform another liveness query.
+[[nodiscard]] bool writeCurrentText(PatchContext &Ctx, uint64_t Offset,
+                                    llvm::ArrayRef<uint8_t> Bytes,
+                                    llvm::StringRef Context);
+
+/// Prove that \p Register's incoming value is not read on any path from the
+/// instruction after [\p InstOffset, +\p InstSize) to the owning function's
+/// exits. The proof decodes the current text bytes rather than relying on the
+/// original PatchContext::Decoded snapshot. Prefer the batch SGPR query above
+/// when selecting among multiple candidates.
+[[nodiscard]] bool
+isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx, uint64_t InstOffset,
+                                       uint32_t InstSize,
+                                       llvm::MCRegister Register);
 
 // -- Trampoline emission helpers (defined in b0a0.cpp) ----------
 

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -1390,9 +1390,11 @@ getReplacementIncomingSgprs(llvm::ArrayRef<uint8_t> Replacement,
                             const LLVMState &LS, unsigned MaxSgprs);
 
 /// Return the complete numbered-SGPR/VCC live set immediately after
-/// [\p InstOffset, +\p InstSize). One current-function decode and bit-vector
-/// dataflow serves every candidate scratch register. Results are cached for
-/// PatchContext::TextMutationGeneration and fail closed with nullopt.
+/// [\p InstOffset, +\p InstSize). Both interval endpoints must be decoded
+/// instruction boundaries in the current function. One current-function decode
+/// and bit-vector dataflow serves every candidate scratch register. Results are
+/// cached for PatchContext::TextMutationGeneration and fail closed with
+/// nullopt.
 [[nodiscard]] std::optional<llvm::BitVector>
 getLiveSgprsAtContinuation(PatchContext &Ctx, uint64_t InstOffset,
                            uint32_t InstSize);

--- a/amd/comgr/src/hotswap/rewriter/llvm.cpp
+++ b/amd/comgr/src/hotswap/rewriter/llvm.cpp
@@ -363,6 +363,11 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_endpgm_saved", "s_endpgm_saved", S,
                                      S.SEndPgmSavedOpcode))
     return S;
+  if (!resolveRequiredOpcodeViaParse("s_rfe_i64 s[0:1]", "s_rfe_i64", S,
+                                     S.SRfeI64Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_trap 0", "s_trap", S, S.STrapOpcode))
+    return S;
   if (!resolveRequiredOpcodeViaParse("s_add_pc_i64 0", "s_add_pc_i64", S,
                                      S.SAddPcI64Opcode))
     return S;

--- a/amd/comgr/src/hotswap/rewriter/llvm.cpp
+++ b/amd/comgr/src/hotswap/rewriter/llvm.cpp
@@ -512,6 +512,7 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
     MCInst Inst;
     uint32_t Size;
     std::string Mnemonic;
+    bool DecodeSoftFailed;
   };
   StringMap<DecodeCacheEntry> LocalCache;
   while (Pos < TextSize) {
@@ -527,7 +528,9 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       DI.Size = It->second.Size;
       DI.Inst = It->second.Inst;
       DI.Mnemonic = It->second.Mnemonic;
-      // Only successful decodes are stored, so a hit is always a success.
+      DI.DecodeSoftFailed = It->second.DecodeSoftFailed;
+      // Only non-failing decodes are stored, so a hit always recovered an
+      // instruction. Preserve SoftFail separately for safety-proof callers.
       DI.DecodeSucceeded = true;
       Pos += DI.Size;
       Decoded.emplace_back(std::move(DI));
@@ -544,6 +547,7 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       DI.Mnemonic = UnknownMnemonic.str();
     } else {
       DI.DecodeSucceeded = true;
+      DI.DecodeSoftFailed = Status == MCDisassembler::SoftFail;
       DI.Size = static_cast<uint32_t>(InstSize);
       // MCInstPrinter::getMnemonic returns a pointer into the generated AsmStrs
       // table. Storage is process-lifetime static; the trailing whitespace
@@ -558,11 +562,13 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
         DI.Mnemonic = UnknownMnemonic.str();
       }
     }
-    // Cache only successful decodes whose key window covers the instruction
-    // (Size <= KeyN); a shorter key could alias a different decode.
+    // Cache only non-failing decodes whose key window covers the instruction
+    // (Size <= KeyN); preserve SoftFail in the entry. A shorter key could
+    // alias a different decode.
     if (Status != MCDisassembler::Fail && DI.Size <= KeyN)
-      LocalCache.try_emplace(Key,
-                             DecodeCacheEntry{DI.Inst, DI.Size, DI.Mnemonic});
+      LocalCache.try_emplace(
+          Key,
+          DecodeCacheEntry{DI.Inst, DI.Size, DI.Mnemonic, DI.DecodeSoftFailed});
     Pos += DI.Size;
     Decoded.emplace_back(std::move(DI));
   }

--- a/amd/comgr/src/hotswap/rewriter/patch-inplace.cpp
+++ b/amd/comgr/src/hotswap/rewriter/patch-inplace.cpp
@@ -101,15 +101,14 @@ SmallVector<uint8_t> encodeMCInst(const MCInst &Inst, const LLVMState &LS) {
 /// Perform an opcode swap: clone the decoded MCInst, set the replacement
 /// opcode, re-encode via MCCodeEmitter, and overwrite in place.
 /// Returns true on success.
-bool swapOpcode(InternalDecodedInst &DI, uint8_t *Text, const LLVMState &LS,
+bool swapOpcode(InternalDecodedInst &DI, PatchContext &Ctx,
                 unsigned NewOpcode) {
   MCInst NewInst = DI.Inst;
   NewInst.setOpcode(NewOpcode);
-  SmallVector<uint8_t> Bytes = encodeMCInst(NewInst, LS);
+  SmallVector<uint8_t> Bytes = encodeMCInst(NewInst, Ctx.LS);
   if (Bytes.empty() || Bytes.size() != DI.Size)
     return false;
-  std::memcpy(Text + DI.Offset, Bytes.data(), DI.Size);
-  return true;
+  return writeCurrentText(Ctx, DI.Offset, Bytes, "in-place opcode swap");
 }
 
 } // anonymous namespace
@@ -119,8 +118,9 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
   StringRef Mnemonic(DI.Mnemonic);
 
   if (DI.Inst.getOpcode() == Ctx.LS.SClauseOpcode) {
-    std::memcpy(Ctx.Text + DI.Offset, Ctx.LS.SNopBytes.data(),
-                Ctx.LS.SNopBytes.size());
+    if (!writeCurrentText(Ctx, DI.Offset, Ctx.LS.SNopBytes,
+                          "s_clause in-place replacement"))
+      return 0;
     log() << "hotswap: inplace: s_clause -> s_nop 0 at 0x"
           << utohexstr(DI.Offset) << "\n";
     return 1;
@@ -144,7 +144,7 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
             << utohexstr(DI.Offset) << "\n";
     } else {
       std::optional<unsigned> NewOpcode = resolveOpcode(ReplacementAsm, Ctx.LS);
-      if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
+      if (NewOpcode && swapOpcode(DI, Ctx, *NewOpcode)) {
         log() << "hotswap: inplace: " << Mnemonic << " -> opcode " << *NewOpcode
               << " at 0x" << utohexstr(DI.Offset) << "\n";
         S.addPatches(1);
@@ -183,7 +183,7 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
         Ctx.Profile.time(HotswapMetric::InPlaceBarrierSignal);
     std::optional<unsigned> NewOpcode =
         resolveOpcode("s_barrier_signal -1", Ctx.LS);
-    if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
+    if (NewOpcode && swapOpcode(DI, Ctx, *NewOpcode)) {
       log() << "hotswap: inplace: s_barrier_signal_isfirst -> opcode "
             << *NewOpcode << " at 0x" << utohexstr(DI.Offset) << "\n";
       S.addPatches(1);

--- a/amd/comgr/src/hotswap/rewriter/patch-trampoline.cpp
+++ b/amd/comgr/src/hotswap/rewriter/patch-trampoline.cpp
@@ -840,24 +840,6 @@ bool instructionDefinesBase(const InternalDecodedInst &DI, MCRegister BaseMCReg,
   return false;
 }
 
-// True when \p DI reads \p Reg (uses its value), including implicit uses.
-bool instructionReadsRegister(const InternalDecodedInst &DI, MCRegister Reg,
-                              const LLVMState &LS) {
-  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
-  const MCRegisterInfo &MRI = *LS.MRI;
-  unsigned NumDefs = Desc.getNumDefs();
-  for (unsigned I = NumDefs, E = DI.Inst.getNumOperands(); I < E; ++I) {
-    const MCOperand &Op = DI.Inst.getOperand(I);
-    if (Op.isReg() && Op.getReg() &&
-        MRI.regsOverlap(MCRegister(Op.getReg()), Reg))
-      return true;
-  }
-  for (MCPhysReg Implicit : Desc.implicit_uses())
-    if (MRI.regsOverlap(MCRegister(Implicit), Reg))
-      return true;
-  return false;
-}
-
 bool isTensorDescriptorUseOnly(const InternalDecodedInst &DI,
                                MCRegister BaseMCReg, const LLVMState &LS) {
   if (DI.Inst.getOpcode() != LS.TensorLoadToLdsOpcode)
@@ -1010,7 +992,7 @@ bool isMaskDefinitionSafe(const PatchContext &Ctx,
         writesBasePreservingZeroLow16(DI, BaseMCReg, Ctx.LS);
     if ((State & BaseValueLive) != 0) {
       if (!PreservesBaseValue) {
-        if (instructionReadsRegister(DI, BaseMCReg, Ctx.LS) &&
+        if (instructionReadsRegister(DI, Ctx.LS, BaseMCReg) &&
             !isTensorDescriptorUseOnly(DI, BaseMCReg, Ctx.LS))
           return false;
         if (instructionDefinesBase(DI, BaseMCReg, Ctx.LS))
@@ -1107,7 +1089,7 @@ TensorMaskDef findTensorMaskSetDefinitions(const PatchContext &Ctx,
     }
 
     if (!PreservesBaseValue &&
-        instructionReadsRegister(DI, BaseMCReg, Ctx.LS) &&
+        instructionReadsRegister(DI, Ctx.LS, BaseMCReg) &&
         !isTensorDescriptorUseOnly(DI, BaseMCReg, Ctx.LS))
       return TensorMaskDef::NotApplicable;
 
@@ -1153,7 +1135,8 @@ bool clearWorkgroupMaskAtDefinition(PatchContext &Ctx, size_t Idx) {
           << utohexstr(DI.Offset) << ": " << Asm << "\n";
     return false;
   }
-  std::memcpy(Ctx.Text + DI.Offset, Bytes.data(), Bytes.size());
+  if (!writeCurrentText(Ctx, DI.Offset, Bytes, "tensor descriptor mask clear"))
+    return false;
   DI.Inst.getOperand(2).setImm(static_cast<int64_t>(Cleared));
 
   log() << "hotswap: tensor_load_to_lds: cleared workgroup_mask at descriptor "

--- a/amd/comgr/src/hotswap/rewriter/patch-vop3px2-src2.cpp
+++ b/amd/comgr/src/hotswap/rewriter/patch-vop3px2-src2.cpp
@@ -98,6 +98,7 @@ static uint32_t applyVop3px2Src2FixImpl(PatchContext &Ctx) {
     ++Scanned;
 
     if (patchScaleSrc2(Ctx.Text + DI.Offset)) {
+      noteCurrentTextMutation(Ctx);
       log() << "hotswap: VOP3PX2 SRC2 fix at 0x" << utohexstr(DI.Offset) << ": "
             << DI.Mnemonic << " scale_src2 -> VGPR0\n";
       ++Patched;

--- a/amd/comgr/src/hotswap/rewriter/patch-wmma-hazard.cpp
+++ b/amd/comgr/src/hotswap/rewriter/patch-wmma-hazard.cpp
@@ -257,6 +257,13 @@ static uint32_t applyWmmaHazardPatchImpl(PatchContext &Ctx) {
             << utohexstr(ValuDI.Offset) << "\n";
       continue;
     }
+    if (std::optional<ElfView::FunctionTextRange> Range =
+            Ctx.Elf.findFunctionTextRangeAtOffset(ValuDI.Offset)) {
+      T.HasFunctionRange = true;
+      T.FunctionStart = Range->Begin;
+      T.FunctionEnd = Range->End;
+    }
+    notePendingTrampolineMutation(Ctx, T);
     Ctx.OutTrampolines.push_back(std::move(T));
 
     log() << "hotswap: WMMA hazard fix at 0x" << utohexstr(ValuDI.Offset)

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -286,6 +286,8 @@ TEST(InitLLVM, ValidGfx1250) {
   EXPECT_LT(S.SDelayAluOpcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SEndPgmOpcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SEndPgmSavedOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SRfeI64Opcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.STrapOpcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SAddNcU64Opcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SAddPcI64Opcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SCallI64Opcode, S.MCII->getNumOpcodes());
@@ -1640,6 +1642,485 @@ TEST(AssembleDecode, SNopRoundTrip) {
   EXPECT_TRUE(Decoded[0].DecodeSucceeded);
   EXPECT_EQ(Decoded[0].Size, MinInstSize);
   EXPECT_EQ(Decoded[0].Mnemonic, "s_nop");
+}
+
+static std::optional<llvm::BitVector> getTestLiveSgprsAtContinuation(
+    llvm::StringRef Assembly, uint64_t InstOffset = 0,
+    uint32_t InstSize = MinInstSize, unsigned MaxSgprs = 106) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  if (!S.Valid)
+    return std::nullopt;
+  llvm::SmallVector<uint8_t> Text = assembleInstructions(Assembly, S);
+  if (Text.empty())
+    return std::nullopt;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  if (!ViewOrErr)
+    return std::nullopt;
+  ElfView &View = *ViewOrErr;
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(View.textData(), View.textSize(), S, Decoded))
+    return std::nullopt;
+
+  RewriteConfig Config;
+  Config.MaxSgprs = MaxSgprs;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+  return getLiveSgprsAtContinuation(Ctx, InstOffset, InstSize);
+}
+
+TEST(RegisterLiveness, TiedAccumulatorDefCountsAsIncomingRead) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("v_fmac_f32_e32 v5, v1, v2", S);
+  ASSERT_EQ(Bytes.size(), MinInstSize);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  const InternalDecodedInst &DI = Decoded[0];
+  const llvm::MCInstrDesc &Desc = S.MCII->get(DI.Inst.getOpcode());
+  ASSERT_GE(Desc.getNumDefs(), 1u);
+  ASSERT_GE(DI.Inst.getNumOperands(), 1u);
+  ASSERT_TRUE(DI.Inst.getOperand(0).isReg());
+
+  bool HasTiedAccumulatorUse = false;
+  for (unsigned I = Desc.getNumDefs(); I != Desc.getNumOperands(); ++I)
+    HasTiedAccumulatorUse |=
+        Desc.getOperandConstraint(I, llvm::MCOI::TIED_TO) == 0;
+  ASSERT_TRUE(HasTiedAccumulatorUse);
+
+  llvm::MCRegister Accumulator(DI.Inst.getOperand(0).getReg());
+  EXPECT_TRUE(instructionReadsRegister(DI, S, Accumulator));
+}
+
+TEST(RegisterLiveness, TargetHasNoVariadicDefOpcodes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  unsigned VariadicDefOpcodes = 0;
+  for (unsigned I = 0; I != S.MCII->getNumOpcodes(); ++I) {
+    const llvm::MCInstrDesc &Candidate = S.MCII->get(I);
+    if (Candidate.isVariadic() && Candidate.variadicOpsAreDefs())
+      ++VariadicDefOpcodes;
+  }
+  // The implementation classifies variadic defs precisely for future
+  // subtargets. GFX1250 currently has no such descriptor, so pin that target
+  // fact instead of inventing an invalid MCInst.
+  EXPECT_EQ(VariadicDefOpcodes, 0u);
+}
+
+TEST(RegisterLiveness, ReplacementReadsBeforeOverwrite) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> ReadThenWrite =
+      assembleInstructions("s_mov_b32 s1, s0\ns_mov_b32 s0, 0", S);
+  llvm::SmallVector<uint8_t> WriteThenRead =
+      assembleInstructions("s_mov_b32 s0, 0\ns_mov_b32 s1, s0", S);
+  llvm::SmallVector<uint8_t> RegisterBytes =
+      assembleSingleInst("s_mov_b32 s1, s0", S);
+  ASSERT_FALSE(ReadThenWrite.empty());
+  ASSERT_FALSE(WriteThenRead.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(RegisterBytes.data(), RegisterBytes.size(), S,
+                                Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  ASSERT_TRUE(Decoded[0].Inst.getOperand(1).isReg());
+  llvm::MCRegister Sgpr0(Decoded[0].Inst.getOperand(1).getReg());
+
+  EXPECT_TRUE(replacementNeedsIncomingRegister(ReadThenWrite, S, Sgpr0));
+  EXPECT_FALSE(replacementNeedsIncomingRegister(WriteThenRead, S, Sgpr0));
+
+  std::array<uint8_t, MinInstSize> Undecodable;
+  Undecodable.fill(0xff);
+  EXPECT_TRUE(replacementNeedsIncomingRegister(Undecodable, S, Sgpr0));
+}
+
+TEST(RegisterLiveness, ReplacementBatchHandlesEmptyAndFailClosedInputs) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::optional<llvm::BitVector> Empty =
+      getReplacementIncomingSgprs(/*Replacement=*/{}, S, /*MaxSgprs=*/106);
+  ASSERT_TRUE(Empty);
+  EXPECT_TRUE(Empty->none());
+
+  llvm::SmallVector<uint8_t> Branch = assembleSingleInst("s_branch 0", S);
+  llvm::SmallVector<uint8_t> Trap = assembleSingleInst("s_trap 0", S);
+  llvm::SmallVector<uint8_t> Barrier = assembleSingleInst("s_code_end", S);
+  EXPECT_FALSE(getReplacementIncomingSgprs(Branch, S, /*MaxSgprs=*/106));
+  EXPECT_FALSE(getReplacementIncomingSgprs(Trap, S, /*MaxSgprs=*/106));
+  EXPECT_FALSE(getReplacementIncomingSgprs(Barrier, S, /*MaxSgprs=*/106));
+
+  std::array<uint8_t, MinInstSize> Undecodable;
+  Undecodable.fill(0xff);
+  EXPECT_FALSE(getReplacementIncomingSgprs(Undecodable, S, /*MaxSgprs=*/106));
+  EXPECT_FALSE(getReplacementIncomingSgprs(
+      /*Replacement=*/{}, S, /*MaxSgprs=*/107));
+  EXPECT_FALSE(getReplacementIncomingSgprs(
+      /*Replacement=*/{}, S, std::numeric_limits<unsigned>::max()));
+}
+
+TEST(RegisterLiveness, ConditionalDiamondUnionsBothPaths) {
+  std::optional<llvm::BitVector> Live =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_cbranch_scc1 2\n"
+                                     "s_mov_b32 s0, 0\n"
+                                     "s_branch 1\n"
+                                     "s_mov_b32 s1, s0\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Live);
+  EXPECT_TRUE(Live->test(0));
+  EXPECT_FALSE(Live->test(2));
+}
+
+TEST(RegisterLiveness, LoopConvergesAndPreservesLoopCarriedUse) {
+  std::optional<llvm::BitVector> Live =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     ".Lloop:\n"
+                                     "s_mov_b32 s1, s0\n"
+                                     "s_cbranch_scc1 .Lloop\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Live);
+  EXPECT_TRUE(Live->test(0));
+  EXPECT_FALSE(Live->test(2));
+}
+
+TEST(RegisterLiveness, ExplicitWriteKillsIncomingValueBeforeLaterRead) {
+  std::optional<llvm::BitVector> Live =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_mov_b32 s0, 0\n"
+                                     "s_mov_b32 s1, s0\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Live);
+  EXPECT_FALSE(Live->test(0));
+}
+
+TEST(RegisterLiveness, OutOfFunctionAndNonBoundaryBranchesFailClosed) {
+  std::optional<llvm::BitVector> Outside =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_branch 100\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Outside);
+  EXPECT_TRUE(Outside->all());
+
+  std::optional<llvm::BitVector> NonBoundary =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_branch 1\n"
+                                     "s_mov_b32 s0, 0x12345678\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(NonBoundary);
+  EXPECT_TRUE(NonBoundary->all());
+}
+
+TEST(RegisterLiveness, IndirectCallReturnAndTrapBoundariesFailClosed) {
+  std::optional<llvm::BitVector> Indirect =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_set_pc_i64 s[0:1]\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Indirect);
+  EXPECT_TRUE(Indirect->all());
+
+  std::optional<llvm::BitVector> Call =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_call_i64 s[30:31], 0\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Call);
+  EXPECT_TRUE(Call->test(4));
+
+  std::optional<llvm::BitVector> Return =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_rfe_i64 s[0:1]\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Return);
+  EXPECT_TRUE(Return->test(4));
+
+  std::optional<llvm::BitVector> Trap =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_trap 0\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Trap);
+  EXPECT_TRUE(Trap->all()) << Trap->count() << "/" << Trap->size();
+}
+
+TEST(RegisterLiveness, CodeEndIsARealBarrierAndFailsClosed) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  ASSERT_NE(S.MIA, nullptr);
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst("s_code_end", S);
+  ASSERT_EQ(Bytes.size(), MinInstSize);
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  EXPECT_TRUE(S.MIA->isBarrier(Decoded[0].Inst));
+
+  std::optional<llvm::BitVector> Live =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_code_end\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Live);
+  EXPECT_TRUE(Live->all()) << Live->count() << "/" << Live->size();
+}
+
+TEST(RegisterLiveness, TracksSubregisterAndImplicitVccOverlap) {
+  std::optional<llvm::BitVector> PairUse =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_mov_b64 s[2:3], s[0:1]\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(PairUse);
+  EXPECT_TRUE(PairUse->test(0));
+  EXPECT_TRUE(PairUse->test(1));
+
+  std::optional<llvm::BitVector> ImplicitUse =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_cbranch_vccnz .Lend\n"
+                                     "s_endpgm\n"
+                                     ".Lend:\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(ImplicitUse);
+  EXPECT_TRUE(ImplicitUse->test(106));
+
+  std::optional<llvm::BitVector> ImplicitDef =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "v_cmp_eq_u32_e32 v0, v1\n"
+                                     "s_cbranch_vccnz .Lend\n"
+                                     ".Lend:\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(ImplicitDef);
+  EXPECT_FALSE(ImplicitDef->test(106));
+}
+
+TEST(RegisterLiveness, RejectsFunctionEndAndContinuationOverflow) {
+  std::optional<llvm::BitVector> AtEnd = getTestLiveSgprsAtContinuation(
+      "s_nop 0\n"
+      "s_endpgm",
+      /*InstOffset=*/MinInstSize, /*InstSize=*/MinInstSize);
+  EXPECT_FALSE(AtEnd);
+
+  std::optional<llvm::BitVector> Overflow = getTestLiveSgprsAtContinuation(
+      "s_nop 0\n"
+      "s_endpgm",
+      /*InstOffset=*/std::numeric_limits<uint64_t>::max() - 1,
+      /*InstSize=*/MinInstSize);
+  EXPECT_FALSE(Overflow);
+
+  EXPECT_FALSE(getTestLiveSgprsAtContinuation(
+      "s_nop 0\n"
+      "s_endpgm",
+      /*InstOffset=*/0, /*InstSize=*/MinInstSize, /*MaxSgprs=*/107));
+  EXPECT_FALSE(
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_endpgm",
+                                     /*InstOffset=*/0, /*InstSize=*/MinInstSize,
+                                     std::numeric_limits<unsigned>::max()));
+}
+
+TEST(RegisterLiveness, UsesCurrentTextAfterEarlierPatchMutation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleInstructions("s_clause 0\n"
+                                                         "s_mov_b32 s0, 0\n"
+                                                         "s_endpgm",
+                                                         S);
+  ASSERT_EQ(Text.size(), 3u * MinInstSize);
+
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> OriginalDecoded;
+  ASSERT_TRUE(
+      decodeTextSection(View.textData(), View.textSize(), S, OriginalDecoded));
+  ASSERT_EQ(OriginalDecoded.size(), 3u);
+  ASSERT_TRUE(OriginalDecoded[1].Inst.getOperand(0).isReg());
+  llvm::MCRegister Sgpr0(OriginalDecoded[1].Inst.getOperand(0).getReg());
+
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   OriginalDecoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+
+  EXPECT_TRUE(isRegisterDefinitelyDeadAtContinuation(
+      Ctx, /*InstOffset=*/0, /*InstSize=*/MinInstSize, Sgpr0));
+  ASSERT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Generation,
+            0u);
+  EXPECT_TRUE(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Valid);
+  ASSERT_TRUE(getLiveSgprsAtContinuation(Ctx, /*InstOffset=*/0,
+                                         /*InstSize=*/MinInstSize));
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+
+  // Exercise a complete production writer, not only the generation helper.
+  // The in-place pass rewrites s_clause to s_nop and must invalidate the
+  // existing cache before the next query in this same PatchContext.
+  HotswapPatchVTable VT;
+  registerInPlacePatch(VT);
+  ASSERT_NE(VT.applyInPlacePatches, nullptr);
+  EXPECT_EQ(VT.applyInPlacePatches(Ctx, /*Idx=*/0), 1u);
+  EXPECT_EQ(Ctx.TextMutationGeneration, 1u);
+  EXPECT_TRUE(Ctx.CurrentFunctionSgprLivenessCache.empty());
+  ASSERT_TRUE(getLiveSgprsAtContinuation(Ctx, /*InstOffset=*/0,
+                                         /*InstSize=*/MinInstSize));
+  ASSERT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Generation,
+            1u);
+
+  // An undecodable current instruction cannot support a liveness proof.
+  std::array<uint8_t, MinInstSize> Undecodable;
+  Undecodable.fill(0xff);
+  ASSERT_TRUE(writeCurrentText(Ctx, MinInstSize, Undecodable,
+                               "unit-test undecodable mutation"));
+  EXPECT_TRUE(Ctx.CurrentFunctionSgprLivenessCache.empty());
+  EXPECT_FALSE(isRegisterDefinitelyDeadAtContinuation(
+      Ctx, /*InstOffset=*/0, /*InstSize=*/MinInstSize, Sgpr0));
+  ASSERT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Generation,
+            2u);
+  EXPECT_FALSE(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Valid);
+
+  // Model an earlier patch that consumed a later NOP sled. The original
+  // decoded snapshot still says the continuation overwrites s0, while the
+  // current text now reads its incoming value first.
+  llvm::SmallVector<uint8_t> Patched =
+      assembleSingleInst("s_mov_b32 s1, s0", S);
+  ASSERT_EQ(Patched.size(), MinInstSize);
+  ASSERT_TRUE(writeCurrentText(Ctx, MinInstSize, Patched,
+                               "unit-test live-read mutation"));
+  EXPECT_TRUE(Ctx.CurrentFunctionSgprLivenessCache.empty());
+  ASSERT_EQ(OriginalDecoded[1].Mnemonic, "s_mov_b32");
+  ASSERT_TRUE(OriginalDecoded[1].Inst.getOperand(1).isImm());
+
+  EXPECT_FALSE(isRegisterDefinitelyDeadAtContinuation(
+      Ctx, /*InstOffset=*/0, /*InstSize=*/MinInstSize, Sgpr0));
+  ASSERT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Generation,
+            3u);
+  EXPECT_TRUE(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Valid);
+
+  EXPECT_FALSE(writeCurrentText(Ctx, Ctx.TextSize, Patched,
+                                "unit-test out-of-bounds mutation"));
+  EXPECT_EQ(Ctx.TextMutationGeneration, 3u);
+
+  std::vector<uint8_t> BeforeFailedSled(Ctx.Text, Ctx.Text + Ctx.TextSize);
+  NopSled TooSmall{Ctx.TextSize - MinInstSize, Ctx.TextSize,
+                   Ctx.TextSize - MinInstSize, /*FunctionStart=*/0,
+                   Ctx.TextSize};
+  EXPECT_FALSE(emitToNopSled(Ctx, TooSmall, /*InstOffset=*/0,
+                             /*InstSize=*/MinInstSize, Patched));
+  EXPECT_EQ(BeforeFailedSled,
+            std::vector<uint8_t>(Ctx.Text, Ctx.Text + Ctx.TextSize));
+  EXPECT_EQ(Ctx.TextMutationGeneration, 3u);
+}
+
+TEST(RegisterLiveness, HighCardinalityFunctionUsesOneBoundedBatch) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  constexpr size_t InstructionCount = 16384;
+  llvm::SmallVector<uint8_t> Text;
+  Text.reserve((InstructionCount + 2) * MinInstSize);
+  for (size_t I = 0; I != InstructionCount; ++I)
+    Text.append(S.SNopBytes);
+  llvm::SmallVector<uint8_t> Tail =
+      assembleInstructions("s_mov_b32 s1, s0\ns_endpgm", S);
+  ASSERT_EQ(Tail.size(), 2u * MinInstSize);
+  Text.append(Tail);
+
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+  std::vector<InternalDecodedInst> OriginalDecoded;
+  ASSERT_TRUE(
+      decodeTextSection(View.textData(), View.textSize(), S, OriginalDecoded));
+
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   OriginalDecoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+
+  std::optional<llvm::BitVector> Live = getLiveSgprsAtContinuation(
+      Ctx, /*InstOffset=*/0, /*InstSize=*/MinInstSize);
+  ASSERT_TRUE(Live);
+  ASSERT_EQ(Live->size(), 107u);
+  EXPECT_TRUE(Live->test(0));
+  EXPECT_FALSE(Live->test(2));
+  ASSERT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+  const CurrentFunctionSgprLiveness &Cached =
+      Ctx.CurrentFunctionSgprLivenessCache.begin()->second;
+  EXPECT_EQ(Cached.LiveBefore.size(), InstructionCount + 2);
+  EXPECT_EQ(Cached.InstructionIndices.size(), InstructionCount + 2);
+
+  std::optional<llvm::BitVector> Second = getLiveSgprsAtContinuation(
+      Ctx, /*InstOffset=*/InstructionCount / 2 * MinInstSize,
+      /*InstSize=*/MinInstSize);
+  ASSERT_TRUE(Second);
+  EXPECT_TRUE(Second->test(0));
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
 }
 
 TEST(AssembleDecode, SingleInstructionRejectsSequence) {

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -1983,6 +1983,24 @@ TEST(RegisterLiveness, RejectsFunctionEndAndContinuationOverflow) {
                                      std::numeric_limits<unsigned>::max()));
 }
 
+TEST(RegisterLiveness,
+     RejectsMidInstructionSourceAtDecodedContinuationBoundary) {
+  constexpr llvm::StringLiteral Assembly = "s_mov_b32 s0, 0x12345678\n"
+                                           "s_endpgm";
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleInstructions(Assembly, S);
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Text.data(), Text.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 2u);
+  ASSERT_EQ(Decoded[0].Size, 2u * MinInstSize);
+  ASSERT_EQ(Decoded[1].Offset, 2u * MinInstSize);
+
+  std::optional<llvm::BitVector> Live = getTestLiveSgprsAtContinuation(
+      Assembly, /*InstOffset=*/MinInstSize, /*InstSize=*/MinInstSize);
+  EXPECT_FALSE(Live);
+}
+
 TEST(RegisterLiveness, UsesCurrentTextAfterEarlierPatchMutation) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -1790,9 +1790,11 @@ TEST(RegisterLiveness, ReplacementBatchHandlesEmptyAndFailClosedInputs) {
   llvm::SmallVector<uint8_t> Branch = assembleSingleInst("s_branch 0", S);
   llvm::SmallVector<uint8_t> Trap = assembleSingleInst("s_trap 0", S);
   llvm::SmallVector<uint8_t> Barrier = assembleSingleInst("s_code_end", S);
+  llvm::SmallVector<uint8_t> Return = assembleSingleInst("s_rfe_i64 s[0:1]", S);
   EXPECT_FALSE(getReplacementIncomingSgprs(Branch, S, /*MaxSgprs=*/106));
   EXPECT_FALSE(getReplacementIncomingSgprs(Trap, S, /*MaxSgprs=*/106));
   EXPECT_FALSE(getReplacementIncomingSgprs(Barrier, S, /*MaxSgprs=*/106));
+  EXPECT_FALSE(getReplacementIncomingSgprs(Return, S, /*MaxSgprs=*/106));
 
   std::array<uint8_t, MinInstSize> Undecodable;
   Undecodable.fill(0xff);
@@ -1801,6 +1803,98 @@ TEST(RegisterLiveness, ReplacementBatchHandlesEmptyAndFailClosedInputs) {
       /*Replacement=*/{}, S, /*MaxSgprs=*/107));
   EXPECT_FALSE(getReplacementIncomingSgprs(
       /*Replacement=*/{}, S, std::numeric_limits<unsigned>::max()));
+}
+
+TEST(RegisterLiveness, SoftFailEncodingIsNotAcceptedAsProofInput) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // Ask the MC layer for a valid VOP3 compare, then discover a one-bit
+  // mutation that the same target disassembler diagnoses as SoftFail. This
+  // exercises a real undefined encoding without embedding opcode bits or
+  // operand-field positions in the test.
+  llvm::SmallVector<uint8_t> ValidVop3Compare =
+      assembleSingleInst("v_cmpx_eq_f32_e64 v0, v1", S);
+  ASSERT_EQ(ValidVop3Compare.size(), 2u * MinInstSize);
+  std::optional<llvm::SmallVector<uint8_t>> MalformedVop3Compare;
+  for (size_t Byte = 0;
+       Byte != ValidVop3Compare.size() && !MalformedVop3Compare; ++Byte) {
+    for (unsigned Bit = 0; Bit != 8; ++Bit) {
+      llvm::SmallVector<uint8_t> Candidate = ValidVop3Compare;
+      Candidate[Byte] ^= uint8_t{1} << Bit;
+      llvm::MCInst Inst;
+      uint64_t Size = 0;
+      llvm::MCDisassembler::DecodeStatus Status = S.MCD->getInstruction(
+          Inst, Size, Candidate, /*Address=*/0, llvm::nulls());
+      if (Status == llvm::MCDisassembler::SoftFail &&
+          Size == Candidate.size()) {
+        MalformedVop3Compare = std::move(Candidate);
+        break;
+      }
+    }
+  }
+  ASSERT_TRUE(MalformedVop3Compare);
+
+  const unsigned MaxInstLen = S.MAI->getMaxInstLength(S.STI.get());
+  const size_t RepetitionCount =
+      (MaxInstLen + MalformedVop3Compare->size() * 2 - 1) /
+      MalformedVop3Compare->size();
+  llvm::SmallVector<uint8_t> Repeated;
+  for (size_t I = 0; I != RepetitionCount; ++I)
+    Repeated.append(*MalformedVop3Compare);
+  ASSERT_GE(Repeated.size(), MaxInstLen + MalformedVop3Compare->size());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Repeated.data(), Repeated.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), RepetitionCount);
+  for (const InternalDecodedInst &DI : Decoded) {
+    EXPECT_TRUE(DI.DecodeSucceeded);
+    EXPECT_TRUE(DI.DecodeSoftFailed);
+  }
+  // The periodic buffer gives offsets zero and InstSize identical full-width
+  // cache keys, so the second instruction must be a cache hit. This pins that
+  // the warning status survives caching.
+  EXPECT_FALSE(getReplacementIncomingSgprs(Repeated, S, /*MaxSgprs=*/106));
+
+  llvm::SmallVector<uint8_t> Text = Repeated;
+  llvm::SmallVector<uint8_t> End = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(End.size(), MinInstSize);
+  Text.append(End);
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+  std::vector<InternalDecodedInst> OriginalDecoded;
+  ASSERT_TRUE(
+      decodeTextSection(View.textData(), View.textSize(), S, OriginalDecoded));
+
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   OriginalDecoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/View.textSize(),
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+  EXPECT_FALSE(getLiveSgprsAtContinuation(
+      Ctx, /*InstOffset=*/0, /*InstSize=*/MalformedVop3Compare->size()));
 }
 
 TEST(RegisterLiveness, ConditionalDiamondUnionsBothPaths) {
@@ -2118,6 +2212,107 @@ TEST(RegisterLiveness, UsesCurrentTextAfterEarlierPatchMutation) {
   EXPECT_EQ(BeforeFailedSled,
             std::vector<uint8_t>(Ctx.Text, Ctx.Text + Ctx.TextSize));
   EXPECT_EQ(Ctx.TextMutationGeneration, 3u);
+}
+
+TEST(RegisterLiveness, PendingTrampolineMutationFailsClosedByFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleInstructions(".Lsite:\n"
+                                                         "s_mov_b32 s0, 0\n"
+                                                         "s_nop 0\n"
+                                                         "s_branch .Lsite\n"
+                                                         "s_endpgm",
+                                                         S);
+  ASSERT_EQ(Text.size(), 4u * MinInstSize);
+
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+  std::vector<InternalDecodedInst> OriginalDecoded;
+  ASSERT_TRUE(
+      decodeTextSection(View.textData(), View.textSize(), S, OriginalDecoded));
+  ASSERT_EQ(OriginalDecoded.size(), 4u);
+  ASSERT_TRUE(OriginalDecoded[0].Inst.getOperand(0).isReg());
+  llvm::MCRegister Sgpr0(OriginalDecoded[0].Inst.getOperand(0).getReg());
+
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   OriginalDecoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/View.textSize(),
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+
+  // The original loop overwrites s0 at .Lsite before reading it, so the
+  // continuation after the NOP can initially prove the incoming value dead.
+  EXPECT_TRUE(isRegisterDefinitelyDeadAtContinuation(
+      Ctx, /*InstOffset=*/MinInstSize, /*InstSize=*/MinInstSize, Sgpr0));
+
+  Trampoline Disjoint;
+  Disjoint.OriginalOffset = View.textSize() + MinInstSize;
+  Disjoint.HasFunctionRange = true;
+  Disjoint.FunctionStart = View.textSize();
+  Disjoint.FunctionEnd = View.textSize() + 2 * MinInstSize;
+  notePendingTrampolineMutation(Ctx, Disjoint);
+  Trampolines.push_back(Disjoint);
+  EXPECT_TRUE(isRegisterDefinitelyDeadAtContinuation(
+      Ctx, /*InstOffset=*/MinInstSize, /*InstSize=*/MinInstSize, Sgpr0));
+  Trampolines.clear();
+
+  PatchContext UnknownCtx{Config,
+                          OriginalDecoded,
+                          View.textData(),
+                          View.textSize(),
+                          /*PoolBaseOffset=*/View.textSize(),
+                          S,
+                          Trampolines,
+                          Sleds,
+                          View,
+                          Liveness,
+                          KernelStats,
+                          ScratchPatches,
+                          ControlFlow,
+                          Prof};
+  Trampoline UnknownOwner;
+  UnknownOwner.OriginalOffset = View.textSize() + MinInstSize;
+  notePendingTrampolineMutation(UnknownCtx, UnknownOwner);
+  Trampolines.push_back(UnknownOwner);
+  EXPECT_FALSE(getLiveSgprsAtContinuation(UnknownCtx,
+                                          /*InstOffset=*/MinInstSize,
+                                          /*InstSize=*/MinInstSize));
+  Trampolines.clear();
+
+  // Queue a replacement at .Lsite that consumes the incoming s0. Its source
+  // branch and body remain deferred, so a later proof from the loop backedge
+  // must not decode the stale full-def at .Lsite and report s0 dead.
+  llvm::SmallVector<uint8_t> Replacement =
+      assembleSingleInst("s_mov_b32 s1, s0", S);
+  ASSERT_EQ(Replacement.size(), MinInstSize);
+  ASSERT_TRUE(emitToTrampoline(Ctx, /*InstOffset=*/0,
+                               /*InstSize=*/MinInstSize, Replacement));
+  ASSERT_EQ(Trampolines.size(), 1u);
+  ASSERT_TRUE(Trampolines[0].HasFunctionRange);
+  EXPECT_FALSE(isRegisterDefinitelyDeadAtContinuation(
+      Ctx, /*InstOffset=*/MinInstSize, /*InstSize=*/MinInstSize, Sgpr0));
 }
 
 TEST(RegisterLiveness, HighCardinalityFunctionUsesOneBoundedBatch) {
@@ -3760,6 +3955,75 @@ TEST(PatchScaleSrc2, PreservesNonScaleSrc2Bits) {
   EXPECT_EQ(Inst[7] & 0xF8, 0xF8);
   EXPECT_EQ(Inst[6] & 0xFC, 0x00);
   EXPECT_EQ(Inst[7] & 0x07, 0x04);
+}
+
+TEST(PatchScaleSrc2, VTableMutationInvalidatesCurrentTextLiveness) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleInstructions(
+      "v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[0:15], v[0:15], "
+      "v[0:7], s0, s0\n"
+      "s_endpgm",
+      S);
+  ASSERT_EQ(Text.size(), 5u * MinInstSize);
+  llvm::SmallVector<uint8_t> ExpectedPatchedText = Text;
+  ASSERT_TRUE(patchScaleSrc2(ExpectedPatchedText.data()));
+
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+  std::vector<InternalDecodedInst> OriginalDecoded;
+  ASSERT_TRUE(
+      decodeTextSection(View.textData(), View.textSize(), S, OriginalDecoded));
+  ASSERT_EQ(OriginalDecoded.size(), 2u);
+  ASSERT_EQ(OriginalDecoded[0].Size, 4u * MinInstSize);
+
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   OriginalDecoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/View.textSize(),
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+
+  ASSERT_TRUE(getLiveSgprsAtContinuation(Ctx, /*InstOffset=*/0,
+                                         /*InstSize=*/OriginalDecoded[0].Size));
+  ASSERT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+  EXPECT_EQ(Ctx.TextMutationGeneration, 0u);
+
+  HotswapPatchVTable VT;
+  registerVop3px2Src2Patch(VT);
+  ASSERT_NE(VT.applyVop3px2Src2Fix, nullptr);
+  EXPECT_EQ(VT.applyVop3px2Src2Fix(Ctx), 1u);
+  EXPECT_EQ(Ctx.TextMutationGeneration, 1u);
+  EXPECT_TRUE(Ctx.CurrentFunctionSgprLivenessCache.empty());
+  EXPECT_EQ(llvm::ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
+            llvm::ArrayRef<uint8_t>(ExpectedPatchedText));
+
+  ASSERT_TRUE(getLiveSgprsAtContinuation(Ctx, /*InstOffset=*/0,
+                                         /*InstSize=*/OriginalDecoded[0].Size));
+  ASSERT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Generation,
+            1u);
 }
 
 // -- HotswapPatchVTable -------------------------------------------------------

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -1759,6 +1759,26 @@ TEST(RegisterLiveness, ReplacementReadsBeforeOverwrite) {
   EXPECT_TRUE(replacementNeedsIncomingRegister(Undecodable, S, Sgpr0));
 }
 
+TEST(RegisterLiveness, ReplacementPartialVccDefsDoNotKillAggregate) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  ASSERT_TRUE(S.VCCRegister.isValid());
+
+  llvm::SmallVector<uint8_t> LowDef =
+      assembleInstructions("s_mov_b32 vcc_lo, s0\ns_mov_b32 s1, vcc_hi", S);
+  llvm::SmallVector<uint8_t> HighDef =
+      assembleInstructions("s_mov_b32 vcc_hi, s0\ns_mov_b32 s1, vcc_lo", S);
+  llvm::SmallVector<uint8_t> FullDef =
+      assembleInstructions("s_mov_b64 vcc, -1\ns_mov_b32 s1, vcc_hi", S);
+  ASSERT_FALSE(LowDef.empty());
+  ASSERT_FALSE(HighDef.empty());
+  ASSERT_FALSE(FullDef.empty());
+
+  EXPECT_TRUE(replacementNeedsIncomingRegister(LowDef, S, S.VCCRegister));
+  EXPECT_TRUE(replacementNeedsIncomingRegister(HighDef, S, S.VCCRegister));
+  EXPECT_FALSE(replacementNeedsIncomingRegister(FullDef, S, S.VCCRegister));
+}
+
 TEST(RegisterLiveness, ReplacementBatchHandlesEmptyAndFailClosedInputs) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -1910,6 +1930,32 @@ TEST(RegisterLiveness, TracksSubregisterAndImplicitVccOverlap) {
                                      "s_endpgm");
   ASSERT_TRUE(ImplicitDef);
   EXPECT_FALSE(ImplicitDef->test(106));
+}
+
+TEST(RegisterLiveness, ContinuationPartialVccDefsDoNotKillAggregate) {
+  std::optional<llvm::BitVector> LowDef =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_mov_b32 vcc_lo, s0\n"
+                                     "s_mov_b32 s1, vcc_hi\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(LowDef);
+  EXPECT_TRUE(LowDef->test(106));
+
+  std::optional<llvm::BitVector> HighDef =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_mov_b32 vcc_hi, s0\n"
+                                     "s_mov_b32 s1, vcc_lo\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(HighDef);
+  EXPECT_TRUE(HighDef->test(106));
+
+  std::optional<llvm::BitVector> FullDef =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_mov_b64 vcc, -1\n"
+                                     "s_mov_b32 s1, vcc_hi\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(FullDef);
+  EXPECT_FALSE(FullDef->test(106));
 }
 
 TEST(RegisterLiveness, RejectsFunctionEndAndContinuationOverflow) {


### PR DESCRIPTION
## Scope

Add the fail-closed register-liveness primitive needed to reuse scratch
registers safely in later far-return routing changes. The proof:

- recognizes explicit, implicit, and tied read/modify/write operands;
- determines whether a replacement consumes an incoming register value before
  overwriting it;
- synchronously decodes the owning function from the current `.text` bytes so
  earlier patch writes cannot make a cached decode snapshot stale; and
- rejects undecodable instructions, invalid boundaries, escaping successors,
  calls, returns, and unresolved control flow.

This first replacement is based directly on current `amd-staging`; later
replacement PRs will depend on its exact head. It establishes the liveness
prerequisite but does not activate a new corpus rewrite by itself.

## Review fixes

The review repair commit `eada1e3b9041`:

- makes deferred trampoline mutations visible to current-text liveness;
- treats `s_rfe_i64` as terminating control flow;
- preserves and rejects MC `SoftFail` in safety proofs;
- fails closed on liveness proof gaps and bounds errors;
- invalidates liveness after specialized in-place VOP3PX2 writes; and
- adds focused unit coverage for the repaired paths.

The branch was then merged with the current target in `065af42b4b0a`.

## Validation

Exact head: `065af42b4b0ae8764b19be22d8d4b6176aeb2b99`

Exact corpus baseline: `39f443516c145f27e2255a41a232d565c9acb409`

All qualification checkouts and builds were created on `mi300x`.

- Release `HotswapMCTests`: 143/143 passed
- Release HotSwap LIT: 125/125 passed
- Release supported COMGR LIT: 148/148 passed, 14 unsupported
- Release COMGR CTest: 31/31 passed
- ASAN `HotswapMCTests`: 143/143 passed
- ASAN supported COMGR LIT: 148/148 passed, 14 unsupported
- ASAN COMGR CTest: 31/31 passed
- ASAN/LSAN reports: 0
- `clang-format`, `git diff --check`, focused review, and two independent
  sibling reviews: clean

## Corpus qualification status

Both exact baseline and candidate runs evaluated the same 2,685 paths with the
audited four-gate harness, four workers, 1,800-second rewrite timeouts, and no
exclusions:

| Variant | Success | Failure | Timeout |
| --- | ---: | ---: | ---: |
| baseline | 2,558 | 127 | 0 |
| candidate | 2,558 | 127 | 0 |

- Corpus safety gate: **PASS** — zero new failures and zero worsened retained
  failures.
- Corpus improvement gate: **FAIL** — zero baseline-failure-to-success
  improvements and no strict reduction in the failing set.

The failed improvement gate remains a blocker to an independent `QUALIFIED`
verdict, but under the revised qualification procedure it does not stop
MI400-3 functional testing.

## MI400-3 qualification status

The complete original-library baseline and isolated candidate matrix is complete
on the current Confluence image. Because the original-library sparse suites
aborted, the authoritative candidate matrix was rerun in a second fresh
container as required by the qualification procedure.

Candidate library SHA-256: `960b67ac1ceb80b74d325730d548171efec6c2c75196d16ae664b24c05792663`

| Required test set | Original library | Candidate |
| --- | ---: | ---: |
| HIP named cases | 24/24 pass | 24/24 pass |
| hipTensor quick | 57/57 pass | 57/57 pass |
| rocPRIM quick | 178/178 pass | 177/178 pass |
| rocThrust quick | 336/336 pass | 336/336 pass |
| hipSPARSE quick | 0/4 pass | 0/4 pass |
| rocSPARSE quick | 0/4 pass | 0/4 pass |
| rocSOLVER quick | 2/2 pass | 2/2 pass |
| hipBLASLt quick | 1/1 pass | 1/1 pass |
| rocThrust test 64 | 1/1 pass | 1/1 pass |

The selected quick counts reflect the current procedure: hipTensor uses the
exact `^quick$` label; rocPRIM, rocThrust, and the remaining suites use the
current `quick` selection, including `ffm-quick` where applicable.

Blocking MI400-3 findings:

- Candidate rocPRIM test #204, `test_device_partition_gpus_quick_suite`,
  timed out at 300.11 seconds in the isolated full matrix. A focused fresh
  A/B subsequently passed with both the original library (92 seconds) and the
  exact candidate (94 seconds), so the timeout was not reproducibly
  candidate-specific; the recorded required-matrix timeout still blocks.
- All four hipSPARSE and all four rocSPARSE candidate tests aborted with
  `HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION`, matching the original-library
  failing cases and failure class. hipSPARSE test #9 took about 228 seconds
  with the candidate versus 3.5 seconds in the original baseline.
- The GPU continued to enumerate as gfx1250 after the complete matrix; no GPU
  reset or device loss occurred.

MI400-3 therefore **FAILS** its required pass gate. Together with the failed
corpus improvement gate, PR #3618 is **NOT QUALIFIED** independently. The
corpus safety gate remains PASS: no new or worsened corpus failures.