### PR TITLE
ci(spirv): build rocThrust for the rocm-examples job

### DIFF
--- a/.github/workflows/spirv-ci-linux-amd-staging.yml
+++ b/.github/workflows/spirv-ci-linux-amd-staging.yml
@@ -15,6 +15,7 @@ env:
   CLR_BUILD: build-clr
   ROCPRIM_BUILD: build-rocprim
   HIPCUB_BUILD: build-hipcub
+  ROCTHRUST_BUILD: build-rocthrust
   ROCRAND_BUILD: build-rocrand
   HIPRAND_BUILD: build-hiprand
   STAGING: staging
@@ -233,6 +234,27 @@ jobs:
           ninja -C "$HIPCUB_BUILD"
           cmake --install "$HIPCUB_BUILD" --prefix $PWD/$STAGING
 
+      # Build rocThrust (header-only; supplies thrust:: iterators to examples).
+      - name: Checkout rocThrust
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ROCm/rocThrust
+          ref: develop
+          path: rocThrust
+          persist-credentials: false
+
+      - name: Configure and install rocThrust
+        run: |
+          cmake -G Ninja -S rocThrust -B "$ROCTHRUST_BUILD" \
+            -DCMAKE_CXX_COMPILER=$PWD/$LLVM_BUILD/bin/clang++ \
+            -DCMAKE_HIP_COMPILER=$PWD/$LLVM_BUILD/bin/clang++ \
+            -DCMAKE_PREFIX_PATH="$PWD/$STAGING;$PWD/$LLVM_BUILD" \
+            -DCMAKE_INSTALL_PREFIX=$PWD/$STAGING \
+            -DBUILD_TEST=OFF \
+            -DBUILD_BENCHMARK=OFF
+          ninja -C "$ROCTHRUST_BUILD"
+          cmake --install "$ROCTHRUST_BUILD" --prefix $PWD/$STAGING
+
       # Build rocRAND.
       - name: Checkout rocRAND
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -288,7 +310,7 @@ jobs:
       - name: Strip binaries
         run: |
           find "$LLVM_BUILD" "$COMGR_BUILD" "$DEVLIBS_BUILD" "$ROCR_BUILD" "$CLR_BUILD" \
-            "$ROCPRIM_BUILD" "$HIPCUB_BUILD" "$ROCRAND_BUILD" "$HIPRAND_BUILD" "$STAGING" \
+            "$ROCPRIM_BUILD" "$HIPCUB_BUILD" "$ROCTHRUST_BUILD" "$ROCRAND_BUILD" "$HIPRAND_BUILD" "$STAGING" \
             -type f \( -executable -o -name '*.so*' -o -name '*.a' \) \
             -exec strip --strip-unneeded {} + 2>/dev/null || true
 
@@ -298,7 +320,7 @@ jobs:
         run: |
           tar -cf linux-build-tree.tar \
             "$LLVM_BUILD" "$COMGR_BUILD" "$DEVLIBS_BUILD" "$ROCR_BUILD" "$CLR_BUILD" \
-            "$ROCPRIM_BUILD" "$HIPCUB_BUILD" "$ROCRAND_BUILD" "$HIPRAND_BUILD" "$STAGING"
+            "$ROCPRIM_BUILD" "$HIPCUB_BUILD" "$ROCTHRUST_BUILD" "$ROCRAND_BUILD" "$HIPRAND_BUILD" "$STAGING"
 
       - name: Upload build tree artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
## Why

`Applications/monte_carlo_pi` was migrated off the CUB-style hipcub iterators that CCCL 3.0 removed (ROCm/rocm-libraries#9931) to the portable `thrust::` iterators — see ROCm/rocm-examples#493. That migration pulls in a rocThrust dependency (`find_package(rocthrust REQUIRED)`), which the SPIRV CI build job doesn't currently install, so the `Test rocm-examples` job would fail at configure with `Could not find rocthrust`.

## What

Add a rocThrust checkout + install into the staging tree so the rocm-examples build can find it:

- Add `ROCTHRUST_BUILD` env var.
- Checkout `ROCm/rocThrust@develop`, configure + install into staging after hipCUB. rocThrust is header-only, so it's a fast configure + install, mirroring the hipCUB step.
- Include the build dir in the strip + tar steps.

## Ordering

The `Test rocm-examples` job stays red until **both** this and rocm-examples#493 land (either order); then the next `amd-staging` run goes green. The job is informational (not a required check), so this doesn't block merges in the meantime.
