### PR TITLE
comgr: Accept new amdgpu<subarch> triples in ISA names

### DIFF
--- a/amd/comgr/src/comgr-metadata.cpp
+++ b/amd/comgr/src/comgr-metadata.cpp
@@ -28,8 +28,10 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/TargetParser/AMDGPUTargetParser.h"
 #include <cstddef>
 #include <iostream>
+#include <optional>
 
 using namespace llvm;
 using namespace llvm::object;
@@ -420,11 +422,28 @@ amd_comgr_status_t getElfIsaName(DataObject *DataP, std::string &IsaName) {
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
 }
 
-amd_comgr_status_t getIsaIndex(StringRef IsaString, size_t &Index) {
-  auto IsaName = IsaString.take_until([](char C) { return C == ':'; });
+amd_comgr_status_t getIsaIndex(StringRef TargetIDString, size_t &Index,
+                               StringRef *Processor) {
+  // Validate the target ID and resolve the processor (derived from the subarch
+  // when the name omits it).
+  std::optional<AMDGPU::TargetID> TID =
+      AMDGPU::TargetID::parseTargetIDString(TargetIDString);
+  if (!TID || TID->getGPUKind() == AMDGPU::GK_NONE) {
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  StringRef CanonicalProcessor = AMDGPU::getArchNameAMDGCN(TID->getGPUKind());
+  if (Processor) {
+    *Processor = CanonicalProcessor;
+  }
+
+  // Match by processor only; TargetID already validated the rest of the triple,
+  // so the vendor/os/environ are not checked against the table (which stores an
+  // empty environment).
   auto *IsaIterator = std::find_if(
-      std::begin(IsaInfos), std::end(IsaInfos),
-      [&](const IsaInfo &IsaInfo) { return IsaName == IsaInfo.IsaName; });
+      std::begin(IsaInfos), std::end(IsaInfos), [&](const IsaInfo &IsaInfo) {
+        return CanonicalProcessor == IsaInfo.Processor;
+      });
   if (IsaIterator == std::end(IsaInfos)) {
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
   }

--- a/amd/comgr/src/comgr-metadata.h
+++ b/amd/comgr/src/comgr-metadata.h
@@ -34,7 +34,10 @@ amd_comgr_status_t lookUpCodeObject(DataObject *DataP,
                                     amd_comgr_code_object_info_t *QueryList,
                                     size_t QueryListsize);
 
-amd_comgr_status_t getIsaIndex(const llvm::StringRef IsaName, size_t &Index);
+/// Look up the ISA table index for \p IsaName, optionally reporting the
+/// resolved canonical processor in \p Processor.
+amd_comgr_status_t getIsaIndex(const llvm::StringRef IsaName, size_t &Index,
+                               llvm::StringRef *Processor = nullptr);
 
 bool isSupportedFeature(size_t IsaIndex, llvm::StringRef Feature);
 

--- a/amd/comgr/src/comgr.cpp
+++ b/amd/comgr/src/comgr.cpp
@@ -258,6 +258,13 @@ StringRef COMGR::getComgrHashIdentifier() {
 
 amd_comgr_status_t COMGR::parseTargetIdentifier(StringRef IdentStr,
                                                 TargetIdentifier &Ident) {
+  // Slice out the raw triple fields as StringRefs into IdentStr. They are
+  // echoed verbatim (getIsaMetadata) and extended by callers (the hotswap
+  // pseudo-feature), so they are kept raw rather than sourced from TargetID,
+  // which would normalize the triple and reject the pseudo-feature. Triple
+  // validation is left to getIsaIndex below.
+  //
+  // TODO: Only use AMDGPU::TargetID for this parsing.
   SmallVector<StringRef, 5> IsaNameComponents;
   IdentStr.split(IsaNameComponents, '-', 4);
   if (IsaNameComponents.size() != 5) {
@@ -272,6 +279,8 @@ amd_comgr_status_t COMGR::parseTargetIdentifier(StringRef IdentStr,
   Ident.Features.clear();
   IsaNameComponents[4].split(Ident.Features, ':');
 
+  // The first ':'-separated token is the processor; it may be empty when the
+  // ISA is encoded in an "amdgpu<subarch>" arch instead.
   Ident.Processor = Ident.Features[0];
   Ident.Features.erase(Ident.Features.begin());
 
@@ -283,8 +292,10 @@ amd_comgr_status_t COMGR::parseTargetIdentifier(StringRef IdentStr,
     return AMD_COMGR_STATUS_SUCCESS;
   }
 
+  // Validate the target ID and resolve the canonical processor.
   size_t IsaIndex;
-  amd_comgr_status_t Status = metadata::getIsaIndex(IdentStr, IsaIndex);
+  amd_comgr_status_t Status =
+      metadata::getIsaIndex(IdentStr, IsaIndex, &Ident.Processor);
   if (Status != AMD_COMGR_STATUS_SUCCESS) {
     return Status;
   }

--- a/amd/comgr/src/comgr.cpp
+++ b/amd/comgr/src/comgr.cpp
@@ -258,12 +258,6 @@ StringRef COMGR::getComgrHashIdentifier() {
 
 amd_comgr_status_t COMGR::parseTargetIdentifier(StringRef IdentStr,
                                                 TargetIdentifier &Ident) {
-  // Slice out the raw triple fields as StringRefs into IdentStr. They are
-  // echoed verbatim (getIsaMetadata) and extended by callers (the hotswap
-  // pseudo-feature), so they are kept raw rather than sourced from TargetID,
-  // which would normalize the triple and reject the pseudo-feature. Triple
-  // validation is left to getIsaIndex below.
-  //
   // TODO: Only use AMDGPU::TargetID for this parsing.
   SmallVector<StringRef, 5> IsaNameComponents;
   IdentStr.split(IsaNameComponents, '-', 4);

--- a/amd/comgr/test-lit/parse-isa-name.c
+++ b/amd/comgr/test-lit/parse-isa-name.c
@@ -13,9 +13,79 @@
 // RUN: parse-isa-name "amdgcn-amd-amdhsa--gfx1010:xnack+" SUCCESS
 // RUN: parse-isa-name "" SUCCESS
 
+// COM: The forward-looking "amdgpu<subarch>" arch spelling is accepted in
+// COM: addition to the legacy "amdgcn" arch.
+// RUN: parse-isa-name "amdgpu8.03-amd-amdhsa--gfx803" SUCCESS
+// RUN: parse-isa-name "amdgpu8.01-amd-amdhsa--gfx801:xnack+" SUCCESS
+// RUN: parse-isa-name "amdgpu8.01-amd-amdhsa--gfx801:xnack-" SUCCESS
+// RUN: parse-isa-name "amdgpu9.08-amd-amdhsa--gfx908:sramecc+" SUCCESS
+// RUN: parse-isa-name "amdgpu9.08-amd-amdhsa--gfx908:xnack+:sramecc+" SUCCESS
+// RUN: parse-isa-name "amdgpu9.00-amd-amdhsa--gfx900" SUCCESS
+// RUN: parse-isa-name "amdgpu9.0a-amd-amdhsa--gfx90a" SUCCESS
+// RUN: parse-isa-name "amdgpu10.10-amd-amdhsa--gfx1010:xnack+" SUCCESS
+// RUN: parse-isa-name "amdgpu12.50-amd-amdhsa--gfx1250" SUCCESS
+
+// COM: Generic targets carry a major-only subarch in the new arch field.
+// RUN: parse-isa-name "amdgpu9-amd-amdhsa--gfx9-generic" SUCCESS
+// RUN: parse-isa-name "amdgpu9.4-amd-amdhsa--gfx9-4-generic" SUCCESS
+// RUN: parse-isa-name "amdgpu10.1-amd-amdhsa--gfx10-1-generic" SUCCESS
+// RUN: parse-isa-name "amdgpu12-amd-amdhsa--gfx12-generic" SUCCESS
+
+// COM: A major-family subarch accepts any specific member processor it covers.
+// RUN: parse-isa-name "amdgpu9-amd-amdhsa--gfx900" SUCCESS
+// RUN: parse-isa-name "amdgpu9-amd-amdhsa--gfx906:sramecc+" SUCCESS
+// RUN: parse-isa-name "amdgpu9-amd-amdhsa--gfx90c" SUCCESS
+// RUN: parse-isa-name "amdgpu10.3-amd-amdhsa--gfx1030" SUCCESS
+// RUN: parse-isa-name "amdgpu11-amd-amdhsa--gfx1100" SUCCESS
+// RUN: parse-isa-name "amdgpu12-amd-amdhsa--gfx1201" SUCCESS
+
+// COM: gfx908 / gfx90a are their own major subarches, not covered by amdgpu9.
+// RUN: parse-isa-name "amdgpu9-amd-amdhsa--gfx908" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu9-amd-amdhsa--gfx90a" INVALID_ARGUMENT
+// COM: gfx1200 is family 12, not covered by the amdgpu11 major subarch.
+// RUN: parse-isa-name "amdgpu11-amd-amdhsa--gfx1200" INVALID_ARGUMENT
+
+// COM: Feature validity is keyed on the resolved processor, so xnack/sramecc
+// COM: combinations behave the same regardless of the arch spelling, including
+// COM: via a major-family or generic arch.
+// RUN: parse-isa-name "amdgpu9.0a-amd-amdhsa--gfx90a:xnack+:sramecc+" SUCCESS
+// RUN: parse-isa-name "amdgpu9.0a-amd-amdhsa--gfx90a:xnack-:sramecc-" SUCCESS
+// RUN: parse-isa-name "amdgpu9.0a-amd-amdhsa--gfx90a:xnack+:sramecc-" SUCCESS
+// RUN: parse-isa-name "amdgpu9.0a-amd-amdhsa--gfx90a:xnack-:sramecc+" SUCCESS
+// RUN: parse-isa-name "amdgpu9.42-amd-amdhsa--gfx942:sramecc+" SUCCESS
+// RUN: parse-isa-name "amdgpu9.42-amd-amdhsa--gfx942:sramecc-" SUCCESS
+// RUN: parse-isa-name "amdgpu9.50-amd-amdhsa--gfx950:xnack+:sramecc+" SUCCESS
+// RUN: parse-isa-name "amdgpu9.06-amd-amdhsa--gfx906:xnack-" SUCCESS
+// RUN: parse-isa-name "amdgpu9-amd-amdhsa--gfx900:xnack+" SUCCESS
+// RUN: parse-isa-name "amdgpu9.4-amd-amdhsa--gfx9-4-generic:xnack+:sramecc+" SUCCESS
+
+// COM: gfx900 supports xnack but not sramecc, so a sramecc feature is rejected
+// COM: regardless of the arch spelling; gfx801 supports neither sramecc nor a
+// COM: xnack+sramecc combo.
+// RUN: parse-isa-name "amdgpu9.00-amd-amdhsa--gfx900:xnack+" SUCCESS
+// RUN: parse-isa-name "amdgpu9.00-amd-amdhsa--gfx900:sramecc+" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu9-amd-amdhsa--gfx900:sramecc+" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu8.01-amd-amdhsa--gfx801:sramecc+" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu8.01-amd-amdhsa--gfx801:xnack+:sramecc+" INVALID_ARGUMENT
+
+// COM: Targets without xnack support reject any xnack feature (either polarity),
+// COM: across early, RDNA, and current generations, under the new arch scheme.
+// RUN: parse-isa-name "amdgpu6.00-amd-amdhsa--gfx600:xnack+" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu6.00-amd-amdhsa--gfx600:xnack-" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu8.02-amd-amdhsa--gfx802:xnack+" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu10.30-amd-amdhsa--gfx1030:xnack+" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu11.00-amd-amdhsa--gfx1100:xnack+" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu12.00-amd-amdhsa--gfx1200:xnack-" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu12.50-amd-amdhsa--gfx1250:xnack+" INVALID_ARGUMENT
+
+// COM: The processor may be omitted; it is derived from the subarch.
+// RUN: parse-isa-name "amdgpu9.00-amd-amdhsa--" SUCCESS
+// RUN: parse-isa-name "amdgpu9.0a-amd-amdhsa--" SUCCESS
+// RUN: parse-isa-name "amdgpu12.50-amd-amdhsa--" SUCCESS
+// RUN: parse-isa-name "amdgpu9.00-amd-amdhsa--:xnack+" SUCCESS
+
 // RUN: parse-isa-name "amdgcn-amd-amdhsa--gfx801:xnack+:sramecc+" INVALID_ARGUMENT
 // RUN: parse-isa-name "amdgcn-amd-amdhsa--gfx803:::" INVALID_ARGUMENT
-// RUN: parse-isa-name "amdgcn-amd-amdhsa-opencl-gfx803" INVALID_ARGUMENT
 // RUN: parse-isa-name "amdgcn-amd-amdhsa-gfx803" INVALID_ARGUMENT
 // RUN: parse-isa-name "gfx803" INVALID_ARGUMENT
 // RUN: parse-isa-name " amdgcn-amd-amdhsa--gfx803" INVALID_ARGUMENT
@@ -24,3 +94,41 @@
 // RUN: parse-isa-name "   amdgcn-amd-amdhsa--gfx803  " INVALID_ARGUMENT
 // RUN: parse-isa-name "amdgcn-amd-amdhsa--gfx803  " INVALID_ARGUMENT
 // RUN: parse-isa-name "spirv64-amd-amdhsa--amdgcnspirv:xnack+" INVALID_ARGUMENT
+
+// COM: Malformed inputs with the new "amdgpu<subarch>" arch are still rejected:
+// COM: unsupported feature combo, missing environ separator, surrounding
+// COM: whitespace.
+// RUN: parse-isa-name "amdgpu8.01-amd-amdhsa--gfx801:xnack+:sramecc+" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu8.03-amd-amdhsa--gfx803:::" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu8.03-amd-amdhsa-gfx803" INVALID_ARGUMENT
+// RUN: parse-isa-name " amdgpu8.03-amd-amdhsa--gfx803" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu8.03-amd-amdhsa--gfx803 " INVALID_ARGUMENT
+
+// COM: The environment field may be non-empty (e.g. "llvm", "unknown"); it is
+// COM: validated as part of the triple rather than matched against the ISA
+// COM: table, so any environment forming a valid AMDGPU triple is accepted.
+// RUN: parse-isa-name "amdgpu9.00-amd-amdhsa-llvm-gfx900" SUCCESS
+// RUN: parse-isa-name "amdgcn-amd-amdhsa-llvm-gfx900" SUCCESS
+// RUN: parse-isa-name "amdgpu9.00-amd-amdhsa-unknown-gfx900" SUCCESS
+// RUN: parse-isa-name "amdgcn-amd-amdhsa-opencl-gfx900" SUCCESS
+// COM: A processor still must be consistent with the arch's subarch, regardless
+// COM: of the environment.
+// RUN: parse-isa-name "amdgpu9.00-amd-amdhsa-llvm-gfx803" INVALID_ARGUMENT
+
+// COM: A processor inconsistent with the arch's subarch is rejected.
+// RUN: parse-isa-name "amdgpu9.00-amd-amdhsa--gfx803" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu9.00-amd-amdhsa--gfx90a" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu9-amd-amdhsa--gfx1010" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu12.50-amd-amdhsa--gfx1251" INVALID_ARGUMENT
+
+// COM: An unrecognized "amdgpu<subarch>" arch is rejected, including when no
+// COM: processor is appended to derive from.
+// RUN: parse-isa-name "amdgpufoo-amd-amdhsa--gfx803" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu99.99-amd-amdhsa--" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgcn-amd-amdhsa--" INVALID_ARGUMENT
+
+// COM: The forward-looking "amdgpu" arch must always carry a subarch; a bare
+// COM: "amdgpu" is rejected even with a valid processor appended.
+// RUN: parse-isa-name "amdgpu-amd-amdhsa--gfx900" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu-amd-amdhsa--gfx900:xnack+" INVALID_ARGUMENT
+// RUN: parse-isa-name "amdgpu-amd-amdhsa--" INVALID_ARGUMENT


### PR DESCRIPTION
LLVM now accepts amdgpu triples with a subarch, but clang does not yet emit them (unless explicitly used). Accept the new target spellings as input so everything stays working when clang makes the switch. Use the code in AMDGPUTargetParser as the authoritative way to parse the target ID string. Ideally parseTargetIdentifier would shrink to just marshalling AMDGPU::TargetID fields into the public struct, but this unification requires additional work.

This also liberalizes treatment of the environment field. In the medium term this will start encoding the runtime libraries available, and we don't want to multiply the size of the static isa tables for it.


