### PR TITLE
[Comgr] Add build hardening options to Comgr

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -340,9 +340,15 @@ if (UNIX)
     -fno-rtti -Wall -Wno-attributes -fms-extensions -fvisibility=hidden)
   # TODO: Confirm this is actually needed due to LLVM/Clang code
   list(APPEND AMD_COMGR_PRIVATE_COMPILE_OPTIONS -fno-strict-aliasing)
+  list(APPEND AMD_COMGR_PRIVATE_COMPILE_OPTIONS -fstack-protector-strong)
+  list(APPEND AMD_COMGR_PRIVATE_COMPILE_DEFINITIONS _FORTIFY_SOURCE=2)
   list(APPEND AMD_COMGR_PRIVATE_COMPILE_DEFINITIONS
     _GNU_SOURCE __STDC_LIMIT_MACROS __STDC_CONSTANT_MACROS AMD_COMGR_BUILD)
   list(APPEND AMD_COMGR_PUBLIC_LINKER_OPTIONS -pthread)
+  # Eager RELRO might cause severe performance regressions in situations
+  # that load many versions of comgr at once (i.e. in dozens or hundreds
+  # of processes), so we're using weak RELRO here
+  list(APPEND AMD_COMGR_PRIVATE_LINKER_OPTIONS -Wl,-z,relro)
   if (NOT APPLE AND COMGR_BUILD_SHARED_LIBS)
     configure_file(
       src/exportmap.in


### PR DESCRIPTION
Add stack protector, fortify source, and partial RELRO to the build configuration for Comgr.

These are all build options which mitigate potential binary vulnerabilities. Stack protector inserts stack canaries to prevent buffer overflows escalating into control-flow hijacking. Fortify source inserts checks at libc call points to prevent overflows and silent memory corruption. RELRO is a linking option that adds protection to the global offset table.

These mitigations shouldn't cause any serious performance regressions. Partial RELRO (non-eager) was chosen over full RELRO because full RELRO could potentially cause performance regressions in some cases.

Also, fortify source will cause additional aborts (in the case that there is some form of misused libc call), so that's something that we might need to look out for.

ISSUE ID: [ROCM-26570](https://amd-hub.atlassian.net/browse/ROCM-26570)

[ROCM-26570]: https://amd-hub.atlassian.net/browse/ROCM-26570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ