### PR TITLE
[Infra] Enable summary for parameterised gha

### DIFF
--- a/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
+++ b/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
@@ -40,7 +40,7 @@ on:
       linux_amdgpu_families:
         type: string
         description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx1201X"
-        default: "gfx94X-dcgpu,gfx110X-all,gfx90a"
+        default: "gfx94x,gfx110x,gfx90a"
       linux_test_labels:
         type: string
         description: "If enabled, reduce test set on Linux to the list of labels prefixed with 'test:'. ex: test:rocprim, test:hipcub"

--- a/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
+++ b/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
@@ -40,7 +40,7 @@ on:
       linux_amdgpu_families:
         type: string
         description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx1201X"
-        default: ""
+        default: "gfx94X-dcgpu,gfx110X-all,gfx90a"
       linux_test_labels:
         type: string
         description: "If enabled, reduce test set on Linux to the list of labels prefixed with 'test:'. ex: test:rocprim, test:hipcub"
@@ -48,7 +48,7 @@ on:
       windows_amdgpu_families:
         type: string
         description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx1201X"
-        default: ""
+        default: "gfx1151"
       windows_test_labels:
         type: string
         description: "If enabled, reduce test set on Windows to the list of labels prefixed with 'test:' ex: test:rocprim, test:hipcub"
@@ -97,6 +97,8 @@ jobs:
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
       build_variant: "release"
+      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || '' }}
+      windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || '' }}      
 
   linux_build_and_test:
     name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}

--- a/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
+++ b/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
@@ -97,8 +97,8 @@ jobs:
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
       build_variant: "release"
-      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || '' }}
-      windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || '' }}      
+      linux_amdgpu_families: ${{ github.event.inputs.linux_amdgpu_families }}
+      windows_amdgpu_families: ${{ github.event.inputs.windows_amdgpu_families }}              
 
   linux_build_and_test:
     name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -126,11 +126,11 @@ jobs:
         id: configure
         env:
           #INPUT_LINUX_AMDGPU_FAMILIES: ${{ github.event.inputs.linux_amdgpu_families }}
-          INPUT_LINUX_AMDGPU_FAMILIES: 'gfx94X-dcgpu,gfx110X-all,gfx1151'
+          LINUX_AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families != '' && inputs.linux_amdgpu_families || 'gfx94x,gfx110x,gfx90a' }}
           LINUX_TEST_LABELS: ${{ github.event.inputs.linux_test_labels }}
           LINUX_USE_PREBUILT_ARTIFACTS: ${{ github.event.inputs.linux_use_prebuilt_artifacts }}
           #INPUT_WINDOWS_AMDGPU_FAMILIES: ${{ github.event.inputs.windows_amdgpu_families }}
-          INPUT_WINDOWS_AMDGPU_FAMILIES: "gfx1151"
+          WINDOWS_AMDGPU_FAMILIES: ${{ inputs.windows_amdgpu_families != '' && inputs.windows_amdgpu_families || 'gfx1151' }}
           WINDOWS_TEST_LABELS: ${{ github.event.inputs.windows_test_labels }}
           WINDOWS_USE_PREBUILT_ARTIFACTS: ${{ github.event.inputs.windows_use_prebuilt_artifacts }}          
           BUILD_VARIANT: ${{ inputs.build_variant }}

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -20,6 +20,14 @@ on:
         description: Prerelease version number such as '2'. This gets appended to the computed version after 'rc', like '7.10.0rc2'
         type: string
         default: ""
+      linux_amdgpu_families:
+        description: 'Comma-separated Linux GPU families. "all" = all, "none" or empty = skip.'
+        type: string
+        default: ""
+      windows_amdgpu_families:
+        description: 'Comma-separated Windows GPU families. "all" = all, "none" or empty = skip.'
+        type: string
+        default: ""          
     outputs:
       enable_build_jobs:
         description: Whether to enable build jobs.


### PR DESCRIPTION
Updates the summary based on linux_amdgpu_families and windows_amdgpu_families

verification links :
PSDB : https://github.com/ROCm/llvm-project/actions/runs/30210963172
Parameterised run: https://github.com/ROCm/llvm-project/actions/runs/30244581346
windows debug:  https://github.com/ROCm/llvm-project/actions/runs/30245287311