### PR TITLE
[cmake] Remove ROCm rocm-llvm backward-compat symlink install

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1589,18 +1589,6 @@ if (LLVM_INCLUDE_UTILS AND LLVM_INCLUDE_TOOLS)
   add_subdirectory(utils/llvm-locstats)
 endif()
 
-# Following variables are required for ROCM backwards compatibility,
-# and should be removed in ROCM 7.0 release.
-set(ROCM_LLVM_BACKWARD_COMPAT_LINK "" CACHE STRING "Old rocm-llvm install path")
-set(ROCM_LLVM_BACKWARD_COMPAT_LINK_TARGET "" CACHE STRING "New rocm-llvm install path")
-if (NOT ROCM_LLVM_BACKWARD_COMPAT_LINK STREQUAL "" AND
-    NOT ROCM_LLVM_BACKWARD_COMPAT_LINK_TARGET STREQUAL "")
-  install(CODE "execute_process(\
-                COMMAND ${CMAKE_COMMAND} -E create_symlink \
-                ${ROCM_LLVM_BACKWARD_COMPAT_LINK_TARGET} \
-                ${ROCM_LLVM_BACKWARD_COMPAT_LINK})")
-endif()
-
 if (XCODE)
   # For additional targets that you would like to add schemes, specify e.g:
   #


### PR DESCRIPTION
This install block (added in 487ce6df495f) creates a legacy rocm-llvm symlink only when ROCM_LLVM_BACKWARD_COMPAT_LINK and *_TARGET are both set. Its own comment states it should be removed in the ROCm 7.0 release, which has since shipped. Nothing in-tree sets these variables.

Remove the dead backward-compatibility block to converge with trunk.


