### PR TITLE
[CI] Update hotswap PR labeler for src/hotswap refactor

### DIFF
--- a/.github/rocm-prs-labeler.yml
+++ b/.github/rocm-prs-labeler.yml
@@ -8,7 +8,9 @@ hotswap:
     - any-glob-to-any-file:
       - amd/comgr/src/hotswap/**
       - amd/comgr/test-lit/hotswap/**
-      - amd/comgr/src/comgr-hotswap*
+      - amd/comgr/test-unit/hotswap/**
+      - amd/comgr/test-lit/comgr-sources/hotswap*
+      - amd/comgr/utils/*hotswap*
 
 device-libs:
   - changed-files:


### PR DESCRIPTION
The hotswap subsystem was reorganized from a flat `src/comgr-hotswap-*.cpp` layout into a structured `src/hotswap/{common,rewriter,raiser}/` directory in 31b98b4 ([Comgr][HotSwap] Refactor hotswap related files into their own directory). The `hotswap` auto-label globs in `.github/rocm-prs-labeler.yml` still referenced the old layout, so they no longer track the moved files.

Changes to the `hotswap` label globs:

- **Drop** `amd/comgr/src/comgr-hotswap*` — the flat files were deleted by the refactor, so this glob can no longer match anything.
- **Add** `amd/comgr/test-unit/hotswap/**` — the refactor created a new unit-test tree (`test-unit/hotswap/{raiser,rewriter}/`) that nothing labeled.
- **Add** `amd/comgr/test-lit/comgr-sources/hotswap*` and `amd/comgr/utils/*hotswap*` — catch the stray hotswap-named files (test input + fast-stub generator) that the directory globs miss.
- **Keep** `amd/comgr/src/hotswap/**` and `amd/comgr/test-lit/hotswap/**` — still valid under the new layout.

Verified all 164 hotswap-named paths on `amd-staging` are matched by the updated globs, with none left unmatched.
