### PR TITLE
[X86] Remove stale GCC 13.3 -O2 workaround

### DIFF
--- a/llvm/lib/Target/X86/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/X86/MCTargetDesc/CMakeLists.txt
@@ -28,4 +28,3 @@ add_llvm_component_library(LLVMX86Desc
   ADD_TO_COMPONENT
   X86
   )
-set_source_files_properties(X86MCCodeEmitter.cpp PROPERTIES COMPILE_FLAGS "-O2")


### PR DESCRIPTION
## Summary

Remove the per-source `-O2` override for `X86MCCodeEmitter.cpp` from the
TheRock 7.14 release branch.

## Why

`X86MCCodeEmitter.cpp` on this branch is **byte-identical to
`llvm/llvm-project@main`**, and upstream has never carried a `-O2` override for
it. The override is a release-branch-only carry that upstream does not need.

ROCm commit
[`3afeb1805010`](https://github.com/ROCm/llvm-project/commit/3afeb1805010e0ae546ac02fb40ba47d69ab16aa)
added it to avoid a GCC 13.3.0 `-O3` miscompile
([gcc PR109934](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109934)) that
surfaced as `Unknown immediate size`. The underlying issue is fixed upstream in
[`6d67794d164e`](https://github.com/llvm/llvm-project/commit/6d67794d164ebeedbd287816e1541964fb5d6c99),
which reads `Desc.TSFlags` instead of the local copy. That fix is present at
this branch's current head, so the override no longer provides a correctness
benefit.

The stale override also prevents Release builds from using precompiled headers.
The PCH is built at `-O3` while this source is forced to `-O2`, and Clang
rejects the mismatch:

```
error: OptimizationLevel differs in precompiled file 'hdr.pch' vs. current file
```

(Minimal reproduction with Clang 22.1.2: build a PCH at `-O3`, compile a TU at
`-O2` with `-include-pch`. In-tree the rejected file is CMake's
`cmake_pch.hxx.pch`. Clang validates `OptimizationLevel` as part of the PCH
record, so the mismatch is a hard error, not a warning.)

`amd-main` and `amd-staging` already lack this override; this PR only removes
the stale release-branch carry.

## Validation

All validation used base commit
`46fcb339fb61119b337f973c7ca9e710a319fdd0`, which is this branch's current head.

### Against an unpatched GCC 13.3.0 (the affected compiler)

This is the compiler the workaround existed for, so it is the one that matters.
Ubuntu 24.04's `gcc-13` is `13.3.0-6ubuntu2~24.04.1`; later 13.x point releases
already carry the gcc fix and cannot exercise the miscompile.

Configuration: `Release`, `LLVM_ENABLE_ASSERTIONS=ON`,
`LLVM_TARGETS_TO_BUILD=X86`, no LTO. Assertions are required — under `NDEBUG`
the failure mode is `__builtin_unreachable()` rather than a diagnosable abort.
The emitter TU was confirmed to compile with `-O3` and no `-O2` before testing.

| Configuration | `2008-08-06-RewriterBug.ll` | X86 CodeGen + MC lit |
|---|---|---|
| `Desc.TSFlags` (as shipped), override removed, `-O3` | pass | **6090 tests, 6073 passed, 15 XFAIL, 2 unsupported, 0 unexpected failures** |
| `TSFlags` reverted to the pre-fix form, `-O3` (control) | `UNREACHABLE executed at X86BaseInfo.h:904` | n/a |

The second row is a positive control: it confirms this toolchain really does
miscompile the pre-fix source, so the passing run in the first row is
meaningful rather than a compiler that was silently already fixed.

Note that `getImmFixupKind(TSFlags)` still appears at three other call sites
(`X86MCCodeEmitter.cpp:1624`, `:1630`, `:1637`) which upstream's fix did not
touch. Those sites were compiled by the vulnerable compiler at `-O3` in the
passing configuration above and exercised across all 6090 tests without
failure. This is empirical evidence for those paths, not a proof that the
pattern is immune in general.

### Against Clang 22.1.2 (production-shaped)

Release, ThinLTO, assertions enabled, PCH enabled, ccache bypassed: full
LLVM/MLIR build passed, with the emitter compiled at `-O3 -flto=thin
-include-pch` and no `-O2`.

For completeness, that broader configuration had pre-existing non-X86 failures:
plugin tests conflict with hidden symbol visibility / static LLVM / ThinLTO, the
build intentionally omits the AMDGPU target, and ROCm defaults MLIR threading
off while one Python test expects an enabled thread pool. None involve this
source file or this change.

### Reproducing the GCC 13.3.0 run

```bash
git clone --depth=1 --single-branch --branch release/therock-7.14 \
  https://github.com/ROCm/llvm-project.git src
podman run --rm -v "$PWD:/work" ubuntu:24.04 bash -c '
  apt-get update -qq && apt-get install -y -qq gcc-13 g++-13 cmake ninja-build python3
  sed -i "/set_source_files_properties(X86MCCodeEmitter.cpp/d" \
    /work/src/llvm/lib/Target/X86/MCTargetDesc/CMakeLists.txt
  cmake -G Ninja -S /work/src/llvm -B /work/build -DCMAKE_BUILD_TYPE=Release \
    -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_TARGETS_TO_BUILD=X86 \
    -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13
  ninja -C /work/build llvm-test-depends
  /work/build/bin/llvm-lit -sv /work/src/llvm/test/CodeGen/X86 /work/src/llvm/test/MC/X86
'
```
