### PR TITLE
[comgr][hotswap] Integrate zero-failure gfx1250 corpus stack

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -5365,14 +5365,14 @@ static bool validateAbiControlTransferModes(
 ///   v_readlane s31, SavedHighVgpr, SavedHighLane
 ///   s_set_pc_i64 s[30:31]
 ///
-/// Both saved VGPRs must be in CSR_AMDGPU_VGPRs, so nested C/Fast/Cold callees
-/// preserve them (SIRegisterInfo::getCallPreservedMask). The locations may
-/// straddle a VGPR boundary when the compiler packs a large SGPR spill into
-/// consecutive wave lanes. A function-local CFG fixed point additionally
-/// proves every caller write to either saved physical VGPR addresses a
-/// different persistent destination bank, writes a different lane, or is the
-/// exact prologue save. Calls are permitted only in full VGPR-MSB mode zero,
-/// the mode required at both call entry and return.
+/// Functions with nested calls must save into CSR_AMDGPU_VGPRs, so nested
+/// C/Fast/Cold callees preserve the lanes
+/// (SIRegisterInfo::getCallPreservedMask). A leaf may use any numbered VGPR:
+/// the function-local CFG proof below establishes that no path clobbers the
+/// saved lanes before the return. The locations may straddle a VGPR boundary
+/// when the compiler packs a large SGPR spill into consecutive wave lanes.
+/// Calls are permitted only in full VGPR-MSB mode zero, the mode required at
+/// both call entry and return.
 static bool validateCanonicalAbiFrameReturns(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, const ElfView::FunctionTextRange &Range,
@@ -5633,9 +5633,13 @@ static bool validateCanonicalAbiFrameReturns(
     std::optional<unsigned> SavedHighIndex =
         CandidateHigh ? numberedVgprIndex(*LS.MRI, CandidateHigh->Vgpr)
                       : std::nullopt;
+    bool SavedLanesSurviveNestedTransfer =
+        SavedLowIndex && SavedHighIndex &&
+        ((!ForceFullCanonicalFrame && !HasNestedCall) ||
+         (isAbiCalleeSavedVgpr(*SavedLowIndex) &&
+          isAbiCalleeSavedVgpr(*SavedHighIndex)));
     if (!Low || !High || !CandidateLow || !CandidateHigh || !SavedLowIndex ||
-        !SavedHighIndex || !isAbiCalleeSavedVgpr(*SavedLowIndex) ||
-        !isAbiCalleeSavedVgpr(*SavedHighIndex) ||
+        !SavedHighIndex || !SavedLanesSurviveNestedTransfer ||
         *CandidateLow == *CandidateHigh ||
         (SavedLow && !(*SavedLow == *CandidateLow)) ||
         (SavedHigh && !(*SavedHigh == *CandidateHigh)))
@@ -8303,6 +8307,417 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
   return true;
 }
 
+/// Collapse dense pair-only far sites onto one text gateway per scratch pair.
+///
+/// The first affine gateway maps source PCs into an object-wide sparse prefix.
+/// Each four-byte first-level stub branches to a nearby 12-byte regional
+/// gateway, which applies a second affine delta into a bounded sparse prefix
+/// whose stubs can reach their corresponding bodies with ordinary s_branch.
+/// The source and both affine levels use only the pair already reserved for
+/// the return edge and do not modify SCC.
+static bool
+planHierarchicalMirroredStubGateways(PatchContext &Ctx,
+                                     std::vector<NopSled> &TextGateways) {
+  struct Candidate {
+    size_t Index = 0;
+    unsigned PairBase = 0;
+    bool UsesVcc = false;
+  };
+  using BucketKey = std::pair<unsigned, bool>;
+  std::map<BucketKey, SmallVector<Candidate, 64>> Buckets;
+
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
+    uint64_t ThisTP = TP;
+    std::optional<uint64_t> Next = checkedAddUint64(
+        TP, T.Bytes.size(), "hierarchical mirrored pool layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+    if (!T.Long || !T.UsesSetPCBack || T.LongBranchPreservesVcc ||
+        T.UsesSharedDispatcherForward || T.UsesMirroredStubForward ||
+        T.OriginalSize < 2 * MinInstSize ||
+        isSBranchReachable(T.OriginalOffset, ThisTP))
+      continue;
+    std::optional<SmallVector<uint8_t>> Direct =
+        encodeSetPCLongBranch(Ctx.LS, T.OriginalOffset, ThisTP,
+                              T.LongBranchSgprBase, T.LongBranchUsesVcc);
+    if (Direct && Direct->size() <= T.OriginalSize)
+      continue;
+    Buckets[{T.LongBranchSgprBase, T.LongBranchUsesVcc}].push_back(
+        {I, T.LongBranchSgprBase, T.LongBranchUsesVcc});
+  }
+
+  constexpr size_t MinHierarchicalSites = 16;
+  constexpr size_t MaxRegionSites = 1024;
+  constexpr uint64_t MaxRegionBytes = 120 * 1024;
+  constexpr uint64_t GatewayBytes = 3 * MinInstSize;
+
+  struct RegionPlan {
+    SmallVector<size_t, 32> Members;
+    uint64_t MinSource = 0;
+    uint64_t MaxSource = 0;
+    uint32_t PrefixBytes = 0;
+    uint32_t GatewayDisplacement = 0;
+    uint32_t RegionGroup = 0;
+  };
+
+  BitVector Assigned(Ctx.OutTrampolines.size());
+  SmallVector<size_t, 64> HierarchicalOrder;
+  uint32_t NextSuperGroup = 1;
+  uint32_t NextRegionGroup = 1;
+  for (const Trampoline &T : Ctx.OutTrampolines) {
+    NextSuperGroup = std::max(NextSuperGroup, T.HierarchicalMirroredGroup + 1);
+    NextRegionGroup = std::max(NextRegionGroup, T.MirroredStubGroup + 1);
+  }
+  uint64_t PlannedSites = 0;
+  uint64_t PlannedSuperGroups = 0;
+  uint64_t PlannedRegions = 0;
+
+  for (auto &BucketEntry : Buckets) {
+    SmallVector<Candidate, 64> &BucketCandidates = BucketEntry.second;
+    if (BucketCandidates.size() < MinHierarchicalSites)
+      continue;
+    llvm::sort(BucketCandidates,
+               [&](const Candidate &LHS, const Candidate &RHS) {
+                 return Ctx.OutTrampolines[LHS.Index].OriginalOffset <
+                        Ctx.OutTrampolines[RHS.Index].OriginalOffset;
+               });
+
+    const auto &[PairBase, UsesVcc] = BucketEntry.first;
+    SmallVector<std::pair<size_t, size_t>, 32> Chunks;
+    Chunks.push_back({0, BucketCandidates.size()});
+    for (size_t ChunkCursor = 0; ChunkCursor != Chunks.size(); ++ChunkCursor) {
+      const auto [ChunkBegin, ChunkEnd] = Chunks[ChunkCursor];
+      size_t ChunkSize = ChunkEnd - ChunkBegin;
+      assert(ChunkSize >= MinHierarchicalSites);
+      ArrayRef<Candidate> Candidates(BucketCandidates.data() + ChunkBegin,
+                                     ChunkSize);
+      auto SplitChunk = [&] {
+        if (ChunkSize < 2 * MinHierarchicalSites)
+          return;
+        size_t Middle = ChunkBegin + ChunkSize / 2;
+        Chunks.push_back({ChunkBegin, Middle});
+        Chunks.push_back({Middle, ChunkEnd});
+      };
+      uint64_t GlobalMin =
+          Ctx.OutTrampolines[Candidates.front().Index].OriginalOffset;
+      uint64_t GlobalMax =
+          Ctx.OutTrampolines[Candidates.back().Index].OriginalOffset;
+      std::optional<uint64_t> GlobalSpan =
+          checkedAddUint64(GlobalMax - GlobalMin, MinInstSize,
+                           "hierarchical mirrored global sparse prefix");
+      if (!GlobalSpan || *GlobalSpan > std::numeric_limits<uint32_t>::max()) {
+        SplitChunk();
+        continue;
+      }
+
+      uint64_t Median =
+          Ctx.OutTrampolines[Candidates[Candidates.size() / 2].Index]
+              .OriginalOffset;
+      auto DirectCallFits = [&](uint64_t Source, uint64_t Target) {
+        const std::string Pair = UsesVcc
+                                     ? "vcc"
+                                     : "s[" + std::to_string(PairBase) + ":" +
+                                           std::to_string(PairBase + 1) + "]";
+        return encodeDirectCall(Ctx.LS, Source, Target, Pair).size() ==
+               MinInstSize;
+      };
+      SmallVector<std::pair<uint64_t, size_t>, 32> GatewayCandidates;
+      for (size_t I = 0; I != TextGateways.size(); ++I) {
+        const NopSled &Sled = TextGateways[I];
+        uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+        bool CoversEverySource =
+            llvm::all_of(Candidates, [&](const Candidate &C) {
+              uint64_t Source = Ctx.OutTrampolines[C.Index].OriginalOffset;
+              return Source >= Sled.FunctionStart && Source < Sled.FunctionEnd;
+            });
+        if (!CoversEverySource || Sled.WritePos > UsableEnd ||
+            GatewayBytes > UsableEnd - Sled.WritePos)
+          continue;
+        uint64_t Distance = Median > Sled.WritePos ? Median - Sled.WritePos
+                                                   : Sled.WritePos - Median;
+        // A gateway directly callable from both extremes needs no scarce
+        // branch-island backbone. Sort those first, then try nearby routed
+        // alternatives transactionally instead of committing the first
+        // median-nearest gateway even when its corridor is disconnected.
+        if (DirectCallFits(GlobalMin, Sled.WritePos) &&
+            DirectCallFits(GlobalMax, Sled.WritePos))
+          Distance = 0;
+        GatewayCandidates.push_back({Distance, I});
+      }
+      llvm::sort(GatewayCandidates);
+      if (GatewayCandidates.empty()) {
+        log() << "hotswap: hierarchical affine pair s[" << PairBase << ":"
+              << PairBase + 1 << "] has no object-wide 12-byte gateway for "
+              << Candidates.size() << " source site(s)\n";
+        SplitChunk();
+        continue;
+      }
+
+      std::vector<NopSled> TrialGateways;
+      uint64_t GlobalGateway = 0;
+      DenseMap<uint64_t, uint64_t> TailTargets;
+      SmallVector<uint64_t, 16> Anchors;
+      constexpr size_t MaxGatewayTrials = 32;
+      bool BackboneValid = false;
+      for (size_t Trial = 0;
+           Trial != std::min(MaxGatewayTrials, GatewayCandidates.size());
+           ++Trial) {
+        std::vector<NopSled> CandidateGateways = TextGateways;
+        uint64_t CandidateGateway =
+            CandidateGateways[GatewayCandidates[Trial].second].WritePos;
+        DenseSet<uint64_t> GlobalGatewaySlots;
+        for (uint64_t Offset = 0; Offset != GatewayBytes; Offset += MinInstSize)
+          GlobalGatewaySlots.insert(CandidateGateway + Offset);
+        subtractOccupiedBranchGatewaySlots(CandidateGateways,
+                                           GlobalGatewaySlots);
+
+        DenseMap<uint64_t, uint64_t> CandidateTailTargets;
+        SmallVector<uint64_t, 16> CandidateAnchors;
+        auto AddBackbonePath = [&](uint64_t Source) {
+          if (DirectCallFits(Source, CandidateGateway))
+            return true;
+          std::optional<SmallVector<uint64_t, 4>> Path =
+              allocateForwardBranchIslands(CandidateGateways, Source,
+                                           CandidateGateway);
+          if (!Path)
+            return false;
+          for (size_t I = 0; I != Path->size(); ++I) {
+            uint64_t Target =
+                I + 1 == Path->size() ? CandidateGateway : (*Path)[I + 1];
+            auto Existing = CandidateTailTargets.find((*Path)[I]);
+            if (Existing != CandidateTailTargets.end() &&
+                Existing->second != Target)
+              return false;
+            CandidateTailTargets[(*Path)[I]] = Target;
+            if (!llvm::is_contained(CandidateAnchors, (*Path)[I]))
+              CandidateAnchors.push_back((*Path)[I]);
+          }
+          return true;
+        };
+        if (!AddBackbonePath(GlobalMin) || !AddBackbonePath(GlobalMax))
+          continue;
+        TrialGateways = std::move(CandidateGateways);
+        GlobalGateway = CandidateGateway;
+        TailTargets = std::move(CandidateTailTargets);
+        Anchors = std::move(CandidateAnchors);
+        BackboneValid = true;
+        break;
+      }
+      if (!BackboneValid) {
+        log() << "hotswap: hierarchical affine pair s[" << PairBase << ":"
+              << PairBase + 1
+              << "] could not allocate its object-wide island backbone\n";
+        SplitChunk();
+        continue;
+      }
+
+      DenseMap<size_t, SmallVector<uint64_t, 4>> SourcePaths;
+      bool PathsValid = true;
+      for (const Candidate &C : Candidates) {
+        const Trampoline &T = Ctx.OutTrampolines[C.Index];
+        if (DirectCallFits(T.OriginalOffset, GlobalGateway))
+          continue;
+        std::optional<uint64_t> First;
+        uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
+        for (uint64_t Anchor : Anchors) {
+          if (!DirectCallFits(T.OriginalOffset, Anchor))
+            continue;
+          uint64_t Distance = T.OriginalOffset > Anchor
+                                  ? T.OriginalOffset - Anchor
+                                  : Anchor - T.OriginalOffset;
+          if (Distance < BestDistance) {
+            BestDistance = Distance;
+            First = Anchor;
+          }
+        }
+        if (!First) {
+          PathsValid = false;
+          break;
+        }
+        SmallVector<uint64_t, 4> Path;
+        uint64_t Cursor = *First;
+        size_t Steps = 0;
+        while (Cursor != GlobalGateway) {
+          Path.push_back(Cursor);
+          auto Target = TailTargets.find(Cursor);
+          if (Target == TailTargets.end() || ++Steps > Anchors.size()) {
+            PathsValid = false;
+            break;
+          }
+          Cursor = Target->second;
+        }
+        if (!PathsValid)
+          break;
+        SourcePaths[C.Index] = std::move(Path);
+      }
+      if (!PathsValid) {
+        log() << "hotswap: hierarchical affine pair s[" << PairBase << ":"
+              << PairBase + 1
+              << "] could not attach every source to its backbone\n";
+        SplitChunk();
+        continue;
+      }
+
+      SmallVector<RegionPlan, 8> Regions;
+      for (const Candidate &C : Candidates) {
+        const Trampoline &T = Ctx.OutTrampolines[C.Index];
+        if (Regions.empty())
+          Regions.push_back({});
+        RegionPlan *Region = &Regions.back();
+        uint64_t NewMin =
+            Region->Members.empty() ? T.OriginalOffset : Region->MinSource;
+        uint64_t NewMax = T.OriginalOffset;
+        uint64_t ExistingBodyBytes = 0;
+        for (size_t Index : Region->Members)
+          ExistingBodyBytes += Ctx.OutTrampolines[Index].Bytes.size();
+        uint64_t Prefix = NewMax - NewMin + MinInstSize;
+        if (!Region->Members.empty() &&
+            (Region->Members.size() == MaxRegionSites ||
+             Prefix > MaxRegionBytes ||
+             ExistingBodyBytes > MaxRegionBytes - Prefix ||
+             T.Bytes.size() > MaxRegionBytes - Prefix - ExistingBodyBytes)) {
+          Regions.push_back({});
+          Region = &Regions.back();
+          NewMin = NewMax = T.OriginalOffset;
+          Prefix = MinInstSize;
+        }
+        Region->Members.push_back(C.Index);
+        Region->MinSource = NewMin;
+        Region->MaxSource = NewMax;
+        Region->PrefixBytes = static_cast<uint32_t>(Prefix);
+      }
+
+      DenseSet<uint64_t> GlobalStubDwords;
+      for (const Candidate &C : Candidates)
+        GlobalStubDwords.insert(Ctx.OutTrampolines[C.Index].OriginalOffset);
+      DenseSet<uint64_t> RegionGatewayDwords;
+      bool RegionsValid = true;
+      for (RegionPlan &Region : Regions) {
+        uint64_t Low = Region.MaxSource > MaxSledDistance
+                           ? Region.MaxSource - MaxSledDistance
+                           : GlobalMin;
+        Low = std::max(Low, GlobalMin);
+        uint64_t High =
+            std::min(Region.MinSource + MaxSledDistance,
+                     GlobalMax >= 2 * MinInstSize ? GlobalMax - 2 * MinInstSize
+                                                  : GlobalMin);
+        Low += (MinInstSize - Low % MinInstSize) % MinInstSize;
+        std::optional<uint64_t> Gap;
+        for (uint64_t Offset = Low; Offset <= High; Offset += MinInstSize) {
+          if (GlobalStubDwords.contains(Offset) ||
+              GlobalStubDwords.contains(Offset + MinInstSize) ||
+              GlobalStubDwords.contains(Offset + 2 * MinInstSize) ||
+              RegionGatewayDwords.contains(Offset) ||
+              RegionGatewayDwords.contains(Offset + MinInstSize) ||
+              RegionGatewayDwords.contains(Offset + 2 * MinInstSize))
+            continue;
+          bool Reachable = llvm::all_of(Region.Members, [&](size_t Index) {
+            uint64_t Source =
+                Ctx.OutTrampolines[Index].OriginalOffset - GlobalMin;
+            return isSBranchReachable(Source, Offset - GlobalMin);
+          });
+          if (!Reachable)
+            continue;
+          Gap = Offset;
+          break;
+        }
+        if (!Gap || *Gap < GlobalMin ||
+            *Gap - GlobalMin > std::numeric_limits<uint32_t>::max()) {
+          RegionsValid = false;
+          break;
+        }
+        Region.GatewayDisplacement = static_cast<uint32_t>(*Gap - GlobalMin);
+        for (uint64_t I = 0; I != GatewayBytes; I += MinInstSize)
+          RegionGatewayDwords.insert(*Gap + I);
+      }
+      if (!RegionsValid) {
+        log() << "hotswap: hierarchical affine pair s[" << PairBase << ":"
+              << PairBase + 1
+              << "] has no collision-free regional gateway gap\n";
+        SplitChunk();
+        continue;
+      }
+
+      uint32_t SuperGroup = NextSuperGroup++;
+      size_t SuperOwnerIndex = Regions.front().Members.front();
+      for (RegionPlan &Region : Regions) {
+        Region.RegionGroup = NextRegionGroup++;
+        size_t RegionOwnerIndex = Region.Members.front();
+        Trampoline &RegionOwner = Ctx.OutTrampolines[RegionOwnerIndex];
+        if (Region.PrefixBytes >
+                std::numeric_limits<size_t>::max() - RegionOwner.Bytes.size() ||
+            Region.PrefixBytes > std::numeric_limits<uint32_t>::max() -
+                                     RegionOwner.PoolEntryPrefixBytes) {
+          log() << "hotswap: error: hierarchical region prefix overflows its "
+                   "pool owner at source 0x"
+                << utohexstr(RegionOwner.OriginalOffset) << "\n";
+          return false;
+        }
+        RegionOwner.Bytes.insert(RegionOwner.Bytes.begin(), Region.PrefixBytes,
+                                 uint8_t{0});
+        RegionOwner.PoolEntryPrefixBytes += Region.PrefixBytes;
+        RegionOwner.HierarchicalRegionPrefixBytes = Region.PrefixBytes;
+        for (size_t Index : Region.Members) {
+          Trampoline &T = Ctx.OutTrampolines[Index];
+          T.UsesMirroredStubForward = true;
+          T.UsesHierarchicalMirroredStubForward = true;
+          T.MirroredStubGroup = Region.RegionGroup;
+          T.HierarchicalMirroredGroup = SuperGroup;
+          T.HierarchicalRegionGatewayDisplacement = Region.GatewayDisplacement;
+          T.MirroredStubGatewayOffset = GlobalGateway;
+          T.ForwardBranchTargetOffset = GlobalGateway;
+          auto Path = SourcePaths.find(Index);
+          if (Path != SourcePaths.end())
+            T.ForwardBranchIslands = std::move(Path->second);
+          Assigned.set(Index);
+          HierarchicalOrder.push_back(Index);
+        }
+      }
+      Trampoline &SuperOwner = Ctx.OutTrampolines[SuperOwnerIndex];
+      if (*GlobalSpan >
+              std::numeric_limits<size_t>::max() - SuperOwner.Bytes.size() ||
+          *GlobalSpan > std::numeric_limits<uint32_t>::max() -
+                            SuperOwner.PoolEntryPrefixBytes) {
+        log() << "hotswap: error: hierarchical global prefix overflows its "
+                 "pool owner at source 0x"
+              << utohexstr(SuperOwner.OriginalOffset) << "\n";
+        return false;
+      }
+      SuperOwner.Bytes.insert(SuperOwner.Bytes.begin(), *GlobalSpan,
+                              uint8_t{0});
+      SuperOwner.PoolEntryPrefixBytes += static_cast<uint32_t>(*GlobalSpan);
+      SuperOwner.HierarchicalGlobalPrefixBytes =
+          static_cast<uint32_t>(*GlobalSpan);
+
+      TextGateways = std::move(TrialGateways);
+      PlannedSites += Candidates.size();
+      ++PlannedSuperGroups;
+      PlannedRegions += Regions.size();
+    }
+  }
+
+  if (PlannedSites == 0)
+    return true;
+
+  std::vector<Trampoline> Reordered;
+  Reordered.reserve(Ctx.OutTrampolines.size());
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I)
+    if (!Assigned.test(I))
+      Reordered.push_back(std::move(Ctx.OutTrampolines[I]));
+  for (size_t Index : HierarchicalOrder)
+    Reordered.push_back(std::move(Ctx.OutTrampolines[Index]));
+  Ctx.OutTrampolines = std::move(Reordered);
+
+  log() << "hotswap: planned " << PlannedSuperGroups
+        << " hierarchical mirrored gateway group(s) with " << PlannedRegions
+        << " bounded region(s) for " << PlannedSites
+        << " pair-only source site(s)\n";
+  return true;
+}
+
 /// Plan a relocation-neutral shared gateway for far sites that have only the
 /// pair already reserved for their return edge. Each source records its own PC
 /// and branches to a common SCC-neutral add/set-PC sequence:
@@ -8555,7 +8970,8 @@ static bool planMirroredStubGateways(PatchContext &Ctx,
 
   for (size_t I = 0; I != Ctx.OutTrampolines.size();) {
     Trampoline &First = Ctx.OutTrampolines[I];
-    if (!First.UsesMirroredStubForward) {
+    if (!First.UsesMirroredStubForward ||
+        First.UsesHierarchicalMirroredStubForward) {
       ++I;
       continue;
     }
@@ -8565,6 +8981,7 @@ static bool planMirroredStubGateways(PatchContext &Ctx,
     uint64_t MaxSource = First.OriginalOffset;
     while (I + Count != Ctx.OutTrampolines.size() &&
            Ctx.OutTrampolines[I + Count].UsesMirroredStubForward &&
+           !Ctx.OutTrampolines[I + Count].UsesHierarchicalMirroredStubForward &&
            Ctx.OutTrampolines[I + Count].MirroredStubGroup == Group) {
       MinSource =
           std::min(MinSource, Ctx.OutTrampolines[I + Count].OriginalOffset);
@@ -9025,6 +9442,192 @@ SmallVector<size_t, 8> promotionCandidateOrderForTest(
   return Order;
 }
 
+static bool emitHierarchicalMirroredStubGateways(PatchContext &Ctx) {
+  DenseMap<uint32_t, SmallVector<size_t, 32>> SuperGroups;
+  DenseMap<uint32_t, SmallVector<size_t, 32>> Regions;
+  SmallVector<uint64_t, 64> PoolOffsets;
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    PoolOffsets.push_back(TP);
+    Trampoline &T = Ctx.OutTrampolines[I];
+    if (T.UsesHierarchicalMirroredStubForward) {
+      SuperGroups[T.HierarchicalMirroredGroup].push_back(I);
+      Regions[T.MirroredStubGroup].push_back(I);
+    }
+    std::optional<uint64_t> Next = checkedAddUint64(
+        TP, T.Bytes.size(), "hierarchical mirrored final layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+  }
+
+  for (auto &SuperEntry : SuperGroups) {
+    ArrayRef<size_t> Members = SuperEntry.second;
+    if (Members.empty())
+      continue;
+    auto fail = [&](Twine Reason) {
+      log() << "hotswap: error: hierarchical mirrored group "
+            << SuperEntry.first << ": " << Reason << "\n";
+      return false;
+    };
+    size_t SuperOwnerIndex = Ctx.OutTrampolines.size();
+    for (size_t Index : Members)
+      if (Ctx.OutTrampolines[Index].HierarchicalGlobalPrefixBytes != 0) {
+        SuperOwnerIndex = Index;
+        break;
+      }
+    if (SuperOwnerIndex == Ctx.OutTrampolines.size())
+      return fail("has no global-prefix owner");
+    Trampoline &SuperOwner = Ctx.OutTrampolines[SuperOwnerIndex];
+    uint64_t GlobalStubBase = PoolOffsets[SuperOwnerIndex];
+    uint32_t GlobalPrefixBytes = SuperOwner.HierarchicalGlobalPrefixBytes;
+    if (GlobalPrefixBytes < MinInstSize ||
+        GlobalPrefixBytes > SuperOwner.Bytes.size())
+      return fail("has an invalid global sparse prefix");
+    for (uint64_t Offset = 0; Offset < GlobalPrefixBytes; Offset += MinInstSize)
+      std::memcpy(SuperOwner.Bytes.data() + Offset, Ctx.LS.SNopBytes.data(),
+                  MinInstSize);
+
+    uint64_t GlobalMin = Ctx.OutTrampolines[Members.front()].OriginalOffset;
+    for (size_t Index : Members)
+      GlobalMin = std::min(GlobalMin, Ctx.OutTrampolines[Index].OriginalOffset);
+    std::optional<uint64_t> SourcePc = checkedAddUint64(
+        GlobalMin, MinInstSize, "hierarchical mirrored minimum source PC");
+    if (!SourcePc || GlobalStubBase < *SourcePc)
+      return fail("cannot encode its global affine delta");
+    uint64_t GlobalDelta = GlobalStubBase - *SourcePc;
+    if (GlobalDelta > std::numeric_limits<uint32_t>::max())
+      return fail("global affine delta exceeds literal32");
+    const std::string Pair =
+        SuperOwner.LongBranchUsesVcc
+            ? "vcc"
+            : "s[" + std::to_string(SuperOwner.LongBranchSgprBase) + ":" +
+                  std::to_string(SuperOwner.LongBranchSgprBase + 1) + "]";
+    SmallVector<std::string, 2> GlobalGatewayLines;
+    GlobalGatewayLines.push_back("s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" +
+                                 utohexstr(GlobalDelta));
+    GlobalGatewayLines.push_back("s_set_pc_i64 " + Pair);
+    SuperOwner.ForwardGatewayBytes =
+        assembleInstructions(joinAsmLines(GlobalGatewayLines), Ctx.LS);
+    if (SuperOwner.ForwardGatewayBytes.empty() ||
+        SuperOwner.ForwardGatewayBytes.size() > 3 * MinInstSize)
+      return fail("global affine gateway did not encode in 12 bytes");
+    SuperOwner.HasForwardGateway = true;
+    SuperOwner.ForwardGatewayOffset = SuperOwner.MirroredStubGatewayOffset;
+
+    DenseSet<uint32_t> EmittedRegions;
+    for (size_t Index : Members) {
+      const Trampoline &Member = Ctx.OutTrampolines[Index];
+      if (!EmittedRegions.insert(Member.MirroredStubGroup).second)
+        continue;
+      ArrayRef<size_t> RegionMembers = Regions[Member.MirroredStubGroup];
+      if (RegionMembers.empty())
+        return fail(Twine("has empty region ") +
+                    Twine(Member.MirroredStubGroup));
+      size_t RegionOwnerIndex = Ctx.OutTrampolines.size();
+      for (size_t RegionMember : RegionMembers)
+        if (Ctx.OutTrampolines[RegionMember].HierarchicalRegionPrefixBytes !=
+            0) {
+          RegionOwnerIndex = RegionMember;
+          break;
+        }
+      if (RegionOwnerIndex == Ctx.OutTrampolines.size())
+        return fail(Twine("region ") + Twine(Member.MirroredStubGroup) +
+                    " has no sparse-prefix owner");
+      Trampoline &RegionOwner = Ctx.OutTrampolines[RegionOwnerIndex];
+      uint64_t RegionMin =
+          Ctx.OutTrampolines[RegionMembers.front()].OriginalOffset;
+      uint64_t RegionMax = RegionMin;
+      for (size_t RegionMember : RegionMembers) {
+        RegionMin = std::min(RegionMin,
+                             Ctx.OutTrampolines[RegionMember].OriginalOffset);
+        RegionMax = std::max(RegionMax,
+                             Ctx.OutTrampolines[RegionMember].OriginalOffset);
+      }
+      uint64_t RegionPrefixBytes = RegionOwner.HierarchicalRegionPrefixBytes;
+      if (RegionPrefixBytes != RegionMax - RegionMin + MinInstSize)
+        return fail(Twine("region ") + Twine(Member.MirroredStubGroup) +
+                    " sparse-prefix size does not match its source span");
+      uint64_t RegionPrefixByteOffset =
+          RegionOwnerIndex == SuperOwnerIndex ? GlobalPrefixBytes : 0;
+      if (RegionPrefixByteOffset > RegionOwner.Bytes.size() ||
+          RegionPrefixBytes > RegionOwner.Bytes.size() - RegionPrefixByteOffset)
+        return fail(Twine("region ") + Twine(Member.MirroredStubGroup) +
+                    " sparse prefix is outside its owner");
+      for (uint64_t Offset = 0; Offset < RegionPrefixBytes;
+           Offset += MinInstSize)
+        std::memcpy(RegionOwner.Bytes.data() + RegionPrefixByteOffset + Offset,
+                    Ctx.LS.SNopBytes.data(), MinInstSize);
+
+      uint64_t RegionStubBase =
+          PoolOffsets[RegionOwnerIndex] + RegionPrefixByteOffset;
+      uint64_t GlobalRegionBase = GlobalStubBase + (RegionMin - GlobalMin);
+      if (RegionStubBase < GlobalRegionBase)
+        return fail(Twine("region ") + Twine(Member.MirroredStubGroup) +
+                    " requires a negative affine delta");
+      uint64_t RegionDelta = RegionStubBase - GlobalRegionBase;
+      if (RegionDelta > std::numeric_limits<uint32_t>::max())
+        return fail(Twine("region ") + Twine(Member.MirroredStubGroup) +
+                    " affine delta exceeds literal32");
+      SmallVector<std::string, 2> RegionGatewayLines;
+      RegionGatewayLines.push_back("s_add_nc_u64 " + Pair + ", " + Pair +
+                                   ", 0x" + utohexstr(RegionDelta));
+      RegionGatewayLines.push_back("s_set_pc_i64 " + Pair);
+      SmallVector<uint8_t> RegionGateway =
+          assembleInstructions(joinAsmLines(RegionGatewayLines), Ctx.LS);
+      uint64_t GatewayDisplacement =
+          RegionOwner.HierarchicalRegionGatewayDisplacement;
+      if (RegionGateway.empty() || RegionGateway.size() > 3 * MinInstSize ||
+          GatewayDisplacement > GlobalPrefixBytes ||
+          RegionGateway.size() > GlobalPrefixBytes - GatewayDisplacement)
+        return fail(Twine("region ") + Twine(Member.MirroredStubGroup) +
+                    " gateway is outside the global sparse prefix");
+      std::memcpy(SuperOwner.Bytes.data() + GatewayDisplacement,
+                  RegionGateway.data(), RegionGateway.size());
+
+      uint64_t RegionGatewayOffset = GlobalStubBase + GatewayDisplacement;
+      for (size_t RegionMember : RegionMembers) {
+        const Trampoline &T = Ctx.OutTrampolines[RegionMember];
+        uint64_t GlobalStubOffset =
+            GlobalStubBase + (T.OriginalOffset - GlobalMin);
+        SmallVector<uint8_t> ToRegion =
+            Ctx.LS.encodeSBranch(GlobalStubOffset, RegionGatewayOffset);
+        if (ToRegion.size() != MinInstSize)
+          return fail(Twine("region ") + Twine(Member.MirroredStubGroup) +
+                      " global stub for source 0x" +
+                      Twine(utohexstr(T.OriginalOffset)) + " at 0x" +
+                      Twine(utohexstr(GlobalStubOffset)) +
+                      " cannot reach regional gateway 0x" +
+                      Twine(utohexstr(RegionGatewayOffset)));
+        std::memcpy(SuperOwner.Bytes.data() + (T.OriginalOffset - GlobalMin),
+                    ToRegion.data(), ToRegion.size());
+
+        uint64_t RegionStubOffset =
+            RegionStubBase + (T.OriginalOffset - RegionMin);
+        uint64_t BodyOffset =
+            PoolOffsets[RegionMember] + T.PoolEntryPrefixBytes;
+        SmallVector<uint8_t> ToBody =
+            Ctx.LS.encodeSBranch(RegionStubOffset, BodyOffset);
+        if (ToBody.size() != MinInstSize)
+          return fail(
+              Twine("region ") + Twine(Member.MirroredStubGroup) +
+              " stub for source 0x" + Twine(utohexstr(T.OriginalOffset)) +
+              " at 0x" + Twine(utohexstr(RegionStubOffset)) +
+              " cannot reach body 0x" + Twine(utohexstr(BodyOffset)) +
+              " (region owner source=0x" +
+              Twine(utohexstr(RegionOwner.OriginalOffset)) + ", owner pool=0x" +
+              Twine(utohexstr(PoolOffsets[RegionOwnerIndex])) +
+              ", member pool=0x" + Twine(utohexstr(PoolOffsets[RegionMember])) +
+              ")");
+        std::memcpy(RegionOwner.Bytes.data() + RegionPrefixByteOffset +
+                        (T.OriginalOffset - RegionMin),
+                    ToBody.data(), ToBody.size());
+      }
+    }
+  }
+  return true;
+}
+
 static bool emitMirroredStubGateways(PatchContext &Ctx) {
   DenseMap<uint32_t, SmallVector<size_t, 32>> Groups;
   SmallVector<uint64_t, 64> PoolOffsets;
@@ -9032,7 +9635,7 @@ static bool emitMirroredStubGateways(PatchContext &Ctx) {
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     PoolOffsets.push_back(TP);
     Trampoline &T = Ctx.OutTrampolines[I];
-    if (T.UsesMirroredStubForward)
+    if (T.UsesMirroredStubForward && !T.UsesHierarchicalMirroredStubForward)
       Groups[T.MirroredStubGroup].push_back(I);
     std::optional<uint64_t> Next =
         checkedAddUint64(TP, T.Bytes.size(), "mirrored-stub final layout");
@@ -9142,6 +9745,7 @@ assignLongBranchGateways(PatchContext &Ctx,
   DenseMap<uint64_t, uint64_t> EarlySourceGatewayOwnerOffsets;
   DenseMap<uint64_t, uint64_t> ReservedBackboneOwnerOffsets;
   DenseMap<uint64_t, uint64_t> LateDirectSuffixOwnerOffsets;
+  DenseSet<uint64_t> ForceOneDwordForwardSources;
   const std::vector<ElfView::FunctionTextRange> FunctionRanges =
       Ctx.Elf.functionTextRanges();
   const FunctionRangeUniquenessIndex FunctionRangeIndex(FunctionRanges,
@@ -9306,13 +9910,32 @@ assignLongBranchGateways(PatchContext &Ctx,
           encodeSetPCLongBranch(Ctx.LS, T.OriginalOffset, ThisTP,
                                 T.LongBranchSgprBase, T.LongBranchUsesVcc);
       if (Direct && Direct->size() <= T.OriginalSize) {
+        uint64_t DirectSuffixBegin = Direct->size();
+        // A sufficiently large/coalesced source will commit this fixed-width
+        // direct set-PC prefix during ordinary mode selection. Its remaining
+        // instruction window is then unreachable, so offer one 12-byte
+        // gateway to the pair-only affine planner now. The encoded target may
+        // move when affine groups are reordered, but the set-PC layout width
+        // and therefore this suffix boundary remain stable.
+        constexpr uint64_t AffineGatewayBytes = 3 * MinInstSize;
+        if (!T.LongBranchPreservesVcc &&
+            Direct->size() + AffineGatewayBytes <= T.OriginalSize) {
+          uint64_t Gateway = T.OriginalOffset + Direct->size();
+          if (HasSafeTail(T, Gateway, Gateway + AffineGatewayBytes)) {
+            EarlySourceGatewayOwnerOffsets[Gateway] = T.OriginalOffset;
+            Gateways.push_back({Gateway, Gateway + AffineGatewayBytes, Gateway,
+                                0, std::numeric_limits<uint64_t>::max(),
+                                /*GatewayOnly=*/true});
+            DirectSuffixBegin += AffineGatewayBytes;
+          }
+        }
         // A direct set-PC sequence consumes only its prefix. Once ordinary
         // mode selection commits that sequence, a safe dword in the remaining
         // source window is unreachable and can serve the same sparse
         // backbone. Keep at most one suffix candidate per owner.
         if (!T.LongBranchPreservesVcc &&
-            Direct->size() + MinInstSize <= T.OriginalSize) {
-          for (uint64_t RelativeOffset = Direct->size();
+            DirectSuffixBegin + MinInstSize <= T.OriginalSize) {
+          for (uint64_t RelativeOffset = DirectSuffixBegin;
                RelativeOffset + MinInstSize <= T.OriginalSize;
                RelativeOffset += MinInstSize) {
             uint64_t Suffix = T.OriginalOffset + RelativeOffset;
@@ -9391,7 +10014,8 @@ assignLongBranchGateways(PatchContext &Ctx,
                           /*GatewayOnly=*/true});
     }
 
-    if (!planMirroredStubGateways(Ctx, Gateways))
+    if (!planHierarchicalMirroredStubGateways(Ctx, Gateways) ||
+        !planMirroredStubGateways(Ctx, Gateways))
       return false;
     DenseMap<uint64_t, size_t> TrampolineAtOriginalOffset;
     for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I)
@@ -9418,13 +10042,13 @@ assignLongBranchGateways(PatchContext &Ctx,
         if (Owner == SourceTailIslandOwners.end())
           continue;
         Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+        // Consuming a pair-backed owner's +4 dword is safe when that owner
+        // receives any one-dword forward transfer. If it did not join a
+        // shared affine group, defer the proof to ordinary mode selection and
+        // prohibit the longer direct set-PC form that would overlap the tail.
         if (OwnerT.UsesSetPCBack && !OwnerT.UsesMirroredStubForward &&
-            !OwnerT.UsesSharedDispatcherForward) {
-          log() << "hotswap: error: affine relay owner at 0x"
-                << utohexstr(OwnerT.OriginalOffset)
-                << " did not receive a mirrored route\n";
-          return false;
-        }
+            !OwnerT.UsesSharedDispatcherForward)
+          ForceOneDwordForwardSources.insert(OwnerT.OriginalOffset);
         uint64_t To = I + 1 == T.ForwardBranchIslands.size()
                           ? T.ForwardBranchTargetOffset
                           : T.ForwardBranchIslands[I + 1];
@@ -9435,6 +10059,9 @@ assignLongBranchGateways(PatchContext &Ctx,
         }
       }
     }
+    if (!ForceOneDwordForwardSources.empty())
+      log() << "hotswap: forced " << ForceOneDwordForwardSources.size()
+            << " affine relay owner(s) onto one-dword forward routes\n";
     for (const Trampoline &T : Ctx.OutTrampolines) {
       if (!T.UsesMirroredStubForward)
         continue;
@@ -9448,7 +10075,9 @@ assignLongBranchGateways(PatchContext &Ctx,
       OwnerT.SourceTailGatewayBytes = 3 * MinInstSize;
     }
     const auto DispatcherEmitStart = std::chrono::steady_clock::now();
-    if (!emitSharedDispatchers(Ctx) || !emitMirroredStubGateways(Ctx))
+    if (!emitSharedDispatchers(Ctx) ||
+        !emitHierarchicalMirroredStubGateways(Ctx) ||
+        !emitMirroredStubGateways(Ctx))
       return false;
     log() << "hotswap: shared/affine gateway emission took "
           << std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -9504,7 +10133,8 @@ assignLongBranchGateways(PatchContext &Ctx,
         std::memcpy(T.Bytes.data(), Ctx.LS.SNopBytes.data(), MinInstSize);
       continue;
     }
-    if (T.UsesSetPCBack) {
+    if (T.UsesSetPCBack &&
+        !ForceOneDwordForwardSources.contains(T.OriginalOffset)) {
       std::optional<SmallVector<uint8_t>> Direct =
           T.LongBranchPreservesVcc
               ? encodeSetPcGateway(Ctx.LS, T.OriginalOffset, TP,

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -3125,11 +3125,31 @@ static SmallVector<SymbolLessReturnRegion, 8> collectSymbolLessReturnRegions(
     Groups[Inserted.first->second].Continuations.push_back(Call.Continuation);
   }
 
+  DenseSet<uint64_t> RejectedRegionEntries;
+  RejectedRegionEntries.insert(DeclaredEntries.begin(), DeclaredEntries.end());
+  RejectedRegionEntries.insert(ExternalEntries.begin(), ExternalEntries.end());
+  size_t RetainedGroups = 0;
+  for (size_t I = 0; I != Groups.size(); ++I) {
+    if (RejectedRegionEntries.contains(Groups[I].Entry))
+      continue;
+    if (RetainedGroups != I)
+      Groups[RetainedGroups] = std::move(Groups[I]);
+    ++RetainedGroups;
+  }
+  Groups.resize(RetainedGroups);
+  if (Groups.empty())
+    return {};
+
   DenseMap<uint64_t, size_t> OffsetToIndex;
   for (size_t I = 0; I != Decoded.size(); ++I)
     OffsetToIndex.try_emplace(Decoded[I].Offset, I);
 
   SmallVector<SymbolLessReturnRegion, 8> Regions;
+  // Track overlap components as regions are proven instead of retaining every
+  // overlapping instruction vector until a final quadratic pass. A value of
+  // -1 is unclaimed, -2 belongs to an already-invalid overlap component, and
+  // every nonnegative value names the sole still-valid owning region.
+  std::vector<int64_t> RegionOwner;
   for (CallGroup &Group : Groups) {
     DenseMap<uint64_t, size_t>::const_iterator Entry =
         OffsetToIndex.find(Group.Entry);
@@ -3341,27 +3361,47 @@ static SmallVector<SymbolLessReturnRegion, 8> collectSymbolLessReturnRegions(
       if (!Safe)
         break;
     }
-    if (Safe)
-      Regions.push_back(std::move(Region));
+    if (!Safe)
+      continue;
+
+    if (RegionOwner.empty())
+      RegionOwner.assign(Decoded.size(), -1);
+    bool Overlaps = false;
+    SmallVector<size_t, 4> OverlappingOwners;
+    for (size_t InstIndex : Region.Instructions) {
+      int64_t Owner = RegionOwner[InstIndex];
+      if (Owner == -1)
+        continue;
+      Overlaps = true;
+      if (Owner >= 0 &&
+          !llvm::is_contained(OverlappingOwners, static_cast<size_t>(Owner)))
+        OverlappingOwners.push_back(static_cast<size_t>(Owner));
+    }
+    if (Overlaps) {
+      // Preserve the transitive overlap component as a compact tombstone so a
+      // later region touching either side is rejected without retaining any
+      // of the invalid regions' instruction vectors.
+      for (size_t Owner : OverlappingOwners) {
+        for (size_t InstIndex : Regions[Owner].Instructions)
+          RegionOwner[InstIndex] = -2;
+        Regions[Owner] = SymbolLessReturnRegion{};
+      }
+      for (size_t InstIndex : Region.Instructions)
+        RegionOwner[InstIndex] = -2;
+      continue;
+    }
+
+    size_t Owner = Regions.size();
+    for (size_t InstIndex : Region.Instructions)
+      RegionOwner[InstIndex] = static_cast<int64_t>(Owner);
+    Regions.push_back(std::move(Region));
   }
 
-  // Two independently inferred call entries may not claim a shared body.
-  BitVector Claimed(Decoded.size());
-  BitVector Overlap(Regions.size());
-  for (size_t I = 0; I != Regions.size(); ++I)
-    for (size_t InstIndex : Regions[I].Instructions) {
-      if (Claimed.test(InstIndex)) {
-        Overlap.set(I);
-        for (size_t J = 0; J != I; ++J)
-          if (llvm::is_contained(Regions[J].Instructions, InstIndex))
-            Overlap.set(J);
-      }
-      Claimed.set(InstIndex);
-    }
+  // Empty slots are regions invalidated by a later overlap.
   SmallVector<SymbolLessReturnRegion, 8> Disjoint;
-  for (size_t I = 0; I != Regions.size(); ++I)
-    if (!Overlap.test(I))
-      Disjoint.push_back(std::move(Regions[I]));
+  for (SymbolLessReturnRegion &Region : Regions)
+    if (!Region.Instructions.empty())
+      Disjoint.push_back(std::move(Region));
   return Disjoint;
 }
 

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2843,6 +2843,8 @@ static amd_comgr_status_t retargetCodeObjectImpl(
           << "parseable ELF64 (" << toString(ViewOrErr.takeError()) << ").\n";
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
   }
+  if (Prof)
+    Profile.add(HotswapMetric::ElfParse, profNowNs() - ParseT0, 0);
   ElfView &Elf = *ViewOrErr;
   if (ViewOrErr->textSize() == 0) {
     if (!Elf.isValidDataOnlyObject()) {
@@ -2850,8 +2852,11 @@ static amd_comgr_status_t retargetCodeObjectImpl(
                "describe a valid data-only code object.\n";
       return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
     }
+    uint64_t OutCopyT0 = Prof ? profNowNs() : 0;
     std::unique_ptr<WritableMemoryBuffer> Result =
         copyOutputBuffer(ElfData, ElfSize, "data-only");
+    if (Prof)
+      Profile.add(HotswapMetric::OutputCopy, profNowNs() - OutCopyT0, 0);
     if (!Result)
       return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
     Out = std::move(Result);
@@ -2859,8 +2864,6 @@ static amd_comgr_status_t retargetCodeObjectImpl(
              "returning a byte-identical copy.\n";
     return AMD_COMGR_STATUS_SUCCESS;
   }
-  if (Prof)
-    Profile.add(HotswapMetric::ElfParse, profNowNs() - ParseT0, 0);
 
   // The CPU name and s_nop padding bytes are the only rewrite state the fast
   // path needs; both are also carried by LLVMState on the MC path. Holding them

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1684,6 +1684,71 @@ struct ReachingCallGroup {
   SmallVector<size_t, 8> Calls;
 };
 
+static std::optional<uint64_t>
+getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
+                    uint64_t TextAddr, uint64_t TextEnd);
+
+/// A reusable target value remains valid after a call only when the exact local
+/// callee is fully decoded, returns through the call's link pair, and cannot
+/// transitively or directly clobber the target pair.
+static bool calleePreservesReusableTarget(
+    uint64_t Target, MCRegister TargetRegister, MCRegister ReturnRegister,
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextEnd,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
+  const ElfView::FunctionTextRange *Callee = nullptr;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin == Target && Range.Begin >= TextAddr &&
+        Range.End > Range.Begin && Range.End <= TextEnd &&
+        (!Callee || Range.End < Callee->End))
+      Callee = &Range;
+  if (!Callee)
+    return false;
+
+  uint64_t CalleeBegin = Callee->Begin - TextAddr;
+  uint64_t CalleeEnd = Callee->End - TextAddr;
+  bool SawInstruction = false;
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (DI.Offset < CalleeBegin || DI.Offset >= CalleeEnd)
+      continue;
+    SawInstruction = true;
+    if (!DI.DecodeSucceeded || LS.MIA->isCall(DI.Inst) ||
+        definesOverlappingRegister(DI, LS, TargetRegister))
+      return false;
+
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      if (DI.Inst.getNumOperands() != 1 ||
+          !isExactRegisterOperand(DI.Inst, 0, ReturnRegister))
+        return false;
+      continue;
+    }
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+    if (LS.MIA->isIndirectBranch(DI.Inst) ||
+        DI.Inst.getOpcode() == LS.SAddPcI64Opcode)
+      return false;
+
+    bool HasFallthrough = true;
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> BranchTarget =
+          getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+      if (!BranchTarget || *BranchTarget < CalleeBegin ||
+          *BranchTarget >= CalleeEnd)
+        return false;
+      HasFallthrough = !LS.MIA->isUnconditionalBranch(DI.Inst);
+    }
+    if (!HasFallthrough)
+      continue;
+    std::optional<uint64_t> Fallthrough =
+        checkedAddUint64(DI.Offset, DI.Size, "reusable callee fallthrough");
+    if (!Fallthrough || *Fallthrough >= CalleeEnd)
+      return false;
+  }
+  return SawInstruction;
+}
+
 struct FiniteSetPcTransfer {
   size_t InstIndex = 0;
   size_t SequenceBeginIndex = 0;
@@ -2024,6 +2089,8 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
+    ArrayRef<uint64_t> DeclaredEntries,
     ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
   std::vector<ReachingCallTargets> Resolved(Decoded.size());
   SmallVector<ReachingCallGroup, 8> Groups;
@@ -2335,11 +2402,6 @@ static bool compareKnownCallEntries(const KnownCallEntry &LHS,
          std::tie(RHS.Entry, RHS.CallIndex);
 }
 
-struct ExternalCallContinuation {
-  size_t InstIndex = 0;
-  uint64_t Continuation = 0;
-};
-
 struct CallContinuationSource {
   size_t InstIndex = 0;
   uint64_t Continuation = 0;
@@ -2359,7 +2421,6 @@ struct ControlFlowScanIndex {
   SmallVector<KnownCallEntry, 16> CallEntries;
   DenseMap<size_t, MCRegister> CallReturnRegistersBySource;
   SmallVector<CallContinuationSource, 4> CallContinuationsByOffset;
-  SmallVector<ExternalCallContinuation, 4> ExternalCallContinuations;
   SmallVector<size_t, 16> SetPcIndices;
   SmallVector<size_t, 4> UnboundedIndirectIndices;
   SmallVector<size_t, 16> BranchOrCallIndices;
@@ -3664,6 +3725,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   BitVector ProvenSetPcCandidates(AllSetPcCandidates.size());
   SmallVector<FiniteSetPcTransfer, 8> EnabledSetPcTransfers;
   std::vector<ReachingCallTargets> ReusableCalls;
+  SmallVector<std::optional<PcMaterializedCallInfo>, 16> MaterializedCalls(
+      Decoded.size());
   std::optional<ControlFlowScanIndex> Index;
   SmallVector<BoundedSetPcReturn, 2> BoundedReturns;
   SmallVector<SymbolLessReturnRegion, 8> SymbolLessRegions;
@@ -3678,12 +3741,18 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     EnabledSetPcTransfers = selectLeastReachableSetPcCandidates(
         Decoded, LS, DeclaredEntries, ExternalEntries, FunctionRanges, TextAddr,
         AllSetPcCandidates, ProvenSetPcCandidates, RejectedSetPcCandidates);
-    ReusableCalls = resolveReusablePcCallTargets(
-        Decoded, LS, TextAddr, *TextEnd, FunctionRanges, EnabledSetPcTransfers);
     Index = buildControlFlowScanIndex(Decoded, LS, TextAddr, *TextEnd,
                                       FunctionRanges);
-    if (!Index || !addReusableCallsToIndex(Decoded, LS, TextAddr, *TextEnd,
-                                           ReusableCalls, *Index))
+    if (!Index)
+      return std::nullopt;
+    std::fill(MaterializedCalls.begin(), MaterializedCalls.end(), std::nullopt);
+    for (const auto &Entry : Index->MaterializedCalls)
+      MaterializedCalls[Entry.first] = Entry.second;
+    ReusableCalls = resolveReusablePcCallTargets(
+        Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls,
+        DeclaredEntries, EnabledSetPcTransfers);
+    if (!addReusableCallsToIndex(Decoded, LS, TextAddr, *TextEnd, ReusableCalls,
+                                 *Index))
       return std::nullopt;
     indexKnownCalls(*Index);
     finalizeCallContinuationIndex(*Index);
@@ -3816,7 +3885,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   for (uint64_t Entry : ExternalEntries)
     if (Entry < TextSize)
       Info.Targets.insert(Entry);
-  for (const BoundedSetPcReturn &Return : BoundedReturns)
+  for (const BoundedSetPcReturn &Return : BoundedReturns) {
     for (uint64_t Target : Return.Targets)
       Info.Targets.insert(Target);
     Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
@@ -4896,7 +4965,7 @@ assignLongBranchGateways(PatchContext &Ctx,
     for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
       const Trampoline &T = Ctx.OutTrampolines[I];
       if (T.OriginalSize < 2 * MinInstSize || T.UsesDirectSetPCForward ||
-          T.UsesSharedDispatcherForward || T.LongBranchPreservesVcc)
+          T.UsesSharedDispatcherForward)
         continue;
       uint64_t Tail = T.OriginalOffset + MinInstSize;
       SourceTailIslandOwners[Tail] = I;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -34,6 +34,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/Endian.h"
 #include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
@@ -1131,6 +1132,331 @@ matchPcMaterializedCall(ArrayRef<InternalDecodedInst> Decoded, size_t CallIndex,
                                 MCRegister(Call.Inst.getOperand(0).getReg())};
 }
 
+using ReachingCallTargets = SmallVector<uint64_t, 8>;
+
+struct ReachingPcState {
+  bool Reached = false;
+  bool HasUnknown = false;
+  ReachingCallTargets Targets;
+  SmallVector<size_t, 4> ActiveMaterializations;
+};
+
+static bool mergeReachingPcState(ReachingPcState &Into,
+                                 const ReachingPcState &From) {
+  if (!From.Reached)
+    return false;
+  ReachingPcState Before = Into;
+  Into.Reached = true;
+  Into.HasUnknown |= From.HasUnknown;
+  for (uint64_t Target : From.Targets)
+    if (!llvm::is_contained(Into.Targets, Target))
+      Into.Targets.push_back(Target);
+  for (size_t Completion : From.ActiveMaterializations)
+    if (!llvm::is_contained(Into.ActiveMaterializations, Completion))
+      Into.ActiveMaterializations.push_back(Completion);
+  llvm::sort(Into.Targets);
+  llvm::sort(Into.ActiveMaterializations);
+  return Before.Reached != Into.Reached ||
+         Before.HasUnknown != Into.HasUnknown ||
+         Before.Targets != Into.Targets ||
+         Before.ActiveMaterializations != Into.ActiveMaterializations;
+}
+
+static bool isExactRegisterOperand(const MCInst &Inst, unsigned Index,
+                                   MCRegister Reg) {
+  return Index < Inst.getNumOperands() && Inst.getOperand(Index).isReg() &&
+         Inst.getOperand(Index).getReg() == Reg;
+}
+
+/// Recognize the two compiler-emitted ways a reusable register-call target is
+/// materialized. The first is the canonical get-PC/add-nc pair. Tensile also
+/// computes a 32-bit displacement in a temporary and propagates carry into the
+/// high half:
+///
+///   s_get_pc_i64 Pair
+///   s_add_co_i32 Tmp, Imm0, Imm1
+///   s_add_co_u32 Pair.lo, Pair.lo, Tmp
+///   s_add_co_ci_u32 Pair.hi, Pair.hi, 0
+///
+/// Return the completion instruction and absolute target. Intermediate
+/// definitions deliberately remain "unknown" in the reaching-value solver.
+static std::optional<std::pair<size_t, uint64_t>>
+matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
+                               size_t GetPcIndex, size_t FunctionEndIndex,
+                               MCRegister Pair, const LLVMState &LS,
+                               uint64_t TextAddr, ArrayRef<uint8_t> Text) {
+  const InternalDecodedInst &GetPc = Decoded[GetPcIndex];
+  if (!GetPc.DecodeSucceeded || GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
+      !isExactRegisterOperand(GetPc.Inst, 0, Pair))
+    return std::nullopt;
+  std::optional<uint64_t> Pc =
+      checkedAddUint64(TextAddr, GetPc.Offset, "reusable get-PC address");
+  if (!Pc)
+    return std::nullopt;
+  Pc = checkedAddUint64(*Pc, GetPc.Size, "reusable get-PC value");
+  if (!Pc)
+    return std::nullopt;
+
+  for (size_t I = GetPcIndex + 1; I < FunctionEndIndex; ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!DI.DecodeSucceeded || isControlFlowBoundary(DI, LS))
+      break;
+    if (!definesOverlappingRegister(DI, LS, Pair))
+      continue;
+    if (DI.Inst.getOpcode() != LS.SAddNcU64Opcode ||
+        DI.Inst.getNumOperands() != 3 ||
+        !isExactRegisterOperand(DI.Inst, 0, Pair) ||
+        !isExactRegisterOperand(DI.Inst, 1, Pair) ||
+        !DI.Inst.getOperand(2).isImm())
+      break;
+    uint64_t Delta = static_cast<uint64_t>(DI.Inst.getOperand(2).getImm());
+    return std::make_pair(I, *Pc + Delta);
+  }
+
+  if (GetPcIndex + 3 >= FunctionEndIndex)
+    return std::nullopt;
+  const InternalDecodedInst &MakeDelta = Decoded[GetPcIndex + 1];
+  const InternalDecodedInst &AddLow = Decoded[GetPcIndex + 2];
+  const InternalDecodedInst &AddHigh = Decoded[GetPcIndex + 3];
+  if (MakeDelta.Mnemonic != "s_add_co_i32" ||
+      AddLow.Mnemonic != "s_add_co_u32" ||
+      AddHigh.Mnemonic != "s_add_co_ci_u32" ||
+      MakeDelta.Inst.getNumOperands() != 3 ||
+      !MakeDelta.Inst.getOperand(0).isReg() ||
+      !MakeDelta.Inst.getOperand(0).getReg() ||
+      !MakeDelta.Inst.getOperand(2).isImm())
+    return std::nullopt;
+  MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
+  if (AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
+      !AddLow.Inst.getOperand(1).isReg() ||
+      !AddLow.Inst.getOperand(0).getReg() ||
+      AddLow.Inst.getOperand(0).getReg() !=
+          AddLow.Inst.getOperand(1).getReg() ||
+      !isExactRegisterOperand(AddLow.Inst, 2, DeltaReg) ||
+      AddHigh.Inst.getNumOperands() != 3 ||
+      !AddHigh.Inst.getOperand(0).isReg() ||
+      !AddHigh.Inst.getOperand(1).isReg() ||
+      !AddHigh.Inst.getOperand(0).getReg() ||
+      AddHigh.Inst.getOperand(0).getReg() !=
+          AddHigh.Inst.getOperand(1).getReg() ||
+      !AddHigh.Inst.getOperand(2).isImm() ||
+      AddHigh.Inst.getOperand(2).getImm() != 0)
+    return std::nullopt;
+  MCRegister Low(AddLow.Inst.getOperand(0).getReg());
+  MCRegister High(AddHigh.Inst.getOperand(0).getReg());
+  std::optional<unsigned> LowIndex = numberedSgprIndex(*LS.MRI, Low);
+  std::optional<unsigned> HighIndex = numberedSgprIndex(*LS.MRI, High);
+  if (!LowIndex || !HighIndex || *HighIndex != *LowIndex + 1 ||
+      !LS.MRI->regsOverlap(Low, Pair) || !LS.MRI->regsOverlap(High, Pair))
+    return std::nullopt;
+
+  std::optional<uint32_t> FirstAddend;
+  if (MakeDelta.Inst.getOperand(1).isImm()) {
+    FirstAddend = static_cast<uint32_t>(MakeDelta.Inst.getOperand(1).getImm());
+  } else if (MakeDelta.Size >= 2 * MinInstSize &&
+             MakeDelta.Offset <= Text.size() &&
+             MakeDelta.Size <= Text.size() - MakeDelta.Offset) {
+    // The disassembler represents a SOP2 literal source as its literal
+    // register marker, not as an immediate operand. The literal dword is the
+    // final dword in this otherwise exact compiler-emitted instruction.
+    FirstAddend = support::endian::read32le(Text.data() + MakeDelta.Offset +
+                                            MakeDelta.Size - MinInstSize);
+  }
+  if (!FirstAddend)
+    return std::nullopt;
+  uint32_t Delta = *FirstAddend +
+                   static_cast<uint32_t>(MakeDelta.Inst.getOperand(2).getImm());
+  return std::make_pair(GetPcIndex + 3, *Pc + Delta);
+}
+
+struct ReachingCallGroup {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  MCRegister TargetRegister;
+  SmallVector<size_t, 8> Calls;
+};
+
+/// Resolve register calls whose target pair is selected once and reused across
+/// control flow. A monotone intraprocedural solver propagates finite target
+/// sets from proven get-PC materializations. Any unrecognized pair definition
+/// introduces Unknown, so a bypass around the selector remains fail-closed.
+static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextEnd,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
+    ArrayRef<uint8_t> Text) {
+  std::vector<ReachingCallTargets> Resolved(Decoded.size());
+  SmallVector<ReachingCallGroup, 8> Groups;
+
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &Call = Decoded[I];
+    if (LocalCalls[I] || !Call.DecodeSucceeded ||
+        Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+        Call.Inst.getNumOperands() < 2)
+      continue;
+    const MCOperand &TargetOp =
+        Call.Inst.getOperand(Call.Inst.getNumOperands() - 1);
+    if (!TargetOp.isReg() || !TargetOp.getReg())
+      continue;
+    MCRegister TargetRegister(TargetOp.getReg());
+
+    const ElfView::FunctionTextRange *Best = nullptr;
+    uint64_t Address = TextAddr + Call.Offset;
+    for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+      if (Range.Begin <= Address && Address < Range.End &&
+          (!Best || Range.Begin > Best->Begin))
+        Best = &Range;
+    if (!Best || Best->Begin < TextAddr || Best->End > TextEnd)
+      continue;
+    uint64_t Begin = Best->Begin - TextAddr;
+    uint64_t End = Best->End - TextAddr;
+    ReachingCallGroup *Group = nullptr;
+    for (ReachingCallGroup &Candidate : Groups)
+      if (Candidate.Begin == Begin && Candidate.End == End &&
+          Candidate.TargetRegister == TargetRegister) {
+        Group = &Candidate;
+        break;
+      }
+    if (!Group) {
+      Groups.push_back({Begin, End, TargetRegister, {}});
+      Group = &Groups.back();
+    }
+    Group->Calls.push_back(I);
+  }
+
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex[Decoded[I].Offset] = I;
+
+  for (const ReachingCallGroup &Group : Groups) {
+    size_t BeginIndex = 0;
+    while (BeginIndex != Decoded.size() &&
+           Decoded[BeginIndex].Offset < Group.Begin)
+      ++BeginIndex;
+    size_t EndIndex = BeginIndex;
+    while (EndIndex != Decoded.size() && Decoded[EndIndex].Offset < Group.End)
+      ++EndIndex;
+    if (BeginIndex == EndIndex)
+      continue;
+
+    DenseMap<size_t, size_t> Starters;
+    DenseMap<size_t, uint64_t> Completions;
+    DenseMap<size_t, SmallVector<size_t, 2>> Intermediates;
+    for (size_t I = BeginIndex; I != EndIndex; ++I) {
+      std::optional<std::pair<size_t, uint64_t>> Match =
+          matchReusablePcMaterialization(
+              Decoded, I, EndIndex, Group.TargetRegister, LS, TextAddr, Text);
+      if (Match) {
+        Starters[I] = Match->first;
+        Completions[Match->first] = Match->second;
+        for (size_t J = I + 1; J != Match->first; ++J)
+          if (definesOverlappingRegister(Decoded[J], LS, Group.TargetRegister))
+            Intermediates[J].push_back(Match->first);
+      }
+    }
+    if (Completions.empty())
+      continue;
+
+    std::vector<ReachingPcState> Before(EndIndex - BeginIndex);
+    Before.front().Reached = true;
+    Before.front().HasUnknown = true;
+    SmallVector<size_t, 32> Worklist;
+    BitVector Queued(EndIndex - BeginIndex);
+    Worklist.push_back(BeginIndex);
+    Queued.set(0);
+
+    while (!Worklist.empty()) {
+      size_t I = Worklist.pop_back_val();
+      Queued.reset(I - BeginIndex);
+      ReachingPcState State = Before[I - BeginIndex];
+      const InternalDecodedInst &DI = Decoded[I];
+
+      DenseMap<size_t, size_t>::const_iterator Starter = Starters.find(I);
+      DenseMap<size_t, uint64_t>::const_iterator Completion =
+          Completions.find(I);
+      if (Starter != Starters.end()) {
+        // The get-PC instruction overwrites the complete target pair. Record a
+        // token proving that this path entered the exact materialization; the
+        // completion may only produce a known target from that token.
+        State.HasUnknown = false;
+        State.Targets.clear();
+        State.ActiveMaterializations.assign(1, Starter->second);
+      } else if (Completion != Completions.end()) {
+        bool HasMatchingToken =
+            llvm::is_contained(State.ActiveMaterializations, I);
+        bool HasBypassPath =
+            State.HasUnknown || !State.Targets.empty() ||
+            llvm::any_of(State.ActiveMaterializations,
+                         [I](size_t Active) { return Active != I; });
+        State.HasUnknown = HasBypassPath || !HasMatchingToken;
+        State.Targets.clear();
+        State.ActiveMaterializations.clear();
+        if (HasMatchingToken)
+          State.Targets.push_back(Completion->second);
+      } else if (definesOverlappingRegister(DI, LS, Group.TargetRegister)) {
+        // Preserve only tokens for which this is a proven instruction inside
+        // the exact matched sequence. All other reaching values are clobbered.
+        SmallVector<size_t, 4> Preserved;
+        DenseMap<size_t, SmallVector<size_t, 2>>::const_iterator Intermediate =
+            Intermediates.find(I);
+        if (Intermediate != Intermediates.end())
+          for (size_t Active : State.ActiveMaterializations)
+            if (llvm::is_contained(Intermediate->second, Active))
+              Preserved.push_back(Active);
+        if (State.HasUnknown || !State.Targets.empty() ||
+            Preserved.size() != State.ActiveMaterializations.size())
+          State.HasUnknown = true;
+        State.Targets.clear();
+        State.ActiveMaterializations = std::move(Preserved);
+      }
+
+      if (llvm::is_contained(Group.Calls, I) && !State.HasUnknown &&
+          State.ActiveMaterializations.empty() && !State.Targets.empty())
+        Resolved[I] = State.Targets;
+
+      SmallVector<size_t, 2> Successors;
+      auto appendFallthrough = [&]() {
+        if (I + 1 < EndIndex)
+          Successors.push_back(I + 1);
+      };
+      if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+          DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+          LS.MIA->isReturn(DI.Inst)) {
+        // No successor.
+      } else if (LS.MIA->isCall(DI.Inst)) {
+        appendFallthrough();
+      } else if (LS.MIA->isIndirectBranch(DI.Inst)) {
+        // An indirect jump or bounded return leaves this intraprocedural path.
+      } else if (LS.MIA->isBranch(DI.Inst)) {
+        std::optional<uint64_t> Target =
+            evaluateDirectControlFlowTarget(DI, LS);
+        if (Target) {
+          DenseMap<uint64_t, size_t>::const_iterator TargetIndex =
+              OffsetToIndex.find(*Target);
+          if (TargetIndex != OffsetToIndex.end() &&
+              TargetIndex->second >= BeginIndex &&
+              TargetIndex->second < EndIndex)
+            Successors.push_back(TargetIndex->second);
+        }
+        if (!LS.MIA->isUnconditionalBranch(DI.Inst))
+          appendFallthrough();
+      } else {
+        appendFallthrough();
+      }
+
+      for (size_t Successor : Successors) {
+        if (mergeReachingPcState(Before[Successor - BeginIndex], State) &&
+            !Queued.test(Successor - BeginIndex)) {
+          Worklist.push_back(Successor);
+          Queued.set(Successor - BeginIndex);
+        }
+      }
+    }
+  }
+  return Resolved;
+}
+
 struct KnownCallSite {
   size_t InstIndex = 0;
   uint64_t Target = 0;
@@ -1210,7 +1536,8 @@ getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
 static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
-    ArrayRef<std::optional<PcMaterializedCallInfo>> MaterializedCalls) {
+    ArrayRef<std::optional<PcMaterializedCallInfo>> MaterializedCalls,
+    ArrayRef<ReachingCallTargets> ReusableCalls) {
   SmallVector<KnownCallSite, 4> Calls;
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &DI = Decoded[I];
@@ -1218,22 +1545,43 @@ static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
     if (!ReturnRegister)
       continue;
 
-    std::optional<uint64_t> Target;
     if (MaterializedCalls[I]) {
       uint64_t AbsoluteTarget = MaterializedCalls[I]->Target;
-      if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
-        Target = AbsoluteTarget - TextAddr;
-    } else {
-      Target = getDirectTextTarget(DI, LS, TextAddr, TextEnd);
-    }
-    if (!Target)
+      if (AbsoluteTarget < TextAddr || AbsoluteTarget >= TextEnd)
+        continue;
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "known call continuation address");
+      if (!Continuation)
+        return std::nullopt;
+      Calls.push_back(
+          {I, AbsoluteTarget - TextAddr, *Continuation, *ReturnRegister});
       continue;
+    }
 
-    std::optional<uint64_t> Continuation =
-        checkedAddUint64(DI.Offset, DI.Size, "known call continuation address");
-    if (!Continuation)
-      return std::nullopt;
-    Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
+    if (!ReusableCalls[I].empty()) {
+      if (llvm::any_of(ReusableCalls[I], [TextAddr, TextEnd](uint64_t Target) {
+            return Target < TextAddr || Target >= TextEnd;
+          }))
+        continue;
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "known call continuation address");
+      if (!Continuation)
+        return std::nullopt;
+      for (uint64_t AbsoluteTarget : ReusableCalls[I])
+        Calls.push_back(
+            {I, AbsoluteTarget - TextAddr, *Continuation, *ReturnRegister});
+      continue;
+    }
+
+    std::optional<uint64_t> Target =
+        getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+    if (Target) {
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "known call continuation address");
+      if (!Continuation)
+        return std::nullopt;
+      Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
+    }
   }
   return Calls;
 }
@@ -1621,7 +1969,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-    ArrayRef<uint64_t> ExternalEntries) {
+    ArrayRef<uint64_t> ExternalEntries, ArrayRef<uint8_t> Text) {
   if (!LS.MIA) {
     log() << "hotswap: MC branch analysis is unavailable; adjacent far "
              "trampolines will not be coalesced\n";
@@ -1637,9 +1985,11 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       Decoded.size());
   for (size_t I = 0; I != Decoded.size(); ++I)
     MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
+  std::vector<ReachingCallTargets> ReusableCalls = resolveReusablePcCallTargets(
+      Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls, Text);
 
-  std::optional<SmallVector<KnownCallSite, 4>> Calls =
-      collectKnownCallSites(Decoded, LS, TextAddr, *TextEnd, MaterializedCalls);
+  std::optional<SmallVector<KnownCallSite, 4>> Calls = collectKnownCallSites(
+      Decoded, LS, TextAddr, *TextEnd, MaterializedCalls, ReusableCalls);
   if (!Calls)
     return std::nullopt;
   std::optional<SmallVector<BoundedSetPcReturn, 2>> BoundedReturns =
@@ -1685,6 +2035,25 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
                      MaterializedCalls[InstIndex]->SequenceEnd)) {
         Target = MaterializedCalls[InstIndex]->Target;
       }
+      if (!ReusableCalls[InstIndex].empty()) {
+        if (llvm::any_of(ReusableCalls[InstIndex],
+                         [TextAddr, TextEnd](uint64_t ReusableTarget) {
+                           return ReusableTarget < TextAddr ||
+                                  ReusableTarget >= *TextEnd;
+                         })) {
+          log() << "hotswap: unresolved call target at 0x"
+                << utohexstr(DI.Offset) << " (reusable target outside .text)\n";
+          Info.HasUnresolvedTargets = true;
+          continue;
+        }
+        for (uint64_t ReusableTarget : ReusableCalls[InstIndex])
+          Info.Targets.insert(ReusableTarget - TextAddr);
+        Info.BoundedIndirectTransfers.insert(DI.Offset);
+        log() << "hotswap: resolved reusable PC-materialized call at 0x"
+              << utohexstr(DI.Offset) << " to "
+              << ReusableCalls[InstIndex].size() << " target(s)\n";
+        continue;
+      }
       if (!Target) {
         log() << "hotswap: unresolved call target at 0x" << utohexstr(DI.Offset)
               << " (" << DI.Mnemonic << ")\n";
@@ -1699,6 +2068,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
           log() << "hotswap: resolved PC-materialized call at 0x"
                 << utohexstr(DI.Offset) << " to .text+0x"
                 << utohexstr(RelativeTarget) << "\n";
+        if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg())
+          Info.BoundedIndirectTransfers.insert(DI.Offset);
       }
       continue;
     }
@@ -1713,6 +2084,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     }
     Info.Targets.insert(*Target);
   }
+  for (const BoundedSetPcReturn &Return : *BoundedReturns)
+    Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
   return Info;
 }
 
@@ -1857,12 +2230,15 @@ collectRelocationProtectedOffsets(ArrayRef<InternalDecodedInst> Decoded,
 /// indirect destination, so leave the complete function in place.
 static DenseSet<uint64_t>
 collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
-                                    const LLVMState &LS, const ElfView &Elf) {
+                                    const LLVMState &LS, const ElfView &Elf,
+                                    const DenseSet<uint64_t> &Bounded) {
   DenseSet<uint64_t> Functions;
   if (!LS.MIA)
     return Functions;
 
   for (const InternalDecodedInst &DI : Decoded) {
+    if (Bounded.contains(DI.Offset))
+      continue;
     if (LS.MIA->isBarrier(DI.Inst) || isEndProgram(DI, LS))
       continue;
     if (!LS.MIA->isIndirectBranch(DI.Inst) &&
@@ -1892,7 +2268,9 @@ expandStraightLineTrampolines(PatchContext &Ctx,
   DenseSet<uint64_t> Protected = collectRelocationProtectedOffsets(
       Ctx.Decoded, Ctx.LS, !Ctx.Config.RunB0A0Patches);
   DenseSet<uint64_t> IndirectControlFlowFunctions =
-      collectIndirectControlFlowFunctions(Ctx.Decoded, Ctx.LS, Ctx.Elf);
+      collectIndirectControlFlowFunctions(
+          Ctx.Decoded, Ctx.LS, Ctx.Elf,
+          Ctx.DirectControlFlow.BoundedIndirectTransfers);
 
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     if (Ctx.OutTrampolines[I].HasFunctionRange &&
@@ -2096,6 +2474,7 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
   uint64_t Current = FromOffset;
 
   while (!isSBranchReachable(Current, TargetOffset)) {
+    bool Forward = TargetOffset > Current;
     size_t BestIndex = Gateways.size();
     uint64_t BestOffset = 0;
     for (size_t I = 0; I != Gateways.size(); ++I) {
@@ -2104,12 +2483,15 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
           FromOffset >= Sled.FunctionEnd)
         continue;
       uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-      if (Sled.WritePos >= TargetOffset || Sled.WritePos <= Current ||
-          Sled.WritePos > UsableEnd ||
+      bool MakesProgress =
+          Forward ? Sled.WritePos > Current && Sled.WritePos < TargetOffset
+                  : Sled.WritePos < Current && Sled.WritePos > TargetOffset;
+      if (!MakesProgress || Sled.WritePos > UsableEnd ||
           MinInstSize > UsableEnd - Sled.WritePos ||
           !isSBranchReachable(Current, Sled.WritePos))
         continue;
-      if (BestIndex == Gateways.size() || Sled.WritePos > BestOffset) {
+      if (BestIndex == Gateways.size() ||
+          (Forward ? Sled.WritePos > BestOffset : Sled.WritePos < BestOffset)) {
         BestIndex = I;
         BestOffset = Sled.WritePos;
       }
@@ -2133,6 +2515,456 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
   return Islands;
 }
 
+static SmallVector<uint8_t> encodeScc1Branch(const LLVMState &LS,
+                                             uint64_t FromOffset,
+                                             uint64_t TargetOffset) {
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(FromOffset, MinInstSize, "conditional branch PC base");
+  if (!PcBase || ((TargetOffset - *PcBase) & (MinInstSize - 1)) != 0)
+    return {};
+  int64_t DwordDelta =
+      static_cast<int64_t>(TargetOffset - *PcBase) / MinInstSize;
+  if (DwordDelta < BranchOffsetMin || DwordDelta > BranchOffsetMax)
+    return {};
+  return assembleSingleInst("s_cbranch_scc1 " + std::to_string(DwordDelta), LS);
+}
+
+/// Plan common far gateways before the final pool layout. An 8-byte source
+/// cannot hold the 20-byte SCC-neutral set-PC sequence, but it can preserve
+/// its identity without touching SCC:
+///
+///   s_get_pc_i64 ScratchSource
+///   s_branch CommonGateway
+///
+/// The common gateway reaches a dispatcher in the pool through a second
+/// scratch pair. The dispatcher saves SCC, compares the recorded source PCs,
+/// restores SCC in the selected stub, and branches to the matching trampoline
+/// body. One 20-byte .text gateway can therefore serve hundreds of otherwise
+/// independent 8-byte patch sites.
+static bool planSharedDispatchGateways(PatchContext &Ctx,
+                                       std::vector<NopSled> &TextGateways) {
+  struct Candidate {
+    size_t Index = 0;
+    unsigned ScratchBase = 0;
+  };
+  SmallVector<Candidate, 64> Candidates;
+  uint64_t MissingScratchCandidates = 0;
+  uint64_t FirstMissingScratch = 0;
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
+    uint64_t ThisTP = TP;
+    std::optional<uint64_t> Next =
+        checkedAddUint64(TP, T.Bytes.size(), "shared dispatcher pool layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+    if (!T.Long || T.OriginalSize < 2 * MinInstSize ||
+        isSBranchReachable(T.OriginalOffset, ThisTP))
+      continue;
+    std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
+        Ctx.LS, T.OriginalOffset, ThisTP, T.LongBranchSgprBase);
+    if (Direct && Direct->size() <= T.OriginalSize)
+      continue;
+    std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
+        Ctx, T.OriginalOffset, /*Count=*/4,
+        /*Alignment=*/2, "shared far-dispatch gateway");
+    if (Scratch) {
+      Candidates.push_back({I, Scratch->Base});
+    } else {
+      if (MissingScratchCandidates == 0)
+        FirstMissingScratch = T.OriginalOffset;
+      ++MissingScratchCandidates;
+    }
+  }
+  if (MissingScratchCandidates != 0)
+    log() << "hotswap: shared far-dispatch skipped " << MissingScratchCandidates
+          << " site(s) without four safe SGPRs"
+          << " (first at 0x" << utohexstr(FirstMissingScratch) << ")\n";
+
+  // The ordinary planner is simpler and uses fewer scratch registers for
+  // small objects. Shared dispatch is a capacity mechanism for dense far-site
+  // workloads, not a replacement for individual gateways.
+  if (Candidates.size() < 8)
+    return true;
+
+  BitVector Assigned(Ctx.OutTrampolines.size());
+  SmallVector<SmallVector<size_t, 32>, 8> Groups;
+  constexpr size_t MaxGroupSites = 1024;
+  for (const Candidate &Seed : Candidates) {
+    if (Assigned.test(Seed.Index))
+      continue;
+    const Trampoline &SeedT = Ctx.OutTrampolines[Seed.Index];
+
+    size_t SledIndex = TextGateways.size();
+    uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
+    for (size_t I = 0; I != TextGateways.size(); ++I) {
+      const NopSled &Sled = TextGateways[I];
+      uint64_t From = SeedT.OriginalOffset + MinInstSize;
+      if (SeedT.OriginalOffset < Sled.FunctionStart ||
+          SeedT.OriginalOffset >= Sled.FunctionEnd)
+        continue;
+      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+      if (Sled.WritePos > UsableEnd ||
+          SetPcForwardSequenceBytes > UsableEnd - Sled.WritePos ||
+          !isSBranchReachable(From, Sled.WritePos))
+        continue;
+      uint64_t Distance =
+          From > Sled.WritePos ? From - Sled.WritePos : Sled.WritePos - From;
+      if (Distance < BestDistance) {
+        BestDistance = Distance;
+        SledIndex = I;
+      }
+    }
+    uint64_t GatewayOffset = 0;
+    uint64_t SecondaryGatewayOffset = 0;
+    std::vector<NopSled> WorkingGateways;
+    SmallVector<uint64_t, 4> SeedIslands;
+    if (SledIndex != TextGateways.size()) {
+      GatewayOffset = TextGateways[SledIndex].WritePos;
+      WorkingGateways = TextGateways;
+      WorkingGateways[SledIndex].WritePos += SetPcForwardSequenceBytes;
+    } else {
+      size_t BestIslandCount = std::numeric_limits<size_t>::max();
+      for (size_t I = 0; I != TextGateways.size(); ++I) {
+        const NopSled &Sled = TextGateways[I];
+        uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+        if (Sled.WritePos > UsableEnd ||
+            SetPcForwardSequenceBytes > UsableEnd - Sled.WritePos)
+          continue;
+        std::vector<NopSled> Trial = TextGateways;
+        uint64_t TrialGateway = Trial[I].WritePos;
+        Trial[I].WritePos += SetPcForwardSequenceBytes;
+        std::optional<SmallVector<uint64_t, 4>> Islands =
+            allocateForwardBranchIslands(
+                Trial, SeedT.OriginalOffset + MinInstSize, TrialGateway);
+        if (!Islands || Islands->empty() || Islands->size() >= BestIslandCount)
+          continue;
+        BestIslandCount = Islands->size();
+        GatewayOffset = TrialGateway;
+        WorkingGateways = std::move(Trial);
+        SeedIslands = std::move(*Islands);
+      }
+      if (WorkingGateways.empty()) {
+        // Split the SCC-neutral 20-byte sequence across an 8-byte get-PC
+        // segment and a 16-byte add/set-PC segment. This admits functions
+        // that have no single 20-byte padding window.
+        for (size_t I = 0; I != TextGateways.size() && WorkingGateways.empty();
+             ++I) {
+          const NopSled &First = TextGateways[I];
+          uint64_t FirstEnd = std::min(First.End, First.FunctionEnd);
+          uint64_t SourceBranch = SeedT.OriginalOffset + MinInstSize;
+          if (SeedT.OriginalOffset < First.FunctionStart ||
+              SeedT.OriginalOffset >= First.FunctionEnd ||
+              First.WritePos > FirstEnd ||
+              2 * MinInstSize > FirstEnd - First.WritePos ||
+              !isSBranchReachable(SourceBranch, First.WritePos))
+            continue;
+          std::vector<NopSled> FirstReserved = TextGateways;
+          GatewayOffset = FirstReserved[I].WritePos;
+          FirstReserved[I].WritePos += 2 * MinInstSize;
+          for (size_t J = 0; J != FirstReserved.size(); ++J) {
+            const NopSled &Second = FirstReserved[J];
+            uint64_t SecondEnd = std::min(Second.End, Second.FunctionEnd);
+            if (SeedT.OriginalOffset < Second.FunctionStart ||
+                SeedT.OriginalOffset >= Second.FunctionEnd ||
+                Second.WritePos > SecondEnd ||
+                4 * MinInstSize > SecondEnd - Second.WritePos ||
+                !isSBranchReachable(GatewayOffset + MinInstSize,
+                                    Second.WritePos))
+              continue;
+            WorkingGateways = FirstReserved;
+            SecondaryGatewayOffset = WorkingGateways[J].WritePos;
+            WorkingGateways[J].WritePos += 4 * MinInstSize;
+            break;
+          }
+        }
+      }
+      if (WorkingGateways.empty())
+        continue;
+    }
+
+    SmallVector<size_t, 32> Members;
+    DenseMap<size_t, SmallVector<uint64_t, 4>> MemberIslands;
+    DenseMap<size_t, uint64_t> MemberRelays;
+    uint64_t GroupBodyBytes = 0;
+    constexpr uint64_t MaxDispatcherSpan = 120 * 1024;
+    for (const Candidate &C : Candidates) {
+      if (Members.size() == MaxGroupSites || Assigned.test(C.Index) ||
+          C.ScratchBase != Seed.ScratchBase)
+        continue;
+      const Trampoline &T = Ctx.OutTrampolines[C.Index];
+      uint64_t ProposedSpan =
+          8 + 28 * (Members.size() + 1) + GroupBodyBytes + T.Bytes.size();
+      if (ProposedSpan > MaxDispatcherSpan)
+        continue;
+      uint64_t From = T.OriginalOffset + MinInstSize;
+      SmallVector<uint64_t, 4> Islands;
+      if (C.Index == Seed.Index && !SeedIslands.empty()) {
+        Islands = SeedIslands;
+      } else if (!isSBranchReachable(From, GatewayOffset)) {
+        continue;
+      }
+      Members.push_back(C.Index);
+      GroupBodyBytes += T.Bytes.size();
+      if (!Islands.empty())
+        MemberIslands[C.Index] = std::move(Islands);
+    }
+    DenseSet<size_t> LocalMembers;
+    SmallVector<std::pair<uint64_t, size_t>, 32> RelayAnchors;
+    for (size_t Index : Members) {
+      LocalMembers.insert(Index);
+      RelayAnchors.push_back(
+          {Ctx.OutTrampolines[Index].OriginalOffset + MinInstSize, Index});
+    }
+    llvm::sort(RelayAnchors);
+    for (const Candidate &C : Candidates) {
+      if (Members.size() == MaxGroupSites || Assigned.test(C.Index) ||
+          LocalMembers.contains(C.Index) || C.ScratchBase != Seed.ScratchBase)
+        continue;
+      const Trampoline &T = Ctx.OutTrampolines[C.Index];
+      uint64_t ProposedSpan =
+          8 + 28 * (Members.size() + 1) + GroupBodyBytes + T.Bytes.size();
+      if (ProposedSpan > MaxDispatcherSpan)
+        continue;
+      uint64_t From = T.OriginalOffset + MinInstSize;
+      auto It =
+          llvm::lower_bound(RelayAnchors, std::make_pair(From, size_t{0}));
+      std::optional<uint64_t> Relay;
+      if (It != RelayAnchors.end() && isSBranchReachable(From, It->first))
+        Relay = It->first;
+      if (It != RelayAnchors.begin()) {
+        --It;
+        if (isSBranchReachable(From, It->first))
+          Relay = It->first;
+      }
+      if (!Relay)
+        continue;
+      Members.push_back(C.Index);
+      LocalMembers.insert(C.Index);
+      MemberRelays[C.Index] = *Relay;
+      GroupBodyBytes += T.Bytes.size();
+      RelayAnchors.insert(
+          llvm::lower_bound(RelayAnchors, std::make_pair(From, C.Index)),
+          {From, C.Index});
+    }
+    // A single site with a normal 20-byte gateway gains nothing from the
+    // dispatcher and would unnecessarily consume two extra SGPRs. Leave it to
+    // the established direct planner. A split 8+16-byte gateway is retained
+    // because the established planner cannot represent it.
+    if (Members.size() == 1 && SecondaryGatewayOffset == 0)
+      continue;
+    if (Members.empty())
+      continue;
+    TextGateways = std::move(WorkingGateways);
+
+    uint32_t Group = Groups.size() + 1;
+    for (size_t Index : Members) {
+      Trampoline &T = Ctx.OutTrampolines[Index];
+      SafeSgprScratchBlock Scratch{Seed.ScratchBase, 4};
+      if (!commitSafeSgprScratchBlock(Ctx, T.OriginalOffset, Scratch,
+                                      "shared far-dispatch gateway"))
+        return false;
+      T.UsesSharedDispatcherForward = true;
+      T.SharedDispatcherGroup = Group;
+      T.SharedDispatcherSgprBase = Seed.ScratchBase;
+      T.SharedDispatcherGatewayOffset = GatewayOffset;
+      DenseMap<size_t, uint64_t>::const_iterator Relay =
+          MemberRelays.find(Index);
+      if (Relay != MemberRelays.end())
+        T.SharedDispatcherRelayOffset = Relay->second;
+      T.SharedDispatcherSecondaryGatewayOffset = SecondaryGatewayOffset;
+      DenseMap<size_t, SmallVector<uint64_t, 4>>::iterator Islands =
+          MemberIslands.find(Index);
+      if (Islands != MemberIslands.end()) {
+        T.ForwardBranchIslands = std::move(Islands->second);
+        T.ForwardBranchTargetOffset = GatewayOffset;
+      }
+      Assigned.set(Index);
+    }
+    Groups.push_back(std::move(Members));
+  }
+
+  if (Groups.empty())
+    return true;
+
+  std::vector<Trampoline> Reordered;
+  Reordered.reserve(Ctx.OutTrampolines.size());
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I)
+    if (!Assigned.test(I))
+      Reordered.push_back(std::move(Ctx.OutTrampolines[I]));
+  for (const SmallVector<size_t, 32> &Group : Groups)
+    for (size_t Index : Group)
+      Reordered.push_back(std::move(Ctx.OutTrampolines[Index]));
+  Ctx.OutTrampolines = std::move(Reordered);
+
+  for (size_t I = 0; I != Ctx.OutTrampolines.size();) {
+    Trampoline &First = Ctx.OutTrampolines[I];
+    if (!First.UsesSharedDispatcherForward) {
+      ++I;
+      continue;
+    }
+    uint32_t Group = First.SharedDispatcherGroup;
+    size_t Count = 0;
+    while (I + Count != Ctx.OutTrampolines.size() &&
+           Ctx.OutTrampolines[I + Count].SharedDispatcherGroup == Group)
+      ++Count;
+    uint64_t Prefix = 8 + 28 * Count;
+    if (Prefix > std::numeric_limits<uint32_t>::max())
+      return false;
+    First.PoolEntryPrefixBytes = static_cast<uint32_t>(Prefix);
+    First.Bytes.insert(First.Bytes.begin(), Prefix, uint8_t{0});
+    I += Count;
+  }
+
+  log() << "hotswap: planned " << Groups.size()
+        << " shared far-dispatch gateway group(s) for " << Assigned.count()
+        << " source site(s)\n";
+  return true;
+}
+
+static bool emitSharedDispatchers(PatchContext &Ctx) {
+  DenseMap<uint32_t, SmallVector<size_t, 32>> Groups;
+  SmallVector<uint64_t, 64> PoolOffsets;
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    PoolOffsets.push_back(TP);
+    Trampoline &T = Ctx.OutTrampolines[I];
+    if (T.UsesSharedDispatcherForward)
+      Groups[T.SharedDispatcherGroup].push_back(I);
+    std::optional<uint64_t> Next =
+        checkedAddUint64(TP, T.Bytes.size(), "shared dispatcher final layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+  }
+
+  for (auto &KV : Groups) {
+    ArrayRef<size_t> Members = KV.second;
+    if (Members.empty())
+      continue;
+    Trampoline &Owner = Ctx.OutTrampolines[Members.front()];
+    uint64_t DispatcherOffset = PoolOffsets[Members.front()];
+    auto fail = [&](const Twine &Reason) {
+      log() << "hotswap: error: shared dispatcher group " << KV.first
+            << " at 0x" << utohexstr(DispatcherOffset) << ": " << Reason
+            << "\n";
+      return false;
+    };
+    unsigned Base = Owner.SharedDispatcherSgprBase;
+    const std::string SourceLow = "s" + std::to_string(Base);
+    const std::string CursorLow = "s" + std::to_string(Base + 2);
+    // After the SCC-neutral gateway has transferred control, only the low
+    // cursor half is needed: every source and pool address differs by less
+    // than 4 GiB, so modulo-2^32 deltas remain exact across a load-address
+    // wrap. Reuse the cursor high half to preserve SCC.
+    const std::string Save = "s" + std::to_string(Base + 3);
+
+    Owner.HasForwardGateway = true;
+    Owner.ForwardGatewayOffset = Owner.SharedDispatcherGatewayOffset;
+    if (Owner.SharedDispatcherSecondaryGatewayOffset == 0) {
+      std::optional<SmallVector<uint8_t>> Gateway =
+          encodeSetPCLongBranch(Ctx.LS, Owner.SharedDispatcherGatewayOffset,
+                                DispatcherOffset, Base + 2);
+      if (!Gateway || Gateway->size() > SetPcForwardSequenceBytes)
+        return fail("single-segment gateway encoding failed");
+      Owner.ForwardGatewayBytes = std::move(*Gateway);
+    } else {
+      const std::string GatewayPair = "s[" + std::to_string(Base + 2) + ":" +
+                                      std::to_string(Base + 3) + "]";
+      Owner.ForwardGatewayBytes =
+          assembleSingleInst("s_get_pc_i64 " + GatewayPair, Ctx.LS);
+      SmallVector<uint8_t> ToSecond =
+          Ctx.LS.encodeSBranch(Owner.SharedDispatcherGatewayOffset +
+                                   Owner.ForwardGatewayBytes.size(),
+                               Owner.SharedDispatcherSecondaryGatewayOffset);
+      if (Owner.ForwardGatewayBytes.size() != MinInstSize ||
+          ToSecond.size() != MinInstSize)
+        return fail("split gateway first segment encoding failed");
+      Owner.ForwardGatewayBytes.append(ToSecond);
+
+      uint64_t PcBase = Owner.SharedDispatcherGatewayOffset + MinInstSize;
+      uint64_t Delta = DispatcherOffset - PcBase;
+      SmallVector<std::string, 2> Lines;
+      Lines.push_back("s_add_nc_u64 " + GatewayPair + ", " + GatewayPair +
+                      ", 0x" + utohexstr(Delta));
+      Lines.push_back("s_set_pc_i64 " + GatewayPair);
+      Owner.SecondaryForwardGatewayBytes =
+          assembleInstructions(joinAsmLines(Lines), Ctx.LS);
+      if (Owner.SecondaryForwardGatewayBytes.empty() ||
+          Owner.SecondaryForwardGatewayBytes.size() > 4 * MinInstSize)
+        return fail("split gateway second segment encoding failed");
+      while (Owner.SecondaryForwardGatewayBytes.size() < 4 * MinInstSize)
+        Owner.SecondaryForwardGatewayBytes.append(Ctx.LS.SNopBytes);
+    }
+
+    SmallVector<uint64_t, 32> BodyOffsets;
+    for (size_t Member : Members)
+      BodyOffsets.push_back(PoolOffsets[Member] +
+                            Ctx.OutTrampolines[Member].PoolEntryPrefixBytes);
+
+    SmallVector<uint8_t> Bytes;
+    auto appendInst = [&](StringRef Asm) {
+      SmallVector<uint8_t> Encoded = assembleSingleInst(Asm, Ctx.LS);
+      if (Encoded.empty())
+        return false;
+      Bytes.append(Encoded);
+      return true;
+    };
+    if (!appendInst("s_cselect_b32 " + Save + ", 1, 0"))
+      return fail("SCC save encoding failed");
+
+    uint64_t CursorValue = DispatcherOffset;
+    uint64_t StubBase =
+        DispatcherOffset + 4 + 20 * Members.size() + MinInstSize;
+    for (size_t J = 0; J != Members.size(); ++J) {
+      const Trampoline &T = Ctx.OutTrampolines[Members[J]];
+      uint64_t SourcePc = T.OriginalOffset + MinInstSize;
+      uint64_t Distance = SourcePc > CursorValue ? SourcePc - CursorValue
+                                                 : CursorValue - SourcePc;
+      if (Distance >= (uint64_t{1} << 32))
+        return fail("source-to-dispatcher span exceeds 32 bits");
+      uint64_t Delta = SourcePc - CursorValue;
+      SmallVector<uint8_t> Add = assembleSingleInst(
+          "s_add_co_u32 " + CursorLow + ", " + CursorLow + ", 0x" +
+              utohexstr(static_cast<uint32_t>(Delta)),
+          Ctx.LS);
+      if (Add.empty() || Add.size() > 3 * MinInstSize)
+        return fail("source-PC cursor add encoding failed");
+      Bytes.append(Add);
+      while (Add.size() < 3 * MinInstSize) {
+        Bytes.append(Ctx.LS.SNopBytes);
+        Add.append(Ctx.LS.SNopBytes);
+      }
+      if (!appendInst("s_cmp_eq_u32 " + SourceLow + ", " + CursorLow))
+        return fail("source-PC compare encoding failed");
+      uint64_t BranchFrom = DispatcherOffset + Bytes.size();
+      SmallVector<uint8_t> Branch =
+          encodeScc1Branch(Ctx.LS, BranchFrom, StubBase + J * 2 * MinInstSize);
+      if (Branch.size() != MinInstSize)
+        return fail("source-PC conditional branch is out of range");
+      Bytes.append(Branch);
+      CursorValue = SourcePc;
+    }
+    if (!appendInst("s_trap 2"))
+      return fail("unmatched-source trap encoding failed");
+    for (size_t J = 0; J != Members.size(); ++J) {
+      if (!appendInst("s_cmp_lg_u32 " + Save + ", 0"))
+        return fail("SCC restore encoding failed");
+      uint64_t BranchFrom = DispatcherOffset + Bytes.size();
+      SmallVector<uint8_t> Branch =
+          Ctx.LS.encodeSBranch(BranchFrom, BodyOffsets[J]);
+      if (Branch.size() != MinInstSize)
+        return fail("selected trampoline body is out of branch range");
+      Bytes.append(Branch);
+    }
+    if (Bytes.size() != Owner.PoolEntryPrefixBytes)
+      return fail("dispatcher size differs from reserved prefix");
+    std::memcpy(Owner.Bytes.data(), Bytes.data(), Bytes.size());
+  }
+  return true;
+}
+
 static bool
 assignLongBranchGateways(PatchContext &Ctx,
                          const DenseSet<uint64_t> &DirectBranchTargets,
@@ -2144,6 +2976,9 @@ assignLongBranchGateways(PatchContext &Ctx,
         DirectBranchTargets);
     for (const NopSled &Sled : Ctx.NopSleds)
       Gateways.push_back(Sled);
+    if (!planSharedDispatchGateways(Ctx, Gateways) ||
+        !emitSharedDispatchers(Ctx))
+      return false;
   }
 
   DenseMap<uint64_t, size_t> PoolIslandOwners;
@@ -2182,6 +3017,8 @@ assignLongBranchGateways(PatchContext &Ctx,
     TrampOffset = *Next;
     if (!T.Long)
       continue;
+    if (T.UsesSharedDispatcherForward)
+      continue;
 
     if (isSBranchReachable(T.OriginalOffset, TP)) {
       T.UsesShortBranchForward = true;
@@ -2210,9 +3047,42 @@ assignLongBranchGateways(PatchContext &Ctx,
     P.InitialCandidateSlots = *CandidateSlots;
   }
 
+  std::stable_sort(Pending.begin(), Pending.end(),
+                   [](const PendingGateway &LHS, const PendingGateway &RHS) {
+                     return LHS.InitialCandidateSlots <
+                            RHS.InitialCandidateSlots;
+                   });
+
   std::vector<PendingGateway> StillPending;
   StillPending.reserve(Pending.size());
+  uint64_t AssignedGateways = 0;
+  for (const PendingGateway &P : Pending) {
+    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
+        findNearestSetPcGateway(Gateways, Ctx.LS, T.OriginalOffset,
+                                P.TargetOffset, T.LongBranchSgprBase);
+    if (!GatewayOrErr) {
+      log() << "hotswap: error: failed to plan gateway for far site 0x"
+            << utohexstr(T.OriginalOffset) << ": "
+            << toString(GatewayOrErr.takeError()) << "\n";
+      return false;
+    }
+    std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
+    if (!Gateway) {
+      StillPending.push_back(P);
+      continue;
+    }
+    T.HasForwardGateway = true;
+    T.ForwardGatewayOffset = Gateway->Sled->WritePos;
+    T.ForwardGatewayBytes = std::move(Gateway->Bytes);
+    Gateway->Sled->WritePos += T.ForwardGatewayBytes.size();
+    ++AssignedGateways;
+  }
+  Pending = std::move(StillPending);
+
   uint64_t BranchIslandChains = 0;
+  StillPending.clear();
+  StillPending.reserve(Pending.size());
   for (const PendingGateway &P : Pending) {
     Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
     std::optional<SmallVector<uint64_t, 4>> Islands =
@@ -2228,38 +3098,15 @@ assignLongBranchGateways(PatchContext &Ctx,
   }
   Pending = std::move(StillPending);
 
-  std::stable_sort(Pending.begin(), Pending.end(),
-                   [](const PendingGateway &LHS, const PendingGateway &RHS) {
-                     return LHS.InitialCandidateSlots <
-                            RHS.InitialCandidateSlots;
-                   });
-
-  uint64_t AssignedGateways = 0;
-  for (const PendingGateway &P : Pending) {
-    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
-    Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
-        findNearestSetPcGateway(Gateways, Ctx.LS, T.OriginalOffset,
-                                P.TargetOffset, T.LongBranchSgprBase);
-    if (!GatewayOrErr) {
-      log() << "hotswap: error: failed to plan gateway for far site 0x"
-            << utohexstr(T.OriginalOffset) << ": "
-            << toString(GatewayOrErr.takeError()) << "\n";
-      return false;
-    }
-    std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
-    if (!Gateway) {
-      log() << "hotswap: error: no safe short-branch gateway for far site 0x"
-            << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
-            << " initial candidate slot(s))\n";
-      return false;
-    }
-    T.HasForwardGateway = true;
-    T.ForwardGatewayOffset = Gateway->Sled->WritePos;
-    T.ForwardGatewayBytes = std::move(Gateway->Bytes);
-    Gateway->Sled->WritePos += T.ForwardGatewayBytes.size();
-    ++AssignedGateways;
+  if (!Pending.empty()) {
+    const PendingGateway &P = Pending.front();
+    const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    log() << "hotswap: error: no safe short-branch gateway for far site 0x"
+          << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
+          << " initial candidate slot(s))\n";
+    return false;
   }
-  if (!Pending.empty())
+  if (AssignedGateways != 0)
     log() << "hotswap: assigned " << AssignedGateways
           << " SCC-neutral forward gateway(s)\n";
   if (BranchIslandChains != 0)
@@ -2277,6 +3124,17 @@ assignLongBranchGateways(PatchContext &Ctx,
       }
       std::memcpy(Ctx.Text + T.ForwardGatewayOffset,
                   T.ForwardGatewayBytes.data(), T.ForwardGatewayBytes.size());
+      if (!T.SecondaryForwardGatewayBytes.empty()) {
+        uint64_t Offset = T.SharedDispatcherSecondaryGatewayOffset;
+        if (Offset > Ctx.TextSize ||
+            T.SecondaryForwardGatewayBytes.size() > Ctx.TextSize - Offset) {
+          log() << "hotswap: error: secondary forward gateway at 0x"
+                << utohexstr(Offset) << " extends past .text.\n";
+          return false;
+        }
+        std::memcpy(Ctx.Text + Offset, T.SecondaryForwardGatewayBytes.data(),
+                    T.SecondaryForwardGatewayBytes.size());
+      }
     }
     for (size_t I = 0; I != T.ForwardBranchIslands.size(); ++I) {
       uint64_t From = T.ForwardBranchIslands[I];
@@ -2394,7 +3252,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       Elf.functionTextRanges();
   std::optional<DirectControlFlowInfo> ControlFlow = collectDirectBranchTargets(
       Decoded, LS, Elf.textAddr(), Elf.textSize(), DeclaredEntries->Entries,
-      FunctionRanges, DeclaredEntries->ExternalEntries);
+      FunctionRanges, DeclaredEntries->ExternalEntries,
+      ArrayRef<uint8_t>(Text, TextSize));
   if (!ControlFlow)
     return std::nullopt;
   if (ControlFlow->HasUnresolvedTargets) {
@@ -2716,7 +3575,23 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
 
     SmallVector<uint8_t> BrFwd;
     if (T.Long) {
-      if (T.UsesShortBranchForward) {
+      if (T.UsesSharedDispatcherForward) {
+        const std::string Pair =
+            "s[" + std::to_string(T.SharedDispatcherSgprBase) + ":" +
+            std::to_string(T.SharedDispatcherSgprBase + 1) + "]";
+        BrFwd = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
+        if (BrFwd.size() != MinInstSize)
+          return false;
+        uint64_t BranchTarget =
+            T.SharedDispatcherRelayOffset    ? T.SharedDispatcherRelayOffset
+            : T.ForwardBranchIslands.empty() ? T.SharedDispatcherGatewayOffset
+                                             : T.ForwardBranchIslands.front();
+        SmallVector<uint8_t> Branch =
+            LS.encodeSBranch(T.OriginalOffset + BrFwd.size(), BranchTarget);
+        if (Branch.size() != MinInstSize)
+          return false;
+        BrFwd.append(Branch);
+      } else if (T.UsesShortBranchForward) {
         BrFwd = LS.encodeSBranch(T.OriginalOffset, TP);
       } else if (!T.ForwardBranchIslands.empty()) {
         BrFwd =

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -6347,7 +6347,12 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       bool IsFiniteExternalMaterializedCall =
           MaterializedCalls[InstIndex] &&
           (MaterializedCalls[InstIndex]->Target < TextAddr ||
-           MaterializedCalls[InstIndex]->Target >= *TextEnd);
+           MaterializedCalls[InstIndex]->Target >= *TextEnd) &&
+          !hasKnownControlFlowEntry(
+              DeclaredEntries, BoundedReturns, BoundedReturnPositions, *Index,
+              HasUnboundedIndirectEntries,
+              MaterializedCalls[InstIndex]->SequenceStart,
+              MaterializedCalls[InstIndex]->SequenceEnd);
       if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
           DI.Inst.getNumOperands() != 0 &&
           DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -797,6 +797,24 @@ summarizeSafeSgprUsage(PatchContext &Ctx,
   return Summary;
 }
 
+static std::string findKernelOwnerAtTextOffset(PatchContext &Ctx,
+                                               uint64_t TextOffset) {
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(TextOffset);
+  if (!FunctionRange)
+    return Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+
+  std::pair<uint64_t, uint64_t> Key{FunctionRange->Begin, FunctionRange->End};
+  auto Cached = Ctx.FunctionKernelOwner.find(Key);
+  if (Cached != Ctx.FunctionKernelOwner.end())
+    return Cached->second;
+
+  std::string Owner =
+      Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+  Ctx.FunctionKernelOwner.try_emplace(Key, Owner);
+  return Owner;
+}
+
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
                          unsigned Alignment, StringRef Context,
@@ -810,8 +828,7 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
 
   std::optional<ElfView::FunctionTextRange> FunctionRange =
       Ctx.Elf.findFunctionTextRangeAtOffset(TextOffset);
-  std::string Owner =
-      Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+  std::string Owner = findKernelOwnerAtTextOffset(Ctx, TextOffset);
   bool ScanWholeObject = Owner.empty() || !FunctionRange;
   SafeSgprUsageSummary *Usage = nullptr;
   if (!ScanWholeObject) {
@@ -917,8 +934,7 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
     return false;
   }
 
-  std::string Owner =
-      Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+  std::string Owner = findKernelOwnerAtTextOffset(Ctx, TextOffset);
   bool ChargedOwner = false;
 
   // llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp::getNumExtraSGPRs returns
@@ -926,7 +942,27 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
   // requirement. This may conservatively overstate a kernel that does not use
   // VCC, but never mistakes VCC for numbered s0-s105 registers.
   constexpr unsigned VccSgprs = 2;
+  if (Block.Count > std::numeric_limits<unsigned>::max() - Block.Base ||
+      VccSgprs >
+          std::numeric_limits<unsigned>::max() - (Block.Base + Block.Count)) {
+    log() << "hotswap: error: " << Context
+          << ": SGPR descriptor requirement overflows unsigned\n";
+    return false;
+  }
   unsigned RequiredSgprs = Block.Base + Block.Count + VccSgprs;
+  unsigned CoveredRequirement = Ctx.AllKernelSgprRequirement;
+  if (!Owner.empty()) {
+    auto Committed = Ctx.KernelSgprRequirements.find(Owner);
+    if (Committed != Ctx.KernelSgprRequirements.end())
+      CoveredRequirement = std::max(CoveredRequirement, Committed->second);
+  }
+  if (CoveredRequirement >= RequiredSgprs)
+    return true;
+
+  // Preflight every selected descriptor before mutating KernelStats. This
+  // keeps a malformed later descriptor from leaving a partial commitment that
+  // the monotone cache cannot describe.
+  SmallVector<std::pair<StringRef, unsigned>, 8> Updates;
   for (const KernelDescriptorInfo &KD : Descriptors) {
     if (!Owner.empty() && KD.KernelName != Owner)
       continue;
@@ -941,8 +977,12 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
     }
     if (*Current >= RequiredSgprs)
       continue;
-    KernelPatchStats &Stats = Ctx.KernelStats[KD.KernelName];
-    Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, RequiredSgprs - *Current);
+    unsigned Existing = 0;
+    auto Stats = Ctx.KernelStats.find(KD.KernelName);
+    if (Stats != Ctx.KernelStats.end())
+      Existing = Stats->second.ExtraSgprs;
+    Updates.push_back(
+        {KD.KernelName, std::max(Existing, RequiredSgprs - *Current)});
   }
 
   if (!ChargedOwner) {
@@ -950,6 +990,15 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
           << "' has no descriptor\n";
     return false;
   }
+
+  for (const auto &[KernelName, ExtraSgprs] : Updates)
+    Ctx.KernelStats[KernelName].ExtraSgprs =
+        std::max(Ctx.KernelStats[KernelName].ExtraSgprs, ExtraSgprs);
+  ++Ctx.SgprDescriptorChargePasses;
+  if (Owner.empty())
+    Ctx.AllKernelSgprRequirement = RequiredSgprs;
+  else
+    Ctx.KernelSgprRequirements[Owner] = RequiredSgprs;
   return true;
 }
 
@@ -1939,8 +1988,7 @@ static FarReturnScratch reserveSafeFarReturn(PatchContext &Ctx,
                             /*UseVcc=*/false, /*PreserveVcc=*/false};
   }
 
-  std::string Owner =
-      Ctx.Elf.findKernelAtAddress(InstOffset + Ctx.Elf.textAddr());
+  std::string Owner = findKernelOwnerAtTextOffset(Ctx, InstOffset);
   std::optional<unsigned> WavefrontSize =
       Owner.empty() ? std::nullopt : Ctx.Elf.getKernelWavefrontSize(Owner);
   if (WavefrontSize == 32 && InstSize >= 2 * MinInstSize) {

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1643,9 +1643,8 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
       !MakeDelta.Inst.getOperand(2).isImm())
     return std::nullopt;
   MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
-  if (LS.MRI->regsOverlap(DeltaReg, Pair))
-    return std::nullopt;
-  if (AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
+  if (LS.MRI->regsOverlap(DeltaReg, Pair) ||
+      AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
       !AddLow.Inst.getOperand(1).isReg() ||
       !AddLow.Inst.getOperand(0).getReg() ||
       AddLow.Inst.getOperand(0).getReg() !=
@@ -1668,8 +1667,20 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
       !LS.MRI->regsOverlap(Low, Pair) || !LS.MRI->regsOverlap(High, Pair))
     return std::nullopt;
 
-  std::optional<uint32_t> FirstAddend =
-      evaluateAbsoluteUint32Operand(MakeDelta.Inst.getOperand(1));
+  std::optional<uint32_t> FirstAddend;
+  if (MakeDelta.Inst.getOperand(1).isImm()) {
+    FirstAddend = static_cast<uint32_t>(MakeDelta.Inst.getOperand(1).getImm());
+  } else if (MakeDelta.Size == 2 * MinInstSize &&
+             MakeDelta.Offset <= Text.size() &&
+             MakeDelta.Size <= Text.size() - MakeDelta.Offset &&
+             Text[MakeDelta.Offset] == 0xff) {
+    // The disassembler represents a SOP2 literal source as its literal
+    // register marker, not as an immediate operand. Require the gfx12 SOP2
+    // src0 literal selector before interpreting the final dword as that
+    // literal; an ordinary register source is not a constant displacement.
+    FirstAddend = support::endian::read32le(Text.data() + MakeDelta.Offset +
+                                            MakeDelta.Size - MinInstSize);
+  }
   if (!FirstAddend)
     return std::nullopt;
   uint32_t Delta = *FirstAddend +
@@ -1684,336 +1695,69 @@ struct ReachingCallGroup {
   SmallVector<size_t, 8> Calls;
 };
 
-struct FiniteSetPcTransfer {
-  size_t InstIndex = 0;
-  size_t SequenceBeginIndex = 0;
-  size_t SequenceEndIndex = 0;
-  uint64_t Target = 0;
-  std::optional<size_t> LocalTargetIndex;
-  uint64_t FunctionBegin = 0;
-  uint64_t FunctionEnd = 0;
-};
+static std::optional<uint64_t>
+getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
+                    uint64_t TextAddr, uint64_t TextEnd);
 
-static const ElfView::FunctionTextRange *
-findInnermostFunctionRange(uint64_t Address,
-                           ArrayRef<ElfView::FunctionTextRange> Ranges) {
-  const ElfView::FunctionTextRange *Best = nullptr;
-  for (const ElfView::FunctionTextRange &Range : Ranges)
-    if (Range.Begin <= Address && Address < Range.End &&
-        (!Best || Range.Begin > Best->Begin ||
-         (Range.Begin == Best->Begin && Range.End < Best->End)))
-      Best = &Range;
-  return Best;
-}
-
-/// Collect exact materialized s_set_pc_i64 transfers. These are candidates,
-/// not proofs: a later closed-world audit must still rule out an alternate
-/// entry into the materialization before the edge can authorize mutation.
-static SmallVector<FiniteSetPcTransfer, 8> collectFiniteSetPcCandidates(
+/// A reusable target value remains valid after a call only when the exact local
+/// callee is fully decoded, returns through the call's link pair, and cannot
+/// transitively or directly clobber the target pair.
+static bool calleePreservesReusableTarget(
+    uint64_t Target, MCRegister TargetRegister, MCRegister ReturnRegister,
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
-  SmallVector<FiniteSetPcTransfer, 8> Candidates;
-  DenseMap<uint64_t, size_t> OffsetToIndex;
-  for (size_t I = 0; I != Decoded.size(); ++I)
-    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
-
-  for (size_t I = 0; I != Decoded.size(); ++I) {
-    const InternalDecodedInst &GetPc = Decoded[I];
-    if (!GetPc.DecodeSucceeded ||
-        GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
-        GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
-        !GetPc.Inst.getOperand(0).getReg())
-      continue;
-    MCRegister Pair(GetPc.Inst.getOperand(0).getReg());
-    std::optional<uint64_t> GetPcAddress = checkedAddUint64(
-        TextAddr, GetPc.Offset, "finite set-PC get-PC address");
-    if (!GetPcAddress)
-      continue;
-    const ElfView::FunctionTextRange *Range =
-        findInnermostFunctionRange(*GetPcAddress, FunctionRanges);
-    if (!Range || Range->Begin < TextAddr || Range->End > TextEnd)
-      continue;
-    ArrayRef<InternalDecodedInst>::const_iterator FunctionEnd =
-        llvm::lower_bound(Decoded, Range->End - TextAddr,
-                          [](const InternalDecodedInst &DI, uint64_t Offset) {
-                            return DI.Offset < Offset;
-                          });
-    size_t FunctionEndIndex =
-        static_cast<size_t>(FunctionEnd - Decoded.begin());
-    auto appendCandidate = [&](size_t SetPcIndex, size_t SequenceEndIndex,
-                               uint64_t Target) {
-      for (size_t J = I; J <= SequenceEndIndex; ++J) {
-        if (!Decoded[J].DecodeSucceeded)
-          return;
-        if (J == SequenceEndIndex)
-          break;
-        std::optional<uint64_t> End =
-            checkedAddUint64(Decoded[J].Offset, Decoded[J].Size,
-                             "finite set-PC materialization instruction end");
-        if (!End || *End != Decoded[J + 1].Offset)
-          return;
-      }
-      std::optional<size_t> LocalTargetIndex;
-      if (Target >= TextAddr && Target < TextEnd) {
-        DenseMap<uint64_t, size_t>::const_iterator LocalTarget =
-            OffsetToIndex.find(Target - TextAddr);
-        // A local transfer to the middle of an instruction is not finite for
-        // purposes of safe rewriting.
-        if (LocalTarget == OffsetToIndex.end())
-          return;
-        LocalTargetIndex = LocalTarget->second;
-      }
-      Candidates.push_back({SetPcIndex, I, SequenceEndIndex, Target,
-                            LocalTargetIndex, Range->Begin - TextAddr,
-                            Range->End - TextAddr});
-    };
-
-    std::optional<std::pair<size_t, uint64_t>> Match =
-        matchReusablePcMaterialization(Decoded, I, FunctionEndIndex, Pair, LS,
-                                       TextAddr);
-    if (Match && Match->first + 1 < FunctionEndIndex) {
-      size_t SetPcIndex = Match->first + 1;
-      const InternalDecodedInst &SetPc = Decoded[SetPcIndex];
-      if (SetPc.DecodeSucceeded &&
-          SetPc.Inst.getOpcode() == LS.SSetPcI64Opcode &&
-          SetPc.Inst.getNumOperands() == 1 &&
-          isExactRegisterOperand(SetPc.Inst, 0, Pair))
-        appendCandidate(SetPcIndex, SetPcIndex, Match->second);
-    }
-
-    // Tensile also emits a signed-direction materialized jump. The signed
-    // displacement is a link-time constant, but the sequence uses a generic
-    // compare/abs/add-or-sub shape:
-    //
-    //   get_pc Pair
-    //   add_co_i32 Delta, Literal, Imm
-    //   cmp_ge_i32 Delta, 0
-    //   cbranch_scc1 Positive
-    //   abs_i32 Delta, Delta
-    //   sub_co_u32/sub_co_ci_u32 Pair, Pair, Delta
-    //   set_pc Pair
-    // Positive:
-    //   add_co_u32/add_co_ci_u32 Pair, Pair, Delta
-    //   set_pc Pair
-    //
-    // Both set-PC instructions have the same finite target. Keep the entire
-    // shape in one audited materialization interval so an alternate entry
-    // into either arm invalidates both candidates.
-    if (I + 10 >= FunctionEndIndex)
-      continue;
-    const InternalDecodedInst &MakeDelta = Decoded[I + 1];
-    const InternalDecodedInst &Compare = Decoded[I + 2];
-    const InternalDecodedInst &Branch = Decoded[I + 3];
-    const InternalDecodedInst &Abs = Decoded[I + 4];
-    const InternalDecodedInst &SubLow = Decoded[I + 5];
-    const InternalDecodedInst &SubHigh = Decoded[I + 6];
-    const InternalDecodedInst &NegativeSetPc = Decoded[I + 7];
-    const InternalDecodedInst &AddLow = Decoded[I + 8];
-    const InternalDecodedInst &AddHigh = Decoded[I + 9];
-    const InternalDecodedInst &PositiveSetPc = Decoded[I + 10];
-    if (!MakeDelta.DecodeSucceeded || !Compare.DecodeSucceeded ||
-        !Branch.DecodeSucceeded || !Abs.DecodeSucceeded ||
-        !SubLow.DecodeSucceeded || !SubHigh.DecodeSucceeded ||
-        !NegativeSetPc.DecodeSucceeded || !AddLow.DecodeSucceeded ||
-        !AddHigh.DecodeSucceeded || !PositiveSetPc.DecodeSucceeded ||
-        MakeDelta.Mnemonic != "s_add_co_i32" ||
-        MakeDelta.Inst.getNumOperands() != 3 ||
-        !MakeDelta.Inst.getOperand(0).isReg() ||
-        !MakeDelta.Inst.getOperand(0).getReg() ||
-        !MakeDelta.Inst.getOperand(2).isImm())
-      continue;
-    MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
-    if (LS.MRI->regsOverlap(DeltaReg, Pair))
-      continue;
-    if (Compare.Mnemonic != "s_cmp_ge_i32" ||
-        Compare.Inst.getNumOperands() != 2 ||
-        !isExactRegisterOperand(Compare.Inst, 0, DeltaReg) ||
-        !Compare.Inst.getOperand(1).isImm() ||
-        Compare.Inst.getOperand(1).getImm() != 0 ||
-        Branch.Mnemonic != "s_cbranch_scc1" || Abs.Mnemonic != "s_abs_i32" ||
-        Abs.Inst.getNumOperands() != 2 ||
-        !isExactRegisterOperand(Abs.Inst, 0, DeltaReg) ||
-        !isExactRegisterOperand(Abs.Inst, 1, DeltaReg) ||
-        NegativeSetPc.Inst.getOpcode() != LS.SSetPcI64Opcode ||
-        NegativeSetPc.Inst.getNumOperands() != 1 ||
-        !isExactRegisterOperand(NegativeSetPc.Inst, 0, Pair) ||
-        PositiveSetPc.Inst.getOpcode() != LS.SSetPcI64Opcode ||
-        PositiveSetPc.Inst.getNumOperands() != 1 ||
-        !isExactRegisterOperand(PositiveSetPc.Inst, 0, Pair))
-      continue;
-    std::optional<uint64_t> PositiveLabel =
-        evaluateDirectControlFlowTarget(Branch, LS);
-    if (!PositiveLabel || *PositiveLabel != AddLow.Offset)
-      continue;
-
-    auto matchesPairArithmetic = [&](const InternalDecodedInst &Low,
-                                     const InternalDecodedInst &High,
-                                     StringRef LowMnemonic,
-                                     StringRef HighMnemonic) {
-      if (Low.Mnemonic != LowMnemonic || High.Mnemonic != HighMnemonic ||
-          Low.Inst.getNumOperands() != 3 || !Low.Inst.getOperand(0).isReg() ||
-          !Low.Inst.getOperand(1).isReg() || !Low.Inst.getOperand(0).getReg() ||
-          Low.Inst.getOperand(0).getReg() != Low.Inst.getOperand(1).getReg() ||
-          !isExactRegisterOperand(Low.Inst, 2, DeltaReg) ||
-          High.Inst.getNumOperands() != 3 || !High.Inst.getOperand(0).isReg() ||
-          !High.Inst.getOperand(1).isReg() ||
-          !High.Inst.getOperand(0).getReg() ||
-          High.Inst.getOperand(0).getReg() !=
-              High.Inst.getOperand(1).getReg() ||
-          !High.Inst.getOperand(2).isImm() ||
-          High.Inst.getOperand(2).getImm() != 0)
-        return false;
-      MCRegister LowReg(Low.Inst.getOperand(0).getReg());
-      MCRegister HighReg(High.Inst.getOperand(0).getReg());
-      std::optional<unsigned> LowIndex = numberedSgprIndex(*LS.MRI, LowReg);
-      std::optional<unsigned> HighIndex = numberedSgprIndex(*LS.MRI, HighReg);
-      return LowIndex && HighIndex && *HighIndex == *LowIndex + 1 &&
-             LS.MRI->regsOverlap(LowReg, Pair) &&
-             LS.MRI->regsOverlap(HighReg, Pair);
-    };
-    if (!matchesPairArithmetic(SubLow, SubHigh, "s_sub_co_u32",
-                               "s_sub_co_ci_u32") ||
-        !matchesPairArithmetic(AddLow, AddHigh, "s_add_co_u32",
-                               "s_add_co_ci_u32"))
-      continue;
-
-    std::optional<uint32_t> FirstAddend =
-        evaluateAbsoluteUint32Operand(MakeDelta.Inst.getOperand(1));
-    if (!FirstAddend)
-      continue;
-    uint32_t DeltaBits =
-        *FirstAddend +
-        static_cast<uint32_t>(MakeDelta.Inst.getOperand(2).getImm());
-    int64_t SignedDelta = static_cast<int32_t>(DeltaBits);
-    std::optional<uint64_t> PcValue = checkedAddUint64(
-        *GetPcAddress, GetPc.Size, "signed finite set-PC get-PC value");
-    if (!PcValue)
-      continue;
-    uint64_t Target = *PcValue + static_cast<uint64_t>(SignedDelta);
-    appendCandidate(I + 7, I + 10, Target);
-    appendCandidate(I + 10, I + 10, Target);
-  }
-  llvm::sort(Candidates, [](const FiniteSetPcTransfer &LHS,
-                            const FiniteSetPcTransfer &RHS) {
-    return LHS.InstIndex < RHS.InstIndex;
-  });
-  Candidates.erase(std::unique(Candidates.begin(), Candidates.end(),
-                               [](const FiniteSetPcTransfer &LHS,
-                                  const FiniteSetPcTransfer &RHS) {
-                                 return LHS.InstIndex == RHS.InstIndex;
-                               }),
-                   Candidates.end());
-  return Candidates;
-}
-
-static BitVector computeStaticallyReachableInstructions(
-    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
-    ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr,
-    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers) {
-  BitVector Reachable(Decoded.size());
-  DenseMap<uint64_t, size_t> OffsetToIndex;
-  for (size_t I = 0; I != Decoded.size(); ++I)
-    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
-  DenseMap<size_t, const FiniteSetPcTransfer *> TransferByInst;
-  for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
-    TransferByInst.try_emplace(Transfer.InstIndex, &Transfer);
-
-  SmallVector<size_t, 32> Worklist;
-  auto addRoot = [&](uint64_t Offset) {
-    DenseMap<uint64_t, size_t>::const_iterator It = OffsetToIndex.find(Offset);
-    if (It != OffsetToIndex.end())
-      Worklist.push_back(It->second);
-  };
-  for (uint64_t Entry : DeclaredEntries)
-    addRoot(Entry);
-  for (uint64_t Entry : ExternalEntries)
-    addRoot(Entry);
+  const ElfView::FunctionTextRange *Callee = nullptr;
   for (const ElfView::FunctionTextRange &Range : FunctionRanges)
-    if (Range.Begin >= TextAddr)
-      addRoot(Range.Begin - TextAddr);
-  if (Worklist.empty() && !Decoded.empty())
-    Worklist.push_back(0);
+    if (Range.Begin == Target && Range.Begin >= TextAddr &&
+        Range.End > Range.Begin && Range.End <= TextEnd &&
+        (!Callee || Range.End < Callee->End))
+      Callee = &Range;
+  if (!Callee)
+    return false;
 
-  while (!Worklist.empty()) {
-    size_t I = Worklist.pop_back_val();
-    if (Reachable.test(I))
+  uint64_t CalleeBegin = Callee->Begin - TextAddr;
+  uint64_t CalleeEnd = Callee->End - TextAddr;
+  bool SawInstruction = false;
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (DI.Offset < CalleeBegin || DI.Offset >= CalleeEnd)
       continue;
-    Reachable.set(I);
-    const InternalDecodedInst &DI = Decoded[I];
-    if (!DI.DecodeSucceeded)
+    SawInstruction = true;
+    if (!DI.DecodeSucceeded || LS.MIA->isCall(DI.Inst) ||
+        definesOverlappingRegister(DI, LS, TargetRegister))
+      return false;
+
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      if (DI.Inst.getNumOperands() != 1 ||
+          !isExactRegisterOperand(DI.Inst, 0, ReturnRegister))
+        return false;
       continue;
-    auto addOffset = [&](uint64_t Offset) {
-      DenseMap<uint64_t, size_t>::const_iterator It =
-          OffsetToIndex.find(Offset);
-      if (It != OffsetToIndex.end())
-        Worklist.push_back(It->second);
-    };
+    }
     if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
         DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
         LS.MIA->isReturn(DI.Inst))
       continue;
-    if (LS.MIA->isCall(DI.Inst)) {
-      std::optional<uint64_t> Fallthrough = checkedAddUint64(
-          DI.Offset, DI.Size, "finite set-PC call continuation");
-      if (Fallthrough)
-        addOffset(*Fallthrough);
-      continue;
-    }
-    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
-        LS.MIA->isIndirectBranch(DI.Inst)) {
-      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator Transfer =
-          TransferByInst.find(I);
-      if (Transfer != TransferByInst.end() &&
-          Transfer->second->LocalTargetIndex)
-        Worklist.push_back(*Transfer->second->LocalTargetIndex);
-      continue;
-    }
-    if (LS.MIA->isBranch(DI.Inst)) {
-      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
-      if (Target)
-        addOffset(*Target);
-      if (LS.MIA->isUnconditionalBranch(DI.Inst))
-        continue;
-    }
-    std::optional<uint64_t> Fallthrough = checkedAddUint64(
-        DI.Offset, DI.Size, "finite set-PC reachability fallthrough");
-    if (Fallthrough)
-      addOffset(*Fallthrough);
-  }
-  return Reachable;
-}
+    if (LS.MIA->isIndirectBranch(DI.Inst) ||
+        DI.Inst.getOpcode() == LS.SAddPcI64Opcode)
+      return false;
 
-static SmallVector<FiniteSetPcTransfer, 8> selectLeastReachableSetPcCandidates(
-    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
-    ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr,
-    ArrayRef<FiniteSetPcTransfer> AllCandidates,
-    const BitVector &ProvenCandidates, const BitVector &RejectedCandidates) {
-  SmallVector<FiniteSetPcTransfer, 8> Selected;
-  BitVector SelectedBits(AllCandidates.size());
-  for (size_t I = 0; I != AllCandidates.size(); ++I)
-    if (ProvenCandidates.test(I) && !RejectedCandidates.test(I)) {
-      SelectedBits.set(I);
-      Selected.push_back(AllCandidates[I]);
+    bool HasFallthrough = true;
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> BranchTarget =
+          getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+      if (!BranchTarget || *BranchTarget < CalleeBegin ||
+          *BranchTarget >= CalleeEnd)
+        return false;
+      HasFallthrough = !LS.MIA->isUnconditionalBranch(DI.Inst);
     }
-  for (;;) {
-    BitVector Reachable = computeStaticallyReachableInstructions(
-        Decoded, LS, DeclaredEntries, ExternalEntries, FunctionRanges, TextAddr,
-        Selected);
-    bool Changed = false;
-    for (size_t I = 0; I != AllCandidates.size(); ++I) {
-      if (RejectedCandidates.test(I) || SelectedBits.test(I) ||
-          !Reachable.test(AllCandidates[I].InstIndex))
-        continue;
-      SelectedBits.set(I);
-      Selected.push_back(AllCandidates[I]);
-      Changed = true;
-    }
-    if (!Changed)
-      return Selected;
+    if (!HasFallthrough)
+      continue;
+    std::optional<uint64_t> Fallthrough =
+        checkedAddUint64(DI.Offset, DI.Size, "reusable callee fallthrough");
+    if (!Fallthrough || *Fallthrough >= CalleeEnd)
+      return false;
   }
+  return SawInstruction;
 }
 
 /// Resolve register calls whose target pair is selected once and reused across
@@ -2024,7 +1768,8 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
+    ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint8_t> Text) {
   std::vector<ReachingCallTargets> Resolved(Decoded.size());
   SmallVector<ReachingCallGroup, 8> Groups;
   DenseMap<size_t, const FiniteSetPcTransfer *> FiniteSetPcByInst;
@@ -2086,15 +1831,15 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
 
   for (const ReachingCallGroup &Group : Groups) {
     ArrayRef<InternalDecodedInst>::const_iterator Begin =
-        llvm::lower_bound(Decoded, Group.Begin,
-                          [](const InternalDecodedInst &DI, uint64_t Offset) {
-                            return DI.Offset < Offset;
-                          });
-    ArrayRef<InternalDecodedInst>::const_iterator End = std::lower_bound(
-        Begin, Decoded.end(), Group.End,
-        [](const InternalDecodedInst &DI, uint64_t Offset) {
-          return DI.Offset < Offset;
-        });
+        std::lower_bound(Decoded.begin(), Decoded.end(), Group.Begin,
+                         [](const InternalDecodedInst &DI, uint64_t Offset) {
+                           return DI.Offset < Offset;
+                         });
+    ArrayRef<InternalDecodedInst>::const_iterator End =
+        std::lower_bound(Begin, Decoded.end(), Group.End,
+                         [](const InternalDecodedInst &DI, uint64_t Offset) {
+                           return DI.Offset < Offset;
+                         });
     size_t BeginIndex = static_cast<size_t>(Begin - Decoded.begin());
     size_t EndIndex = static_cast<size_t>(End - Decoded.begin());
     if (BeginIndex == EndIndex)
@@ -2198,29 +1943,15 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
       }
 
       bool IsReusableCall = llvm::is_contained(Group.Calls, I);
-      bool HasFiniteState = !State.HasUnknown &&
-                            State.ActiveMaterializations.empty() &&
-                            !State.Targets.empty();
-      if (IsReusableCall && HasFiniteState)
+      bool HasFiniteTargets = IsReusableCall && !State.HasUnknown &&
+                              State.ActiveMaterializations.empty() &&
+                              !State.Targets.empty();
+      if (HasFiniteTargets)
         Resolved[I] = State.Targets;
 
-      // The first call after a straight-line materialization is also resolved
-      // by the one-shot matcher. Let that bootstrap call preserve the reaching
-      // value only when both analyses prove the same singleton target through
-      // this exact target pair.
-      bool IsMatchingBootstrapCall = false;
-      if (LocalCalls[I] && HasFiniteState && State.Targets.size() == 1 &&
-          State.Targets.front() == LocalCalls[I]->Target &&
-          DI.Inst.getNumOperands() >= 2) {
-        const MCOperand &TargetOp =
-            DI.Inst.getOperand(DI.Inst.getNumOperands() - 1);
-        IsMatchingBootstrapCall =
-            TargetOp.isReg() && TargetOp.getReg() == Group.TargetRegister;
-      }
-      bool CalleesPreserve = (IsReusableCall || IsMatchingBootstrapCall) &&
-                             HasFiniteState && DI.Inst.getNumOperands() != 0 &&
-                             DI.Inst.getOperand(0).isReg() &&
-                             DI.Inst.getOperand(0).getReg();
+      bool CalleesPreserve =
+          HasFiniteTargets && DI.Inst.getNumOperands() != 0 &&
+          DI.Inst.getOperand(0).isReg() && DI.Inst.getOperand(0).getReg();
       if (CalleesPreserve) {
         MCRegister ReturnRegister(DI.Inst.getOperand(0).getReg());
         uint64_t RegisterKey = static_cast<uint64_t>(Group.TargetRegister.id())
@@ -3657,18 +3388,13 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   if (!TextEnd)
     return std::nullopt;
 
-  SmallVector<FiniteSetPcTransfer, 8> AllSetPcCandidates =
-      collectFiniteSetPcCandidates(Decoded, LS, TextAddr, *TextEnd,
-                                   FunctionRanges);
-  BitVector RejectedSetPcCandidates(AllSetPcCandidates.size());
-  BitVector ProvenSetPcCandidates(AllSetPcCandidates.size());
-  SmallVector<FiniteSetPcTransfer, 8> EnabledSetPcTransfers;
-  std::vector<ReachingCallTargets> ReusableCalls;
-  std::optional<ControlFlowScanIndex> Index;
-  SmallVector<BoundedSetPcReturn, 2> BoundedReturns;
-  SmallVector<SymbolLessReturnRegion, 8> SymbolLessRegions;
-  bool IndirectControlFlowClosed = false;
-  bool HasUnboundedIndirectEntries = false;
+  SmallVector<std::optional<PcMaterializedCallInfo>, 16> MaterializedCalls(
+      Decoded.size());
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
+  std::vector<ReachingCallTargets> ReusableCalls = resolveReusablePcCallTargets(
+      Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls,
+      DeclaredEntries, Text);
 
   // Exact set-PC edges are an optimistic over-approximation used only to
   // discover later finite call targets. Rebuild from scratch whenever the

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1153,15 +1153,57 @@ bool isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx,
   return Valid && RegisterBits.any() && !Live->anyCommon(RegisterBits);
 }
 
+static std::optional<unsigned>
+findLocallyDeadSgprPair(PatchContext &Ctx, uint64_t InstOffset,
+                        uint32_t InstSize, ArrayRef<uint8_t> Replacement) {
+  if (Ctx.Config.MaxSgprs < 2)
+    return std::nullopt;
+
+  std::optional<BitVector> ReplacementIncoming =
+      getReplacementIncomingSgprs(Replacement, Ctx.LS, Ctx.Config.MaxSgprs);
+  std::optional<BitVector> ContinuationLive =
+      getLiveSgprsAtContinuation(Ctx, InstOffset, InstSize);
+  if (!ReplacementIncoming || !ContinuationLive ||
+      ReplacementIncoming->size() != ContinuationLive->size())
+    return std::nullopt;
+
+  BitVector Unsafe = *ReplacementIncoming;
+  Unsafe |= *ContinuationLive;
+  unsigned Base = (Ctx.Config.MaxSgprs - 2) & ~1u;
+  for (;;) {
+    if (!Unsafe.test(Base) && !Unsafe.test(Base + 1)) {
+      SafeSgprScratchBlock Scratch{Base, 2};
+      if (commitSafeSgprScratchBlock(Ctx, InstOffset, Scratch,
+                                     "locally dead far-return SGPR pair"))
+        return Base;
+    }
+    if (Base == 0)
+      break;
+    Base -= 2;
+  }
+  return std::nullopt;
+}
+
 static std::optional<SafeSgprScratchBlock>
-reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset) {
+reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+                     ArrayRef<uint8_t> Replacement) {
   std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
       Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return");
-  if (!Scratch)
+  if (Scratch) {
+    if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch,
+                                    "safe far return"))
+      return std::nullopt;
+    return Scratch;
+  }
+
+  std::optional<unsigned> LocalPair =
+      findLocallyDeadSgprPair(Ctx, InstOffset, InstSize, Replacement);
+  if (!LocalPair)
     return std::nullopt;
-  if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch, "safe far return"))
-    return std::nullopt;
-  return Scratch;
+  log() << "hotswap: safe far return: reusing locally dead s[" << *LocalPair
+        << ":" << *LocalPair + 1 << "] at 0x" << utohexstr(InstOffset)
+        << "\n";
+  return SafeSgprScratchBlock{*LocalPair, 2};
 }
 
 bool isSBranchReachable(uint64_t From, uint64_t To) {
@@ -1248,9 +1290,9 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
       return declineFar(Twine(InstSize) + " B, smaller than " +
                         Twine(MinInstSize) + " B forward branch");
     std::optional<SafeSgprScratchBlock> Scratch =
-        reserveSafeFarReturn(Ctx, InstOffset);
+        reserveSafeFarReturn(Ctx, InstOffset, InstSize, Replacement);
     if (!Scratch)
-      return declineFar("no safe SGPR triple for set-PC return");
+      return declineFar("no safe SGPR pair for set-PC return");
     T.Bytes.insert(T.Bytes.end(), SetPcReturnReserveBytes, uint8_t{0});
     T.Long = true;
     T.UsesSetPCBack = true;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -407,8 +407,79 @@ truncateNopSledsAtDirectTargets(std::vector<NopSled> &Sleds,
   for (uint32_t I = MinInstSize; I < InstSize; I += MinInstSize)
     std::memcpy(Ctx.Text + InstOffset + I, LS.SNopBytes.data(), MinInstSize);
 
+  // The branch-forward makes every remaining source dword unreachable by
+  // fallthrough. Expose target-free tail dwords to the later whole-object
+  // island planner instead of discarding this spatially distributed branch
+  // capacity. Closed control-flow auditing is required before this path is
+  // selected; direct targets and declared entries remain protected.
+  uint64_t TailBegin = InstOffset + MinInstSize;
+  uint64_t TailEnd = InstOffset + InstSize;
+  for (uint64_t Offset = TailBegin; Offset < TailEnd; Offset += MinInstSize) {
+    if (Ctx.DirectControlFlow.Targets.contains(Offset) ||
+        llvm::is_contained(Ctx.DeclaredEntries, Offset))
+      break;
+    Ctx.LocalReplacementSourceTails.push_back(
+        {Offset, Offset + MinInstSize, Offset, 0, Ctx.TextSize});
+  }
+
   Sled.WritePos += Replacement.size() + MinInstSize;
   // Count-only row: patch placed in-line via a nearby NOP sled, no trampoline.
+  Ctx.Profile.count(HotswapMetric::JumpNopSled);
+  return true;
+}
+
+[[nodiscard]] bool emitSplitDs2Continuation(PatchContext &Ctx,
+                                            uint64_t InstOffset,
+                                            ArrayRef<uint8_t> FirstInstruction,
+                                            uint32_t OverwrittenSize,
+                                            ArrayRef<uint8_t> Continuation) {
+  Ctx.LastReplacementUsedNopSled = false;
+  if (FirstInstruction.empty() || FirstInstruction.size() % MinInstSize != 0 ||
+      OverwrittenSize < MinInstSize || OverwrittenSize % MinInstSize != 0)
+    return false;
+
+  std::optional<uint64_t> BranchFrom = checkedAddUint64(
+      InstOffset, FirstInstruction.size(), "split DS2 branch source");
+  std::optional<uint64_t> ReturnTo =
+      BranchFrom ? checkedAddUint64(*BranchFrom, OverwrittenSize,
+                                    "split DS2 continuation target")
+                 : std::nullopt;
+  if (!BranchFrom || !ReturnTo || *ReturnTo > Ctx.TextSize)
+    return false;
+
+  uint64_t Needed = Continuation.size() + MinInstSize;
+  NopSled *Sled =
+      findNearestSled(Ctx.PreferredDs2ContinuationSleds, *BranchFrom, Needed);
+  // A displaced eight- or twelve-byte follower makes the continuation larger
+  // than the dedicated 20-byte tail. The separately audited 44-byte ordinary
+  // far-body partition is still much smaller than a complete DS2 trampoline
+  // route and avoids both registerless island chains.
+  if (!Sled)
+    Sled =
+        findNearestSled(Ctx.PreferredFarReplacementSleds, *BranchFrom, Needed);
+  if (!Sled)
+    return false;
+
+  SmallVector<uint8_t> BranchBack =
+      Ctx.LS.encodeSBranch(Sled->WritePos + Continuation.size(), *ReturnTo);
+  SmallVector<uint8_t> BranchForward =
+      Ctx.LS.encodeSBranch(*BranchFrom, Sled->WritePos);
+  if (BranchBack.empty() || BranchForward.empty())
+    return false;
+
+  std::memcpy(Ctx.Text + InstOffset, FirstInstruction.data(),
+              FirstInstruction.size());
+  std::memcpy(Ctx.Text + *BranchFrom, BranchForward.data(),
+              BranchForward.size());
+  for (uint32_t I = MinInstSize; I < OverwrittenSize; I += MinInstSize)
+    std::memcpy(Ctx.Text + *BranchFrom + I, Ctx.LS.SNopBytes.data(),
+                MinInstSize);
+  std::memcpy(Ctx.Text + Sled->WritePos, Continuation.data(),
+              Continuation.size());
+  std::memcpy(Ctx.Text + Sled->WritePos + Continuation.size(),
+              BranchBack.data(), BranchBack.size());
+  Sled->WritePos += Needed;
+  Ctx.LastReplacementUsedNopSled = true;
   Ctx.Profile.count(HotswapMetric::JumpNopSled);
   return true;
 }
@@ -2035,7 +2106,8 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
 /// edge executes gfx1250's broken s_add_pc_i64 instruction.
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    ArrayRef<uint8_t> Replacement) {
+                                    ArrayRef<uint8_t> Replacement,
+                                    bool AllowRegisterless) {
   // This trampoline lands at the appended pool base and after every trampoline
   // already queued -- later ones are appended behind it and cannot shift it,
   // and fixupTrampolineBranches walks the same list in the same order -- so its
@@ -2062,6 +2134,8 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   FarReturnScratch Scratch;
   if (Far)
     Scratch = reserveSafeFarReturn(Ctx, InstOffset, InstSize, Replacement);
+  if (Far && !Scratch.Available && !AllowRegisterless)
+    return false;
   uint64_t ReturnReserve = MinInstSize;
   uint64_t BodyPrefix = 0;
   if (Far && Scratch.Available) {
@@ -7265,10 +7339,10 @@ static void appendGatewaySled(std::vector<NopSled> &Sleds, uint64_t Start,
 }
 
 /// Find zero-filled alignment holes, including holes covered by an oversized
-/// function symbol, and s_nop padding outside every function. Such padding is
-/// a safe branch gateway only when it follows a no-fallthrough instruction and
-/// contains no direct branch/call target. In-function s_nop runs are added from
-/// Ctx.NopSleds separately.
+/// function symbol, s_code_end alignment guards, and s_nop padding outside
+/// every function. Such padding is a safe branch gateway only when it follows
+/// a no-fallthrough instruction and contains no direct branch/call target.
+/// In-function s_nop runs are added from Ctx.NopSleds separately.
 static std::vector<NopSled>
 buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
                           const LLVMState &LS, const ElfView &Elf,
@@ -7290,7 +7364,14 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
         ZeroPadding &= Byte == 0;
     bool IsExternalNop = DI.Inst.getOpcode() == LS.SNopOpcode &&
                          !Elf.findFunctionTextRangeAtOffset(DI.Offset);
-    bool GatewayPadding = ZeroPadding || IsExternalNop;
+    // Toolchains use repeated s_code_end instructions as executable alignment
+    // guards after s_endpgm. Once the same closed control-flow audit proves
+    // the run unreachable, an explicitly targeted s_branch relay is safe
+    // there just as it is in a zero-filled alignment hole. This distinction
+    // matters for large linked objects whose only relay capacity in a
+    // short-branch corridor is code-end padding.
+    bool IsCodeEnd = DI.Mnemonic == "s_code_end";
+    bool GatewayPadding = ZeroPadding || IsExternalNop || IsCodeEnd;
     if (!GatewayPadding || (Active && DI.Offset != End)) {
       if (Active)
         appendGatewaySled(Sleds, Start, End, Text.size(), Safe, HasTarget);
@@ -7421,6 +7502,100 @@ buildBranchGatewayHeads(std::vector<NopSled> &Gateways,
   return Heads;
 }
 
+/// Materialize one branch-sized view into the interior of a free padding run
+/// when its low-address head lies outside the current reach corridor. The
+/// ordinary head index consumes ranges from low to high, which is appropriate
+/// for variable-width set-PC gateways but can hide usable interior dwords from
+/// a one-dword branch chain. The synthetic view aliases the original range;
+/// the shared Occupied set prevents either view from committing the same
+/// physical dword, and the later range subtraction preserves both sides.
+static bool materializeInteriorBranchGatewayHead(
+    std::vector<NopSled> &Gateways, BranchGatewayHeadSet &Heads,
+    const DenseSet<uint64_t> &Occupied, uint64_t OwnerOffset,
+    uint64_t CurrentOffset, uint64_t TargetOffset, bool Forward) {
+  std::optional<NopSled> Best;
+  uint64_t BestOffset = Forward ? 0 : std::numeric_limits<uint64_t>::max();
+
+  for (const NopSled &Sled : Gateways) {
+    if (!hasFreeBranchGatewaySlot(Sled) || OwnerOffset < Sled.FunctionStart ||
+        OwnerOffset >= Sled.FunctionEnd)
+      continue;
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    uint64_t Candidate = 0;
+    if (Forward) {
+      if (CurrentOffset >
+          std::numeric_limits<uint64_t>::max() - MaxSledDistance)
+        continue;
+      uint64_t ReachEnd = CurrentOffset + MaxSledDistance;
+      if (CurrentOffset > std::numeric_limits<uint64_t>::max() - MinInstSize ||
+          TargetOffset < MinInstSize)
+        continue;
+      uint64_t Lower = std::max(Sled.WritePos, CurrentOffset + MinInstSize);
+      uint64_t Upper = std::min(
+          {UsableEnd - MinInstSize, ReachEnd, TargetOffset - MinInstSize});
+      if (Lower > Upper)
+        continue;
+      Candidate = Upper - (Upper % MinInstSize);
+      while (Candidate >= Lower && Occupied.contains(Candidate)) {
+        if (Candidate < Lower + MinInstSize) {
+          Candidate = 0;
+          break;
+        }
+        Candidate -= MinInstSize;
+      }
+      if (Candidate == 0 || !isSBranchReachable(CurrentOffset, Candidate) ||
+          (Best && Candidate <= BestOffset))
+        continue;
+    } else {
+      if (TargetOffset > std::numeric_limits<uint64_t>::max() - MinInstSize ||
+          CurrentOffset > std::numeric_limits<uint64_t>::max() - MinInstSize ||
+          CurrentOffset <= TargetOffset + MinInstSize)
+        continue;
+      uint64_t ReachBegin = CurrentOffset + MinInstSize >= MaxSledDistance
+                                ? CurrentOffset + MinInstSize - MaxSledDistance
+                                : 0;
+      uint64_t Lower =
+          std::max({Sled.WritePos, ReachBegin, TargetOffset + MinInstSize});
+      uint64_t Remainder = Lower % MinInstSize;
+      if (Remainder != 0) {
+        if (Lower >
+            std::numeric_limits<uint64_t>::max() - (MinInstSize - Remainder))
+          continue;
+        Lower += MinInstSize - Remainder;
+      }
+      Candidate = Lower;
+      while (Candidate < CurrentOffset &&
+             Candidate <= UsableEnd - MinInstSize &&
+             Occupied.contains(Candidate)) {
+        if (Candidate > std::numeric_limits<uint64_t>::max() - MinInstSize) {
+          Candidate = CurrentOffset;
+          break;
+        }
+        Candidate += MinInstSize;
+      }
+      if (Candidate >= CurrentOffset || Candidate > UsableEnd - MinInstSize ||
+          !isSBranchReachable(CurrentOffset, Candidate) ||
+          (Best && Candidate >= BestOffset))
+        continue;
+    }
+    // If the normal low-address head were usable, the caller would already
+    // have selected it. Require a true interior carve to avoid duplicate head
+    // entries for the common case.
+    if (Candidate == Sled.WritePos)
+      continue;
+    BestOffset = Candidate;
+    Best = NopSled{Candidate, Candidate + MinInstSize, Candidate,
+                   Sled.FunctionStart, Sled.FunctionEnd};
+  }
+
+  if (!Best)
+    return false;
+  size_t Index = Gateways.size();
+  Gateways.push_back(*Best);
+  Heads.insert({BestOffset, Index});
+  return true;
+}
+
 static void
 subtractOccupiedBranchGatewaySlots(std::vector<NopSled> &Gateways,
                                    const DenseSet<uint64_t> &Occupied) {
@@ -7521,6 +7696,10 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
     }
 
     if (BestIndex == Gateways.size()) {
+      if (materializeInteriorBranchGatewayHead(Gateways, Heads, Occupied,
+                                               FromOffset, Current,
+                                               TargetOffset, Forward))
+        continue;
       uint64_t Corridor = Forward ? std::numeric_limits<uint64_t>::max() : 0;
       if (Forward) {
         uint64_t AfterCurrent = Current == std::numeric_limits<uint64_t>::max()
@@ -8600,6 +8779,10 @@ static std::optional<SmallVector<uint64_t, 4>> allocateBackwardBranchIslands(
     }
 
     if (BestIndex == Gateways.size()) {
+      if (materializeInteriorBranchGatewayHead(
+              Gateways, Heads, Occupied, OwnerOffset, Current, TargetOffset,
+              /*Forward=*/false))
+        continue;
       uint64_t Corridor = TargetOffset;
       auto CorridorIt = Heads.lower_bound({Current, 0});
       while (CorridorIt != Heads.begin()) {
@@ -8974,6 +9157,11 @@ assignLongBranchGateways(PatchContext &Ctx,
         DirectBranchTargets);
     for (const NopSled &Sled : Ctx.NopSleds)
       Gateways.push_back(Sled);
+    for (const NopSled &Sled : Ctx.LocalReplacementSourceTails)
+      Gateways.push_back(Sled);
+    if (!Ctx.LocalReplacementSourceTails.empty())
+      log() << "hotswap: exposed " << Ctx.LocalReplacementSourceTails.size()
+            << " unreachable local-replacement source-tail branch slot(s)\n";
     subtractTrampolineSources(Gateways, Ctx.OutTrampolines);
 
     // Keep one 12-byte tail from each safe padding window available for the
@@ -10163,12 +10351,15 @@ assignLongBranchGateways(PatchContext &Ctx,
 }
 
 /// Emit \p Replacement for the instruction at [\p InstOffset,
-/// \p InstOffset + \p InstSize). Prefers an in-place NOP-sled rewrite when a
-/// reachable sled with sufficient headroom exists; otherwise falls back to a
-/// deferred trampoline.
+/// \p InstOffset + \p InstSize). Uses a reachable NOP sled when the pool is
+/// near, or unconditionally attempts one when \p PreferNopSled is set;
+/// otherwise falls back to a deferred trampoline.
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       ArrayRef<uint8_t> Replacement) {
+                                       ArrayRef<uint8_t> Replacement,
+                                       bool PreferNopSled,
+                                       bool AllowTrampoline) {
+  Ctx.LastReplacementUsedNopSled = false;
   std::optional<uint64_t> ReturnTo = checkedAddUint64(
       InstOffset, InstSize, "replacement trampoline return target");
   std::optional<uint64_t> PoolReturnFrom =
@@ -10177,26 +10368,59 @@ assignLongBranchGateways(PatchContext &Ctx,
   if (!ReturnTo || !PoolReturnFrom)
     return false;
 
-  // When the pool base is already out of short-branch reach, defer every site
-  // to the global trampoline pass. That pass can coalesce adjacent patches
-  // before allocating gateways; consuming NOP padding greedily here can strand
-  // a later small or clause/delay-constrained source window.
+  // Function-scoped NOP padding remains the first choice for a near pool.
+  // Explicit callers may prefer it regardless of pool distance; ordinary far
+  // sites try the separately audited object-wide padding below.
   bool PoolBaseFar = !isSBranchReachable(InstOffset, Ctx.PoolBaseOffset) ||
                      !isSBranchReachable(*PoolReturnFrom, *ReturnTo);
-  if (!PoolBaseFar && !Ctx.DirectControlFlow.HasUnresolvedTargets) {
+  if ((!PoolBaseFar || PreferNopSled) &&
+      !Ctx.DirectControlFlow.HasUnresolvedTargets) {
     // findNearestSled enforces sled headroom. emitToNopSled still validates
     // exact branch reachability because branch-back distance includes the
     // replacement size, not just the original instruction offset.
     uint64_t Needed = Replacement.size() + MinInstSize;
     if (NopSled *Sled = findNearestSled(Ctx.NopSleds, InstOffset, Needed)) {
-      if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement))
+      if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement)) {
+        Ctx.LastReplacementUsedNopSled = true;
         return true;
+      }
       log() << "hotswap: emitReplacementCode: NOP sled at offset 0x"
             << utohexstr(Sled->WritePos)
             << " is not branch-reachable after assembly; using trampoline.\n";
     }
   }
-  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
+  // A far appended pool would require one source-to-pool and one return
+  // routing chain per replacement. Prefer audited object-wide padding for all
+  // patch families in that case, while explicit callers such as DS2 may opt
+  // into the same policy even for a near pool.
+  if ((PoolBaseFar || PreferNopSled) &&
+      !Ctx.DirectControlFlow.HasUnresolvedTargets) {
+    uint64_t Needed = Replacement.size() + MinInstSize;
+    auto TryPreferredSleds = [&](std::vector<NopSled> &PreferredSleds) {
+      NopSled *Sled = findNearestSled(PreferredSleds, InstOffset, Needed);
+      if (!Sled)
+        return false;
+      if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement)) {
+        Ctx.LastReplacementUsedNopSled = true;
+        return true;
+      }
+      log() << "hotswap: emitReplacementCode: external padding sled at "
+               "offset 0x"
+            << utohexstr(Sled->WritePos)
+            << " is not branch-reachable after assembly; using trampoline.\n";
+      return false;
+    };
+    if (PreferNopSled && TryPreferredSleds(Ctx.PreferredLocalReplacementSleds))
+      return true;
+    // Ordinary replacements may consume only their explicit unowned-padding
+    // partition. DS2 uses the two audited DS2 pools above and leaves this
+    // partition intact for later patch families.
+    if (!PreferNopSled && TryPreferredSleds(Ctx.PreferredFarReplacementSleds))
+      return true;
+  }
+  return AllowTrampoline
+             ? emitToTrampoline(Ctx, InstOffset, InstSize, Replacement)
+             : false;
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------
@@ -10250,6 +10474,9 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       ArrayRef<uint8_t>(Text, TextSize), &Elf, DeclaredEntries->NonCallEntries);
   if (!ControlFlow)
     return std::nullopt;
+  std::vector<NopSled> PreferredLocalReplacementSleds;
+  std::vector<NopSled> PreferredFarReplacementSleds;
+  std::vector<NopSled> PreferredDs2ContinuationSleds;
   if (ControlFlow->HasUnresolvedTargets) {
     log() << "hotswap: unresolved control-flow target disables NOP-sled "
              "emission, trampoline coalescing, source relocation, and .text "
@@ -10257,6 +10484,81 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     Sleds.clear();
   } else {
     truncateNopSledsAtDirectTargets(Sleds, ControlFlow->Targets);
+    if (!ControlFlow->HasUnboundedIndirectEntries) {
+      std::vector<NopSled> AuditedExternalSleds = buildExternalGatewaySleds(
+          Decoded, LS, Elf, ArrayRef<uint8_t>(Text, TextSize),
+          ControlFlow->Targets);
+      // Replacement bodies respect function ownership. Unowned audited runs
+      // are partitioned between complete DS2 bodies, ordinary far bodies, and
+      // a compact DS2-continuation/global-routing tail.
+      uint64_t UnownedExternalCount = 0;
+      uint64_t UnownedDs2ExternalCount = 0;
+      uint64_t FarReplacementPartitionCount = 0;
+      uint64_t Ds2ContinuationPartitionCount = 0;
+      uint64_t PreservedContinuationBackboneCount = 0;
+      std::optional<uint64_t> LastContinuationBackboneBucket;
+      constexpr uint64_t GlobalRoutingReserveBytes = SetPcReturnReserveBytes;
+      constexpr uint64_t FarReplacementPartitionBytes = 11 * MinInstSize;
+      constexpr uint64_t LocalPartitionReserveBytes =
+          GlobalRoutingReserveBytes + FarReplacementPartitionBytes;
+      constexpr uint64_t ContinuationBackboneBucketBytes = MaxSledDistance / 4;
+      for (NopSled &Sled : AuditedExternalSleds) {
+        if (Elf.findFunctionTextRangeAtOffset(Sled.WritePos))
+          continue;
+        ++UnownedExternalCount;
+        uint64_t OriginalEnd = Sled.End;
+        // Partition each run so instruction-order traversal cannot let early
+        // DS2 sites consume all capacity before later patch families arrive:
+        //   [DS2 bodies][one ordinary far body][global routing tail].
+        uint64_t FarBegin = OriginalEnd - std::min(OriginalEnd - Sled.WritePos,
+                                                   LocalPartitionReserveBytes);
+        uint64_t FarEnd = OriginalEnd - std::min(OriginalEnd - Sled.WritePos,
+                                                 GlobalRoutingReserveBytes);
+        if (FarEnd < OriginalEnd) {
+          uint64_t Bucket = FarEnd / ContinuationBackboneBucketBytes;
+          if (!LastContinuationBackboneBucket ||
+              *LastContinuationBackboneBucket != Bucket) {
+            LastContinuationBackboneBucket = Bucket;
+            ++PreservedContinuationBackboneCount;
+          } else {
+            PreferredDs2ContinuationSleds.push_back({FarEnd, OriginalEnd,
+                                                     FarEnd, Sled.FunctionStart,
+                                                     Sled.FunctionEnd});
+            ++Ds2ContinuationPartitionCount;
+          }
+        }
+        if (FarBegin < FarEnd) {
+          PreferredFarReplacementSleds.push_back({FarBegin, FarEnd, FarBegin,
+                                                  Sled.FunctionStart,
+                                                  Sled.FunctionEnd});
+          ++FarReplacementPartitionCount;
+        }
+        if (Sled.End - Sled.WritePos > LocalPartitionReserveBytes) {
+          Sled.End -= LocalPartitionReserveBytes;
+          PreferredLocalReplacementSleds.push_back(Sled);
+          ++UnownedDs2ExternalCount;
+        }
+      }
+      if (UnownedExternalCount != 0)
+        log() << "hotswap: exposed " << UnownedDs2ExternalCount << " of "
+              << UnownedExternalCount
+              << " unowned unreachable external padding sled(s) for local "
+                 "DS2 bodies while partitioning "
+              << FarReplacementPartitionBytes
+              << " bytes for ordinary far replacements and "
+              << GlobalRoutingReserveBytes
+              << " bytes for global routing per run\n";
+      if (FarReplacementPartitionCount != 0)
+        log() << "hotswap: exposed " << FarReplacementPartitionCount
+              << " disjoint external padding partition(s) for ordinary far "
+                 "replacement bodies\n";
+      if (Ds2ContinuationPartitionCount != 0)
+        log() << "hotswap: exposed " << Ds2ContinuationPartitionCount
+              << " surplus external padding tail(s) for compact DS2 "
+                 "continuations while preserving "
+              << PreservedContinuationBackboneCount
+              << " spatial-backbone tail(s) for global routing\n";
+    }
   }
 
   HotswapProfile::Scope CfgScope = Profile.time(HotswapMetric::CfgBuild);
@@ -10289,6 +10591,10 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
                    OutTrampolines, Sleds,           Elf,
                    Liveness,       KernelStats,     OutScratchPatches,
                    *ControlFlow,   Profile,         DeclaredEntries->Entries};
+  Ctx.PreferredLocalReplacementSleds =
+      std::move(PreferredLocalReplacementSleds);
+  Ctx.PreferredFarReplacementSleds = std::move(PreferredFarReplacementSleds);
+  Ctx.PreferredDs2ContinuationSleds = std::move(PreferredDs2ContinuationSleds);
 
   const HotswapPatchVTable &VT = getHotswapPatchVTable();
 
@@ -10324,6 +10630,7 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       continue;
 
     for (TimedPass &Pass : Passes) {
+      Ctx.CurrentPatchPreservesSgprLiveness = false;
       const uint64_t T0 = Prof ? profNowNs() : 0;
       std::optional<uint32_t> P = runPerInstPass(Pass.Fn, Ctx, Idx);
       if (Prof) {
@@ -10335,7 +10642,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       if (*P == 0)
         continue;
       Patched += *P;
-      noteCurrentTextMutation(Ctx);
+      if (!Ctx.CurrentPatchPreservesSgprLiveness)
+        noteCurrentTextMutation(Ctx);
       break;
     }
   }

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -43,8 +43,10 @@
 #include <cassert>
 #include <chrono>
 #include <cstdio>
+#include <functional>
 #include <limits>
 #include <mutex>
+#include <set>
 #include <tuple>
 
 using namespace llvm;
@@ -525,8 +527,7 @@ encodeSetPcGateway(const LLVMState &LS, uint64_t FromOffset,
 
 static std::optional<uint32_t>
 getSetPcGatewayLayoutSize(uint64_t FromOffset, uint64_t TargetOffset,
-                          unsigned SgprBase, bool UseVcc,
-                          bool PreserveVcc) {
+                          unsigned SgprBase, bool UseVcc, bool PreserveVcc) {
   if (PreserveVcc && !UseVcc)
     return std::nullopt;
   if (!UseVcc && (SgprBase & 1u) != 0)
@@ -535,9 +536,9 @@ getSetPcGatewayLayoutSize(uint64_t FromOffset, uint64_t TargetOffset,
   uint64_t SetPcOffset = FromOffset;
   uint32_t PrefixBytes = 0;
   if (PreserveVcc) {
-    std::optional<uint64_t> Offset = checkedAddUint64(
-        FromOffset, VccMoveBytes,
-        "VCC-preserving set-PC gateway layout offset");
+    std::optional<uint64_t> Offset =
+        checkedAddUint64(FromOffset, VccMoveBytes,
+                         "VCC-preserving set-PC gateway layout offset");
     if (!Offset)
       return std::nullopt;
     SetPcOffset = *Offset;
@@ -551,10 +552,21 @@ getSetPcGatewayLayoutSize(uint64_t FromOffset, uint64_t TargetOffset,
   return PrefixBytes + *SetPcBytes;
 }
 
+static bool gatewayRangeIsOccupied(uint64_t Begin, uint64_t Size,
+                                   const DenseSet<uint64_t> *Occupied) {
+  if (!Occupied)
+    return false;
+  for (uint64_t Offset = 0; Offset < Size; Offset += MinInstSize)
+    if (Occupied->contains(Begin + Offset))
+      return true;
+  return false;
+}
+
 Expected<std::optional<EncodedSetPcGateway>>
 findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                         uint64_t FromOffset, uint64_t TargetOffset,
-                        unsigned SgprBase, bool UseVcc, bool PreserveVcc) {
+                        unsigned SgprBase, bool UseVcc, bool PreserveVcc,
+                        const DenseSet<uint64_t> *Occupied) {
   NopSled *Best = nullptr;
   uint32_t BestLayoutSize = 0;
   uint64_t BestUsableEnd = 0;
@@ -570,15 +582,14 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
     if (Distance >= MaxSledDistance || Distance >= BestDistance ||
         LS.encodeSBranch(FromOffset, Sled.WritePos).empty())
       continue;
-
-    std::optional<uint32_t> LayoutSize =
-        getSetPcGatewayLayoutSize(Sled.WritePos, TargetOffset, SgprBase,
-                                  UseVcc, PreserveVcc);
+    std::optional<uint32_t> LayoutSize = getSetPcGatewayLayoutSize(
+        Sled.WritePos, TargetOffset, SgprBase, UseVcc, PreserveVcc);
     if (!LayoutSize)
       return createStringError(
           Twine("failed to encode set-PC gateway at candidate offset 0x") +
           utohexstr(Sled.WritePos));
-    if (*LayoutSize > UsableEnd - Sled.WritePos)
+    if (*LayoutSize > UsableEnd - Sled.WritePos ||
+        gatewayRangeIsOccupied(Sled.WritePos, *LayoutSize, Occupied))
       continue;
 
     Best = &Sled;
@@ -588,9 +599,8 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
   }
   if (!Best)
     return std::nullopt;
-  std::optional<SmallVector<uint8_t>> BestBytes =
-      encodeSetPcGateway(LS, Best->WritePos, TargetOffset, SgprBase, UseVcc,
-                         PreserveVcc);
+  std::optional<SmallVector<uint8_t>> BestBytes = encodeSetPcGateway(
+      LS, Best->WritePos, TargetOffset, SgprBase, UseVcc, PreserveVcc);
   if (!BestBytes)
     return createStringError(
         Twine("failed to encode set-PC gateway at candidate offset 0x") +
@@ -613,7 +623,7 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
 std::optional<EncodedSplitVccGateway>
 findSplitVccGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                     uint64_t FromOffset, uint64_t TargetOffset,
-                    unsigned SaveSgpr) {
+                    unsigned SaveSgpr, const DenseSet<uint64_t> *Occupied) {
   constexpr uint64_t PrimaryBytes = 2 * MinInstSize;
   constexpr uint64_t SecondaryBytes = SetPcForwardSequenceBytes - MinInstSize;
   SmallVector<size_t, 32> PrimaryCandidates;
@@ -623,6 +633,7 @@ findSplitVccGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
     if (Sled.GatewayOnly || FromOffset < Sled.FunctionStart ||
         FromOffset >= Sled.FunctionEnd || Sled.WritePos > UsableEnd ||
         PrimaryBytes > UsableEnd - Sled.WritePos ||
+        gatewayRangeIsOccupied(Sled.WritePos, PrimaryBytes, Occupied) ||
         !isSBranchReachable(FromOffset, Sled.WritePos))
       continue;
     PrimaryCandidates.push_back(I);
@@ -648,6 +659,8 @@ findSplitVccGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
           FromOffset >= Secondary.FunctionEnd ||
           Secondary.WritePos > UsableEnd ||
           SecondaryBytes > UsableEnd - Secondary.WritePos ||
+          gatewayRangeIsOccupied(Secondary.WritePos, SecondaryBytes,
+                                 Occupied) ||
           (PrimaryOffset < Secondary.WritePos + SecondaryBytes &&
            Secondary.WritePos < PrimaryOffset + PrimaryBytes) ||
           !isSBranchReachable(PrimaryOffset + MinInstSize, Secondary.WritePos))
@@ -683,6 +696,23 @@ static std::optional<unsigned> numberedSgprIndex(const MCRegisterInfo &MRI,
   if (Name.getAsInteger(10, Index))
     return std::nullopt;
   return Index;
+}
+
+static std::optional<unsigned>
+numberedSgprPairLowIndex(const MCRegisterInfo &MRI, MCRegister Reg) {
+  SmallVector<unsigned, 2> Indices;
+  auto Add = [&](MCRegister Candidate) {
+    std::optional<unsigned> Index = numberedSgprIndex(MRI, Candidate);
+    if (Index && !llvm::is_contained(Indices, *Index))
+      Indices.push_back(*Index);
+  };
+  Add(Reg);
+  for (MCPhysReg Sub : MRI.subregs(Reg))
+    Add(MCRegister(Sub));
+  llvm::sort(Indices);
+  if (Indices.size() != 2 || Indices[1] != Indices[0] + 1)
+    return std::nullopt;
+  return Indices[0];
 }
 
 static bool updateNumberedSgprHighWatermark(const MCRegisterInfo &MRI,
@@ -971,8 +1001,8 @@ bool instructionReadsRegister(const InternalDecodedInst &DI,
 }
 
 static void addTrackedSgprBits(const LLVMState &LS, MCRegister Register,
-                               unsigned MaxSgprs, BitVector &Bits,
-                               bool &Valid) {
+                               unsigned MaxSgprs, BitVector &Bits, bool &Valid,
+                               bool RequireFullDefinition = false) {
   if (!Register.isValid())
     return;
   SmallVector<MCRegister, 8> Candidates;
@@ -988,14 +1018,75 @@ static void addTrackedSgprBits(const LLVMState &LS, MCRegister Register,
     std::optional<unsigned> Index = numberedSgprIndex(*LS.MRI, Candidate);
     if (!Index)
       continue;
+    if (RequireFullDefinition && !LS.MRI->isSubRegisterEq(Register, Candidate))
+      continue;
     if (*Index >= MaxSgprs) {
       Valid = false;
       continue;
     }
     Bits.set(*Index);
   }
-  if (isVccRegister(LS, Register))
+  if (isVccRegister(LS, Register) &&
+      (!RequireFullDefinition ||
+       LS.MRI->isSubRegisterEq(Register, LS.VCCRegister)))
     Bits.set(MaxSgprs);
+}
+
+static bool instructionWritesRegister(const InternalDecodedInst &DI,
+                                      const LLVMState &LS,
+                                      MCRegister Register) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != DefCount; ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (Operand.isReg() && Operand.getReg() &&
+        LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+      return true;
+  }
+  if (Desc.variadicOpsAreDefs()) {
+    unsigned VariadicBegin =
+        std::min(Desc.getNumOperands(), DI.Inst.getNumOperands());
+    for (unsigned I = VariadicBegin; I != DI.Inst.getNumOperands(); ++I) {
+      const MCOperand &Operand = DI.Inst.getOperand(I);
+      if (Operand.isReg() && Operand.getReg() &&
+          LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+        return true;
+    }
+  }
+  for (MCPhysReg ImplicitDef : Desc.implicit_defs())
+    if (LS.MRI->regsOverlap(MCRegister(ImplicitDef), Register))
+      return true;
+  return false;
+}
+
+bool instructionFullyWritesRegister(const InternalDecodedInst &DI,
+                                    const LLVMState &LS, MCRegister Register) {
+  auto DefinitionCoversRegister = [&](MCRegister Def) {
+    return Def.isValid() && LS.MRI->isSubRegisterEq(Def, Register);
+  };
+
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != DefCount; ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (Operand.isReg() &&
+        DefinitionCoversRegister(MCRegister(Operand.getReg())))
+      return true;
+  }
+  if (Desc.variadicOpsAreDefs()) {
+    unsigned VariadicBegin =
+        std::min(Desc.getNumOperands(), DI.Inst.getNumOperands());
+    for (unsigned I = VariadicBegin; I != DI.Inst.getNumOperands(); ++I) {
+      const MCOperand &Operand = DI.Inst.getOperand(I);
+      if (Operand.isReg() &&
+          DefinitionCoversRegister(MCRegister(Operand.getReg())))
+        return true;
+    }
+  }
+  for (MCPhysReg ImplicitDef : Desc.implicit_defs())
+    if (DefinitionCoversRegister(MCRegister(ImplicitDef)))
+      return true;
+  return false;
 }
 
 static bool collectTrackedSgprUsesAndDefs(const InternalDecodedInst &DI,
@@ -1015,7 +1106,8 @@ static bool collectTrackedSgprUsesAndDefs(const InternalDecodedInst &DI,
     if (!Operand.isReg() || !Operand.getReg())
       continue;
     MCRegister Register(Operand.getReg());
-    addTrackedSgprBits(LS, Register, MaxSgprs, Defs, Valid);
+    addTrackedSgprBits(LS, Register, MaxSgprs, Defs, Valid,
+                       /*RequireFullDefinition=*/true);
     for (unsigned Use = Desc.getNumDefs(); Use != Desc.getNumOperands();
          ++Use) {
       if (Desc.getOperandConstraint(Use, MCOI::TIED_TO) != static_cast<int>(I))
@@ -1035,12 +1127,14 @@ static bool collectTrackedSgprUsesAndDefs(const InternalDecodedInst &DI,
     if (!Operand.isReg() || !Operand.getReg())
       continue;
     addTrackedSgprBits(LS, MCRegister(Operand.getReg()), MaxSgprs,
-                       Desc.variadicOpsAreDefs() ? Defs : Uses, Valid);
+                       Desc.variadicOpsAreDefs() ? Defs : Uses, Valid,
+                       /*RequireFullDefinition=*/Desc.variadicOpsAreDefs());
   }
   for (MCPhysReg Register : Desc.implicit_uses())
     addTrackedSgprBits(LS, MCRegister(Register), MaxSgprs, Uses, Valid);
   for (MCPhysReg Register : Desc.implicit_defs())
-    addTrackedSgprBits(LS, MCRegister(Register), MaxSgprs, Defs, Valid);
+    addTrackedSgprBits(LS, MCRegister(Register), MaxSgprs, Defs, Valid,
+                       /*RequireFullDefinition=*/true);
   return Valid;
 }
 
@@ -1258,6 +1352,286 @@ std::optional<BitVector> getLiveSgprsAtContinuation(PatchContext &Ctx,
   return Cached->second.LiveBefore[Index->second];
 }
 
+std::optional<DenseSet<uint64_t>>
+computeIncomingRegisterNeeds(ArrayRef<InternalDecodedInst> Decoded,
+                             const LLVMState &LS, uint64_t FunctionBegin,
+                             uint64_t FunctionEnd, MCRegister Register) {
+  if (!LS.MIA || FunctionBegin >= FunctionEnd)
+    return std::nullopt;
+
+  auto Begin =
+      llvm::lower_bound(Decoded, FunctionBegin,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  auto End = llvm::lower_bound(
+      Decoded, FunctionEnd, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  if (Begin == End)
+    return std::nullopt;
+
+  const size_t Count = End - Begin;
+  std::vector<SmallVector<size_t, 2>> Predecessors(Count);
+  BitVector NeedsIncoming(Count);
+  BitVector FullDefinitions(Count);
+
+  auto FindLocalIndex = [&](uint64_t Offset) -> std::optional<size_t> {
+    if (Offset < FunctionBegin || Offset >= FunctionEnd)
+      return std::nullopt;
+    auto It = std::lower_bound(
+        Begin, End, Offset, [](const InternalDecodedInst &DI, uint64_t Target) {
+          return DI.Offset < Target;
+        });
+    if (It == End || It->Offset != Offset)
+      return std::nullopt;
+    return It - Begin;
+  };
+
+  for (size_t I = 0; I != Count; ++I) {
+    const InternalDecodedInst &DI = Begin[I];
+    if (!DI.DecodeSucceeded) {
+      NeedsIncoming.set(I);
+      continue;
+    }
+    if (instructionReadsRegister(DI, LS, Register)) {
+      NeedsIncoming.set(I);
+      continue;
+    }
+    if (instructionFullyWritesRegister(DI, LS, Register)) {
+      FullDefinitions.set(I);
+      continue;
+    }
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode)
+      continue;
+    if (LS.MIA->isCall(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
+        LS.MIA->isReturn(DI.Inst)) {
+      NeedsIncoming.set(I);
+      continue;
+    }
+
+    auto AddSuccessor = [&](uint64_t Offset) {
+      std::optional<size_t> Successor = FindLocalIndex(Offset);
+      if (!Successor) {
+        NeedsIncoming.set(I);
+        return;
+      }
+      Predecessors[*Successor].push_back(I);
+    };
+
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (Target)
+        AddSuccessor(*Target);
+      else
+        NeedsIncoming.set(I);
+      if (LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
+               !LS.MIA->isBarrier(DI.Inst)) {
+      NeedsIncoming.set(I);
+      continue;
+    }
+
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "batched register liveness fallthrough");
+    if (Fallthrough)
+      AddSuccessor(*Fallthrough);
+    else
+      NeedsIncoming.set(I);
+  }
+
+  SmallVector<size_t, 32> Worklist;
+  for (int I = NeedsIncoming.find_first(); I >= 0;
+       I = NeedsIncoming.find_next(I))
+    Worklist.push_back(static_cast<size_t>(I));
+  while (!Worklist.empty()) {
+    size_t Successor = Worklist.pop_back_val();
+    for (size_t Predecessor : Predecessors[Successor]) {
+      if (NeedsIncoming.test(Predecessor) || FullDefinitions.test(Predecessor))
+        continue;
+      NeedsIncoming.set(Predecessor);
+      Worklist.push_back(Predecessor);
+    }
+  }
+
+  DenseSet<uint64_t> Result;
+  for (int I = NeedsIncoming.find_first(); I >= 0;
+       I = NeedsIncoming.find_next(I))
+    Result.insert(Begin[static_cast<size_t>(I)].Offset);
+  return Result;
+}
+
+std::optional<SmallVector<MCRegister, 128>>
+resolveNumberedSgprRegisters(const MCRegisterInfo &MRI, unsigned MaxSgprs) {
+  SmallVector<MCRegister, 128> Registers(MaxSgprs);
+  for (unsigned I = 1; I != MRI.getNumRegs(); ++I) {
+    MCRegister Register(I);
+    std::optional<unsigned> Index = numberedSgprIndex(MRI, Register);
+    if (Index && *Index < MaxSgprs)
+      Registers[*Index] = Register;
+  }
+  if (llvm::any_of(Registers,
+                   [](MCRegister Register) { return !Register.isValid(); }))
+    return std::nullopt;
+  return Registers;
+}
+
+void getNumberedSgprUsesAndDefs(const InternalDecodedInst &DI,
+                                const LLVMState &LS,
+                                ArrayRef<MCRegister> NumberedSgprs,
+                                BitVector &Uses, BitVector &Defs) {
+  assert(Uses.size() == NumberedSgprs.size() &&
+         Defs.size() == NumberedSgprs.size());
+  for (unsigned I = 0; I != NumberedSgprs.size(); ++I) {
+    if (instructionReadsRegister(DI, LS, NumberedSgprs[I]))
+      Uses.set(I);
+    if (instructionWritesRegister(DI, LS, NumberedSgprs[I]))
+      Defs.set(I);
+  }
+}
+
+/// Return the numbered SGPRs whose incoming values can be observed by the
+/// replacement. A malformed or control-flow-bearing replacement conservatively
+/// keeps every value that has not already been overwritten.
+BitVector
+unsafeIncomingNumberedSgprsInReplacement(ArrayRef<uint8_t> Replacement,
+                                         const LLVMState &LS,
+                                         ArrayRef<MCRegister> NumberedSgprs) {
+  const unsigned MaxSgprs = NumberedSgprs.size();
+  BitVector Unsafe(MaxSgprs);
+  BitVector Incoming(MaxSgprs, true);
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Replacement.data(), Replacement.size(), LS, Decoded)) {
+    Unsafe.set();
+    return Unsafe;
+  }
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (!DI.DecodeSucceeded || !LS.MIA) {
+      Unsafe |= Incoming;
+      break;
+    }
+    BitVector Uses(MaxSgprs);
+    BitVector Defs(MaxSgprs);
+    getNumberedSgprUsesAndDefs(DI, LS, NumberedSgprs, Uses, Defs);
+    Uses &= Incoming;
+    Unsafe |= Uses;
+    Incoming.reset(Defs);
+    if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+      Unsafe |= Incoming;
+      break;
+    }
+  }
+  return Unsafe;
+}
+
+/// Analyze all numbered SGPR incoming values in one monotone CFG walk.
+/// Unsafe contains a register when some path reads its incoming value before
+/// overwriting it, or reaches control flow that cannot be bounded precisely.
+std::optional<BitVector>
+unsafeIncomingNumberedSgprsInRange(ArrayRef<InternalDecodedInst> Decoded,
+                                   const LLVMState &LS, uint64_t FunctionBegin,
+                                   uint64_t FunctionEnd, uint64_t Continuation,
+                                   ArrayRef<MCRegister> NumberedSgprs) {
+  const unsigned MaxSgprs = NumberedSgprs.size();
+  if (!LS.MIA)
+    return std::nullopt;
+
+  auto FindInstruction = [&](uint64_t Offset) -> std::optional<size_t> {
+    if (Offset < FunctionBegin || Offset >= FunctionEnd)
+      return std::nullopt;
+    auto It =
+        std::lower_bound(Decoded.begin(), Decoded.end(), Offset,
+                         [](const InternalDecodedInst &DI, uint64_t Target) {
+                           return DI.Offset < Target;
+                         });
+    if (It == Decoded.end() || It->Offset != Offset)
+      return std::nullopt;
+    return It - Decoded.begin();
+  };
+  std::optional<size_t> ContinuationIndex = FindInstruction(Continuation);
+  if (!ContinuationIndex)
+    return std::nullopt;
+
+  DenseMap<size_t, BitVector> IncomingAt;
+  IncomingAt.try_emplace(*ContinuationIndex, MaxSgprs, true);
+  SmallVector<size_t, 16> Worklist(1, *ContinuationIndex);
+  BitVector Queued(Decoded.size());
+  Queued.set(*ContinuationIndex);
+  BitVector Unsafe(MaxSgprs);
+
+  auto Propagate = [&](uint64_t Offset, const BitVector &Incoming) {
+    std::optional<size_t> Successor = FindInstruction(Offset);
+    if (!Successor) {
+      Unsafe |= Incoming;
+      return;
+    }
+    auto It = IncomingAt.try_emplace(*Successor, MaxSgprs).first;
+    BitVector NewValues = Incoming;
+    NewValues.reset(It->second);
+    if (NewValues.none())
+      return;
+    It->second |= Incoming;
+    if (!Queued.test(*Successor)) {
+      Queued.set(*Successor);
+      Worklist.push_back(*Successor);
+    }
+  };
+
+  while (!Worklist.empty()) {
+    size_t Index = Worklist.pop_back_val();
+    Queued.reset(Index);
+    const InternalDecodedInst &DI = Decoded[Index];
+    BitVector Incoming = IncomingAt.find(Index)->second;
+    if (!DI.DecodeSucceeded || DI.Offset < FunctionBegin ||
+        DI.Offset >= FunctionEnd) {
+      Unsafe |= Incoming;
+      continue;
+    }
+
+    BitVector Uses(MaxSgprs);
+    BitVector Defs(MaxSgprs);
+    getNumberedSgprUsesAndDefs(DI, LS, NumberedSgprs, Uses, Defs);
+    Uses &= Incoming;
+    Unsafe |= Uses;
+    Incoming.reset(Defs);
+    if (Incoming.none())
+      continue;
+
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode)
+      continue;
+    if (LS.MIA->isCall(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
+        LS.MIA->isReturn(DI.Inst)) {
+      Unsafe |= Incoming;
+      continue;
+    }
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (Target)
+        Propagate(*Target, Incoming);
+      else
+        Unsafe |= Incoming;
+      if (LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
+               !LS.MIA->isBarrier(DI.Inst)) {
+      Unsafe |= Incoming;
+      continue;
+    }
+
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "far-return SGPR liveness fallthrough");
+    if (Fallthrough)
+      Propagate(*Fallthrough, Incoming);
+    else
+      Unsafe |= Incoming;
+  }
+  return Unsafe;
+}
+
 void noteCurrentTextMutation(PatchContext &Ctx) {
   if (Ctx.TextMutationGeneration == std::numeric_limits<uint64_t>::max()) {
     Ctx.CurrentFunctionSgprLivenessCache.clear();
@@ -1301,10 +1675,7 @@ findLocallyDeadSgprPair(PatchContext &Ctx, uint64_t InstOffset,
   unsigned Base = (Ctx.Config.MaxSgprs - 2) & ~1u;
   for (;;) {
     if (!Unsafe.test(Base) && !Unsafe.test(Base + 1)) {
-      SafeSgprScratchBlock Scratch{Base, 2};
-      if (commitSafeSgprScratchBlock(Ctx, InstOffset, Scratch,
-                                     "locally dead far-return SGPR pair"))
-        return Base;
+      return Base;
     }
     if (Base == 0)
       break;
@@ -1348,6 +1719,10 @@ static FarReturnScratch reserveSafeFarReturn(PatchContext &Ctx,
 
   if (std::optional<unsigned> LocalPair =
           findLocallyDeadSgprPair(Ctx, InstOffset, InstSize, Replacement)) {
+    SafeSgprScratchBlock Scratch{*LocalPair, 2};
+    if (!commitSafeSgprScratchBlock(Ctx, InstOffset, Scratch,
+                                    "locally dead far-return SGPR pair"))
+      return {};
     log() << "hotswap: safe far return: reusing locally dead s[" << *LocalPair
           << ":" << *LocalPair + 1 << "] at 0x" << utohexstr(InstOffset)
           << "\n";
@@ -1581,6 +1956,7 @@ static bool isControlFlowBoundary(const InternalDecodedInst &DI,
 struct DeclaredTextEntryInfo {
   SmallVector<uint64_t, 16> Entries;
   SmallVector<uint64_t, 16> ExternalEntries;
+  SmallVector<uint64_t, 16> NonCallEntries;
 };
 
 static std::optional<DeclaredTextEntryInfo>
@@ -1619,6 +1995,7 @@ collectDeclaredTextEntries(const ElfView &Elf) {
       uint64_t Entry = *EntryAddress - Elf.textAddr();
       Info.Entries.push_back(Entry);
       Info.ExternalEntries.push_back(Entry);
+      Info.NonCallEntries.push_back(Entry);
     }
   }
   return Info;
@@ -1630,6 +2007,18 @@ struct PcMaterializedCallInfo {
   uint64_t SequenceEnd = 0;
   MCRegister ReturnRegister;
 };
+
+static std::optional<uint64_t>
+evaluateAbsoluteUint64Operand(const MCOperand &Operand) {
+  if (Operand.isImm())
+    return static_cast<uint64_t>(Operand.getImm());
+  if (!Operand.isExpr())
+    return std::nullopt;
+  int64_t Value = 0;
+  if (!Operand.getExpr()->evaluateAsAbsolute(Value))
+    return std::nullopt;
+  return static_cast<uint64_t>(Value);
+}
 
 /// Resolve the compiler-emitted PC materialization used by the production
 /// reproducer:
@@ -1654,7 +2043,7 @@ resolveMaterializedPcTarget(ArrayRef<InternalDecodedInst> Decoded,
                             size_t TransferIndex, MCRegister TargetRegister,
                             const LLVMState &LS, uint64_t TextAddr) {
   std::optional<size_t> AddIndex;
-  int64_t AddImmediate = 0;
+  uint64_t AddImmediate = 0;
   for (size_t I = TransferIndex; I != 0;) {
     --I;
     const InternalDecodedInst &Candidate = Decoded[I];
@@ -1667,11 +2056,14 @@ resolveMaterializedPcTarget(ArrayRef<InternalDecodedInst> Decoded,
         !Candidate.Inst.getOperand(0).isReg() ||
         Candidate.Inst.getOperand(0).getReg() != TargetRegister ||
         !Candidate.Inst.getOperand(1).isReg() ||
-        Candidate.Inst.getOperand(1).getReg() != TargetRegister ||
-        !Candidate.Inst.getOperand(2).isImm())
+        Candidate.Inst.getOperand(1).getReg() != TargetRegister)
       return std::nullopt;
     AddIndex = I;
-    AddImmediate = Candidate.Inst.getOperand(2).getImm();
+    std::optional<uint64_t> Immediate =
+        evaluateAbsoluteUint64Operand(Candidate.Inst.getOperand(2));
+    if (!Immediate)
+      return std::nullopt;
+    AddImmediate = *Immediate;
     break;
   }
   if (!AddIndex)
@@ -1701,8 +2093,7 @@ resolveMaterializedPcTarget(ArrayRef<InternalDecodedInst> Decoded,
     // s_add_nc_u64 uses modulo-2^64 arithmetic. Casting the signed MC
     // immediate to uint64_t and adding it reproduces both positive and
     // negative literals, including INT64_MIN, without signed overflow.
-    return MaterializedPcSequence{
-        *PcValue + static_cast<uint64_t>(AddImmediate), Candidate.Offset};
+    return MaterializedPcSequence{*PcValue + AddImmediate, Candidate.Offset};
   }
   return std::nullopt;
 }
@@ -1814,11 +2205,13 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
     if (DI.Inst.getOpcode() != LS.SAddNcU64Opcode ||
         DI.Inst.getNumOperands() != 3 ||
         !isExactRegisterOperand(DI.Inst, 0, Pair) ||
-        !isExactRegisterOperand(DI.Inst, 1, Pair) ||
-        !DI.Inst.getOperand(2).isImm())
+        !isExactRegisterOperand(DI.Inst, 1, Pair))
       break;
-    uint64_t Delta = static_cast<uint64_t>(DI.Inst.getOperand(2).getImm());
-    return std::make_pair(I, *Pc + Delta);
+    std::optional<uint64_t> Delta =
+        evaluateAbsoluteUint64Operand(DI.Inst.getOperand(2));
+    if (!Delta)
+      break;
+    return std::make_pair(I, *Pc + *Delta);
   }
 
   if (GetPcIndex + 3 >= FunctionEndIndex)
@@ -1940,6 +2333,10 @@ static bool calleePreservesReusableTarget(
   }
   return SawInstruction;
 }
+struct ReachingPcUse {
+  size_t InstIndex = 0;
+  MCRegister Register;
+};
 
 struct FiniteSetPcTransfer {
   size_t InstIndex = 0;
@@ -1974,6 +2371,8 @@ static SmallVector<FiniteSetPcTransfer, 8> collectFiniteSetPcCandidates(
   DenseMap<uint64_t, size_t> OffsetToIndex;
   for (size_t I = 0; I != Decoded.size(); ++I)
     OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+  std::optional<SmallVector<MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*LS.MRI, Gfx1250MaxSgprs);
 
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &GetPc = Decoded[I];
@@ -2037,6 +2436,59 @@ static SmallVector<FiniteSetPcTransfer, 8> collectFiniteSetPcCandidates(
           SetPc.Inst.getNumOperands() == 1 &&
           isExactRegisterOperand(SetPc.Inst, 0, Pair))
         appendCandidate(SetPcIndex, SetPcIndex, Match->second);
+    }
+
+    // gfx1250 also materializes a local 64-bit PC delta directly into the
+    // low/high halves of the get-PC pair:
+    //
+    //   s_get_pc_i64 Pair
+    //   s_add_co_u32 Pair.lo, Pair.lo, Delta.lo
+    //   s_add_co_ci_u32 Pair.hi, Pair.hi, Delta.hi
+    //   s_set_pc_i64 Pair
+    //
+    // The two immediate halves are linker constants. Treat the four-op shape
+    // as one candidate; appendCandidate and the later closed-world audit still
+    // reject gaps, instruction-interior targets, and alternate entries.
+    if (I + 3 < FunctionEndIndex) {
+      const InternalDecodedInst &AddLow = Decoded[I + 1];
+      const InternalDecodedInst &AddHigh = Decoded[I + 2];
+      const InternalDecodedInst &SetPc = Decoded[I + 3];
+      if (AddLow.Mnemonic == "s_add_co_u32" &&
+          AddHigh.Mnemonic == "s_add_co_ci_u32" &&
+          AddLow.Inst.getNumOperands() == 3 &&
+          AddHigh.Inst.getNumOperands() == 3 &&
+          SetPc.Inst.getOpcode() == LS.SSetPcI64Opcode &&
+          SetPc.Inst.getNumOperands() == 1 &&
+          isExactRegisterOperand(SetPc.Inst, 0, Pair)) {
+        std::optional<unsigned> PairIndex =
+            numberedSgprPairLowIndex(*LS.MRI, Pair);
+        std::optional<uint32_t> LowDelta =
+            evaluateAbsoluteUint32Operand(AddLow.Inst.getOperand(2));
+        std::optional<uint32_t> HighDelta =
+            evaluateAbsoluteUint32Operand(AddHigh.Inst.getOperand(2));
+        if (PairIndex && LowDelta && HighDelta && NumberedSgprs &&
+            *PairIndex + 1 < NumberedSgprs->size() &&
+            isExactRegisterOperand(AddLow.Inst, 0,
+                                   (*NumberedSgprs)[*PairIndex]) &&
+            isExactRegisterOperand(AddLow.Inst, 1,
+                                   AddLow.Inst.getOperand(0).getReg()) &&
+            isExactRegisterOperand(AddHigh.Inst, 0,
+                                   (*NumberedSgprs)[*PairIndex + 1]) &&
+            isExactRegisterOperand(AddHigh.Inst, 1,
+                                   AddHigh.Inst.getOperand(0).getReg())) {
+          std::optional<uint64_t> PcValue = checkedAddUint64(
+              *GetPcAddress, GetPc.Size, "split-immediate set-PC value");
+          if (PcValue) {
+            uint64_t Delta = static_cast<uint64_t>(*LowDelta) |
+                             (static_cast<uint64_t>(*HighDelta) << 32);
+            // s_add_co_u32 / s_add_co_ci_u32 form one modulo-2^64 add.
+            // A negative linker delta therefore wraps in unsigned arithmetic;
+            // appendCandidate still requires every local result to be an
+            // exact decoded instruction boundary.
+            appendCandidate(I + 3, I + 3, *PcValue + Delta);
+          }
+        }
+      }
     }
 
     // Tensile also emits a signed-direction materialized jump. The signed
@@ -2151,17 +2603,91 @@ static SmallVector<FiniteSetPcTransfer, 8> collectFiniteSetPcCandidates(
     appendCandidate(I + 7, I + 10, Target);
     appendCandidate(I + 10, I + 10, Target);
   }
+
+  // The one-shot get-PC/add-nc resolver permits unrelated register restores
+  // between the add and transfer while stopping at any target-pair clobber or
+  // control-flow boundary. Reuse it for set-PC as well as swap-PC so compiler
+  // epilogues with delayed transfers remain finite candidates.
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &SetPc = Decoded[I];
+    if (!SetPc.DecodeSucceeded ||
+        SetPc.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        SetPc.Inst.getNumOperands() != 1 || !SetPc.Inst.getOperand(0).isReg() ||
+        !SetPc.Inst.getOperand(0).getReg())
+      continue;
+    MCRegister Pair(SetPc.Inst.getOperand(0).getReg());
+    std::optional<MaterializedPcSequence> Sequence =
+        resolveMaterializedPcTarget(Decoded, I, Pair, LS, TextAddr);
+    if (!Sequence)
+      continue;
+    DenseMap<uint64_t, size_t>::const_iterator Begin =
+        OffsetToIndex.find(Sequence->SequenceStart);
+    if (Begin == OffsetToIndex.end() || Begin->second > I)
+      continue;
+    std::optional<uint64_t> SetPcAddress = checkedAddUint64(
+        TextAddr, SetPc.Offset, "delayed finite set-PC address");
+    if (!SetPcAddress)
+      continue;
+    const ElfView::FunctionTextRange *Range =
+        findInnermostFunctionRange(*SetPcAddress, FunctionRanges);
+    if (!Range || Range->Begin < TextAddr || Range->End > TextEnd ||
+        Decoded[Begin->second].Offset < Range->Begin - TextAddr)
+      continue;
+    bool Contiguous = true;
+    for (size_t J = Begin->second; J < I; ++J) {
+      std::optional<uint64_t> End =
+          checkedAddUint64(Decoded[J].Offset, Decoded[J].Size,
+                           "delayed finite set-PC instruction end");
+      if (!Decoded[J].DecodeSucceeded || !End ||
+          *End != Decoded[J + 1].Offset) {
+        Contiguous = false;
+        break;
+      }
+    }
+    if (!Contiguous)
+      continue;
+    std::optional<size_t> LocalTargetIndex;
+    if (Sequence->Target >= TextAddr && Sequence->Target < TextEnd) {
+      DenseMap<uint64_t, size_t>::const_iterator Target =
+          OffsetToIndex.find(Sequence->Target - TextAddr);
+      if (Target == OffsetToIndex.end())
+        continue;
+      LocalTargetIndex = Target->second;
+    }
+    Candidates.push_back({I, Begin->second, I, Sequence->Target,
+                          LocalTargetIndex, Range->Begin - TextAddr,
+                          Range->End - TextAddr});
+  }
   llvm::sort(Candidates, [](const FiniteSetPcTransfer &LHS,
                             const FiniteSetPcTransfer &RHS) {
-    return LHS.InstIndex < RHS.InstIndex;
+    return std::tie(LHS.InstIndex, LHS.Target, LHS.SequenceBeginIndex,
+                    LHS.SequenceEndIndex) < std::tie(RHS.InstIndex, RHS.Target,
+                                                     RHS.SequenceBeginIndex,
+                                                     RHS.SequenceEndIndex);
   });
-  Candidates.erase(std::unique(Candidates.begin(), Candidates.end(),
-                               [](const FiniteSetPcTransfer &LHS,
-                                  const FiniteSetPcTransfer &RHS) {
-                                 return LHS.InstIndex == RHS.InstIndex;
-                               }),
-                   Candidates.end());
-  return Candidates;
+  SmallVector<FiniteSetPcTransfer, 8> Unambiguous;
+  for (size_t I = 0; I != Candidates.size();) {
+    size_t After = I + 1;
+    while (After != Candidates.size() &&
+           Candidates[After].InstIndex == Candidates[I].InstIndex)
+      ++After;
+    bool Same = llvm::all_of(
+        ArrayRef<FiniteSetPcTransfer>(Candidates).slice(I, After - I),
+        [&](const FiniteSetPcTransfer &Candidate) {
+          return Candidate.Target == Candidates[I].Target &&
+                 Candidate.SequenceBeginIndex ==
+                     Candidates[I].SequenceBeginIndex &&
+                 Candidate.SequenceEndIndex == Candidates[I].SequenceEndIndex;
+        });
+    if (Same)
+      Unambiguous.push_back(Candidates[I]);
+    else
+      log() << "hotswap: rejected ambiguous exact set-PC materialization at "
+               "0x"
+            << utohexstr(Decoded[Candidates[I].InstIndex].Offset) << "\n";
+    I = After;
+  }
+  return Unambiguous;
 }
 
 static BitVector computeStaticallyReachableInstructions(
@@ -2273,16 +2799,16 @@ static SmallVector<FiniteSetPcTransfer, 8> selectLeastReachableSetPcCandidates(
   }
 }
 
-/// Resolve register calls whose target pair is selected once and reused across
-/// control flow. A monotone intraprocedural solver propagates finite target
-/// sets from proven get-PC materializations. Any unrecognized pair definition
+/// Resolve uses of an SGPR pair whose value is selected once and reused across
+/// control flow. A monotone intraprocedural solver propagates finite values
+/// from proven get-PC materializations. Any unrecognized pair definition
 /// introduces Unknown, so a bypass around the selector remains fail-closed.
-static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
+static std::vector<ReachingCallTargets> resolveReusablePcValuesAtUses(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
     ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
-    ArrayRef<uint64_t> DeclaredEntries,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<ReachingPcUse> Uses,
     ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
   std::vector<ReachingCallTargets> Resolved(Decoded.size());
   SmallVector<ReachingCallGroup, 8> Groups;
@@ -2290,19 +2816,14 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
   for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
     FiniteSetPcByInst.try_emplace(Transfer.InstIndex, &Transfer);
 
-  for (size_t I = 0; I != Decoded.size(); ++I) {
-    const InternalDecodedInst &Call = Decoded[I];
-    if (!Call.DecodeSucceeded || Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
-        Call.Inst.getNumOperands() < 2)
+  for (const ReachingPcUse &Use : Uses) {
+    size_t I = Use.InstIndex;
+    if (I >= Decoded.size() || !Decoded[I].DecodeSucceeded || !Use.Register)
       continue;
-    const MCOperand &TargetOp =
-        Call.Inst.getOperand(Call.Inst.getNumOperands() - 1);
-    if (!TargetOp.isReg() || !TargetOp.getReg())
-      continue;
-    MCRegister TargetRegister(TargetOp.getReg());
+    MCRegister TargetRegister = Use.Register;
 
     const ElfView::FunctionTextRange *Best = nullptr;
-    uint64_t Address = TextAddr + Call.Offset;
+    uint64_t Address = TextAddr + Decoded[I].Offset;
     for (const ElfView::FunctionTextRange &Range : FunctionRanges)
       if (Range.Begin <= Address && Address < Range.End &&
           (!Best || Range.Begin > Best->Begin))
@@ -2349,11 +2870,11 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
                           [](const InternalDecodedInst &DI, uint64_t Offset) {
                             return DI.Offset < Offset;
                           });
-    ArrayRef<InternalDecodedInst>::const_iterator End = std::lower_bound(
-        Begin, Decoded.end(), Group.End,
-        [](const InternalDecodedInst &DI, uint64_t Offset) {
-          return DI.Offset < Offset;
-        });
+    ArrayRef<InternalDecodedInst>::const_iterator End =
+        std::lower_bound(Begin, Decoded.end(), Group.End,
+                         [](const InternalDecodedInst &DI, uint64_t Offset) {
+                           return DI.Offset < Offset;
+                         });
     size_t BeginIndex = static_cast<size_t>(Begin - Decoded.begin());
     size_t EndIndex = static_cast<size_t>(End - Decoded.begin());
     if (BeginIndex == EndIndex)
@@ -2559,6 +3080,30 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     }
   }
   return Resolved;
+}
+
+/// Call-specific wrapper for the generic reusable-PC value solver.
+static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextEnd,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
+    ArrayRef<uint64_t> DeclaredEntries,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
+  SmallVector<ReachingPcUse, 8> Uses;
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &Call = Decoded[I];
+    if (!Call.DecodeSucceeded || Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+        Call.Inst.getNumOperands() < 2)
+      continue;
+    const MCOperand &TargetOp =
+        Call.Inst.getOperand(Call.Inst.getNumOperands() - 1);
+    if (TargetOp.isReg() && TargetOp.getReg())
+      Uses.push_back({I, MCRegister(TargetOp.getReg())});
+  }
+  return resolveReusablePcValuesAtUses(
+      Decoded, LS, TextAddr, TextEnd, FunctionRanges, LocalCalls,
+      DeclaredEntries, Uses, FiniteSetPcTransfers);
 }
 
 struct KnownCallSite {
@@ -2854,8 +3399,7 @@ static bool hasUnprovenFallthroughEntry(ArrayRef<InternalDecodedInst> Decoded,
     return true;
   }
 
-  for (const ExternalCallContinuation &Call :
-       Index.ExternalCallContinuations) {
+  for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations) {
     uint64_t Source = Decoded[Call.InstIndex].Offset;
     if (Call.Continuation >= ChainBegin && Call.Continuation < FunctionBegin) {
       log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
@@ -3859,6 +4403,1377 @@ hasKnownControlFlowEntry(ArrayRef<uint64_t> DeclaredEntries,
   return false;
 }
 
+struct WellFormedAbiEntrySet {
+  DenseSet<size_t> Calls;
+  DenseSet<size_t> SetPcs;
+  DenseSet<uint64_t> Targets;
+};
+
+static std::optional<unsigned> numberedVgprIndex(const MCRegisterInfo &MRI,
+                                                 MCRegister Reg) {
+  if (!Reg)
+    return std::nullopt;
+  StringRef Name(MRI.getName(Reg));
+  if (!Name.consume_front("VGPR") || Name.empty() || Name.contains('_'))
+    return std::nullopt;
+  unsigned Index = 0;
+  if (Name.getAsInteger(10, Index))
+    return std::nullopt;
+  return Index;
+}
+
+static bool isAbiCalleeSavedVgpr(unsigned Vgpr) {
+  // CSR_AMDGPU_VGPRs in AMDGPUCallingConv.td uses eight-register saved
+  // stripes alternating with eight caller-saved registers, starting at v40.
+  return Vgpr >= 40 && Vgpr <= 255 && ((Vgpr - 40) % 16) < 8;
+}
+
+static bool instructionDefinesRegisterNamed(const InternalDecodedInst &DI,
+                                            StringRef Name,
+                                            const LLVMState &LS) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I)
+    if (DI.Inst.getOperand(I).isReg() && DI.Inst.getOperand(I).getReg() &&
+        StringRef(LS.MRI->getName(DI.Inst.getOperand(I).getReg())) == Name)
+      return true;
+  return llvm::any_of(Desc.implicit_defs(), [&](MCPhysReg Reg) {
+    return StringRef(LS.MRI->getName(Reg)) == Name;
+  });
+}
+
+/// Return the exact packed VGPR-MSB mode installed by this instruction, or
+/// std::nullopt when it does not install one. The constants mirror the
+/// documented HW_REG_WAVE_MODE decode used by the WMMA mode analysis.
+static std::optional<unsigned>
+getExactAbiVgprMode(const InternalDecodedInst &DI, const LLVMState &LS) {
+  if (DI.Inst.getOpcode() == LS.SSetVgprMsbOpcode) {
+    if (DI.Inst.getNumOperands() != 1 || !DI.Inst.getOperand(0).isImm())
+      return std::nullopt;
+    return static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) & 0xff;
+  }
+  if (DI.Inst.getOpcode() != LS.SSetregImm32Opcode ||
+      DI.Inst.getNumOperands() != 2 || !DI.Inst.getOperand(0).isImm() ||
+      !DI.Inst.getOperand(1).isImm())
+    return std::nullopt;
+  constexpr unsigned HwregIdMask = 0x3f;
+  constexpr unsigned HwregIdMode = 1;
+  unsigned Simm16 = static_cast<unsigned>(DI.Inst.getOperand(1).getImm());
+  if ((Simm16 & HwregIdMask) != HwregIdMode)
+    return std::nullopt;
+  unsigned Raw =
+      (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) >> 12) & 0xff;
+  return ((Raw >> 2) | (Raw << 6)) & 0xff;
+}
+
+static bool mayWriteAbiVgprBankUnknown(const InternalDecodedInst &DI,
+                                       const LLVMState &LS) {
+  if (DI.Inst.getOpcode() == LS.SSetVgprMsbOpcode)
+    return !getExactAbiVgprMode(DI, LS);
+  if (DI.Inst.getOpcode() == LS.SSetregImm32Opcode ||
+      DI.Inst.getOpcode() == LS.SSetregB32Opcode) {
+    if (DI.Inst.getNumOperands() == 0 ||
+        !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm())
+      return true;
+    constexpr unsigned HwregIdMask = 0x3f;
+    constexpr unsigned HwregIdMode = 1;
+    unsigned Simm16 = static_cast<unsigned>(
+        DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
+    if ((Simm16 & HwregIdMask) != HwregIdMode)
+      return false;
+    return !getExactAbiVgprMode(DI, LS);
+  }
+  return instructionDefinesRegisterNamed(DI, "MODE", LS);
+}
+
+bool matchesCanonicalLaneTransfer(const InternalDecodedInst &DI,
+                                  StringRef Mnemonic, MCRegister Dst,
+                                  MCRegister Src, int64_t Lane) {
+  unsigned ExpectedOperands = Mnemonic == "v_readlane_b32"    ? 3
+                              : Mnemonic == "v_writelane_b32" ? 4
+                                                              : 0;
+  if (!ExpectedOperands || DI.Mnemonic != Mnemonic ||
+      DI.Inst.getNumOperands() != ExpectedOperands ||
+      !isExactRegisterOperand(DI.Inst, 0, Dst) ||
+      !isExactRegisterOperand(DI.Inst, 1, Src) ||
+      !DI.Inst.getOperand(2).isImm() || DI.Inst.getOperand(2).getImm() != Lane)
+    return false;
+  return Mnemonic == "v_readlane_b32" ||
+         isExactRegisterOperand(DI.Inst, 3, Dst);
+}
+
+/// MachineInstr analysis historically classifies a few EXEC-mask operations as
+/// branches even though they do not change the PC.  The canonical-frame proof
+/// needs the narrower hardware notion: an explicit PC opcode, a return or
+/// indirect branch, or a branch/call carrying a PC-relative target.
+bool isTruePcTransfer(const InternalDecodedInst &DI, const LLVMState &LS) {
+  if (!DI.DecodeSucceeded)
+    return false;
+  if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode ||
+      DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
+      DI.Inst.getOpcode() == LS.SAddPcI64Opcode || LS.MIA->isReturn(DI.Inst) ||
+      LS.MIA->isIndirectBranch(DI.Inst))
+    return true;
+  return (LS.MIA->isBranch(DI.Inst) || LS.MIA->isCall(DI.Inst)) &&
+         hasPcRelativeOperand(DI, LS);
+}
+
+struct CanonicalSavedLane {
+  MCRegister Vgpr;
+  int64_t Lane = -1;
+
+  bool operator==(const CanonicalSavedLane &Other) const {
+    return Vgpr == Other.Vgpr && Lane == Other.Lane;
+  }
+};
+
+struct CanonicalAbiReturn {
+  size_t ReturnIndex = 0;
+  size_t RestoreLowIndex = 0;
+  size_t RestoreHighIndex = 0;
+  CanonicalSavedLane SavedLow;
+  CanonicalSavedLane SavedHigh;
+};
+
+struct AbiVgprModeState {
+  int8_t Dst = -2;
+  int8_t Src0 = -2;
+  int8_t Src1 = -2;
+  int8_t Src2 = -2;
+};
+
+static AbiVgprModeState abiVgprModeState(unsigned Mode) {
+  return {static_cast<int8_t>((Mode >> 6) & 3), static_cast<int8_t>(Mode & 3),
+          static_cast<int8_t>((Mode >> 2) & 3),
+          static_cast<int8_t>((Mode >> 4) & 3)};
+}
+
+static bool isUnreachable(AbiVgprModeState State) { return State.Dst == -2; }
+
+static AbiVgprModeState mergeAbiVgprMode(AbiVgprModeState Old,
+                                         AbiVgprModeState Incoming) {
+  if (isUnreachable(Old))
+    return Incoming;
+  if (isUnreachable(Incoming))
+    return Old;
+  auto Merge = [](int8_t LHS, int8_t RHS) {
+    return LHS == RHS ? LHS : int8_t{-1};
+  };
+  return {Merge(Old.Dst, Incoming.Dst), Merge(Old.Src0, Incoming.Src0),
+          Merge(Old.Src1, Incoming.Src1), Merge(Old.Src2, Incoming.Src2)};
+}
+
+static bool sameAbiVgprMode(AbiVgprModeState LHS, AbiVgprModeState RHS) {
+  return std::tie(LHS.Dst, LHS.Src0, LHS.Src1, LHS.Src2) ==
+         std::tie(RHS.Dst, RHS.Src0, RHS.Src1, RHS.Src2);
+}
+
+static bool isAbiVgprModeZero(AbiVgprModeState State) {
+  return State.Dst == 0 && State.Src0 == 0 && State.Src1 == 0 &&
+         State.Src2 == 0;
+}
+
+/// Prove full VGPR-MSB mode zero at every call and s30 ABI return accepted by
+/// the linked-object fallback. Every defined function/declared entry is seeded
+/// with the HSA ABI entry mode; cross-function direct edges and CFG joins are
+/// then modeled explicitly so a non-ABI caller cannot be hidden by reseeding
+/// its callee.
+static bool validateAbiControlTransferModes(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextSize, ArrayRef<uint64_t> AbiRootEntries,
+    const DenseMap<size_t, const FiniteSetPcTransfer *> &ExactSetPcs,
+    MCRegister AbiLinkPair) {
+  DenseMap<uint64_t, unsigned> OffsetToIndex;
+  OffsetToIndex.reserve(Decoded.size());
+  for (unsigned I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+
+  std::vector<SmallVector<unsigned, 2>> Successors(Decoded.size());
+  auto addTarget = [&](SmallVectorImpl<unsigned> &Out, uint64_t Target) {
+    if (Target >= TextSize)
+      return true;
+    DenseMap<uint64_t, unsigned>::const_iterator It =
+        OffsetToIndex.find(Target);
+    if (It == OffsetToIndex.end())
+      return false;
+    Out.push_back(It->second);
+    return true;
+  };
+  auto addFallthrough = [&](SmallVectorImpl<unsigned> &Out, unsigned I) {
+    if (I + 1 == Decoded.size())
+      return true;
+    std::optional<uint64_t> End = checkedAddUint64(
+        Decoded[I].Offset, Decoded[I].Size, "ABI mode fallthrough");
+    return End && (*End >= TextSize || addTarget(Out, *End));
+  };
+
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    SmallVectorImpl<unsigned> &Out = Successors[I];
+    if (!DI.DecodeSucceeded)
+      return false;
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator Exact =
+          ExactSetPcs.find(I);
+      if (Exact != ExactSetPcs.end() && Exact->second->LocalTargetIndex &&
+          !addTarget(Out, Decoded[*Exact->second->LocalTargetIndex].Offset))
+        return false;
+      continue;
+    }
+    if (LS.MIA->isCall(DI.Inst) && isTruePcTransfer(DI, LS)) {
+      if (!addFallthrough(Out, I))
+        return false;
+      continue;
+    }
+    if (LS.MIA->isBranch(DI.Inst) && hasPcRelativeOperand(DI, LS)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (!Target || !addTarget(Out, *Target))
+        return false;
+      if (LS.MIA->isConditionalBranch(DI.Inst)) {
+        if (!addFallthrough(Out, I))
+          return false;
+      } else if (!LS.MIA->isUnconditionalBranch(DI.Inst)) {
+        return false;
+      }
+      continue;
+    }
+    if (isTruePcTransfer(DI, LS))
+      continue;
+    if (!addFallthrough(Out, I))
+      return false;
+  }
+
+  SmallVector<AbiVgprModeState, 0> ModeBefore(Decoded.size());
+  SmallVector<unsigned, 64> Worklist;
+  for (uint64_t Root : AbiRootEntries) {
+    DenseMap<uint64_t, unsigned>::const_iterator It = OffsetToIndex.find(Root);
+    if (It == OffsetToIndex.end())
+      return false;
+    AbiVgprModeState Seeded =
+        mergeAbiVgprMode(ModeBefore[It->second], abiVgprModeState(0));
+    if (!sameAbiVgprMode(Seeded, ModeBefore[It->second])) {
+      ModeBefore[It->second] = Seeded;
+      Worklist.push_back(It->second);
+    }
+  }
+  for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+    unsigned I = Worklist[Next];
+    AbiVgprModeState ModeOut = ModeBefore[I];
+    if (std::optional<unsigned> Mode = getExactAbiVgprMode(Decoded[I], LS))
+      ModeOut = abiVgprModeState(*Mode);
+    else if (mayWriteAbiVgprBankUnknown(Decoded[I], LS))
+      ModeOut = {-1, -1, -1, -1};
+    for (unsigned Successor : Successors[I]) {
+      AbiVgprModeState Merged =
+          mergeAbiVgprMode(ModeBefore[Successor], ModeOut);
+      if (!sameAbiVgprMode(Merged, ModeBefore[Successor])) {
+        ModeBefore[Successor] = Merged;
+        Worklist.push_back(Successor);
+      }
+    }
+  }
+
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    bool IsCall = LS.MIA->isCall(DI.Inst) && isTruePcTransfer(DI, LS);
+    bool IsAbiReturn = DI.Inst.getOpcode() == LS.SSetPcI64Opcode &&
+                       isExactRegisterOperand(DI.Inst, 0, AbiLinkPair) &&
+                       !ExactSetPcs.contains(I);
+    if (!IsCall && !IsAbiReturn)
+      continue;
+    if (isUnreachable(ModeBefore[I])) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "control transfer at 0x"
+            << utohexstr(DI.Offset) << " is unreachable from an ABI root\n";
+      return false;
+    }
+    if (!isAbiVgprModeZero(ModeBefore[I])) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "control transfer at 0x"
+            << utohexstr(DI.Offset) << " is not in full VGPR-MSB mode 0\n";
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Prove the compiler's canonical AMDGPU nested-call frame for a group of
+/// s[30:31] returns in one local STT_FUNC:
+///
+///   v_writelane SavedLowVgpr,  s30, SavedLowLane
+///   v_writelane SavedHighVgpr, s31, SavedHighLane
+///     ... s_swap_pc_i64 s[30:31], Target ...
+///   v_readlane s30, SavedLowVgpr,  SavedLowLane
+///   v_readlane s31, SavedHighVgpr, SavedHighLane
+///   s_set_pc_i64 s[30:31]
+///
+/// Both saved VGPRs must be in CSR_AMDGPU_VGPRs, so nested C/Fast/Cold callees
+/// preserve them (SIRegisterInfo::getCallPreservedMask). The locations may
+/// straddle a VGPR boundary when the compiler packs a large SGPR spill into
+/// consecutive wave lanes. A function-local CFG fixed point additionally
+/// proves every caller write to either saved physical VGPR addresses a
+/// different persistent destination bank, writes a different lane, or is the
+/// exact prologue save. Calls are permitted only in full VGPR-MSB mode zero,
+/// the mode required at both call entry and return.
+static bool validateCanonicalAbiFrameReturns(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, const ElfView::FunctionTextRange &Range,
+    ArrayRef<size_t> ReturnIndices,
+    const DenseMap<size_t, const FiniteSetPcTransfer *> &ExactSetPcs,
+    ArrayRef<DirectTargetSource> ExactSetPcEntries,
+    ArrayRef<CallContinuationSource> AllCallContinuations,
+    const DenseSet<uint64_t> &PotentialEntries,
+    ArrayRef<uint64_t> ActualRootEntries, ArrayRef<uint64_t> AbiModeRootEntries,
+    const ControlFlowScanIndex &Index, MCRegister AbiLinkPair,
+    ArrayRef<MCRegister> NumberedSgprs,
+    const DenseSet<size_t> &CanonicalAbiTailTransfers,
+    bool ForceFullCanonicalFrame, DenseSet<size_t> &SafeReturns) {
+  if (!Range.Symbol || Range.Symbol->getType() != ELF::STT_FUNC ||
+      Range.Symbol->getBinding() != ELF::STB_LOCAL || Range.Begin < TextAddr ||
+      Range.End <= Range.Begin)
+    return false;
+  uint64_t BeginOffset = Range.Begin - TextAddr;
+  uint64_t EndOffset = Range.End - TextAddr;
+  auto reject = [&](const Twine &Reason) {
+    log() << "hotswap: canonical s30 frame at 0x" << utohexstr(BeginOffset)
+          << " rejected: " << Reason << "\n";
+    return false;
+  };
+  auto BeginIt = llvm::lower_bound(
+      Decoded, BeginOffset, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  auto EndIt =
+      std::lower_bound(BeginIt, Decoded.end(), EndOffset,
+                       [](const InternalDecodedInst &DI, uint64_t Offset) {
+                         return DI.Offset < Offset;
+                       });
+  if (BeginIt == EndIt || BeginIt->Offset != BeginOffset)
+    return reject("function start is not a decoded instruction");
+  size_t BeginIndex = static_cast<size_t>(BeginIt - Decoded.begin());
+  size_t EndIndex = static_cast<size_t>(EndIt - Decoded.begin());
+  if (hasUnprovenFallthroughEntry(Decoded, BeginOffset,
+                                  Decoded[ReturnIndices.front()].Offset,
+                                  AbiModeRootEntries, Index)) {
+    // A compiler-emitted noreturn/trap tail may be laid out immediately
+    // before the next local function. It is still a valid linked-call entry
+    // when every path through that fallthrough suffix executes one exact ABI
+    // call that defines s[30:31], and no root or transfer can bypass the call.
+    auto Fallthrough = Index.FallthroughEntries.find(BeginOffset);
+    std::optional<size_t> LinkCall;
+    if (Fallthrough != Index.FallthroughEntries.end() &&
+        Fallthrough->second.Proven) {
+      uint64_t ChainBegin = Fallthrough->second.ChainBegin;
+      for (size_t I = BeginIndex; I != 0;) {
+        --I;
+        if (Decoded[I].Offset < ChainBegin)
+          break;
+        if (!LS.MIA->isCall(Decoded[I].Inst) ||
+            !isTruePcTransfer(Decoded[I], LS))
+          continue;
+        std::optional<MCRegister> Link = getCallReturnRegister(Decoded[I], LS);
+        if (Link && *Link == AbiLinkPair)
+          LinkCall = I;
+        break;
+      }
+    }
+    if (!LinkCall)
+      return reject("function entry has an unproven layout fallthrough");
+    std::optional<uint64_t> Continuation =
+        checkedAddUint64(Decoded[*LinkCall].Offset, Decoded[*LinkCall].Size,
+                         "canonical frame prefix call continuation");
+    if (!Continuation || *Continuation >= BeginOffset)
+      return reject("function entry has an invalid link-defining prefix call");
+    ArrayRef<uint64_t>::iterator Root =
+        llvm::lower_bound(AbiModeRootEntries, *Continuation);
+    if (Root != AbiModeRootEntries.end() && *Root < BeginOffset)
+      return reject(Twine("ABI root bypasses prefix link call at 0x") +
+                    utohexstr(*Root));
+    auto Direct = llvm::lower_bound(
+        Index.DirectTargetsByTarget, *Continuation,
+        [](const DirectTargetSource &Source, uint64_t Target) {
+          return Source.Target < Target;
+        });
+    if (Direct != Index.DirectTargetsByTarget.end() &&
+        Direct->Target < BeginOffset)
+      return reject(Twine("control flow bypasses prefix link call at 0x") +
+                    utohexstr(Direct->Target));
+    auto Exact = llvm::lower_bound(
+        ExactSetPcEntries, *Continuation,
+        [](const DirectTargetSource &Source, uint64_t Target) {
+          return Source.Target < Target;
+        });
+    if (Exact != ExactSetPcEntries.end() && Exact->Target < BeginOffset)
+      return reject(Twine("exact set-PC bypasses prefix link call at 0x") +
+                    utohexstr(Exact->Target));
+    auto OtherCall = llvm::lower_bound(
+        AllCallContinuations, *Continuation,
+        [](const CallContinuationSource &Source, uint64_t Target) {
+          return Source.Continuation < Target;
+        });
+    for (; OtherCall != AllCallContinuations.end() &&
+           OtherCall->Continuation < BeginOffset;
+         ++OtherCall)
+      if (OtherCall->InstIndex != *LinkCall)
+        return reject(Twine("foreign call continuation bypasses prefix link "
+                            "call at 0x") +
+                      utohexstr(OtherCall->Continuation));
+    for (size_t I = *LinkCall + 1; I != BeginIndex; ++I)
+      if (definesOverlappingRegister(Decoded[I], LS, NumberedSgprs[30]) ||
+          definesOverlappingRegister(Decoded[I], LS, NumberedSgprs[31]) ||
+          (isTruePcTransfer(Decoded[I], LS) && LS.MIA->isCall(Decoded[I].Inst)))
+        return reject(Twine("prefix link is clobbered at 0x") +
+                      utohexstr(Decoded[I].Offset));
+  }
+  ArrayRef<uint64_t>::iterator FunctionRoot =
+      llvm::upper_bound(AbiModeRootEntries, BeginOffset);
+  if (FunctionRoot != AbiModeRootEntries.end() && *FunctionRoot < EndOffset)
+    return reject(Twine("ABI function root enters at 0x") +
+                  utohexstr(*FunctionRoot));
+  ArrayRef<uint64_t>::iterator ActualRoot =
+      llvm::lower_bound(ActualRootEntries, BeginOffset);
+  if (ActualRoot != ActualRootEntries.end() && *ActualRoot < EndOffset)
+    return reject(Twine("declared/external root enters at 0x") +
+                  utohexstr(*ActualRoot));
+  SmallVector<size_t, 4> BeginReentrySources;
+  auto Direct =
+      llvm::lower_bound(Index.DirectTargetsByTarget, BeginOffset,
+                        [](const DirectTargetSource &Source, uint64_t Target) {
+                          return Source.Target < Target;
+                        });
+  for (; Direct != Index.DirectTargetsByTarget.end() &&
+         Direct->Target < EndOffset;
+       ++Direct) {
+    const DirectTargetSource &Source = *Direct;
+    uint64_t SourceOffset = Decoded[Source.InstIndex].Offset;
+    bool SourceInside = SourceOffset >= BeginOffset && SourceOffset < EndOffset;
+    if (SourceInside) {
+      if (Source.Target == BeginOffset)
+        BeginReentrySources.push_back(Source.InstIndex);
+      continue;
+    }
+    if (Source.Target == BeginOffset) {
+      if (CanonicalAbiTailTransfers.contains(Source.InstIndex))
+        continue;
+      std::optional<MCRegister> Link =
+          getCallReturnRegister(Decoded[Source.InstIndex], LS);
+      if (!Link || *Link != AbiLinkPair)
+        return reject(Twine("non-ABI control transfer enters function at 0x") +
+                      utohexstr(SourceOffset));
+      continue;
+    }
+    return reject(Twine("external direct transfer enters at 0x") +
+                  utohexstr(Source.Target));
+  }
+  auto Exact =
+      llvm::lower_bound(ExactSetPcEntries, BeginOffset,
+                        [](const DirectTargetSource &Source, uint64_t Target) {
+                          return Source.Target < Target;
+                        });
+  for (; Exact != ExactSetPcEntries.end() && Exact->Target < EndOffset;
+       ++Exact) {
+    uint64_t Target = Exact->Target;
+    uint64_t Source = Decoded[Exact->InstIndex].Offset;
+    bool SourceInside = Source >= BeginOffset && Source < EndOffset;
+    // A separately validated canonical tail thunk may enter exactly at Begin:
+    // its source frame proves s[30:31] was restored to the incoming link
+    // before this exact set-PC. Interior entries and all other external exact
+    // transfers remain forbidden.
+    if (Target == BeginOffset && !SourceInside &&
+        CanonicalAbiTailTransfers.contains(Exact->InstIndex))
+      continue;
+    if (Target == BeginOffset || (Target > BeginOffset && !SourceInside))
+      return reject(Twine("external exact set-PC enters at 0x") +
+                    utohexstr(Target));
+  }
+  auto Continuation = llvm::lower_bound(
+      AllCallContinuations, BeginOffset,
+      [](const CallContinuationSource &Source, uint64_t Target) {
+        return Source.Continuation < Target;
+      });
+  for (; Continuation != AllCallContinuations.end() &&
+         Continuation->Continuation < EndOffset;
+       ++Continuation)
+    if (Decoded[Continuation->InstIndex].Offset < BeginOffset ||
+        Decoded[Continuation->InstIndex].Offset >= EndOffset)
+      return reject(Twine("external call continuation enters at 0x") +
+                    utohexstr(Continuation->Continuation));
+
+  bool HasNestedCall = false;
+  for (size_t I = BeginIndex; I != EndIndex; ++I)
+    HasNestedCall |=
+        LS.MIA->isCall(Decoded[I].Inst) && isTruePcTransfer(Decoded[I], LS);
+  if (!ForceFullCanonicalFrame && !HasNestedCall) {
+    bool DefinesLink = false;
+    for (size_t I = BeginIndex; I != EndIndex; ++I) {
+      const InternalDecodedInst &DI = Decoded[I];
+      DefinesLink |= definesOverlappingRegister(DI, LS, NumberedSgprs[30]) ||
+                     definesOverlappingRegister(DI, LS, NumberedSgprs[31]);
+    }
+    if (!DefinesLink) {
+      for (size_t Return : ReturnIndices)
+        SafeReturns.insert(Return);
+      return true;
+    }
+  }
+
+  SmallVector<CanonicalAbiReturn, 4> Returns;
+  std::optional<CanonicalSavedLane> SavedLow;
+  std::optional<CanonicalSavedLane> SavedHigh;
+  DenseSet<size_t> RestoreInstructions;
+  DenseSet<size_t> PostRestoreTeardownInstructions;
+  for (size_t ReturnIndex : ReturnIndices) {
+    std::optional<size_t> Low;
+    std::optional<size_t> High;
+    std::optional<CanonicalSavedLane> CandidateLow;
+    std::optional<CanonicalSavedLane> CandidateHigh;
+    for (size_t I = ReturnIndex; I != BeginIndex;) {
+      --I;
+      const InternalDecodedInst &DI = Decoded[I];
+      if (!DI.DecodeSucceeded)
+        return reject("undecoded restore instruction");
+      if (!Low && definesOverlappingRegister(DI, LS, NumberedSgprs[30])) {
+        if (DI.Mnemonic != "v_readlane_b32" || DI.Inst.getNumOperands() != 3 ||
+            !isExactRegisterOperand(DI.Inst, 0, NumberedSgprs[30]) ||
+            !DI.Inst.getOperand(1).isReg() || !DI.Inst.getOperand(1).getReg() ||
+            !DI.Inst.getOperand(2).isImm() ||
+            DI.Inst.getOperand(2).getImm() < 0 ||
+            DI.Inst.getOperand(2).getImm() >= 32)
+          return reject(Twine("invalid s30 restore before return 0x") +
+                        utohexstr(Decoded[ReturnIndex].Offset));
+        Low = I;
+        CandidateLow =
+            CanonicalSavedLane{MCRegister(DI.Inst.getOperand(1).getReg()),
+                               DI.Inst.getOperand(2).getImm()};
+      }
+      if (!High && definesOverlappingRegister(DI, LS, NumberedSgprs[31])) {
+        if (DI.Mnemonic != "v_readlane_b32" || DI.Inst.getNumOperands() != 3 ||
+            !isExactRegisterOperand(DI.Inst, 0, NumberedSgprs[31]) ||
+            !DI.Inst.getOperand(1).isReg() || !DI.Inst.getOperand(1).getReg() ||
+            !DI.Inst.getOperand(2).isImm() ||
+            DI.Inst.getOperand(2).getImm() < 0 ||
+            DI.Inst.getOperand(2).getImm() >= 32)
+          return reject(Twine("invalid s31 restore before return 0x") +
+                        utohexstr(Decoded[ReturnIndex].Offset));
+        High = I;
+        CandidateHigh =
+            CanonicalSavedLane{MCRegister(DI.Inst.getOperand(1).getReg()),
+                               DI.Inst.getOperand(2).getImm()};
+      }
+      if (Low && High)
+        break;
+      if (PotentialEntries.contains(DI.Offset))
+        return reject(Twine("entry at 0x") + utohexstr(DI.Offset) +
+                      " interrupts the restore search");
+      if (isTruePcTransfer(DI, LS))
+        return reject(Twine("control flow at 0x") + utohexstr(DI.Offset) +
+                      " interrupts the restore search (" + DI.Mnemonic + ")");
+    }
+    std::optional<unsigned> SavedLowIndex =
+        CandidateLow ? numberedVgprIndex(*LS.MRI, CandidateLow->Vgpr)
+                     : std::nullopt;
+    std::optional<unsigned> SavedHighIndex =
+        CandidateHigh ? numberedVgprIndex(*LS.MRI, CandidateHigh->Vgpr)
+                      : std::nullopt;
+    if (!Low || !High || !CandidateLow || !CandidateHigh || !SavedLowIndex ||
+        !SavedHighIndex || !isAbiCalleeSavedVgpr(*SavedLowIndex) ||
+        !isAbiCalleeSavedVgpr(*SavedHighIndex) ||
+        *CandidateLow == *CandidateHigh ||
+        (SavedLow && !(*SavedLow == *CandidateLow)) ||
+        (SavedHigh && !(*SavedHigh == *CandidateHigh)))
+      return reject(Twine("return 0x") +
+                    utohexstr(Decoded[ReturnIndex].Offset) +
+                    " has no consistent callee-saved VGPR-lane restore");
+    SavedLow = *CandidateLow;
+    SavedHigh = *CandidateHigh;
+    size_t RestoreBegin = std::min(*Low, *High);
+    size_t RestoreEnd = std::max(*Low, *High);
+    for (size_t I = RestoreBegin + 1; I <= ReturnIndex; ++I) {
+      if (PotentialEntries.contains(Decoded[I].Offset) ||
+          (I != ReturnIndex && isTruePcTransfer(Decoded[I], LS)))
+        return reject(Twine("entry or control flow interrupts epilogue at 0x") +
+                      utohexstr(Decoded[I].Offset));
+      if (I > RestoreEnd && I < ReturnIndex)
+        PostRestoreTeardownInstructions.insert(I);
+    }
+    Returns.push_back(
+        {ReturnIndex, *Low, *High, *CandidateLow, *CandidateHigh});
+    RestoreInstructions.insert(*Low);
+    RestoreInstructions.insert(*High);
+  }
+  if (!SavedLow || !SavedHigh)
+    return reject("no saved VGPR lanes recovered");
+
+  std::optional<size_t> SaveLow;
+  std::optional<size_t> SaveHigh;
+  for (size_t I = BeginIndex; I != EndIndex; ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.Offset - BeginOffset > 512)
+      break;
+    if (matchesCanonicalLaneTransfer(DI, "v_writelane_b32", SavedLow->Vgpr,
+                                     NumberedSgprs[30], SavedLow->Lane))
+      SaveLow = I;
+    if (matchesCanonicalLaneTransfer(DI, "v_writelane_b32", SavedHigh->Vgpr,
+                                     NumberedSgprs[31], SavedHigh->Lane))
+      SaveHigh = I;
+    if (SaveLow && SaveHigh)
+      break;
+    if (isTruePcTransfer(DI, LS))
+      return reject(Twine("control flow at 0x") + utohexstr(DI.Offset) +
+                    " precedes the prologue saves (" + DI.Mnemonic + ")");
+  }
+  if (!SaveLow || !SaveHigh)
+    return reject("matching prologue saves are absent");
+  size_t SaveEnd = std::max(*SaveLow, *SaveHigh);
+  for (size_t I = BeginIndex + 1; I <= SaveEnd; ++I)
+    if (PotentialEntries.contains(Decoded[I].Offset))
+      return reject(Twine("entry bypasses a prologue save at 0x") +
+                    utohexstr(Decoded[I].Offset));
+
+  const size_t Count = EndIndex - BeginIndex;
+  DenseMap<uint64_t, unsigned> OffsetToLocal;
+  OffsetToLocal.reserve(Count);
+  for (unsigned I = 0; I != Count; ++I)
+    OffsetToLocal.try_emplace(Decoded[BeginIndex + I].Offset, I);
+  std::vector<SmallVector<unsigned, 2>> Successors(Count);
+  bool Valid = true;
+  auto addTarget = [&](SmallVectorImpl<unsigned> &Out, uint64_t Target) {
+    if (Target < BeginOffset || Target >= EndOffset)
+      return;
+    DenseMap<uint64_t, unsigned>::const_iterator It =
+        OffsetToLocal.find(Target);
+    if (It == OffsetToLocal.end()) {
+      Valid = false;
+      return;
+    }
+    Out.push_back(It->second);
+  };
+  auto addFallthrough = [&](SmallVectorImpl<unsigned> &Out, unsigned I) {
+    if (I + 1 != Count)
+      Out.push_back(I + 1);
+  };
+  for (unsigned Local = 0; Local != Count && Valid; ++Local) {
+    size_t Global = BeginIndex + Local;
+    const InternalDecodedInst &DI = Decoded[Global];
+    SmallVectorImpl<unsigned> &Out = Successors[Local];
+    if (!DI.DecodeSucceeded) {
+      Valid = false;
+      break;
+    }
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode)
+      continue;
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator Exact =
+          ExactSetPcs.find(Global);
+      if (Exact != ExactSetPcs.end() && Exact->second->LocalTargetIndex)
+        addTarget(Out, Decoded[*Exact->second->LocalTargetIndex].Offset);
+      else if (!llvm::is_contained(ReturnIndices, Global))
+        Valid = false;
+      continue;
+    }
+    if (LS.MIA->isReturn(DI.Inst))
+      continue;
+    if (LS.MIA->isCall(DI.Inst) && isTruePcTransfer(DI, LS)) {
+      addFallthrough(Out, Local);
+      continue;
+    }
+    if (LS.MIA->isBranch(DI.Inst) && hasPcRelativeOperand(DI, LS)) {
+      if (LS.MIA->isIndirectBranch(DI.Inst)) {
+        Valid = false;
+        break;
+      }
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (!Target) {
+        Valid = false;
+        break;
+      }
+      addTarget(Out, *Target);
+      if (LS.MIA->isConditionalBranch(DI.Inst))
+        addFallthrough(Out, Local);
+      else if (!LS.MIA->isUnconditionalBranch(DI.Inst))
+        Valid = false;
+      continue;
+    }
+    if (isTruePcTransfer(DI, LS)) {
+      Valid = false;
+      break;
+    }
+    addFallthrough(Out, Local);
+  }
+  if (!Valid)
+    return reject("local CFG is open");
+
+  // A control-flow edge back to the function entry may execute the prologue
+  // again. It is safe only while s[30:31] still contains the function's
+  // original incoming link. Compute that as a must fact: every path reaching
+  // the edge source must be free of calls and s30/s31 definitions. Merging by
+  // AND is important for cycles where a lexically early backedge can be
+  // revisited from after a nested call.
+  SmallVector<int8_t, 0> IncomingLinkIntactBefore(Count, int8_t{-1});
+  IncomingLinkIntactBefore[0] = 1;
+  SmallVector<unsigned, 64> LinkWorklist(1, 0);
+  for (size_t Next = 0; Next != LinkWorklist.size(); ++Next) {
+    unsigned Local = LinkWorklist[Next];
+    size_t Global = BeginIndex + Local;
+    const InternalDecodedInst &DI = Decoded[Global];
+    int8_t IntactOut = IncomingLinkIntactBefore[Local];
+    if ((LS.MIA->isCall(DI.Inst) && isTruePcTransfer(DI, LS)) ||
+        definesOverlappingRegister(DI, LS, NumberedSgprs[30]) ||
+        definesOverlappingRegister(DI, LS, NumberedSgprs[31]))
+      IntactOut = 0;
+    for (unsigned Succ : Successors[Local]) {
+      int8_t Merged = IncomingLinkIntactBefore[Succ] == -1
+                          ? IntactOut
+                          : (IncomingLinkIntactBefore[Succ] & IntactOut);
+      if (Merged != IncomingLinkIntactBefore[Succ]) {
+        IncomingLinkIntactBefore[Succ] = Merged;
+        LinkWorklist.push_back(Succ);
+      }
+    }
+  }
+  for (size_t Source : BeginReentrySources) {
+    unsigned Local = static_cast<unsigned>(Source - BeginIndex);
+    if (IncomingLinkIntactBefore[Local] == 0)
+      return reject(Twine("internal transfer reenters the prologue with a "
+                          "clobbered s30 link at 0x") +
+                    utohexstr(Decoded[Source].Offset));
+  }
+
+  SmallVector<AbiVgprModeState, 0> ModeBefore(Count);
+  ModeBefore[0] = abiVgprModeState(0);
+  SmallVector<int8_t, 0> SavesBefore(Count, int8_t{-1});
+  SavesBefore[0] = 0;
+  SmallVector<unsigned, 64> Worklist(1, 0);
+  for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+    unsigned Local = Worklist[Next];
+    size_t Global = BeginIndex + Local;
+    const InternalDecodedInst &DI = Decoded[BeginIndex + Local];
+    AbiVgprModeState ModeOut = ModeBefore[Local];
+    if (std::optional<unsigned> Mode = getExactAbiVgprMode(DI, LS))
+      ModeOut = abiVgprModeState(*Mode);
+    else if (mayWriteAbiVgprBankUnknown(DI, LS))
+      ModeOut = {-1, -1, -1, -1};
+    int8_t SavesOut = SavesBefore[Local];
+    if (Global == *SaveLow)
+      SavesOut |= 1;
+    if (Global == *SaveHigh)
+      SavesOut |= 2;
+    for (unsigned Succ : Successors[Local]) {
+      AbiVgprModeState MergedMode = mergeAbiVgprMode(ModeBefore[Succ], ModeOut);
+      int8_t MergedSaves =
+          SavesBefore[Succ] == -1 ? SavesOut : (SavesBefore[Succ] & SavesOut);
+      if (!sameAbiVgprMode(MergedMode, ModeBefore[Succ]) ||
+          MergedSaves != SavesBefore[Succ]) {
+        ModeBefore[Succ] = MergedMode;
+        SavesBefore[Succ] = MergedSaves;
+        Worklist.push_back(Succ);
+      }
+    }
+  }
+
+  for (unsigned Local = 0; Local != Count; ++Local) {
+    if (isUnreachable(ModeBefore[Local]))
+      continue;
+    size_t Global = BeginIndex + Local;
+    const InternalDecodedInst &DI = Decoded[Global];
+    if (LS.MIA->isCall(DI.Inst) && !isAbiVgprModeZero(ModeBefore[Local])) {
+      log() << "hotswap: canonical s30 frame: call at 0x"
+            << utohexstr(DI.Offset) << " is not in full VGPR-MSB mode 0\n";
+      return false;
+    }
+    if (llvm::is_contained(ReturnIndices, Global) && SavesBefore[Local] != 3) {
+      log() << "hotswap: canonical s30 frame: prologue saves do not dominate "
+               "return at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return false;
+    }
+    if (llvm::is_contained(ReturnIndices, Global) &&
+        !isAbiVgprModeZero(ModeBefore[Local])) {
+      log() << "hotswap: canonical s30 frame: return at 0x"
+            << utohexstr(DI.Offset) << " is not in full VGPR-MSB mode 0\n";
+      return false;
+    }
+    if (RestoreInstructions.contains(Global) && ModeBefore[Local].Src0 != 0) {
+      log() << "hotswap: canonical s30 frame: readlane at 0x"
+            << utohexstr(DI.Offset) << " does not read VGPR bank 0\n";
+      return false;
+    }
+
+    bool DefinesLink = definesOverlappingRegister(DI, LS, NumberedSgprs[30]) ||
+                       definesOverlappingRegister(DI, LS, NumberedSgprs[31]);
+    if (DefinesLink && !RestoreInstructions.contains(Global) &&
+        SavesBefore[Local] != 3) {
+      log() << "hotswap: canonical s30 frame: link definition before both "
+               "prologue saves at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return false;
+    }
+
+    bool WritesSavedLow = instructionWritesRegister(DI, LS, SavedLow->Vgpr);
+    bool WritesSavedHigh = instructionWritesRegister(DI, LS, SavedHigh->Vgpr);
+    if (!WritesSavedLow && !WritesSavedHigh)
+      continue;
+    // The canonical epilogue may restore the caller's old callee-saved VGPR
+    // from scratch after both link halves have already been copied into
+    // s[30:31]. The entry/control-flow checks above make this a straight-line
+    // teardown interval, so that write cannot affect the return address.
+    if (PostRestoreTeardownInstructions.contains(Global))
+      continue;
+    if (Global == *SaveLow || Global == *SaveHigh) {
+      if (ModeBefore[Local].Dst != 0) {
+        log() << "hotswap: canonical s30 frame: writelane save at 0x"
+              << utohexstr(DI.Offset) << " does not write VGPR bank 0\n";
+        return false;
+      }
+      continue;
+    }
+    if (ModeBefore[Local].Dst > 0)
+      continue;
+    if (ModeBefore[Local].Dst < 0) {
+      log() << "hotswap: canonical s30 frame: saved-VGPR write at 0x"
+            << utohexstr(DI.Offset) << " has unknown destination bank\n";
+      return false;
+    }
+    if (DI.Mnemonic == "v_writelane_b32" && DI.Inst.getNumOperands() == 4 &&
+        DI.Inst.getOperand(0).isReg() && DI.Inst.getOperand(0).getReg() &&
+        isExactRegisterOperand(DI.Inst, 3,
+                               MCRegister(DI.Inst.getOperand(0).getReg())) &&
+        DI.Inst.getOperand(2).isImm()) {
+      CanonicalSavedLane Written{MCRegister(DI.Inst.getOperand(0).getReg()),
+                                 DI.Inst.getOperand(2).getImm()};
+      if (!(Written == *SavedLow) && !(Written == *SavedHigh))
+        continue;
+    }
+    log() << "hotswap: canonical s30 frame: saved lower-bank VGPR clobber at "
+             "0x"
+          << utohexstr(DI.Offset) << "\n";
+    return false;
+  }
+  for (const CanonicalAbiReturn &Return : Returns)
+    SafeReturns.insert(Return.ReturnIndex);
+  return true;
+}
+
+/// Validate the linked-code-object ABI entry set as a late, all-or-nothing
+/// fallback after the ordinary machine-level closed-world proof remains open.
+///
+/// A valid compiler-produced, linked AMDGPU HSA code object may contain calls
+/// whose selector is intentionally opaque to static analysis. This fallback
+/// relies on the linked-code ABI contract that every such selector denotes a
+/// defined STT_FUNC entry and that every callee obeys the AMDGPU calling
+/// convention, including preservation of CSR_AMDGPU_VGPRs. It is not a proof
+/// for arbitrary or adversarial machine code. Under that explicit contract,
+/// the ABI gives those transfers a finite local entry set when all of the
+/// following object-wide invariants hold:
+///   * every opaque register call is exactly
+///       s_swap_pc_i64 s[30:31], TargetPair;
+///   * every s_set_pc_i64 s[30:31] is a return to one of the syntactic call
+///     continuations;
+///   * every other set-PC is an exact local PC materialization;
+///   * no other indirect transfer exists; and
+///   * every function start, continuation, and exact jump target is a decoded
+///     instruction boundary outside the interior of a PC materialization.
+///
+/// This is deliberately not a replacement for auditFiniteIndirectControlFlow:
+/// callers invoke it only when that stronger proof did not close. Any opcode,
+/// register, symbol, boundary, or entry-set variation rejects the whole
+/// fallback and preserves the existing fail-closed result.
+static std::optional<WellFormedAbiEntrySet> validateWellFormedAbiEntrySet(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextSize,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    ArrayRef<uint64_t> NonCallEntries, const ControlFlowScanIndex &Index,
+    ArrayRef<FiniteSetPcTransfer> SetPcCandidates, const ElfView &Elf) {
+  const auto Header = Elf.file().getHeader();
+  std::optional<uint64_t> TextEnd =
+      checkedAddUint64(TextAddr, TextSize, "well-formed ABI text end");
+  if (Header.e_type != ELF::ET_DYN || Header.e_machine != ELF::EM_AMDGPU ||
+      Header.e_ident[ELF::EI_OSABI] != ELF::ELFOSABI_AMDGPU_HSA ||
+      TextAddr != Elf.textAddr() || TextSize != Elf.textSize() || !TextEnd ||
+      Decoded.empty() || !Elf.functionTextRangesComplete()) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "object preconditions do not hold\n";
+    return std::nullopt;
+  }
+
+  DenseMap<uint64_t, size_t> InstructionAt;
+  InstructionAt.reserve(Decoded.size());
+  uint64_t ExpectedOffset = 0;
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!DI.DecodeSucceeded || DI.Size == 0 || DI.Offset != ExpectedOffset ||
+        !InstructionAt.try_emplace(DI.Offset, I).second) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "non-contiguous decode at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return std::nullopt;
+    }
+    std::optional<uint64_t> End =
+        checkedAddUint64(DI.Offset, DI.Size, "well-formed ABI instruction end");
+    if (!End || *End > TextSize) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "instruction end exceeds .text at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return std::nullopt;
+    }
+    ExpectedOffset = *End;
+  }
+  if (ExpectedOffset != TextSize) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "decoded instructions do not cover .text\n";
+    return std::nullopt;
+  }
+
+  WellFormedAbiEntrySet Result;
+  auto addBoundary = [&](uint64_t Offset) {
+    if (Offset >= TextSize || !InstructionAt.contains(Offset))
+      return false;
+    Result.Targets.insert(Offset);
+    return true;
+  };
+
+  bool SawFunctionEntry = false;
+  SmallVector<uint64_t, 32> AbiRootEntries;
+  DenseSet<uint64_t> DefinedFunctionBeginOffsets;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+    // Internal users can supply synthetic ranges to the stronger machine
+    // audit. Only actual defined STT_FUNC symbols expand this ABI fallback's
+    // function-pointer target set.
+    if (!Range.Symbol || Range.Symbol->getType() != ELF::STT_FUNC)
+      continue;
+    bool SizedRangeValid =
+        Range.Symbol->st_size == 0 ||
+        (Range.Symbol->st_value <=
+             std::numeric_limits<uint64_t>::max() - Range.Symbol->st_size &&
+         Range.Symbol->st_value + Range.Symbol->st_size == Range.End &&
+         Range.End <= *TextEnd);
+    if (Range.Symbol->st_shndx != Elf.textSectionIndex() ||
+        Range.Symbol->st_value != Range.Begin || !SizedRangeValid ||
+        Range.Begin < TextAddr || Range.Begin >= *TextEnd ||
+        Range.End <= Range.Begin || Range.End > *TextEnd ||
+        !addBoundary(Range.Begin - TextAddr) ||
+        (Range.End != *TextEnd &&
+         !InstructionAt.contains(Range.End - TextAddr))) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "STT_FUNC range is not bounded by exact .text instructions\n";
+      return std::nullopt;
+    }
+    SawFunctionEntry = true;
+    uint64_t BeginOffset = Range.Begin - TextAddr;
+    AbiRootEntries.push_back(BeginOffset);
+    DefinedFunctionBeginOffsets.insert(BeginOffset);
+  }
+  if (!SawFunctionEntry) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "no defined STT_FUNC entry\n";
+    return std::nullopt;
+  }
+  for (uint64_t Entry : DeclaredEntries)
+    if (!addBoundary(Entry)) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "declared entry 0x"
+            << utohexstr(Entry) << " is not an instruction boundary\n";
+      return std::nullopt;
+    }
+  AbiRootEntries.append(DeclaredEntries.begin(), DeclaredEntries.end());
+  for (uint64_t Entry : ExternalEntries)
+    if (!addBoundary(Entry)) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "external entry 0x"
+            << utohexstr(Entry) << " is not an instruction boundary\n";
+      return std::nullopt;
+    }
+  AbiRootEntries.append(ExternalEntries.begin(), ExternalEntries.end());
+  llvm::sort(AbiRootEntries);
+  AbiRootEntries.erase(
+      std::unique(AbiRootEntries.begin(), AbiRootEntries.end()),
+      AbiRootEntries.end());
+  SmallVector<uint64_t, 32> ActualRootEntries(NonCallEntries.begin(),
+                                              NonCallEntries.end());
+  llvm::sort(ActualRootEntries);
+  ActualRootEntries.erase(
+      std::unique(ActualRootEntries.begin(), ActualRootEntries.end()),
+      ActualRootEntries.end());
+
+  DenseSet<size_t> FiniteCalls;
+  for (const KnownCallSite &Call : Index.Calls)
+    FiniteCalls.insert(Call.InstIndex);
+  for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
+    FiniteCalls.insert(Call.InstIndex);
+
+  std::optional<SmallVector<MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*LS.MRI, Gfx1250MaxSgprs);
+  if (!NumberedSgprs || NumberedSgprs->size() <= 31) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "numbered SGPR map is unavailable\n";
+    return std::nullopt;
+  }
+  MCRegister AbiLinkPair;
+  for (const InternalDecodedInst &DI : Decoded)
+    if (DI.DecodeSucceeded && DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
+        DI.Inst.getNumOperands() >= 1 && DI.Inst.getOperand(0).isReg()) {
+      std::optional<unsigned> Index =
+          numberedSgprPairLowIndex(*LS.MRI, DI.Inst.getOperand(0).getReg());
+      if (Index && *Index == 30) {
+        AbiLinkPair = DI.Inst.getOperand(0).getReg();
+        break;
+      }
+    }
+  if (!AbiLinkPair) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "no s30 ABI link pair\n";
+    return std::nullopt;
+  }
+
+  DenseMap<size_t, const FiniteSetPcTransfer *> ExactSetPcs;
+  for (const FiniteSetPcTransfer &Candidate : SetPcCandidates) {
+    auto Inserted = ExactSetPcs.try_emplace(Candidate.InstIndex, &Candidate);
+    if (!Inserted.second)
+      return std::nullopt;
+  }
+  if (!validateAbiControlTransferModes(Decoded, LS, TextSize, AbiRootEntries,
+                                       ExactSetPcs, AbiLinkPair))
+    return std::nullopt;
+
+  DenseSet<uint64_t> PotentialEntries(Result.Targets.begin(),
+                                      Result.Targets.end());
+  for (const DirectTargetSource &Source : Index.DirectTargetsByTarget)
+    if (Source.Target < TextSize)
+      PotentialEntries.insert(Source.Target);
+  SmallVector<CallContinuationSource, 16> AllCallContinuations;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    if (LS.MIA->isCall(Decoded[I].Inst)) {
+      std::optional<uint64_t> Continuation =
+          checkedAddUint64(Decoded[I].Offset, Decoded[I].Size,
+                           "canonical ABI call continuation");
+      if (!Continuation || !addBoundary(*Continuation))
+        return std::nullopt;
+      PotentialEntries.insert(*Continuation);
+      AllCallContinuations.push_back({I, *Continuation});
+    }
+  llvm::sort(AllCallContinuations, [](const CallContinuationSource &LHS,
+                                      const CallContinuationSource &RHS) {
+    return std::tie(LHS.Continuation, LHS.InstIndex) <
+           std::tie(RHS.Continuation, RHS.InstIndex);
+  });
+  SmallVector<DirectTargetSource, 16> ExactSetPcEntries;
+  for (const auto &Entry : ExactSetPcs)
+    if (Entry.second->LocalTargetIndex) {
+      uint64_t Target = Decoded[*Entry.second->LocalTargetIndex].Offset;
+      if (!addBoundary(Target))
+        return std::nullopt;
+      PotentialEntries.insert(Target);
+      ExactSetPcEntries.push_back({Entry.first, Target});
+    }
+  llvm::sort(ExactSetPcEntries,
+             [](const DirectTargetSource &LHS, const DirectTargetSource &RHS) {
+               return std::tie(LHS.Target, LHS.InstIndex) <
+                      std::tie(RHS.Target, RHS.InstIndex);
+             });
+
+  DenseMap<std::pair<uint64_t, uint64_t>, SmallVector<size_t, 4>>
+      ReturnsByFunction;
+  DenseMap<std::pair<uint64_t, uint64_t>, const ElfView::FunctionTextRange *>
+      ReturnFunctionRanges;
+  SmallVector<const ElfView::FunctionTextRange *, 32> LocalFunctionRanges;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Symbol && Range.Symbol->getType() == ELF::STT_FUNC &&
+        Range.Symbol->getBinding() == ELF::STB_LOCAL)
+      LocalFunctionRanges.push_back(&Range);
+  llvm::sort(LocalFunctionRanges, [](const ElfView::FunctionTextRange *LHS,
+                                     const ElfView::FunctionTextRange *RHS) {
+    if (LHS->Begin != RHS->Begin)
+      return LHS->Begin < RHS->Begin;
+    return LHS->End > RHS->End;
+  });
+  size_t RangeTreeBase = 1;
+  while (RangeTreeBase < LocalFunctionRanges.size())
+    RangeTreeBase *= 2;
+  SmallVector<uint64_t, 0> MaxRangeEnd(2 * RangeTreeBase);
+  for (size_t I = 0; I != LocalFunctionRanges.size(); ++I)
+    MaxRangeEnd[RangeTreeBase + I] = LocalFunctionRanges[I]->End;
+  for (size_t I = RangeTreeBase; I-- != 1;)
+    MaxRangeEnd[I] = std::max(MaxRangeEnd[2 * I], MaxRangeEnd[2 * I + 1]);
+  auto FindRightmostContaining =
+      [&](auto &&Self, size_t Node, size_t Begin, size_t End, size_t Limit,
+          uint64_t Address) -> std::optional<size_t> {
+    if (Begin >= Limit || MaxRangeEnd[Node] <= Address)
+      return std::nullopt;
+    if (End - Begin == 1)
+      return Begin;
+    size_t Middle = Begin + (End - Begin) / 2;
+    if (std::optional<size_t> Right =
+            Self(Self, 2 * Node + 1, Middle, End, Limit, Address))
+      return Right;
+    return Self(Self, 2 * Node, Begin, Middle, Limit, Address);
+  };
+  auto FindLocalFunction = [&](uint64_t Address) {
+    auto Candidate = llvm::upper_bound(
+        LocalFunctionRanges, Address,
+        [](uint64_t Value, const ElfView::FunctionTextRange *Range) {
+          return Value < Range->Begin;
+        });
+    size_t Limit = static_cast<size_t>(Candidate - LocalFunctionRanges.begin());
+    std::optional<size_t> BestIndex = FindRightmostContaining(
+        FindRightmostContaining, 1, 0, RangeTreeBase, Limit, Address);
+    return BestIndex ? LocalFunctionRanges[*BestIndex] : nullptr;
+  };
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.Inst.getOpcode() != LS.SSetPcI64Opcode || ExactSetPcs.contains(I) ||
+        DI.Inst.getNumOperands() != 1 ||
+        !isExactRegisterOperand(DI.Inst, 0, AbiLinkPair))
+      continue;
+    uint64_t Address = TextAddr + DI.Offset;
+    const ElfView::FunctionTextRange *Best = FindLocalFunction(Address);
+    if (!Best)
+      continue;
+    std::pair<uint64_t, uint64_t> Key{Best->Begin, Best->End};
+    ReturnsByFunction[Key].push_back(I);
+    ReturnFunctionRanges.try_emplace(Key, Best);
+  }
+
+  // A compiler tail thunk restores its incoming s30 link and then performs an
+  // exact set-PC to another defined function entry. Validate the source thunk
+  // with the same canonical save/restore proof used for ordinary s30 returns;
+  // only then may the target function accept that otherwise-external entry.
+  DenseMap<std::pair<uint64_t, uint64_t>, SmallVector<size_t, 2>>
+      TailExitsByFunction;
+  DenseMap<std::pair<uint64_t, uint64_t>, const ElfView::FunctionTextRange *>
+      TailFunctionRanges;
+  DenseSet<uint64_t> ReturningFunctionBegins;
+  for (const auto &Entry : ReturnsByFunction)
+    ReturningFunctionBegins.insert(Entry.first.first - TextAddr);
+  for (const auto &Exact : ExactSetPcs) {
+    size_t I = Exact.first;
+    if (!Exact.second->LocalTargetIndex)
+      continue;
+    uint64_t Target = Decoded[*Exact.second->LocalTargetIndex].Offset;
+    if (!DefinedFunctionBeginOffsets.contains(Target) ||
+        !ReturningFunctionBegins.contains(Target))
+      continue;
+    const ElfView::FunctionTextRange *Source =
+        FindLocalFunction(TextAddr + Decoded[I].Offset);
+    if (!Source || Source->Begin - TextAddr == Target)
+      continue;
+    std::pair<uint64_t, uint64_t> Key{Source->Begin, Source->End};
+    TailExitsByFunction[Key].push_back(I);
+    TailFunctionRanges.try_emplace(Key, Source);
+  }
+
+  // Phase 1 proves tail sources under the original strict entry policy. This
+  // deliberately rejects tail chains: no candidate is authorized merely by
+  // being present in the candidate set. A source function's ordinary s30
+  // returns are included so its complete local CFG remains closed.
+  const DenseSet<size_t> NoSafeTailTransfers;
+  DenseSet<size_t> SafeAbiTailTransfers;
+  for (const auto &Entry : TailExitsByFunction) {
+    const ElfView::FunctionTextRange *Range =
+        TailFunctionRanges.lookup(Entry.first);
+    SmallVector<size_t, 4> SourceExits(Entry.second.begin(),
+                                       Entry.second.end());
+    auto Returns = ReturnsByFunction.find(Entry.first);
+    if (Returns != ReturnsByFunction.end())
+      SourceExits.append(Returns->second.begin(), Returns->second.end());
+    llvm::sort(SourceExits);
+    SourceExits.erase(std::unique(SourceExits.begin(), SourceExits.end()),
+                      SourceExits.end());
+    DenseSet<size_t> ValidatedSourceExits;
+    if (!Range || !validateCanonicalAbiFrameReturns(
+                      Decoded, LS, TextAddr, *Range, SourceExits, ExactSetPcs,
+                      ExactSetPcEntries, AllCallContinuations, PotentialEntries,
+                      ActualRootEntries, AbiRootEntries, Index, AbiLinkPair,
+                      *NumberedSgprs, NoSafeTailTransfers,
+                      /*ForceFullCanonicalFrame=*/true, ValidatedSourceExits)) {
+      log() << "hotswap: tail source function at 0x"
+            << utohexstr(Entry.first.first - TextAddr)
+            << " was not certified to preserve the incoming s30 link\n";
+      continue;
+    }
+    for (size_t Tail : Entry.second)
+      if (ValidatedSourceExits.contains(Tail))
+        SafeAbiTailTransfers.insert(Tail);
+  }
+
+  // Phase 2 may now authorize only the exact source indices proven above
+  // while validating ordinary s30-return functions.
+  DenseSet<size_t> CanonicalAbiReturns;
+  for (const auto &Entry : ReturnsByFunction) {
+    const ElfView::FunctionTextRange *Range =
+        ReturnFunctionRanges.lookup(Entry.first);
+    if (!Range || !validateCanonicalAbiFrameReturns(
+                      Decoded, LS, TextAddr, *Range, Entry.second, ExactSetPcs,
+                      ExactSetPcEntries, AllCallContinuations, PotentialEntries,
+                      ActualRootEntries, AbiRootEntries, Index, AbiLinkPair,
+                      *NumberedSgprs, SafeAbiTailTransfers,
+                      /*ForceFullCanonicalFrame=*/false, CanonicalAbiReturns)) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "local function at 0x"
+            << utohexstr(Entry.first.first - TextAddr)
+            << " does not use a provable canonical s30 call frame\n";
+      return std::nullopt;
+    }
+  }
+
+  bool SawAbiCall = false;
+  bool SawAbiReturn = false;
+  SmallVector<std::pair<size_t, uint64_t>, 16> CallContinuations;
+  SmallVector<const FiniteSetPcTransfer *, 16> SelectedSetPcs;
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "well-formed ABI call continuation");
+      if (!Continuation || !addBoundary(*Continuation)) {
+        log() << "hotswap: linked-code-object ABI entry-set fallback "
+                 "rejected: call continuation at 0x"
+              << utohexstr(DI.Offset) << " is not an instruction boundary\n";
+        return std::nullopt;
+      }
+      CallContinuations.push_back({I, *Continuation});
+
+      const MCOperand *Target =
+          DI.Inst.getNumOperands() == 0
+              ? nullptr
+              : &DI.Inst.getOperand(DI.Inst.getNumOperands() - 1);
+      if (Target && Target->isReg()) {
+        if (DI.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+            DI.Inst.getNumOperands() != 2 ||
+            !isExactRegisterOperand(DI.Inst, 0, AbiLinkPair) ||
+            !Target->getReg() ||
+            LS.MRI->regsOverlap(AbiLinkPair, Target->getReg()) ||
+            !numberedSgprPairLowIndex(*LS.MRI, Target->getReg())) {
+          log() << "hotswap: linked-code-object ABI entry-set fallback "
+                   "rejected: register call at 0x"
+                << utohexstr(DI.Offset)
+                << " does not use the exact s30 swap-call shape\n";
+          return std::nullopt;
+        }
+        Result.Calls.insert(I);
+        if (!FiniteCalls.contains(I))
+          SawAbiCall = true;
+      } else if (!FiniteCalls.contains(I)) {
+        log() << "hotswap: linked-code-object ABI entry-set fallback "
+                 "rejected: non-register call at 0x"
+              << utohexstr(DI.Offset) << " is not finite\n";
+        return std::nullopt;
+      }
+    }
+
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      if (DI.Inst.getNumOperands() != 1 || !DI.Inst.getOperand(0).isReg() ||
+          !DI.Inst.getOperand(0).getReg()) {
+        log() << "hotswap: linked-code-object ABI entry-set fallback "
+                 "rejected: malformed set-PC at 0x"
+              << utohexstr(DI.Offset) << "\n";
+        return std::nullopt;
+      }
+      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator It =
+          ExactSetPcs.find(I);
+      if (It != ExactSetPcs.end()) {
+        if (!It->second->LocalTargetIndex ||
+            *It->second->LocalTargetIndex >= Decoded.size() ||
+            !addBoundary(Decoded[*It->second->LocalTargetIndex].Offset)) {
+          log() << "hotswap: linked-code-object ABI entry-set fallback "
+                   "rejected: exact set-PC at 0x"
+                << utohexstr(DI.Offset)
+                << " has an ambiguous or non-boundary target\n";
+          return std::nullopt;
+        }
+        Result.SetPcs.insert(I);
+        SelectedSetPcs.push_back(It->second);
+      } else if (isExactRegisterOperand(DI.Inst, 0, AbiLinkPair) &&
+                 CanonicalAbiReturns.contains(I)) {
+        SawAbiReturn = true;
+        Result.SetPcs.insert(I);
+      } else {
+        log() << "hotswap: linked-code-object ABI entry-set fallback "
+                 "rejected: non-s30 set-PC at 0x"
+              << utohexstr(DI.Offset)
+              << " is not an exact local PC materialization\n";
+        return std::nullopt;
+      }
+    }
+
+    if (DI.Inst.getOpcode() == LS.SAddPcI64Opcode) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "s_add_pc_i64 at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return std::nullopt;
+    }
+    if (LS.MIA->isIndirectBranch(DI.Inst) &&
+        DI.Inst.getOpcode() != LS.SSetPcI64Opcode &&
+        !(LS.MIA->isCall(DI.Inst) &&
+          DI.Inst.getOpcode() == LS.SSwapPcI64Opcode)) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "unsupported indirect transfer at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return std::nullopt;
+    }
+  }
+  if (!SawAbiCall || !SawAbiReturn) {
+    log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+             "no opaque s30 call/return pair\n";
+    return std::nullopt;
+  }
+
+  auto hasInteriorEntry = [&](const FiniteSetPcTransfer &Candidate) {
+    uint64_t Begin = Decoded[Candidate.SequenceBeginIndex].Offset;
+    std::optional<uint64_t> End =
+        checkedAddUint64(Decoded[Candidate.SequenceEndIndex].Offset,
+                         Decoded[Candidate.SequenceEndIndex].Size,
+                         "well-formed ABI materialization end");
+    if (!End)
+      return true;
+    auto IsInterior = [&](uint64_t Offset) {
+      return Offset > Begin && Offset < *End;
+    };
+    auto SourceIsSequence = [&](size_t InstIndex) {
+      return InstIndex >= Candidate.SequenceBeginIndex &&
+             InstIndex <= Candidate.SequenceEndIndex;
+    };
+    for (uint64_t Entry : Result.Targets)
+      if (IsInterior(Entry))
+        return true;
+    for (const DirectTargetSource &Source : Index.DirectTargetsByTarget)
+      if (!SourceIsSequence(Source.InstIndex) && IsInterior(Source.Target))
+        return true;
+    for (const auto &Call : CallContinuations)
+      if (!SourceIsSequence(Call.first) && IsInterior(Call.second))
+        return true;
+    for (const FiniteSetPcTransfer *Transfer : SelectedSetPcs)
+      if (Transfer->LocalTargetIndex &&
+          IsInterior(Decoded[*Transfer->LocalTargetIndex].Offset))
+        return true;
+    return false;
+  };
+  for (const FiniteSetPcTransfer *Candidate : SelectedSetPcs)
+    if (Candidate->SequenceBeginIndex > Candidate->SequenceEndIndex ||
+        Candidate->SequenceEndIndex >= Decoded.size() ||
+        hasInteriorEntry(*Candidate)) {
+      log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
+               "alternate entry inside set-PC materialization ending at 0x"
+            << utohexstr(Decoded[Candidate->InstIndex].Offset) << "\n";
+      return std::nullopt;
+    }
+
+  for (const auto &Call : CallContinuations)
+    Result.Targets.insert(Call.second);
+  log() << "hotswap: accepted well-formed linked-code-object ABI entry set "
+           "for "
+        << Result.Calls.size() << " register call(s), " << Result.SetPcs.size()
+        << " set-PC transfer(s), and " << Result.Targets.size()
+        << " finite local entry point(s)\n";
+  return Result;
+}
+
 static bool addReusableCallsToIndex(ArrayRef<InternalDecodedInst> Decoded,
                                     const LLVMState &LS, uint64_t TextAddr,
                                     uint64_t TextEnd,
@@ -3931,7 +5846,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-    ArrayRef<uint64_t> ExternalEntries, ArrayRef<uint8_t> Text) {
+    ArrayRef<uint64_t> ExternalEntries, ArrayRef<uint8_t> Text,
+    const ElfView *Elf, ArrayRef<uint64_t> NonCallEntries) {
   if (!LS.MIA) {
     log() << "hotswap: MC branch analysis is unavailable; adjacent far "
              "trampolines will not be coalesced\n";
@@ -4103,6 +6019,12 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     LocallyProvenMaterializedCalls.set(I);
   }
 
+  std::optional<WellFormedAbiEntrySet> AbiEntrySet;
+  if (!IndirectControlFlowClosed && Elf)
+    AbiEntrySet = validateWellFormedAbiEntrySet(
+        Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
+        ExternalEntries, NonCallEntries, *Index, AllSetPcCandidates, *Elf);
+
   DirectControlFlowInfo Info;
   for (uint64_t Entry : DeclaredEntries)
     if (Entry < TextSize)
@@ -4115,10 +6037,16 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       Info.Targets.insert(Target);
     Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
   }
-  for (const ExternalCallContinuation &Call :
-       Index->ExternalCallContinuations)
+  for (const ExternalCallContinuation &Call : Index->ExternalCallContinuations)
     Info.Targets.insert(Call.Continuation);
-
+  if (AbiEntrySet) {
+    for (uint64_t Target : AbiEntrySet->Targets)
+      Info.Targets.insert(Target);
+    for (size_t InstIndex : AbiEntrySet->Calls)
+      Info.BoundedIndirectTransfers.insert(Decoded[InstIndex].Offset);
+    for (size_t InstIndex : AbiEntrySet->SetPcs)
+      Info.BoundedIndirectTransfers.insert(Decoded[InstIndex].Offset);
+  }
   for (size_t InstIndex : Index->BranchOrCallIndices) {
     const InternalDecodedInst &DI = Decoded[InstIndex];
     // Existing indirect branches are handled by
@@ -4161,12 +6089,11 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       }
       if (!ReusableCalls[InstIndex].empty() &&
           !IsFiniteExternalMaterializedCall) {
-        bool HasExternalReusableTarget =
-            llvm::any_of(ReusableCalls[InstIndex],
-                         [TextAddr, TextEnd](uint64_t ReusableTarget) {
-                           return ReusableTarget < TextAddr ||
-                                  ReusableTarget >= *TextEnd;
-                         });
+        bool HasExternalReusableTarget = llvm::any_of(
+            ReusableCalls[InstIndex],
+            [TextAddr, TextEnd](uint64_t ReusableTarget) {
+              return ReusableTarget < TextAddr || ReusableTarget >= *TextEnd;
+            });
         if (HasExternalReusableTarget && !IndirectControlFlowClosed) {
           log() << "hotswap: unresolved call target at 0x"
                 << utohexstr(DI.Offset) << " (reusable target outside .text)\n";
@@ -4190,6 +6117,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
         continue;
       }
       if (!Target) {
+        if (AbiEntrySet && AbiEntrySet->Calls.contains(InstIndex))
+          continue;
         log() << "hotswap: unresolved call target at 0x" << utohexstr(DI.Offset)
               << " (" << DI.Mnemonic << ")\n";
         Info.HasUnresolvedTargets = true;
@@ -4234,7 +6163,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   }
   for (const BoundedSetPcReturn &Return : BoundedReturns)
     Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
-  if (!IndirectControlFlowClosed && HasUnboundedIndirectEntries)
+  if (!AbiEntrySet && !IndirectControlFlowClosed && HasUnboundedIndirectEntries)
     Info.HasUnboundedIndirectEntries = true;
   return Info;
 }
@@ -4700,10 +6629,8 @@ countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
       if (Distance >= MaxSledDistance ||
           LS.encodeSBranch(FromOffset, Candidate).empty())
         break;
-
-      std::optional<uint32_t> LayoutSize =
-          getSetPcGatewayLayoutSize(Candidate, TargetOffset, SgprBase, UseVcc,
-                                    PreserveVcc);
+      std::optional<uint32_t> LayoutSize = getSetPcGatewayLayoutSize(
+          Candidate, TargetOffset, SgprBase, UseVcc, PreserveVcc);
       if (!LayoutSize)
         return createStringError(
             Twine("invalid set-PC gateway while counting candidate "
@@ -4720,56 +6647,205 @@ countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
   return Slots;
 }
 
+struct BranchIslandFailure {
+  uint64_t CurrentOffset = 0;
+  uint64_t TargetOffset = 0;
+  uint64_t CorridorOffset = 0;
+  bool Forward = false;
+};
+
+using BranchIslandPromoter = std::function<bool(const BranchIslandFailure &)>;
+
+using BranchGatewayHead = std::pair<uint64_t, size_t>;
+using BranchGatewayHeadSet = std::set<BranchGatewayHead>;
+
+static bool hasFreeBranchGatewaySlot(const NopSled &Sled) {
+  uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+  return !Sled.GatewayOnly && Sled.WritePos <= UsableEnd &&
+         MinInstSize <= UsableEnd - Sled.WritePos;
+}
+
+static BranchGatewayHeadSet
+buildBranchGatewayHeads(std::vector<NopSled> &Gateways,
+                        const DenseSet<uint64_t> &Occupied) {
+  BranchGatewayHeadSet Heads;
+  for (size_t I = 0; I != Gateways.size(); ++I) {
+    while (hasFreeBranchGatewaySlot(Gateways[I]) &&
+           Occupied.contains(Gateways[I].WritePos))
+      Gateways[I].WritePos += MinInstSize;
+    if (hasFreeBranchGatewaySlot(Gateways[I]))
+      Heads.insert({Gateways[I].WritePos, I});
+  }
+  return Heads;
+}
+
+static void
+subtractOccupiedBranchGatewaySlots(std::vector<NopSled> &Gateways,
+                                   const DenseSet<uint64_t> &Occupied) {
+  SmallVector<uint64_t, 32> SortedOccupied(Occupied.begin(), Occupied.end());
+  llvm::sort(SortedOccupied);
+  std::vector<NopSled> Available;
+  Available.reserve(Gateways.size());
+  for (const NopSled &Sled : Gateways) {
+    uint64_t Cursor = Sled.WritePos;
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    if (Cursor >= UsableEnd)
+      continue;
+    auto It = llvm::lower_bound(SortedOccupied, Cursor);
+    while (It != SortedOccupied.end() && *It < UsableEnd) {
+      if (Cursor < *It)
+        Available.push_back({Cursor, *It, Cursor, Sled.FunctionStart,
+                             Sled.FunctionEnd, Sled.GatewayOnly});
+      Cursor = std::max(Cursor, *It + MinInstSize);
+      ++It;
+    }
+    if (Cursor < UsableEnd)
+      Available.push_back({Cursor, UsableEnd, Cursor, Sled.FunctionStart,
+                           Sled.FunctionEnd, Sled.GatewayOnly});
+  }
+  Gateways = std::move(Available);
+}
+
 static std::optional<SmallVector<uint64_t, 4>>
 allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
-                             uint64_t FromOffset, uint64_t TargetOffset) {
+                             uint64_t FromOffset, uint64_t TargetOffset,
+                             BranchIslandFailure *Failure = nullptr,
+                             BranchGatewayHeadSet *PersistentHeads = nullptr,
+                             DenseSet<uint64_t> *PersistentOccupied = nullptr,
+                             BranchIslandPromoter Promote = {}) {
   struct Allocation {
     size_t SledIndex = 0;
     uint64_t PreviousWritePos = 0;
   };
+  BranchGatewayHeadSet LocalHeads;
+  DenseSet<uint64_t> LocalOccupied;
+  if (!PersistentOccupied)
+    PersistentOccupied = &LocalOccupied;
+  if (!PersistentHeads) {
+    LocalHeads = buildBranchGatewayHeads(Gateways, *PersistentOccupied);
+    PersistentHeads = &LocalHeads;
+  }
+  BranchGatewayHeadSet &Heads = *PersistentHeads;
+  DenseSet<uint64_t> &Occupied = *PersistentOccupied;
   SmallVector<Allocation, 4> Allocations;
   SmallVector<uint64_t, 4> Islands;
-  DenseSet<size_t> UsedSleds;
   uint64_t Current = FromOffset;
 
   while (!isSBranchReachable(Current, TargetOffset)) {
     bool Forward = TargetOffset > Current;
     size_t BestIndex = Gateways.size();
     uint64_t BestOffset = 0;
-    for (size_t I = 0; I != Gateways.size(); ++I) {
-      NopSled &Sled = Gateways[I];
-      if (Sled.GatewayOnly || UsedSleds.contains(I) ||
-          FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
-        continue;
-      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-      bool MakesProgress =
-          Forward ? Sled.WritePos > Current && Sled.WritePos < TargetOffset
-                  : Sled.WritePos < Current && Sled.WritePos > TargetOffset;
-      if (!MakesProgress || Sled.WritePos > UsableEnd ||
-          MinInstSize > UsableEnd - Sled.WritePos ||
-          !isSBranchReachable(Current, Sled.WritePos))
-        continue;
-      if (BestIndex == Gateways.size() ||
-          (Forward ? Sled.WritePos > BestOffset : Sled.WritePos < BestOffset)) {
-        BestIndex = I;
-        BestOffset = Sled.WritePos;
+    if (Forward) {
+      uint64_t ReachEnd =
+          Current > std::numeric_limits<uint64_t>::max() - MaxSledDistance
+              ? std::numeric_limits<uint64_t>::max()
+              : Current + MaxSledDistance;
+      uint64_t Upper = std::min(TargetOffset, ReachEnd);
+      auto It =
+          TargetOffset <= ReachEnd
+              ? Heads.lower_bound({Upper, 0})
+              : Heads.upper_bound({Upper, std::numeric_limits<size_t>::max()});
+      while (It != Heads.begin()) {
+        --It;
+        if (It->first <= Current)
+          break;
+        const NopSled &Sled = Gateways[It->second];
+        if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd ||
+            Sled.WritePos != It->first ||
+            !isSBranchReachable(Current, It->first))
+          continue;
+        BestIndex = It->second;
+        BestOffset = It->first;
+        break;
+      }
+    } else {
+      uint64_t ReachBegin =
+          Current > MaxSledDistance ? Current - MaxSledDistance : 0;
+      uint64_t Lower = TargetOffset == std::numeric_limits<uint64_t>::max()
+                           ? TargetOffset
+                           : TargetOffset + 1;
+      Lower = std::max(Lower, ReachBegin);
+      for (auto It = Heads.lower_bound({Lower, 0});
+           It != Heads.end() && It->first < Current; ++It) {
+        const NopSled &Sled = Gateways[It->second];
+        if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd ||
+            Sled.WritePos != It->first ||
+            !isSBranchReachable(Current, It->first))
+          continue;
+        BestIndex = It->second;
+        BestOffset = It->first;
+        break;
       }
     }
 
     if (BestIndex == Gateways.size()) {
+      uint64_t Corridor = Forward ? std::numeric_limits<uint64_t>::max() : 0;
+      if (Forward) {
+        uint64_t AfterCurrent = Current == std::numeric_limits<uint64_t>::max()
+                                    ? Current
+                                    : Current + 1;
+        for (auto It = Heads.lower_bound({AfterCurrent, 0});
+             It != Heads.end() && It->first < TargetOffset; ++It) {
+          const NopSled &Sled = Gateways[It->second];
+          if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
+            continue;
+          Corridor = It->first;
+          break;
+        }
+      } else {
+        auto It = Heads.lower_bound({Current, 0});
+        while (It != Heads.begin()) {
+          --It;
+          if (It->first <= TargetOffset)
+            break;
+          const NopSled &Sled = Gateways[It->second];
+          if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
+            continue;
+          Corridor = It->first;
+          break;
+        }
+      }
+      if (Forward && Corridor == std::numeric_limits<uint64_t>::max())
+        Corridor = TargetOffset;
+      if (!Forward && Corridor == 0)
+        Corridor = TargetOffset;
+      BranchIslandFailure ThisFailure{Current, TargetOffset, Corridor, Forward};
+      if (Failure)
+        *Failure = ThisFailure;
+      // No Gateways reference or Heads iterator survives this call. The
+      // promoter may grow both vectors/sets; successful promotion resumes the
+      // same transaction with all prior heads still held.
+      if (Promote && Promote(ThisFailure))
+        continue;
       for (size_t I = Allocations.size(); I != 0; --I) {
         const Allocation &A = Allocations[I - 1];
         Gateways[A.SledIndex].WritePos = A.PreviousWritePos;
+        Heads.insert({A.PreviousWritePos, A.SledIndex});
       }
+      for (uint64_t Offset : Islands)
+        Occupied.erase(Offset);
       return std::nullopt;
     }
 
-    NopSled &Best = Gateways[BestIndex];
-    Allocations.push_back({BestIndex, Best.WritePos});
-    Islands.push_back(Best.WritePos);
-    Current = Best.WritePos;
-    Best.WritePos += MinInstSize;
-    UsedSleds.insert(BestIndex);
+    auto AliasBegin = Heads.lower_bound({BestOffset, 0});
+    auto AliasEnd =
+        Heads.upper_bound({BestOffset, std::numeric_limits<size_t>::max()});
+    for (auto It = AliasBegin; It != AliasEnd; ++It) {
+      NopSled &Alias = Gateways[It->second];
+      Allocations.push_back({It->second, Alias.WritePos});
+      Alias.WritePos += MinInstSize;
+    }
+    Heads.erase(AliasBegin, AliasEnd);
+    Occupied.insert(BestOffset);
+    Islands.push_back(BestOffset);
+    Current = BestOffset;
+  }
+  for (const Allocation &A : Allocations) {
+    NopSled &Sled = Gateways[A.SledIndex];
+    while (hasFreeBranchGatewaySlot(Sled) && Occupied.contains(Sled.WritePos))
+      Sled.WritePos += MinInstSize;
+    if (hasFreeBranchGatewaySlot(Sled))
+      Heads.insert({Gateways[A.SledIndex].WritePos, A.SledIndex});
   }
   return Islands;
 }
@@ -4789,8 +6865,8 @@ static SmallVector<uint8_t> encodeScc1Branch(const LLVMState &LS,
 }
 
 bool sourceHasUniqueFunctionRange(
-    const Trampoline &T,
-    ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr) {
+    const Trampoline &T, ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    uint64_t TextAddr) {
   if (!T.HasFunctionRange)
     return false;
   std::optional<uint64_t> SourceEnd = checkedAddUint64(
@@ -4810,12 +6886,88 @@ bool sourceHasUniqueFunctionRange(
     std::pair<uint64_t, uint64_t> Bounds{Begin, End};
     if (!llvm::is_contained(DistinctCoveringRanges, Bounds))
       DistinctCoveringRanges.push_back(Bounds);
-    MatchesSelectedRange |=
-        Begin == T.FunctionStart && End == T.FunctionEnd;
+    MatchesSelectedRange |= Begin == T.FunctionStart && End == T.FunctionEnd;
     if (DistinctCoveringRanges.size() > 1)
       return false;
   }
   return DistinctCoveringRanges.size() == 1 && MatchesSelectedRange;
+}
+
+class FunctionRangeUniquenessIndex {
+  using Bounds = std::pair<uint64_t, uint64_t>;
+  static constexpr size_t NoRange = std::numeric_limits<size_t>::max();
+
+  struct PrefixMaximums {
+    size_t First = NoRange;
+    size_t Second = NoRange;
+  };
+
+  std::vector<Bounds> Ranges;
+  std::vector<PrefixMaximums> Prefix;
+
+public:
+  FunctionRangeUniquenessIndex(
+      ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr) {
+    Ranges.reserve(FunctionRanges.size());
+    for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+      if (Range.Begin < TextAddr || Range.End < TextAddr)
+        continue;
+      Bounds Relative{Range.Begin - TextAddr, Range.End - TextAddr};
+      if (Relative.first < Relative.second)
+        Ranges.push_back(Relative);
+    }
+    llvm::sort(Ranges);
+    Ranges.erase(std::unique(Ranges.begin(), Ranges.end()), Ranges.end());
+
+    Prefix.reserve(Ranges.size());
+    PrefixMaximums Top;
+    for (size_t I = 0; I != Ranges.size(); ++I) {
+      if (Top.First == NoRange || Ranges[I].second > Ranges[Top.First].second) {
+        Top.Second = Top.First;
+        Top.First = I;
+      } else if (Top.Second == NoRange ||
+                 Ranges[I].second > Ranges[Top.Second].second) {
+        Top.Second = I;
+      }
+      Prefix.push_back(Top);
+    }
+  }
+
+  bool hasUniqueFunctionRange(const Trampoline &T) const {
+    if (!T.HasFunctionRange || T.FunctionStart >= T.FunctionEnd)
+      return false;
+    std::optional<uint64_t> SourceEnd =
+        checkedAddUint64(T.OriginalOffset, T.OriginalSize,
+                         "indexed source-tail unique function end");
+    if (!SourceEnd || T.FunctionStart > T.OriginalOffset ||
+        T.FunctionEnd < *SourceEnd)
+      return false;
+
+    Bounds Selected{T.FunctionStart, T.FunctionEnd};
+    auto SelectedIt = llvm::lower_bound(Ranges, Selected);
+    if (SelectedIt == Ranges.end() || *SelectedIt != Selected)
+      return false;
+
+    auto PrefixEnd =
+        std::upper_bound(Ranges.begin(), Ranges.end(), T.OriginalOffset,
+                         [](uint64_t Offset, const Bounds &Range) {
+                           return Offset < Range.first;
+                         });
+    if (PrefixEnd == Ranges.begin())
+      return false;
+    const PrefixMaximums &Top = Prefix[PrefixEnd - Ranges.begin() - 1];
+    size_t Other = Top.First != NoRange && Ranges[Top.First] == Selected
+                       ? Top.Second
+                       : Top.First;
+    return Other == NoRange || Ranges[Other].second < *SourceEnd;
+  }
+};
+
+bool sourceHasUniqueFunctionRangeIndexedForTest(
+    const Trampoline &T, ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    uint64_t TextAddr) {
+  return FunctionRangeUniquenessIndex(FunctionRanges, TextAddr)
+      .hasUniqueFunctionRange(T);
 }
 
 bool isSafeSourceTailRange(const Trampoline &T,
@@ -4826,8 +6978,8 @@ bool isSafeSourceTailRange(const Trampoline &T,
       ControlFlow.HasUnboundedIndirectEntries || !HasUniqueFunctionRange ||
       Begin >= End)
     return false;
-  std::optional<uint64_t> FirstTailByte = checkedAddUint64(
-      T.OriginalOffset, MinInstSize, "source-tail first byte");
+  std::optional<uint64_t> FirstTailByte =
+      checkedAddUint64(T.OriginalOffset, MinInstSize, "source-tail first byte");
   std::optional<uint64_t> SourceEnd = checkedAddUint64(
       T.OriginalOffset, T.OriginalSize, "source-tail source end");
   if (!FirstTailByte || !SourceEnd || Begin < *FirstTailByte ||
@@ -4840,6 +6992,28 @@ bool isSafeSourceTailRange(const Trampoline &T,
     if (ControlFlow.Targets.contains(Offset))
       return false;
   return true;
+}
+
+bool mustReserveSourceTailForRegisterlessReturn(const Trampoline &T) {
+  return T.Long && !T.UsesSetPCBack && !T.LongBranchPreservesVcc &&
+         !T.UsesSharedDispatcherForward && T.OriginalSize >= 2 * MinInstSize;
+}
+
+std::optional<std::pair<uint64_t, uint64_t>>
+registerlessSourceAffineGatewayRange(const Trampoline &T) {
+  constexpr uint64_t GatewayStart = 2 * MinInstSize;
+  constexpr uint64_t GatewayBytes = 5 * MinInstSize;
+  if (!mustReserveSourceTailForRegisterlessReturn(T) ||
+      T.OriginalSize < GatewayStart + GatewayBytes)
+    return std::nullopt;
+  std::optional<uint64_t> Begin = checkedAddUint64(
+      T.OriginalOffset, GatewayStart, "registerless affine gateway begin");
+  std::optional<uint64_t> End =
+      checkedAddUint64(T.OriginalOffset, GatewayStart + GatewayBytes,
+                       "registerless affine gateway end");
+  if (!Begin || !End)
+    return std::nullopt;
+  return std::pair<uint64_t, uint64_t>{*Begin, *End};
 }
 
 static SmallVector<uint8_t> encodeDirectCall(const LLVMState &LS,
@@ -4910,9 +7084,10 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
         Ctx.LS, T.OriginalOffset, ThisTP, T.LongBranchSgprBase);
     if (Direct && Direct->size() <= T.OriginalSize)
       continue;
-    std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
-        Ctx, T.OriginalOffset, /*Count=*/4,
-        /*Alignment=*/2, "shared far-dispatch gateway");
+    std::optional<SafeSgprScratchBlock> Scratch =
+        findSafeSgprScratchBlock(Ctx, T.OriginalOffset, /*Count=*/4,
+                                 /*Alignment=*/2, "shared far-dispatch gateway",
+                                 /*ReportNoSpace=*/false);
     if (Scratch) {
       Candidates.push_back({I, Scratch->Base});
     } else {
@@ -4937,9 +7112,10 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
 
   const std::vector<ElfView::FunctionTextRange> FunctionRanges =
       Ctx.Elf.functionTextRanges();
+  const FunctionRangeUniquenessIndex FunctionRangeIndex(FunctionRanges,
+                                                        Ctx.Elf.textAddr());
   auto HasSafeTail = [&](const Trampoline &T, uint64_t Begin, uint64_t End) {
-    bool HasUniqueFunctionRange = sourceHasUniqueFunctionRange(
-        T, FunctionRanges, Ctx.Elf.textAddr());
+    bool HasUniqueFunctionRange = FunctionRangeIndex.hasUniqueFunctionRange(T);
     return isSafeSourceTailRange(T, Ctx.DirectControlFlow,
                                  HasUniqueFunctionRange, Begin, End);
   };
@@ -5096,8 +7272,7 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
       AddedRelayMember = false;
       for (const Candidate &C : Candidates) {
         if (Members.size() == MaxGroupSites || Assigned.test(C.Index) ||
-            LocalMembers.contains(C.Index) ||
-            C.ScratchBase != Seed.ScratchBase)
+            LocalMembers.contains(C.Index) || C.ScratchBase != Seed.ScratchBase)
           continue;
         const Trampoline &T = Ctx.OutTrampolines[C.Index];
         if (T.OriginalOffset < GatewayFunctionStart ||
@@ -5638,55 +7813,291 @@ static bool emitSharedDispatchers(PatchContext &Ctx) {
   return true;
 }
 
-static std::optional<SmallVector<uint64_t, 4>>
-allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
-                              uint64_t OwnerOffset, uint64_t FromOffset,
-                              uint64_t TargetOffset) {
+static std::optional<SmallVector<uint64_t, 4>> allocateBackwardBranchIslands(
+    std::vector<NopSled> &Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
+    uint64_t TargetOffset, BranchIslandFailure *Failure = nullptr,
+    BranchGatewayHeadSet *PersistentHeads = nullptr,
+    DenseSet<uint64_t> *PersistentOccupied = nullptr,
+    BranchIslandPromoter Promote = {}) {
   struct Allocation {
     size_t SledIndex = 0;
     uint64_t PreviousWritePos = 0;
   };
+  BranchGatewayHeadSet LocalHeads;
+  DenseSet<uint64_t> LocalOccupied;
+  if (!PersistentOccupied)
+    PersistentOccupied = &LocalOccupied;
+  if (!PersistentHeads) {
+    LocalHeads = buildBranchGatewayHeads(Gateways, *PersistentOccupied);
+    PersistentHeads = &LocalHeads;
+  }
+  BranchGatewayHeadSet &Heads = *PersistentHeads;
+  DenseSet<uint64_t> &Occupied = *PersistentOccupied;
   SmallVector<Allocation, 4> Allocations;
   SmallVector<uint64_t, 4> Islands;
-  DenseSet<size_t> UsedSleds;
   uint64_t Current = FromOffset;
 
   while (!isSBranchReachable(Current, TargetOffset)) {
     size_t BestIndex = Gateways.size();
     uint64_t BestOffset = std::numeric_limits<uint64_t>::max();
-    for (size_t I = 0; I != Gateways.size(); ++I) {
-      NopSled &Sled = Gateways[I];
-      if (Sled.GatewayOnly || UsedSleds.contains(I) ||
-          OwnerOffset < Sled.FunctionStart || OwnerOffset >= Sled.FunctionEnd)
+    uint64_t ReachBegin =
+        Current > MaxSledDistance ? Current - MaxSledDistance : 0;
+    uint64_t Lower = TargetOffset == std::numeric_limits<uint64_t>::max()
+                         ? TargetOffset
+                         : TargetOffset + 1;
+    Lower = std::max(Lower, ReachBegin);
+    for (auto It = Heads.lower_bound({Lower, 0});
+         It != Heads.end() && It->first < Current; ++It) {
+      const NopSled &Sled = Gateways[It->second];
+      if (OwnerOffset < Sled.FunctionStart || OwnerOffset >= Sled.FunctionEnd ||
+          Sled.WritePos != It->first || !isSBranchReachable(Current, It->first))
         continue;
-      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-      if (Sled.WritePos <= TargetOffset || Sled.WritePos >= Current ||
-          Sled.WritePos > UsableEnd ||
-          MinInstSize > UsableEnd - Sled.WritePos ||
-          !isSBranchReachable(Current, Sled.WritePos))
-        continue;
-      if (BestIndex == Gateways.size() || Sled.WritePos < BestOffset) {
-        BestIndex = I;
-        BestOffset = Sled.WritePos;
-      }
+      BestIndex = It->second;
+      BestOffset = It->first;
+      break;
     }
 
     if (BestIndex == Gateways.size()) {
+      uint64_t Corridor = TargetOffset;
+      auto CorridorIt = Heads.lower_bound({Current, 0});
+      while (CorridorIt != Heads.begin()) {
+        --CorridorIt;
+        if (CorridorIt->first <= TargetOffset)
+          break;
+        const NopSled &Sled = Gateways[CorridorIt->second];
+        if (OwnerOffset < Sled.FunctionStart || OwnerOffset >= Sled.FunctionEnd)
+          continue;
+        Corridor = CorridorIt->first;
+        break;
+      }
+      BranchIslandFailure ThisFailure{Current, TargetOffset, Corridor,
+                                      /*Forward=*/false};
+      if (Failure)
+        *Failure = ThisFailure;
+      // Keep the partial chain transactional while recoverable capacity is
+      // added. There are no live vector references or set iterators here.
+      if (Promote && Promote(ThisFailure))
+        continue;
+
+      uint64_t EligibleOwnerSleds = 0;
+      uint64_t FreeCorridorSleds = 0;
+      uint64_t ReachableFromCurrent = 0;
+      uint64_t ReachableToTarget = 0;
+      uint64_t LowestCorridor = std::numeric_limits<uint64_t>::max();
+      uint64_t HighestCorridor = 0;
+      uint64_t LowestReachableFromCurrent =
+          std::numeric_limits<uint64_t>::max();
+      uint64_t HighestReachableToTarget = 0;
+      for (const BranchGatewayHead &Head : Heads) {
+        const NopSled &Sled = Gateways[Head.second];
+        if (OwnerOffset < Sled.FunctionStart || OwnerOffset >= Sled.FunctionEnd)
+          continue;
+        ++EligibleOwnerSleds;
+        if (Head.first <= TargetOffset || Head.first >= Current)
+          continue;
+        ++FreeCorridorSleds;
+        LowestCorridor = std::min(LowestCorridor, Head.first);
+        HighestCorridor = std::max(HighestCorridor, Head.first);
+        if (isSBranchReachable(Current, Head.first)) {
+          ++ReachableFromCurrent;
+          LowestReachableFromCurrent =
+              std::min(LowestReachableFromCurrent, Head.first);
+        }
+        if (isSBranchReachable(Head.first, TargetOffset)) {
+          ++ReachableToTarget;
+          HighestReachableToTarget =
+              std::max(HighestReachableToTarget, Head.first);
+        }
+      }
+      if (Failure)
+        *Failure = {Current, TargetOffset,
+                    HighestCorridor ? HighestCorridor : TargetOffset,
+                    /*Forward=*/false};
+      log() << "hotswap: backward return allocator stranded owner 0x"
+            << utohexstr(OwnerOffset) << ": from=0x" << utohexstr(FromOffset)
+            << ", current=0x" << utohexstr(Current) << ", target=0x"
+            << utohexstr(TargetOffset) << ", selected=" << Islands.size()
+            << ", owner-sleds=" << EligibleOwnerSleds
+            << ", free-corridor=" << FreeCorridorSleds
+            << ", reachable-from-current=" << ReachableFromCurrent
+            << ", reachable-to-target=" << ReachableToTarget;
+      if (LowestCorridor != std::numeric_limits<uint64_t>::max())
+        log() << ", corridor=[0x" << utohexstr(LowestCorridor) << ",0x"
+              << utohexstr(HighestCorridor) << "]";
+      if (LowestReachableFromCurrent != std::numeric_limits<uint64_t>::max())
+        log() << ", lowest-reachable-from-current=0x"
+              << utohexstr(LowestReachableFromCurrent);
+      if (HighestReachableToTarget)
+        log() << ", highest-reachable-to-target=0x"
+              << utohexstr(HighestReachableToTarget);
+      log() << "\n";
       for (size_t I = Allocations.size(); I != 0; --I) {
         const Allocation &A = Allocations[I - 1];
         Gateways[A.SledIndex].WritePos = A.PreviousWritePos;
+        Heads.insert({A.PreviousWritePos, A.SledIndex});
       }
+      for (uint64_t Offset : Islands)
+        Occupied.erase(Offset);
       return std::nullopt;
     }
 
-    NopSled &Best = Gateways[BestIndex];
-    Allocations.push_back({BestIndex, Best.WritePos});
-    Islands.push_back(Best.WritePos);
-    Current = Best.WritePos;
-    Best.WritePos += MinInstSize;
-    UsedSleds.insert(BestIndex);
+    auto AliasBegin = Heads.lower_bound({BestOffset, 0});
+    auto AliasEnd =
+        Heads.upper_bound({BestOffset, std::numeric_limits<size_t>::max()});
+    for (auto It = AliasBegin; It != AliasEnd; ++It) {
+      NopSled &Alias = Gateways[It->second];
+      Allocations.push_back({It->second, Alias.WritePos});
+      Alias.WritePos += MinInstSize;
+    }
+    Heads.erase(AliasBegin, AliasEnd);
+    Occupied.insert(BestOffset);
+    Islands.push_back(BestOffset);
+    Current = BestOffset;
+  }
+  for (const Allocation &A : Allocations) {
+    NopSled &Sled = Gateways[A.SledIndex];
+    while (hasFreeBranchGatewaySlot(Sled) && Occupied.contains(Sled.WritePos))
+      Sled.WritePos += MinInstSize;
+    if (hasFreeBranchGatewaySlot(Sled))
+      Heads.insert({Gateways[A.SledIndex].WritePos, A.SledIndex});
   }
   return Islands;
+}
+
+BranchIslandAllocatorTestResult runBranchIslandAllocatorForTest(
+    std::vector<NopSled> Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
+    uint64_t TargetOffset, bool Backward, DenseSet<uint64_t> Occupied) {
+  BranchGatewayHeadSet Heads = buildBranchGatewayHeads(Gateways, Occupied);
+  std::optional<SmallVector<uint64_t, 4>> Islands =
+      Backward
+          ? allocateBackwardBranchIslands(Gateways, OwnerOffset, FromOffset,
+                                          TargetOffset, nullptr, &Heads,
+                                          &Occupied)
+          : allocateForwardBranchIslands(Gateways, FromOffset, TargetOffset,
+                                         nullptr, &Heads, &Occupied);
+  BranchIslandAllocatorTestResult Result;
+  Result.Success = Islands.has_value();
+  if (Islands)
+    Result.Islands = std::move(*Islands);
+  Result.Gateways = std::move(Gateways);
+  Result.Occupied = std::move(Occupied);
+  return Result;
+}
+
+BranchIslandAllocatorTestResult runBranchIslandAllocatorWithPromotionsForTest(
+    std::vector<NopSled> Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
+    uint64_t TargetOffset, bool Backward, ArrayRef<NopSled> Promotions) {
+  DenseSet<uint64_t> Occupied;
+  BranchGatewayHeadSet Heads = buildBranchGatewayHeads(Gateways, Occupied);
+  SmallVector<size_t, 4> HeldCounts;
+  size_t NextPromotion = 0;
+  BranchIslandPromoter Promote = [&](const BranchIslandFailure &) {
+    if (NextPromotion == Promotions.size())
+      return false;
+    HeldCounts.push_back(Occupied.size());
+    size_t Index = Gateways.size();
+    Gateways.push_back(Promotions[NextPromotion++]);
+    NopSled &Added = Gateways.back();
+    while (hasFreeBranchGatewaySlot(Added) && Occupied.contains(Added.WritePos))
+      Added.WritePos += MinInstSize;
+    if (hasFreeBranchGatewaySlot(Added))
+      Heads.insert({Added.WritePos, Index});
+    return true;
+  };
+  std::optional<SmallVector<uint64_t, 4>> Islands =
+      Backward
+          ? allocateBackwardBranchIslands(Gateways, OwnerOffset, FromOffset,
+                                          TargetOffset, nullptr, &Heads,
+                                          &Occupied, Promote)
+          : allocateForwardBranchIslands(Gateways, FromOffset, TargetOffset,
+                                         nullptr, &Heads, &Occupied, Promote);
+  BranchIslandAllocatorTestResult Result;
+  Result.Success = Islands.has_value();
+  if (Islands)
+    Result.Islands = std::move(*Islands);
+  Result.HeldIslandCountsAtPromotion = std::move(HeldCounts);
+  Result.Gateways = std::move(Gateways);
+  Result.Occupied = std::move(Occupied);
+  return Result;
+}
+
+std::vector<NopSled>
+subtractOccupiedBranchGatewaySlotsForTest(std::vector<NopSled> Gateways,
+                                          const DenseSet<uint64_t> &Occupied) {
+  subtractOccupiedBranchGatewaySlots(Gateways, Occupied);
+  return Gateways;
+}
+
+std::pair<uint64_t, uint64_t>
+branchPromotionSearchRangeForTest(uint64_t CurrentOffset,
+                                  uint64_t CorridorOffset, bool Forward) {
+  constexpr uint64_t MinSourceBytes = SetPcForwardSequenceBytes + MinInstSize;
+  if (Forward) {
+    uint64_t ReachEnd =
+        CurrentOffset > std::numeric_limits<uint64_t>::max() - MaxSledDistance
+            ? std::numeric_limits<uint64_t>::max()
+            : CurrentOffset + MaxSledDistance;
+    return {CurrentOffset, std::min(CorridorOffset, ReachEnd)};
+  }
+
+  uint64_t CorridorBegin =
+      CorridorOffset > MinSourceBytes ? CorridorOffset - MinSourceBytes : 0;
+  constexpr uint64_t ReachWithPrefix =
+      MaxSledDistance + SetPcForwardSequenceBytes;
+  uint64_t ReachBegin =
+      CurrentOffset > ReachWithPrefix ? CurrentOffset - ReachWithPrefix : 0;
+  return {std::max(CorridorBegin, ReachBegin), CurrentOffset};
+}
+
+static int findNextPromotionCandidateIndex(
+    const BitVector &StillPossible, size_t BeginIndex, size_t EndIndex,
+    bool Forward, std::optional<size_t> Previous = std::nullopt) {
+  BeginIndex = std::min(BeginIndex, static_cast<size_t>(StillPossible.size()));
+  EndIndex = std::min(EndIndex, static_cast<size_t>(StillPossible.size()));
+  if (BeginIndex >= EndIndex)
+    return -1;
+
+  int Found = -1;
+  if (Forward) {
+    size_t Before = Previous.value_or(EndIndex);
+    if (Before == 0)
+      return -1;
+    Found = StillPossible.find_prev(static_cast<unsigned>(Before));
+    if (Found < 0 || static_cast<size_t>(Found) < BeginIndex)
+      return -1;
+  } else {
+    if (Previous)
+      Found = StillPossible.find_next(static_cast<unsigned>(*Previous));
+    else if (BeginIndex == 0)
+      Found = StillPossible.find_first();
+    else
+      Found = StillPossible.find_next(static_cast<unsigned>(BeginIndex - 1));
+    if (Found < 0 || static_cast<size_t>(Found) >= EndIndex)
+      return -1;
+  }
+  return Found;
+}
+
+SmallVector<size_t, 8> promotionCandidateOrderForTest(
+    size_t CandidateCount, ArrayRef<size_t> PermanentlyRejected,
+    size_t BeginIndex, size_t EndIndex, bool Forward) {
+  BitVector StillPossible(CandidateCount, true);
+  for (size_t Index : PermanentlyRejected)
+    if (Index < CandidateCount)
+      StillPossible.reset(Index);
+
+  SmallVector<size_t, 8> Order;
+  std::optional<size_t> Previous;
+  while (true) {
+    int Found = findNextPromotionCandidateIndex(StillPossible, BeginIndex,
+                                                EndIndex, Forward, Previous);
+    if (Found < 0)
+      break;
+    size_t Index = static_cast<size_t>(Found);
+    Order.push_back(Index);
+    Previous = Index;
+  }
+  return Order;
 }
 
 static bool emitMirroredStubGateways(PatchContext &Ctx) {
@@ -5774,21 +8185,44 @@ static bool emitMirroredStubGateways(PatchContext &Ctx) {
   return true;
 }
 
+static std::optional<uint64_t> sourceTailBranchTarget(const Trampoline &T,
+                                                      uint64_t Offset) {
+  for (const auto &[RelayOffset, TargetOffset] : T.SourceTailBranchIslands)
+    if (RelayOffset == Offset)
+      return TargetOffset;
+  return std::nullopt;
+}
+
+static bool recordSourceTailBranchIsland(Trampoline &T, uint64_t Offset,
+                                         uint64_t Target) {
+  if (std::optional<uint64_t> Existing = sourceTailBranchTarget(T, Offset))
+    return *Existing == Target;
+  T.SourceTailBranchIslands.push_back({Offset, Target});
+  return true;
+}
+
 static bool
 assignLongBranchGateways(PatchContext &Ctx,
                          const DenseSet<uint64_t> &DirectBranchTargets,
                          bool AllowTextGateways) {
+  struct PoolIslandOwner {
+    size_t TrampolineIndex = 0;
+    uint64_t RelativeOffset = 0;
+  };
   std::vector<NopSled> Gateways;
-  DenseMap<uint64_t, size_t> PoolIslandOwners;
+  DenseMap<uint64_t, PoolIslandOwner> PoolIslandOwners;
   DenseMap<uint64_t, size_t> SourceTailIslandOwners;
   DenseMap<uint64_t, size_t> SourceTailGatewayOwners;
   DenseMap<uint64_t, uint64_t> EarlySourceTailOwnerOffsets;
   DenseMap<uint64_t, uint64_t> EarlySourceGatewayOwnerOffsets;
+  DenseMap<uint64_t, uint64_t> ReservedBackboneOwnerOffsets;
+  DenseMap<uint64_t, uint64_t> LateDirectSuffixOwnerOffsets;
   const std::vector<ElfView::FunctionTextRange> FunctionRanges =
       Ctx.Elf.functionTextRanges();
+  const FunctionRangeUniquenessIndex FunctionRangeIndex(FunctionRanges,
+                                                        Ctx.Elf.textAddr());
   auto HasSafeTail = [&](const Trampoline &T, uint64_t Begin, uint64_t End) {
-    bool HasUniqueFunctionRange = sourceHasUniqueFunctionRange(
-        T, FunctionRanges, Ctx.Elf.textAddr());
+    bool HasUniqueFunctionRange = FunctionRangeIndex.hasUniqueFunctionRange(T);
     return isSafeSourceTailRange(T, Ctx.DirectControlFlow,
                                  HasUniqueFunctionRange, Begin, End);
   };
@@ -5818,14 +8252,14 @@ assignLongBranchGateways(PatchContext &Ctx,
           T.OriginalSize < 2 * MinInstSize ||
           isSBranchReachable(T.OriginalOffset, ThisTP))
         continue;
-      std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
-          Ctx.LS, T.OriginalOffset, ThisTP, T.LongBranchSgprBase,
-          T.LongBranchUsesVcc);
+      std::optional<SmallVector<uint8_t>> Direct =
+          encodeSetPCLongBranch(Ctx.LS, T.OriginalOffset, ThisTP,
+                                T.LongBranchSgprBase, T.LongBranchUsesVcc);
       if (Direct && Direct->size() <= T.OriginalSize)
         continue;
-      if (!findSafeSgprScratchBlock(
-              Ctx, T.OriginalOffset, /*Count=*/4, /*Alignment=*/2,
-              "affine reserve demand", /*ReportNoSpace=*/false)) {
+      if (!findSafeSgprScratchBlock(Ctx, T.OriginalOffset, /*Count=*/4,
+                                    /*Alignment=*/2, "affine reserve demand",
+                                    /*ReportNoSpace=*/false)) {
         HasPairOnlyAffineDemand = true;
         break;
       }
@@ -5858,10 +8292,16 @@ assignLongBranchGateways(PatchContext &Ctx,
     Gateways.insert(Gateways.end(), MirroredGatewayReserves.begin(),
                     MirroredGatewayReserves.end());
 
+    // Collect pair-backed source tails into one sparse backbone. These tails
+    // are withheld from affine planning below, then reactivated after
+    // forward-mode selection proves that their second dword is unreachable.
+    SmallVector<std::pair<uint64_t, uint64_t>, 64> SourceTailBackboneCandidates;
+
     // Shared-dispatch sources can also use one-dword direct calls: their link
     // pair is exactly the source-PC identity consumed by the dispatcher. Keep
     // tails that the shared planner already selected as relays on that route,
-    // and expose every other tail to the later affine planner.
+    // collect independent tails for the sparse backbone, and
+    // expose every other tail to the later affine planner.
     DenseSet<uint64_t> RequiredSharedRelayTails;
     for (const Trampoline &T : Ctx.OutTrampolines)
       if (T.UsesSharedDispatcherForward && T.SharedDispatcherRelayOffset != 0)
@@ -5878,14 +8318,12 @@ assignLongBranchGateways(PatchContext &Ctx,
           : T.ForwardBranchIslands.empty() ? T.SharedDispatcherGatewayOffset
                                            : T.ForwardBranchIslands.front();
       if (RequiredSharedRelayTails.contains(Tail)) {
-        T.HasSourceTailBranchIsland = true;
-        T.SourceTailBranchIslandOffset = Tail;
-        T.SourceTailBranchTargetOffset = Route;
+        if (!recordSourceTailBranchIsland(T, Tail, Route))
+          return false;
         continue;
       }
-      EarlySourceTailOwnerOffsets[Tail] = T.OriginalOffset;
-      Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
-                          std::numeric_limits<uint64_t>::max()});
+      SourceTailBackboneCandidates.push_back({Tail, T.OriginalOffset});
+      continue;
     }
 
     // Shared-dispatch sources reserve one direct call in their first dword,
@@ -5915,9 +8353,12 @@ assignLongBranchGateways(PatchContext &Ctx,
     }
 
     // s_call_i64 records source+4 in the reserved pair and transfers control
-    // in one dword. Expose the now-unreachable second dword of every affine
-    // candidate as an object-wide relay before planning; this lets isolated
-    // pairs share a registerless path to a 12-byte gateway.
+    // in one dword. Most now-unreachable second dwords are offered to affine
+    // planning. Withhold a sparse 96-KiB backbone, however: affine routes can
+    // consume every relay in a dense text interval and leave no path for a
+    // later registerless return. Only pair-backed sources with a proven-safe
+    // second dword participate, so a member that receives a mirrored
+    // one-dword call has an independently-proven unreachable +4 dword.
     CandidateTP = Ctx.PoolBaseOffset;
     for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
       const Trampoline &T = Ctx.OutTrampolines[I];
@@ -5934,43 +8375,90 @@ assignLongBranchGateways(PatchContext &Ctx,
       std::optional<SmallVector<uint8_t>> Direct =
           encodeSetPCLongBranch(Ctx.LS, T.OriginalOffset, ThisTP,
                                 T.LongBranchSgprBase, T.LongBranchUsesVcc);
-      if (Direct && Direct->size() <= T.OriginalSize)
+      if (Direct && Direct->size() <= T.OriginalSize) {
+        // A direct set-PC sequence consumes only its prefix. Once ordinary
+        // mode selection commits that sequence, a safe dword in the remaining
+        // source window is unreachable and can serve the same sparse
+        // backbone. Keep at most one suffix candidate per owner.
+        if (!T.LongBranchPreservesVcc &&
+            Direct->size() + MinInstSize <= T.OriginalSize) {
+          for (uint64_t RelativeOffset = Direct->size();
+               RelativeOffset + MinInstSize <= T.OriginalSize;
+               RelativeOffset += MinInstSize) {
+            uint64_t Suffix = T.OriginalOffset + RelativeOffset;
+            if (!HasSafeTail(T, Suffix, Suffix + MinInstSize))
+              continue;
+            LateDirectSuffixOwnerOffsets[Suffix] = T.OriginalOffset;
+            break;
+          }
+        }
         continue;
+      }
       uint64_t Tail = T.OriginalOffset + MinInstSize;
       if (!HasSafeTail(T, Tail, Tail + MinInstSize))
         continue;
-      EarlySourceTailOwnerOffsets[Tail] = T.OriginalOffset;
-      Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
-                          std::numeric_limits<uint64_t>::max()});
+      SourceTailBackboneCandidates.push_back({Tail, T.OriginalOffset});
+      continue;
     }
-
-    // A registerless far source always emits a one-dword branch. Its remaining
-    // tail is therefore safe before the ordinary planner runs and can bridge a
-    // pair-only source to a 12-byte affine gateway. Unlike arbitrary padding,
-    // these relays are unreachable by original fallthrough and are valid
-    // object-wide.
-    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
-      const Trampoline &T = Ctx.OutTrampolines[I];
-      if (T.UsesSetPCBack || T.LongBranchPreservesVcc ||
-          T.UsesSharedDispatcherForward || T.OriginalSize < 2 * MinInstSize)
-        continue;
-      uint64_t Tail = T.OriginalOffset + MinInstSize;
-      if (HasSafeTail(T, Tail, Tail + MinInstSize)) {
-        EarlySourceTailOwnerOffsets[Tail] = T.OriginalOffset;
+    llvm::sort(SourceTailBackboneCandidates);
+    SourceTailBackboneCandidates.erase(
+        std::unique(SourceTailBackboneCandidates.begin(),
+                    SourceTailBackboneCandidates.end()),
+        SourceTailBackboneCandidates.end());
+    constexpr uint64_t SourceTailBackboneSpacing = 96 * 1024;
+    BitVector ReservedSourceTails(SourceTailBackboneCandidates.size());
+    if (!SourceTailBackboneCandidates.empty()) {
+      ReservedSourceTails.set(0);
+      size_t LastReserved = 0;
+      for (size_t I = 1; I != SourceTailBackboneCandidates.size(); ++I) {
+        if (SourceTailBackboneCandidates[I].first -
+                SourceTailBackboneCandidates[LastReserved].first <=
+            SourceTailBackboneSpacing)
+          continue;
+        ReservedSourceTails.set(I - 1);
+        LastReserved = I - 1;
+        // A gap between adjacent candidates cannot be filled by this
+        // backbone. Preserve both sides so other stable text/pool relays can
+        // still connect to the nearest available endpoint.
+        if (SourceTailBackboneCandidates[I].first -
+                SourceTailBackboneCandidates[LastReserved].first >
+            SourceTailBackboneSpacing) {
+          ReservedSourceTails.set(I);
+          LastReserved = I;
+        }
+      }
+      ReservedSourceTails.set(SourceTailBackboneCandidates.size() - 1);
+    }
+    for (size_t I = 0; I != SourceTailBackboneCandidates.size(); ++I) {
+      const auto &[Tail, Owner] = SourceTailBackboneCandidates[I];
+      if (ReservedSourceTails.test(I)) {
+        ReservedBackboneOwnerOffsets[Tail] = Owner;
+      } else {
+        EarlySourceTailOwnerOffsets[Tail] = Owner;
         Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
                             std::numeric_limits<uint64_t>::max()});
       }
-      constexpr uint64_t GatewayStart = 2 * MinInstSize;
-      constexpr uint64_t GatewayBytes = 5 * MinInstSize;
-      if (T.OriginalSize >= GatewayStart + GatewayBytes) {
-        uint64_t Start = T.OriginalOffset + GatewayStart;
-        if (!HasSafeTail(T, Start, Start + GatewayBytes))
-          continue;
-        EarlySourceGatewayOwnerOffsets[Start] = T.OriginalOffset;
-        Gateways.push_back({Start, Start + GatewayBytes, Start, 0,
-                            std::numeric_limits<uint64_t>::max(),
-                            /*GatewayOnly=*/true});
-      }
+    }
+
+    // A registerless far source needs its second dword for its own return
+    // chain. Do not expose that owner tail to the affine planner: a greedy
+    // forward chain could consume it and strand the source before return
+    // allocation runs. Bytes after the reserved second dword remain eligible
+    // as a source-local gateway when the original window is large enough.
+    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+      const Trampoline &T = Ctx.OutTrampolines[I];
+      std::optional<std::pair<uint64_t, uint64_t>> Range =
+          registerlessSourceAffineGatewayRange(T);
+      if (!Range)
+        continue;
+      uint64_t Start = Range->first;
+      uint64_t End = Range->second;
+      if (!HasSafeTail(T, Start, End))
+        continue;
+      EarlySourceGatewayOwnerOffsets[Start] = T.OriginalOffset;
+      Gateways.push_back({Start, End, Start, 0,
+                          std::numeric_limits<uint64_t>::max(),
+                          /*GatewayOnly=*/true});
     }
 
     if (!planMirroredStubGateways(Ctx, Gateways))
@@ -6010,15 +8498,11 @@ assignLongBranchGateways(PatchContext &Ctx,
         uint64_t To = I + 1 == T.ForwardBranchIslands.size()
                           ? T.ForwardBranchTargetOffset
                           : T.ForwardBranchIslands[I + 1];
-        if (OwnerT.HasSourceTailBranchIsland &&
-            OwnerT.SourceTailBranchTargetOffset != To) {
+        if (!recordSourceTailBranchIsland(OwnerT, From, To)) {
           log() << "hotswap: error: affine source tail at 0x" << utohexstr(From)
                 << " has conflicting relay targets\n";
           return false;
         }
-        OwnerT.HasSourceTailBranchIsland = true;
-        OwnerT.SourceTailBranchIslandOffset = From;
-        OwnerT.SourceTailBranchTargetOffset = To;
       }
     }
     for (const Trampoline &T : Ctx.OutTrampolines) {
@@ -6052,7 +8536,8 @@ assignLongBranchGateways(PatchContext &Ctx,
       return false;
     if (T.HasPoolBranchIsland) {
       T.PoolBranchIslandOffset = *Next - PoolBranchIslandBytes;
-      PoolIslandOwners[T.PoolBranchIslandOffset] = I;
+      PoolIslandOwners[T.PoolBranchIslandOffset] = {
+          I, T.Bytes.size() - PoolBranchIslandBytes};
       Gateways.push_back({T.PoolBranchIslandOffset,
                           T.PoolBranchIslandOffset + PoolBranchIslandBytes,
                           T.PoolBranchIslandOffset, 0,
@@ -6117,6 +8602,68 @@ assignLongBranchGateways(PatchContext &Ctx,
                std::chrono::steady_clock::now() - OrdinaryPlanStart)
                .count()
         << " ms\n";
+  uint64_t PoolEndOffset = TrampOffset;
+
+  // Affine planning has finished and ordinary mode selection has now either
+  // committed a direct set-PC source or left a pair-backed owner on its
+  // one-dword branch path. Reactivate the withheld backbone only at this
+  // point: its +4 dword is provably unreachable for both mirrored calls and
+  // pending ordinary branches, while it could not be consumed by an earlier
+  // affine route.
+  DenseMap<uint64_t, size_t> FinalTrampolineAtOriginalOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I)
+    FinalTrampolineAtOriginalOffset[Ctx.OutTrampolines[I].OriginalOffset] = I;
+  uint64_t ActivatedBackboneRelays = 0;
+  for (const auto &KV : ReservedBackboneOwnerOffsets) {
+    DenseMap<uint64_t, size_t>::const_iterator Owner =
+        FinalTrampolineAtOriginalOffset.find(KV.second);
+    if (Owner == FinalTrampolineAtOriginalOffset.end())
+      continue;
+    const Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+    if (KV.first < OwnerT.OriginalOffset)
+      continue;
+    uint64_t RelativeOffset = KV.first - OwnerT.OriginalOffset;
+    bool HasOneDwordForward =
+        RelativeOffset == MinInstSize &&
+        (OwnerT.UsesSharedDispatcherForward ||
+         (OwnerT.UsesSetPCBack && !OwnerT.UsesDirectSetPCForward));
+    if (!OwnerT.Long || OwnerT.LongBranchPreservesVcc || !HasOneDwordForward ||
+        !HasSafeTail(OwnerT, KV.first, KV.first + MinInstSize) ||
+        sourceTailBranchTarget(OwnerT, KV.first))
+      continue;
+    SourceTailIslandOwners[KV.first] = Owner->second;
+    Gateways.push_back({KV.first, KV.first + MinInstSize, KV.first, 0,
+                        std::numeric_limits<uint64_t>::max()});
+    ++ActivatedBackboneRelays;
+  }
+  uint64_t ActivatedDirectSuffixRelays = 0;
+  for (const auto &KV : LateDirectSuffixOwnerOffsets) {
+    DenseMap<uint64_t, size_t>::const_iterator Owner =
+        FinalTrampolineAtOriginalOffset.find(KV.second);
+    if (Owner == FinalTrampolineAtOriginalOffset.end())
+      continue;
+    const Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+    if (KV.first < OwnerT.OriginalOffset)
+      continue;
+    uint64_t RelativeOffset = KV.first - OwnerT.OriginalOffset;
+    if (!OwnerT.Long || OwnerT.LongBranchPreservesVcc ||
+        !OwnerT.UsesDirectSetPCForward ||
+        RelativeOffset < OwnerT.DirectSetPCForwardBytes.size() ||
+        RelativeOffset + MinInstSize > OwnerT.OriginalSize ||
+        !HasSafeTail(OwnerT, KV.first, KV.first + MinInstSize) ||
+        sourceTailBranchTarget(OwnerT, KV.first))
+      continue;
+    SourceTailIslandOwners[KV.first] = Owner->second;
+    Gateways.push_back({KV.first, KV.first + MinInstSize, KV.first, 0,
+                        std::numeric_limits<uint64_t>::max()});
+    ++ActivatedDirectSuffixRelays;
+  }
+  if (ActivatedBackboneRelays != 0)
+    log() << "hotswap: reserved " << ActivatedBackboneRelays
+          << " source-tail backbone relay(s) from affine planning\n";
+  if (ActivatedDirectSuffixRelays != 0)
+    log() << "hotswap: exposed " << ActivatedDirectSuffixRelays
+          << " direct set-PC source-suffix relay(s) after affine planning\n";
 
   // Once a source is replaced by a one-dword branch, the remainder of its
   // original instruction window is unreachable and can provide a safe relay.
@@ -6128,8 +8675,7 @@ assignLongBranchGateways(PatchContext &Ctx,
     const Trampoline &T = Ctx.OutTrampolines[I];
     if (!AllowTextGateways ||
         Ctx.DirectControlFlow.HasUnboundedIndirectEntries ||
-        T.OriginalSize < 2 * MinInstSize ||
-        T.UsesDirectSetPCForward ||
+        T.OriginalSize < 2 * MinInstSize || T.UsesDirectSetPCForward ||
         T.UsesSharedDispatcherForward || T.UsesMirroredStubForward ||
         T.LongBranchPreservesVcc)
       continue;
@@ -6146,8 +8692,351 @@ assignLongBranchGateways(PatchContext &Ctx,
   // one-dword branch. Allocate registerless returns only now, so they can use
   // the complete set of unreachable source tails. Returns retain first access
   // to those relays before ordinary forward gateways and island chains.
+  //
+  // Reserve each registerless source's own second dword before allocating any
+  // chain. That dword lies four bytes before ReturnTo, so the generic
+  // monotonically-backward allocator cannot select it directly; without this
+  // reservation an earlier return can consume it as an ordinary relay and
+  // strand its owner. The owner's chain targets the reserved tail, whose final
+  // branch then advances to ReturnTo.
+  DenseMap<size_t, uint64_t> ReservedReturnTails;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    const Trampoline &T = Ctx.OutTrampolines[I];
+    if (!mustReserveSourceTailForRegisterlessReturn(T))
+      continue;
+    uint64_t Tail = T.OriginalOffset + MinInstSize;
+    DenseMap<uint64_t, size_t>::const_iterator Owner =
+        SourceTailIslandOwners.find(Tail);
+    if (Owner == SourceTailIslandOwners.end() || Owner->second != I)
+      continue;
+    for (NopSled &Gateway : Gateways) {
+      if (Gateway.WritePos != Tail || Gateway.End < Tail + MinInstSize)
+        continue;
+      Gateway.WritePos += MinInstSize;
+      ReservedReturnTails[I] = Tail;
+      break;
+    }
+  }
+
+  DenseSet<uint64_t> OccupiedBranchGatewaySlots;
+  BranchGatewayHeadSet BranchGatewayHeads =
+      buildBranchGatewayHeads(Gateways, OccupiedBranchGatewaySlots);
+  uint64_t RemainingRelayDemand = 0;
+  for (const Trampoline &T : Ctx.OutTrampolines)
+    RemainingRelayDemand += T.Long && !T.UsesSetPCBack;
+  RemainingRelayDemand += Pending.size();
+
+  BitVector PromotionStillPossible(Ctx.Decoded.size(), true);
+  DenseSet<uint64_t> PromotionProtectedOffsets =
+      collectRelocationProtectedOffsets(Ctx.Decoded, Ctx.LS,
+                                        /*ProtectClauseMembers=*/true);
+  DenseSet<uint64_t> PromotionEntryOffsets = Ctx.DirectControlFlow.Targets;
+  PromotionEntryOffsets.insert(DirectBranchTargets.begin(),
+                               DirectBranchTargets.end());
+  PromotionEntryOffsets.insert(Ctx.DeclaredEntries.begin(),
+                               Ctx.DeclaredEntries.end());
+  DenseSet<uint64_t> PromotionIndirectFunctions =
+      collectIndirectControlFlowFunctions(
+          Ctx.Decoded, Ctx.LS, Ctx.Elf,
+          Ctx.DirectControlFlow.BoundedIndirectTransfers);
+  DenseMap<std::pair<uint64_t, uint64_t>, std::optional<DenseSet<uint64_t>>>
+      PromotionVccNeedsCache;
+  using PromotionRange = std::pair<uint64_t, uint64_t>;
+  std::set<PromotionRange> PromotionReservedRanges;
+  auto ReservePromotionRange = [&](uint64_t Begin, uint64_t End) {
+    if (Begin >= End)
+      return;
+    auto It = PromotionReservedRanges.lower_bound({Begin, 0});
+    if (It != PromotionReservedRanges.begin()) {
+      auto Previous = std::prev(It);
+      if (Previous->second >= Begin)
+        It = Previous;
+    }
+    while (It != PromotionReservedRanges.end() && It->first <= End) {
+      Begin = std::min(Begin, It->first);
+      End = std::max(End, It->second);
+      It = PromotionReservedRanges.erase(It);
+    }
+    PromotionReservedRanges.insert(It, {Begin, End});
+  };
+  auto OverlapsPromotionRange = [&](uint64_t Begin, uint64_t End) {
+    if (Begin >= End)
+      return false;
+    auto It = PromotionReservedRanges.lower_bound({End, 0});
+    if (It == PromotionReservedRanges.begin())
+      return false;
+    --It;
+    return It->second > Begin;
+  };
+  for (const Trampoline &T : Ctx.OutTrampolines)
+    ReservePromotionRange(T.OriginalOffset, T.OriginalOffset + T.OriginalSize);
+  for (const NopSled &Gateway : Gateways)
+    ReservePromotionRange(Gateway.Start, Gateway.End);
+  auto IsVccDeadAtContinuation = [&](const ElfView::FunctionTextRange &Function,
+                                     uint64_t Start, uint32_t Size) {
+    std::optional<uint64_t> Continuation =
+        checkedAddUint64(Start, Size, "promoted VCC liveness continuation");
+    if (!Continuation || *Continuation < Function.Begin ||
+        *Continuation >= Function.End)
+      return false;
+    auto ContinuationIt =
+        llvm::lower_bound(Ctx.Decoded, *Continuation,
+                          [](const InternalDecodedInst &DI, uint64_t Offset) {
+                            return DI.Offset < Offset;
+                          });
+    if (ContinuationIt == Ctx.Decoded.end() ||
+        ContinuationIt->Offset != *Continuation)
+      return false;
+
+    std::pair<uint64_t, uint64_t> Key{Function.Begin, Function.End};
+    auto CacheIt = PromotionVccNeedsCache.find(Key);
+    if (CacheIt == PromotionVccNeedsCache.end()) {
+      std::optional<DenseSet<uint64_t>> Needs =
+          computeIncomingRegisterNeeds(Ctx.Decoded, Ctx.LS, Function.Begin,
+                                       Function.End, Ctx.LS.VCCRegister);
+      CacheIt = PromotionVccNeedsCache.try_emplace(Key, std::move(Needs)).first;
+    }
+    return CacheIt->second && !CacheIt->second->contains(*Continuation);
+  };
+  uint64_t PromotedBranchCapacityRelays = 0;
+  SmallVector<std::pair<size_t, uint64_t>, 8> ReturnPromotionBranchOnlyRanges;
+  bool PlanningRegisterlessReturns = true;
+  constexpr uint64_t MinBranchCapacitySourceBytes =
+      SetPcForwardSequenceBytes + MinInstSize;
+  auto PromoteBranchCapacityRelay =
+      [&](const BranchIslandFailure &Failure) -> bool {
+    auto [SearchBegin, SearchEnd] = branchPromotionSearchRangeForTest(
+        Failure.CurrentOffset, Failure.CorridorOffset, Failure.Forward);
+    if (SearchBegin >= SearchEnd)
+      return false;
+    auto TryPromote = [&](bool AllowLocalPair) -> bool {
+      auto Begin =
+          llvm::lower_bound(Ctx.Decoded, SearchBegin,
+                            [](const InternalDecodedInst &DI, uint64_t Offset) {
+                              return DI.Offset < Offset;
+                            });
+      auto End =
+          llvm::lower_bound(Ctx.Decoded, SearchEnd,
+                            [](const InternalDecodedInst &DI, uint64_t Offset) {
+                              return DI.Offset < Offset;
+                            });
+      size_t BeginIndex = static_cast<size_t>(Begin - Ctx.Decoded.begin());
+      size_t EndIndex = static_cast<size_t>(End - Ctx.Decoded.begin());
+      std::optional<size_t> PreviousIndex;
+      while (true) {
+        int CandidateIndex = findNextPromotionCandidateIndex(
+            PromotionStillPossible, BeginIndex, EndIndex, Failure.Forward,
+            PreviousIndex);
+        if (CandidateIndex < 0)
+          break;
+        size_t Index = static_cast<size_t>(CandidateIndex);
+        PreviousIndex = Index;
+        auto It = Ctx.Decoded.begin() + Index;
+        uint64_t Start = It->Offset;
+
+        // Scratch selection does not change the fixed set-PC width. Reject
+        // offsets outside the depleted branch corridor before function,
+        // overlap, or liveness analysis.
+        std::optional<uint32_t> ProbeDirectSize =
+            getSetPcLongBranchLayoutSize(Start, PoolEndOffset);
+        if (!ProbeDirectSize) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        uint64_t Tail = Start + *ProbeDirectSize;
+        bool MakesReachableProgress =
+            Failure.Forward
+                ? Tail > Failure.CurrentOffset &&
+                      Tail < Failure.CorridorOffset &&
+                      Tail < Failure.TargetOffset &&
+                      isSBranchReachable(Failure.CurrentOffset, Tail)
+                : Tail < Failure.CurrentOffset &&
+                      Tail > Failure.CorridorOffset &&
+                      Tail > Failure.TargetOffset &&
+                      isSBranchReachable(Failure.CurrentOffset, Tail);
+        if (!MakesReachableProgress)
+          continue;
+
+        std::optional<ElfView::FunctionTextRange> Function =
+            Ctx.Elf.findFunctionTextRangeAtOffset(Start);
+        if (!Function || PromotionIndirectFunctions.contains(Function->Begin)) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+
+        uint64_t DemandBytes =
+            RemainingRelayDemand >
+                    (std::numeric_limits<uint32_t>::max() - *ProbeDirectSize) /
+                        MinInstSize
+                ? std::numeric_limits<uint32_t>::max() - *ProbeDirectSize
+                : RemainingRelayDemand * MinInstSize;
+        uint64_t DesiredSourceBytes = *ProbeDirectSize + DemandBytes;
+        DesiredSourceBytes =
+            std::max(DesiredSourceBytes, MinBranchCapacitySourceBytes);
+        DesiredSourceBytes =
+            std::min(DesiredSourceBytes, Function->End - Start);
+
+        SmallVector<uint8_t, 32> Replacement;
+        uint64_t Cursor = Start;
+        auto Member = It;
+        uint32_t MinimumReplacementSize = 0;
+        uint32_t BestVccReplacementSize = 0;
+        bool NeedsIncomingVcc = false;
+        bool FullyWritesVcc = false;
+        while (Replacement.size() < DesiredSourceBytes) {
+          if (Member == Ctx.Decoded.end() || Member->Offset != Cursor ||
+              PromotionEntryOffsets.contains(Member->Offset))
+            break;
+          std::optional<ElfView::FunctionTextRange> MemberFunction =
+              Ctx.Elf.findFunctionTextRangeAtOffset(Member->Offset);
+          std::optional<InternalDecodedInst> Current =
+              decodeCurrentInstruction(Ctx, *Member);
+          if (!MemberFunction || MemberFunction->Begin != Function->Begin ||
+              MemberFunction->End != Function->End || !Current ||
+              !isSafeStraightLineRelocation(*Current, Ctx.LS,
+                                            PromotionProtectedOffsets) ||
+              Current->Inst.getOpcode() == Ctx.LS.SNopOpcode)
+            break;
+          std::optional<uint64_t> MemberEnd =
+              checkedAddUint64(Member->Offset, Member->Size,
+                               "promoted branch-capacity member end");
+          if (!MemberEnd || *MemberEnd > Function->End ||
+              Replacement.size() + Member->Size > DesiredSourceBytes ||
+              OverlapsPromotionRange(Member->Offset, *MemberEnd))
+            break;
+
+          if (!FullyWritesVcc &&
+              instructionReadsRegister(*Current, Ctx.LS, Ctx.LS.VCCRegister))
+            NeedsIncomingVcc = true;
+          if (instructionFullyWritesRegister(*Current, Ctx.LS,
+                                             Ctx.LS.VCCRegister))
+            FullyWritesVcc = true;
+          Replacement.append(Ctx.Text + Member->Offset,
+                             Ctx.Text + Member->Offset + Member->Size);
+          Cursor = *MemberEnd;
+          ++Member;
+
+          if (!MinimumReplacementSize &&
+              Replacement.size() >= MinBranchCapacitySourceBytes)
+            MinimumReplacementSize = Replacement.size();
+          if (Replacement.size() >= MinBranchCapacitySourceBytes &&
+              !NeedsIncomingVcc && Ctx.LS.VCCRegister.isValid() &&
+              IsVccDeadAtContinuation(*Function, Start, Replacement.size()))
+            BestVccReplacementSize = Replacement.size();
+        }
+        if (!MinimumReplacementSize ||
+            Replacement.size() > std::numeric_limits<uint32_t>::max()) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        bool UseVcc = BestVccReplacementSize != 0;
+        if (!UseVcc && !AllowLocalPair)
+          continue;
+        Replacement.resize(UseVcc ? BestVccReplacementSize
+                                  : MinimumReplacementSize);
+        std::optional<unsigned> Scratch;
+        if (!UseVcc)
+          Scratch = findLocallyDeadSgprPair(Ctx, Start, Replacement.size(),
+                                            Replacement);
+        if (!Scratch && !UseVcc) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        uint64_t End = Start + Replacement.size();
+        Trampoline Promoted;
+        Promoted.OriginalOffset = Start;
+        Promoted.OriginalSize = Replacement.size();
+        Promoted.HasFunctionRange = true;
+        Promoted.FunctionStart = Function->Begin;
+        Promoted.FunctionEnd = Function->End;
+        if (!HasSafeTail(Promoted, Tail, End)) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
+            Ctx.LS, Start, PoolEndOffset, Scratch.value_or(0), UseVcc);
+        if (!Direct || Direct->size() != *ProbeDirectSize) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        if (Scratch) {
+          SafeSgprScratchBlock ScratchBlock{*Scratch, 2};
+          if (!commitSafeSgprScratchBlock(
+                  Ctx, Start, ScratchBlock,
+                  "promoted branch-capacity trampoline SGPR pair")) {
+            PromotionStillPossible.reset(Index);
+            continue;
+          }
+        }
+        Promoted.Bytes.append(Replacement.begin(), Replacement.end());
+        Promoted.Bytes.append(SetPcReturnReserveBytes, uint8_t{0});
+        Promoted.Bytes.append(PoolBranchIslandBytes, uint8_t{0});
+        Promoted.Long = true;
+        Promoted.UsesSetPCBack = true;
+        Promoted.LongBranchSgprBase = Scratch.value_or(0);
+        Promoted.LongBranchUsesVcc = UseVcc;
+        Promoted.UsesDirectSetPCForward = true;
+        Promoted.DirectSetPCForwardBytes = std::move(*Direct);
+        Promoted.HasPoolBranchIsland = true;
+
+        std::optional<uint64_t> NewPoolEnd =
+            checkedAddUint64(PoolEndOffset, Promoted.Bytes.size(),
+                             "promoted branch-capacity trampoline layout");
+        if (!NewPoolEnd)
+          return false;
+        Promoted.PoolBranchIslandOffset = *NewPoolEnd - PoolBranchIslandBytes;
+        size_t NewIndex = Ctx.OutTrampolines.size();
+        Ctx.OutTrampolines.emplace_back(std::move(Promoted));
+        PoolIslandOwners[*NewPoolEnd - PoolBranchIslandBytes] = {
+            NewIndex,
+            Ctx.OutTrampolines.back().Bytes.size() - PoolBranchIslandBytes};
+        size_t PoolGatewayIndex = Gateways.size();
+        Gateways.push_back({*NewPoolEnd - PoolBranchIslandBytes, *NewPoolEnd,
+                            *NewPoolEnd - PoolBranchIslandBytes, 0,
+                            std::numeric_limits<uint64_t>::max()});
+        BranchGatewayHeads.insert(
+            {*NewPoolEnd - PoolBranchIslandBytes, PoolGatewayIndex});
+        FinalTrampolineAtOriginalOffset[Start] = NewIndex;
+        for (uint64_t Relay = Tail; Relay + MinInstSize <= End;
+             Relay += MinInstSize)
+          SourceTailIslandOwners[Relay] = NewIndex;
+        size_t SourceGatewayIndex = Gateways.size();
+        Gateways.push_back(
+            {Tail, End, Tail, 0, std::numeric_limits<uint64_t>::max()});
+        BranchGatewayHeads.insert({Tail, SourceGatewayIndex});
+        if (PlanningRegisterlessReturns)
+          ReturnPromotionBranchOnlyRanges.push_back({SourceGatewayIndex, End});
+        ReservePromotionRange(Start, End);
+
+        PromotionStillPossible.reset(Index);
+        PoolEndOffset = *NewPoolEnd;
+        Ctx.QueuedTrampolineBytes = PoolEndOffset - Ctx.PoolBaseOffset;
+        Ctx.Profile.count(HotswapMetric::JumpLong);
+        ++PromotedBranchCapacityRelays;
+        // Keep small fixtures fully observable while bounding verbose output
+        // for giant objects with tens of thousands of promotions.
+        if (PromotedBranchCapacityRelays <= 16 ||
+            isPowerOf2_64(PromotedBranchCapacityRelays))
+          log() << "hotswap: promoted safe straight-line source at 0x"
+                << utohexstr(Start) << " (size=" << Replacement.size()
+                << ") to provide " << (Failure.Forward ? "forward" : "return")
+                << "-capacity relay window [0x" << utohexstr(Tail) << ",0x"
+                << utohexstr(End) << ") with " << (End - Tail) / MinInstSize
+                << " slot(s) using " << (UseVcc ? "VCC" : "a local SGPR pair")
+                << " (promotion " << PromotedBranchCapacityRelays << ")\n";
+        return true;
+      }
+      return false;
+    };
+    if (TryPromote(/*AllowLocalPair=*/false))
+      return true;
+    return TryPromote(/*AllowLocalPair=*/true);
+  };
+
+  const auto ReturnBranchPlanStart = std::chrono::steady_clock::now();
   TrampOffset = Ctx.PoolBaseOffset;
-  for (Trampoline &T : Ctx.OutTrampolines) {
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
     std::optional<uint64_t> Next = checkedAddUint64(
         TrampOffset, T.Bytes.size(), "return-island trampoline layout");
     if (!Next)
@@ -6169,20 +9058,62 @@ assignLongBranchGateways(PatchContext &Ctx,
                          "registerless trampoline return target");
     if (!ReturnTo)
       return false;
+    uint64_t OwnerOffset = T.OriginalOffset;
+    uint32_t OwnerSize = T.OriginalSize;
+    bool OwnerPreservesVcc = T.LongBranchPreservesVcc;
+    bool OwnerUsesShared = T.UsesSharedDispatcherForward;
+    bool OwnerUsesMirrored = T.UsesMirroredStubForward;
+    uint64_t ChainTarget = ReservedReturnTails.lookup(I);
+    BranchIslandFailure Failure;
     std::optional<SmallVector<uint64_t, 4>> ReturnIslands =
-        allocateBackwardBranchIslands(Gateways, T.OriginalOffset, BackSlot,
-                                      *ReturnTo);
+        allocateBackwardBranchIslands(Gateways, OwnerOffset, BackSlot,
+                                      ChainTarget ? ChainTarget : *ReturnTo,
+                                      &Failure, &BranchGatewayHeads,
+                                      &OccupiedBranchGatewaySlots,
+                                      PromoteBranchCapacityRelay);
     if (!ReturnIslands) {
       log() << "hotswap: error: no safe return s_branch island chain for far "
                "site 0x"
-            << utohexstr(T.OriginalOffset) << "\n";
+            << utohexstr(OwnerOffset) << " (size=" << OwnerSize
+            << ", pool-back-slot=0x" << utohexstr(BackSlot) << ", return-to=0x"
+            << utohexstr(*ReturnTo) << ", reserved-tail=0x"
+            << utohexstr(ChainTarget) << ", preserve-vcc=" << OwnerPreservesVcc
+            << ", shared=" << OwnerUsesShared
+            << ", mirrored=" << OwnerUsesMirrored << ")\n";
       return false;
     }
-    T.ReturnBranchIslands = std::move(*ReturnIslands);
-    T.ReturnBranchTargetOffset = *ReturnTo;
-    ReturnBranchIslandChains += !T.ReturnBranchIslands.empty();
+    if (ChainTarget)
+      ReturnIslands->push_back(ChainTarget);
+    Trampoline &Planned = Ctx.OutTrampolines[I];
+    Planned.ReturnBranchIslands = std::move(*ReturnIslands);
+    Planned.ReturnBranchTargetOffset = *ReturnTo;
+    ReturnBranchIslandChains += !Planned.ReturnBranchIslands.empty();
+    if (RemainingRelayDemand)
+      --RemainingRelayDemand;
   }
-
+  log() << "hotswap: return branch-island planning took "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - ReturnBranchPlanStart)
+               .count()
+        << " ms\n";
+  PlanningRegisterlessReturns = false;
+  // A return-phase promotion reserves its source suffix specifically for
+  // registerless branch relays. Hide its remaining slots from the ordinary
+  // set-PC planners, which do not record source-tail gateway ownership and
+  // would otherwise have their bytes overwritten by final source padding.
+  SmallVector<std::pair<uint64_t, uint64_t>, 8> HiddenReturnPromotionRanges;
+  for (const auto &[GatewayIndex, OriginalEnd] :
+       ReturnPromotionBranchOnlyRanges) {
+    if (Gateways[GatewayIndex].WritePos < OriginalEnd)
+      HiddenReturnPromotionRanges.push_back(
+          {Gateways[GatewayIndex].WritePos, OriginalEnd});
+    Gateways[GatewayIndex].End = Gateways[GatewayIndex].WritePos;
+  }
+  // Remove every committed branch dword from all physical aliases before a
+  // variable-width ordinary gateway can cross and overwrite it. Splitting a
+  // range preserves the free prefix and suffix while making the occupied
+  // dword a hard layout boundary.
+  subtractOccupiedBranchGatewaySlots(Gateways, OccupiedBranchGatewaySlots);
   const auto CandidateCountStart = std::chrono::steady_clock::now();
   for (PendingGateway &P : Pending) {
     const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
@@ -6216,6 +9147,10 @@ assignLongBranchGateways(PatchContext &Ctx,
   StillPending.reserve(Pending.size());
   uint64_t AssignedGateways = 0;
   uint64_t AssignedSplitVccGateways = 0;
+  auto OccupyOrdinaryGateway = [&](uint64_t Begin, uint64_t Size) {
+    for (uint64_t Offset = 0; Offset < Size; Offset += MinInstSize)
+      OccupiedBranchGatewaySlots.insert(Begin + Offset);
+  };
   for (const PendingGateway &P : Pending) {
     Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
     if (!T.UsesSetPCBack) {
@@ -6225,8 +9160,8 @@ assignLongBranchGateways(PatchContext &Ctx,
     Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
         findNearestSetPcGateway(Gateways, Ctx.LS, T.OriginalOffset,
                                 P.TargetOffset, T.LongBranchSgprBase,
-                                T.LongBranchUsesVcc,
-                                T.LongBranchPreservesVcc);
+                                T.LongBranchUsesVcc, T.LongBranchPreservesVcc,
+                                &OccupiedBranchGatewaySlots);
     if (!GatewayOrErr) {
       log() << "hotswap: error: failed to plan gateway for far site 0x"
             << utohexstr(T.OriginalOffset) << ": "
@@ -6236,9 +9171,9 @@ assignLongBranchGateways(PatchContext &Ctx,
     std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
     if (!Gateway) {
       if (T.LongBranchPreservesVcc) {
-        std::optional<EncodedSplitVccGateway> Split =
-            findSplitVccGateway(Gateways, Ctx.LS, T.OriginalOffset,
-                                P.TargetOffset, T.LongBranchSgprBase);
+        std::optional<EncodedSplitVccGateway> Split = findSplitVccGateway(
+            Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
+            T.LongBranchSgprBase, &OccupiedBranchGatewaySlots);
         if (Split) {
           NopSled &Primary = Gateways[Split->PrimaryIndex];
           NopSled &Secondary = Gateways[Split->SecondaryIndex];
@@ -6266,8 +9201,14 @@ assignLongBranchGateways(PatchContext &Ctx,
           }
           Primary.WritePos += T.ForwardGatewayBytes.size();
           Secondary.WritePos += T.SecondaryForwardGatewayBytes.size();
+          OccupyOrdinaryGateway(T.ForwardGatewayOffset,
+                                T.ForwardGatewayBytes.size());
+          OccupyOrdinaryGateway(T.SharedDispatcherSecondaryGatewayOffset,
+                                T.SecondaryForwardGatewayBytes.size());
           ++AssignedGateways;
           ++AssignedSplitVccGateways;
+          if (RemainingRelayDemand)
+            --RemainingRelayDemand;
           continue;
         }
       }
@@ -6294,29 +9235,50 @@ assignLongBranchGateways(PatchContext &Ctx,
       OwnerT.SourceTailGatewayBytes = T.ForwardGatewayBytes.size();
     }
     Gateway->Sled->WritePos += T.ForwardGatewayBytes.size();
+    OccupyOrdinaryGateway(T.ForwardGatewayOffset, T.ForwardGatewayBytes.size());
     ++AssignedGateways;
+    if (RemainingRelayDemand)
+      --RemainingRelayDemand;
   }
   Pending = std::move(StillPending);
 
+  for (const auto &[Begin, End] : HiddenReturnPromotionRanges)
+    Gateways.push_back(
+        {Begin, End, Begin, 0, std::numeric_limits<uint64_t>::max()});
+  subtractOccupiedBranchGatewaySlots(Gateways, OccupiedBranchGatewaySlots);
+  BranchGatewayHeads =
+      buildBranchGatewayHeads(Gateways, OccupiedBranchGatewaySlots);
   uint64_t BranchIslandChains = 0;
   StillPending.clear();
   StillPending.reserve(Pending.size());
+  const auto ForwardBranchPlanStart = std::chrono::steady_clock::now();
   for (const PendingGateway &P : Pending) {
-    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    uint64_t OwnerOffset = Ctx.OutTrampolines[P.TrampolineIndex].OriginalOffset;
+    BranchIslandFailure Failure;
     std::optional<SmallVector<uint64_t, 4>> Islands =
-        allocateForwardBranchIslands(Gateways, T.OriginalOffset,
-                                     P.TargetOffset);
+        allocateForwardBranchIslands(Gateways, OwnerOffset, P.TargetOffset,
+                                     &Failure, &BranchGatewayHeads,
+                                     &OccupiedBranchGatewaySlots,
+                                     PromoteBranchCapacityRelay);
     if (!Islands || Islands->empty()) {
       StillPending.push_back(P);
       continue;
     }
+    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
     T.ForwardBranchIslands = std::move(*Islands);
     T.ForwardBranchTargetOffset = P.TargetOffset;
     if (T.LongBranchPreservesVcc)
       std::memcpy(T.Bytes.data(), Ctx.LS.SNopBytes.data(), MinInstSize);
     ++BranchIslandChains;
+    if (RemainingRelayDemand)
+      --RemainingRelayDemand;
   }
   Pending = std::move(StillPending);
+  log() << "hotswap: forward branch-island planning took "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - ForwardBranchPlanStart)
+               .count()
+        << " ms\n";
 
   if (!Pending.empty()) {
     const PendingGateway &P = Pending.front();
@@ -6346,6 +9308,9 @@ assignLongBranchGateways(PatchContext &Ctx,
   if (ReturnBranchIslandChains != 0)
     log() << "hotswap: assigned " << ReturnBranchIslandChains
           << " return s_branch island chain(s)\n";
+  if (PromotedBranchCapacityRelays != 0)
+    log() << "hotswap: promoted " << PromotedBranchCapacityRelays
+          << " safe straight-line source(s) for branch-island capacity\n";
 
   for (Trampoline &T : Ctx.OutTrampolines) {
     if (T.HasForwardGateway) {
@@ -6382,19 +9347,20 @@ assignLongBranchGateways(PatchContext &Ctx,
               << utohexstr(From) << "\n";
         return false;
       }
-      DenseMap<uint64_t, size_t>::const_iterator Owner =
+      DenseMap<uint64_t, PoolIslandOwner>::const_iterator Owner =
           PoolIslandOwners.find(From);
       DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
           SourceTailIslandOwners.find(From);
       if (SourceOwner != SourceTailIslandOwners.end()) {
         Trampoline &OwnerT = Ctx.OutTrampolines[SourceOwner->second];
-        OwnerT.HasSourceTailBranchIsland = true;
-        OwnerT.SourceTailBranchIslandOffset = From;
-        OwnerT.SourceTailBranchTargetOffset = To;
+        if (!recordSourceTailBranchIsland(OwnerT, From, To)) {
+          log() << "hotswap: error: forward source-tail relay at 0x"
+                << utohexstr(From) << " has conflicting targets\n";
+          return false;
+        }
       } else if (Owner != PoolIslandOwners.end()) {
-        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
-        std::memcpy(OwnerT.Bytes.data() + OwnerT.Bytes.size() -
-                        PoolBranchIslandBytes,
+        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second.TrampolineIndex];
+        std::memcpy(OwnerT.Bytes.data() + Owner->second.RelativeOffset,
                     Branch.data(), Branch.size());
       } else {
         if (From > Ctx.TextSize || Branch.size() > Ctx.TextSize - From) {
@@ -6416,19 +9382,20 @@ assignLongBranchGateways(PatchContext &Ctx,
               << utohexstr(From) << "\n";
         return false;
       }
-      DenseMap<uint64_t, size_t>::const_iterator Owner =
+      DenseMap<uint64_t, PoolIslandOwner>::const_iterator Owner =
           PoolIslandOwners.find(From);
       DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
           SourceTailIslandOwners.find(From);
       if (SourceOwner != SourceTailIslandOwners.end()) {
         Trampoline &OwnerT = Ctx.OutTrampolines[SourceOwner->second];
-        OwnerT.HasSourceTailBranchIsland = true;
-        OwnerT.SourceTailBranchIslandOffset = From;
-        OwnerT.SourceTailBranchTargetOffset = To;
+        if (!recordSourceTailBranchIsland(OwnerT, From, To)) {
+          log() << "hotswap: error: return source-tail relay at 0x"
+                << utohexstr(From) << " has conflicting targets\n";
+          return false;
+        }
       } else if (Owner != PoolIslandOwners.end()) {
-        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
-        std::memcpy(OwnerT.Bytes.data() + OwnerT.Bytes.size() -
-                        PoolBranchIslandBytes,
+        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second.TrampolineIndex];
+        std::memcpy(OwnerT.Bytes.data() + Owner->second.RelativeOffset,
                     Branch.data(), Branch.size());
       } else {
         if (From > Ctx.TextSize || Branch.size() > Ctx.TextSize - From) {
@@ -6528,7 +9495,7 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
   std::optional<DirectControlFlowInfo> ControlFlow = collectDirectBranchTargets(
       Decoded, LS, Elf.textAddr(), Elf.textSize(), DeclaredEntries->Entries,
       FunctionRanges, DeclaredEntries->ExternalEntries,
-      ArrayRef<uint8_t>(Text, TextSize));
+      ArrayRef<uint8_t>(Text, TextSize), &Elf, DeclaredEntries->NonCallEntries);
   if (!ControlFlow)
     return std::nullopt;
   if (ControlFlow->HasUnresolvedTargets) {
@@ -6668,8 +9635,7 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     appendPoolBranchIslands(OutTrampolines);
     bool AllowTextGateways = !ControlFlow->HasUnresolvedTargets &&
                              !ControlFlow->HasUnboundedIndirectEntries;
-    if (!assignLongBranchGateways(Ctx, ControlFlow->Targets,
-                                  AllowTextGateways))
+    if (!assignLongBranchGateways(Ctx, ControlFlow->Targets, AllowTextGateways))
       return std::nullopt;
   }
 
@@ -6978,26 +9944,26 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
       std::memcpy(Text + T.OriginalOffset + I, LS.SNopBytes.data(),
                   MinInstSize);
     }
-    if (T.HasSourceTailBranchIsland) {
-      if (T.SourceTailBranchIslandOffset < T.OriginalOffset ||
-          T.SourceTailBranchIslandOffset - T.OriginalOffset < PadStart ||
-          T.SourceTailBranchIslandOffset - T.OriginalOffset >
-              T.OriginalSize - MinInstSize) {
+    for (const auto &[RelayOffset, RelayTarget] : T.SourceTailBranchIslands) {
+      if (RelayOffset < T.OriginalOffset ||
+          RelayOffset - T.OriginalOffset < PadStart ||
+          RelayOffset - T.OriginalOffset > T.OriginalSize - MinInstSize ||
+          (T.HasSourceTailGateway && RelayOffset >= T.SourceTailGatewayOffset &&
+           RelayOffset - T.SourceTailGatewayOffset <
+               T.SourceTailGatewayBytes)) {
         log() << "hotswap: error: source-tail branch island overlaps the "
                  "forward sequence at 0x"
               << utohexstr(T.OriginalOffset) << "\n";
         return false;
       }
-      SmallVector<uint8_t> Relay = LS.encodeSBranch(
-          T.SourceTailBranchIslandOffset, T.SourceTailBranchTargetOffset);
+      SmallVector<uint8_t> Relay = LS.encodeSBranch(RelayOffset, RelayTarget);
       if (Relay.size() != MinInstSize) {
         log() << "hotswap: error: source-tail branch island encoding failed "
                  "at 0x"
-              << utohexstr(T.SourceTailBranchIslandOffset) << "\n";
+              << utohexstr(RelayOffset) << "\n";
         return false;
       }
-      std::memcpy(Text + T.SourceTailBranchIslandOffset, Relay.data(),
-                  Relay.size());
+      std::memcpy(Text + RelayOffset, Relay.data(), Relay.size());
     }
   }
   return true;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1718,8 +1718,7 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
 
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &Call = Decoded[I];
-    if (LocalCalls[I] || !Call.DecodeSucceeded ||
-        Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+    if (!Call.DecodeSucceeded || Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
         Call.Inst.getNumOperands() < 2)
       continue;
     const MCOperand &TargetOp =
@@ -2566,6 +2565,24 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
                                  Calls->External, ExternalEntries);
   if (!BoundedReturns)
     return std::nullopt;
+  // Canonical one-shot materializations also participate in the reusable
+  // reaching-value solver so CFG joins can prove their exact path. Preserve
+  // the established fail-closed entry proof once bounded returns are known:
+  // an interior alias, fallthrough, or unbounded transfer may still bypass
+  // the materialization even when its local dataflow token is exact.
+  BitVector LocallyProvenMaterializedCalls(Decoded.size());
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    if (!MaterializedCalls[I] || ReusableCalls[I].empty())
+      continue;
+    if (hasKnownControlFlowEntry(Decoded, LS, TextAddr, *TextEnd,
+                                 DeclaredEntries, *BoundedReturns,
+                                 MaterializedCalls[I]->SequenceStart,
+                                 MaterializedCalls[I]->SequenceEnd)) {
+      ReusableCalls[I].clear();
+      continue;
+    }
+    LocallyProvenMaterializedCalls.set(I);
+  }
 
   DirectControlFlowInfo Info;
   for (const BoundedSetPcReturn &Return : *BoundedReturns) {
@@ -2611,7 +2628,12 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
                      MaterializedCalls[InstIndex]->SequenceEnd)) {
         Target = MaterializedCalls[InstIndex]->Target;
       }
-      if (!ReusableCalls[InstIndex].empty()) {
+      bool IsFiniteExternalMaterializedCall =
+          MaterializedCalls[InstIndex] &&
+          (MaterializedCalls[InstIndex]->Target < TextAddr ||
+           MaterializedCalls[InstIndex]->Target >= *TextEnd);
+      if (!ReusableCalls[InstIndex].empty() &&
+          !IsFiniteExternalMaterializedCall) {
         if (llvm::any_of(ReusableCalls[InstIndex],
                          [TextAddr, TextEnd](uint64_t ReusableTarget) {
                            return ReusableTarget < TextAddr ||
@@ -2625,9 +2647,16 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
         for (uint64_t ReusableTarget : ReusableCalls[InstIndex])
           Info.Targets.insert(ReusableTarget - TextAddr);
         Info.BoundedIndirectTransfers.insert(DI.Offset);
-        log() << "hotswap: resolved reusable PC-materialized call at 0x"
-              << utohexstr(DI.Offset) << " to "
-              << ReusableCalls[InstIndex].size() << " target(s)\n";
+        if (LocallyProvenMaterializedCalls.test(InstIndex)) {
+          log() << "hotswap: resolved PC-materialized call at 0x"
+                << utohexstr(DI.Offset) << " to .text+0x"
+                << utohexstr(ReusableCalls[InstIndex].front() - TextAddr)
+                << "\n";
+        } else {
+          log() << "hotswap: resolved reusable PC-materialized call at 0x"
+                << utohexstr(DI.Offset) << " to "
+                << ReusableCalls[InstIndex].size() << " target(s)\n";
+        }
         continue;
       }
       if (!Target) {
@@ -3571,6 +3600,7 @@ assignLongBranchGateways(PatchContext &Ctx,
   }
 
   DenseMap<uint64_t, size_t> PoolIslandOwners;
+  DenseMap<uint64_t, size_t> SourceTailIslandOwners;
   uint64_t IslandLayoutOffset = Ctx.PoolBaseOffset;
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     Trampoline &T = Ctx.OutTrampolines[I];
@@ -3622,6 +3652,24 @@ assignLongBranchGateways(PatchContext &Ctx,
     }
     Pending.push_back({I, TP, 0});
   }
+
+  // Once a source is replaced by a one-dword branch, the remainder of its
+  // original instruction window is unreachable and can provide a safe relay.
+  // Add these only after selecting direct set-PC sources, whose longer forward
+  // sequence consumes the tail. Shared dispatch and VCC preservation likewise
+  // reserve the second dword. Relays are object-wide: unlike an arbitrary NOP
+  // sled they cannot be reached by the owning function's original fallthrough.
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    const Trampoline &T = Ctx.OutTrampolines[I];
+    if (T.OriginalSize < 2 * MinInstSize || T.UsesDirectSetPCForward ||
+        T.UsesSharedDispatcherForward)
+      continue;
+    uint64_t Tail = T.OriginalOffset + MinInstSize;
+    SourceTailIslandOwners[Tail] = I;
+    Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
+                        std::numeric_limits<uint64_t>::max()});
+  }
+
   for (PendingGateway &P : Pending) {
     const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
     Expected<uint64_t> CandidateSlots = countReachableSetPcGatewaySlots(
@@ -3739,7 +3787,14 @@ assignLongBranchGateways(PatchContext &Ctx,
       }
       DenseMap<uint64_t, size_t>::const_iterator Owner =
           PoolIslandOwners.find(From);
-      if (Owner != PoolIslandOwners.end()) {
+      DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
+          SourceTailIslandOwners.find(From);
+      if (SourceOwner != SourceTailIslandOwners.end()) {
+        Trampoline &OwnerT = Ctx.OutTrampolines[SourceOwner->second];
+        OwnerT.HasSourceTailBranchIsland = true;
+        OwnerT.SourceTailBranchIslandOffset = From;
+        OwnerT.SourceTailBranchTargetOffset = To;
+      } else if (Owner != PoolIslandOwners.end()) {
         Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
         std::memcpy(OwnerT.Bytes.data() + OwnerT.Bytes.size() -
                         PoolBranchIslandBytes,
@@ -3747,6 +3802,40 @@ assignLongBranchGateways(PatchContext &Ctx,
       } else {
         if (From > Ctx.TextSize || Branch.size() > Ctx.TextSize - From) {
           log() << "hotswap: error: forward branch island at 0x"
+                << utohexstr(From) << " is outside .text and trampoline pool\n";
+          return false;
+        }
+        std::memcpy(Ctx.Text + From, Branch.data(), Branch.size());
+      }
+    }
+    for (size_t I = 0; I != T.ReturnBranchIslands.size(); ++I) {
+      uint64_t From = T.ReturnBranchIslands[I];
+      uint64_t To = I + 1 == T.ReturnBranchIslands.size()
+                        ? T.ReturnBranchTargetOffset
+                        : T.ReturnBranchIslands[I + 1];
+      SmallVector<uint8_t> Branch = Ctx.LS.encodeSBranch(From, To);
+      if (Branch.size() != MinInstSize) {
+        log() << "hotswap: error: failed to encode return branch island at 0x"
+              << utohexstr(From) << "\n";
+        return false;
+      }
+      DenseMap<uint64_t, size_t>::const_iterator Owner =
+          PoolIslandOwners.find(From);
+      DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
+          SourceTailIslandOwners.find(From);
+      if (SourceOwner != SourceTailIslandOwners.end()) {
+        Trampoline &OwnerT = Ctx.OutTrampolines[SourceOwner->second];
+        OwnerT.HasSourceTailBranchIsland = true;
+        OwnerT.SourceTailBranchIslandOffset = From;
+        OwnerT.SourceTailBranchTargetOffset = To;
+      } else if (Owner != PoolIslandOwners.end()) {
+        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+        std::memcpy(OwnerT.Bytes.data() + OwnerT.Bytes.size() -
+                        PoolBranchIslandBytes,
+                    Branch.data(), Branch.size());
+      } else {
+        if (From > Ctx.TextSize || Branch.size() > Ctx.TextSize - From) {
+          log() << "hotswap: error: return branch island at 0x"
                 << utohexstr(From) << " is outside .text and trampoline pool\n";
           return false;
         }
@@ -4213,6 +4302,27 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
          I += MinInstSize)
       std::memcpy(Text + T.OriginalOffset + I, LS.SNopBytes.data(),
                   MinInstSize);
+    if (T.HasSourceTailBranchIsland) {
+      if (T.SourceTailBranchIslandOffset < T.OriginalOffset ||
+          T.SourceTailBranchIslandOffset - T.OriginalOffset < BrFwd.size() ||
+          T.SourceTailBranchIslandOffset - T.OriginalOffset >
+              T.OriginalSize - MinInstSize) {
+        log() << "hotswap: error: source-tail branch island overlaps the "
+                 "forward sequence at 0x"
+              << utohexstr(T.OriginalOffset) << "\n";
+        return false;
+      }
+      SmallVector<uint8_t> Relay = LS.encodeSBranch(
+          T.SourceTailBranchIslandOffset, T.SourceTailBranchTargetOffset);
+      if (Relay.size() != MinInstSize) {
+        log() << "hotswap: error: source-tail branch island encoding failed "
+                 "at 0x"
+              << utohexstr(T.SourceTailBranchIslandOffset) << "\n";
+        return false;
+      }
+      std::memcpy(Text + T.SourceTailBranchIslandOffset, Relay.data(),
+                  Relay.size());
+    }
   }
   return true;
 }

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -4544,10 +4544,6 @@ static FiniteControlFlowAudit auditFiniteIndirectControlFlow(
     if (Reachable.test(SetPc) && !BoundedSetPc.test(SetPc))
       markUnboundedIndirectEntry();
 
-  for (size_t InstIndex : Index.UnboundedIndirectIndices)
-    if (Reachable.test(InstIndex))
-      markUnboundedIndirectEntry();
-
   // Every call is also an indirect entry source until either a finite local
   // target or a finite external target has been recorded for it.
   BitVector FiniteCalls(Decoded.size());
@@ -4555,6 +4551,15 @@ static FiniteControlFlowAudit auditFiniteIndirectControlFlow(
     FiniteCalls.set(Call.InstIndex);
   for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
     FiniteCalls.set(Call.InstIndex);
+
+  // MC may also classify a register call as an indirect branch. Do not let
+  // that generic classification create a false unbounded self-edge after the
+  // exact call target and continuation have been admitted to this same joint
+  // audit. Unknown calls remain unbounded in the call-specific loop below.
+  for (size_t InstIndex : Index.UnboundedIndirectIndices)
+    if (Reachable.test(InstIndex) && !FiniteCalls.test(InstIndex))
+      markUnboundedIndirectEntry();
+
   for (size_t InstIndex : Index.BranchOrCallIndices) {
     if (!Reachable.test(InstIndex) || !LS.MIA->isCall(Decoded[InstIndex].Inst))
       continue;
@@ -4579,6 +4584,7 @@ hasKnownControlFlowEntry(ArrayRef<uint64_t> DeclaredEntries,
                          ArrayRef<BoundedSetPcReturn> BoundedReturns,
                          const DenseMap<size_t, size_t> &BoundedReturnPositions,
                          const ControlFlowScanIndex &Index,
+                         bool HasUnboundedIndirectEntries,
                          uint64_t SequenceStart, uint64_t SequenceEnd) {
   for (uint64_t Entry : DeclaredEntries)
     if (Entry > SequenceStart && Entry <= SequenceEnd)
@@ -4598,8 +4604,18 @@ hasKnownControlFlowEntry(ArrayRef<uint64_t> DeclaredEntries,
   // Without bounding an indirect target, it may enter at any instruction in
   // the materialization. Keep the call unresolved rather than relying on the
   // indirect transfer's containing function alone.
-  if (Index.HasUnboundedIndirectEntry)
+  if (HasUnboundedIndirectEntries)
     return true;
+
+  auto EntersSequence = [&](uint64_t Target) {
+    return Target > SequenceStart && Target <= SequenceEnd;
+  };
+  for (const KnownCallSite &Call : Index.Calls)
+    if (EntersSequence(Call.Target) || EntersSequence(Call.Continuation))
+      return true;
+  for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
+    if (EntersSequence(Call.Continuation))
+      return true;
 
   SmallVector<DirectTargetSource, 16>::const_iterator First =
       llvm::upper_bound(Index.DirectTargetsByTarget, SequenceStart,
@@ -5814,6 +5830,7 @@ static std::optional<WellFormedAbiEntrySet> validateWellFormedAbiEntrySet(
   // Phase 2 may now authorize only the exact source indices proven above
   // while validating ordinary s30-return functions.
   DenseSet<size_t> CanonicalAbiReturns;
+  DenseSet<uint64_t> CanonicalReturningFunctionBegins;
   for (const auto &Entry : ReturnsByFunction) {
     const ElfView::FunctionTextRange *Range =
         ReturnFunctionRanges.lookup(Entry.first);
@@ -5829,6 +5846,11 @@ static std::optional<WellFormedAbiEntrySet> validateWellFormedAbiEntrySet(
             << " does not use a provable canonical s30 call frame\n";
       return std::nullopt;
     }
+    for (size_t Return : Entry.second)
+      if (CanonicalAbiReturns.contains(Return)) {
+        CanonicalReturningFunctionBegins.insert(Entry.first.first - TextAddr);
+        break;
+      }
   }
 
   bool SawAbiCall = false;
@@ -5927,7 +5949,16 @@ static std::optional<WellFormedAbiEntrySet> validateWellFormedAbiEntrySet(
       return std::nullopt;
     }
   }
-  if (!SawAbiCall || !SawAbiReturn) {
+  bool SawExactCanonicalCall = false;
+  if (!SawAbiCall && SawAbiReturn)
+    for (const KnownCallSite &Call : Index.Calls)
+      if (Index.MaterializedCalls.contains(Call.InstIndex) &&
+          Call.ReturnRegister == AbiLinkPair &&
+          CanonicalReturningFunctionBegins.contains(Call.Target)) {
+        SawExactCanonicalCall = true;
+        break;
+      }
+  if (!SawAbiReturn || (!SawAbiCall && !SawExactCanonicalCall)) {
     log() << "hotswap: linked-code-object ABI entry-set fallback rejected: "
              "no opaque s30 call/return pair\n";
     return std::nullopt;
@@ -5975,11 +6006,12 @@ static std::optional<WellFormedAbiEntrySet> validateWellFormedAbiEntrySet(
 
   for (const auto &Call : CallContinuations)
     Result.Targets.insert(Call.second);
-  log() << "hotswap: accepted well-formed linked-code-object ABI entry set "
-           "for "
-        << Result.Calls.size() << " register call(s), " << Result.SetPcs.size()
-        << " set-PC transfer(s), and " << Result.Targets.size()
-        << " finite local entry point(s)\n";
+  log() << "hotswap: accepted "
+        << (SawAbiCall ? "well-formed linked-code-object ABI entry set"
+                       : "exact materialized-call/canonical-return closure")
+        << " for " << Result.Calls.size() << " register call(s), "
+        << Result.SetPcs.size() << " set-PC transfer(s), and "
+        << Result.Targets.size() << " finite local entry point(s)\n";
   return Result;
 }
 
@@ -6221,7 +6253,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       continue;
     if (hasKnownControlFlowEntry(
             DeclaredEntries, BoundedReturns, BoundedReturnPositions, *Index,
-            Entry.second.SequenceStart, Entry.second.SequenceEnd)) {
+            HasUnboundedIndirectEntries, Entry.second.SequenceStart,
+            Entry.second.SequenceEnd)) {
       ReusableCalls[I].clear();
       continue;
     }
@@ -6290,10 +6323,10 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
         DenseMap<size_t, PcMaterializedCallInfo>::const_iterator Materialized =
             Index->MaterializedCalls.find(InstIndex);
         if (Materialized != Index->MaterializedCalls.end() &&
-            !hasKnownControlFlowEntry(DeclaredEntries, BoundedReturns,
-                                      BoundedReturnPositions, *Index,
-                                      Materialized->second.SequenceStart,
-                                      Materialized->second.SequenceEnd))
+            !hasKnownControlFlowEntry(
+                DeclaredEntries, BoundedReturns, BoundedReturnPositions, *Index,
+                HasUnboundedIndirectEntries, Materialized->second.SequenceStart,
+                Materialized->second.SequenceEnd))
           Target = Materialized->second.Target;
       }
       if (!ReusableCalls[InstIndex].empty() &&

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -5964,6 +5964,42 @@ static std::optional<WellFormedAbiEntrySet> validateWellFormedAbiEntrySet(
     return std::nullopt;
   }
 
+  if (!SawAbiCall) {
+    auto HasMaterializationEntry =
+        [&](const PcMaterializedCallInfo &Materialized) {
+          auto IsInterior = [&](uint64_t Offset) {
+            return Offset > Materialized.SequenceStart &&
+                   Offset <= Materialized.SequenceEnd;
+          };
+          for (uint64_t Entry : Result.Targets)
+            if (IsInterior(Entry))
+              return true;
+          for (const DirectTargetSource &Source : Index.DirectTargetsByTarget)
+            if (IsInterior(Source.Target))
+              return true;
+          for (const KnownCallSite &Call : Index.Calls)
+            if (IsInterior(Call.Target) || IsInterior(Call.Continuation))
+              return true;
+          for (const auto &Call : CallContinuations)
+            if (IsInterior(Call.second))
+              return true;
+          for (const FiniteSetPcTransfer *Transfer : SelectedSetPcs)
+            if (Transfer->LocalTargetIndex &&
+                IsInterior(Decoded[*Transfer->LocalTargetIndex].Offset))
+              return true;
+          return false;
+        };
+    for (const auto &Entry : Index.MaterializedCalls)
+      if (Result.Calls.contains(Entry.first) &&
+          HasMaterializationEntry(Entry.second)) {
+        log() << "hotswap: exact materialized-call/canonical-return closure "
+                 "rejected: alternate entry inside call materialization "
+                 "ending at 0x"
+              << utohexstr(Decoded[Entry.first].Offset) << "\n";
+        return std::nullopt;
+      }
+  }
+
   auto hasInteriorEntry = [&](const FiniteSetPcTransfer &Candidate) {
     uint64_t Begin = Decoded[Candidate.SequenceBeginIndex].Offset;
     std::optional<uint64_t> End =

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -38,6 +38,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/MathExtras.h"
+#include "llvm/TargetParser/AMDGPUMCOperand.h"
 
 #include <algorithm>
 #include <cassert>
@@ -2538,6 +2539,32 @@ static std::optional<uint64_t>
 getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
                     uint64_t TextAddr, uint64_t TextEnd);
 
+static const MCOperand *getAMDGPUNamedOperand(const MCInst &Inst,
+                                              AMDGPU::NamedOperand Name) {
+  int16_t Index = AMDGPU::getNamedOperandIdx(Inst.getOpcode(), Name);
+  if (Index < 0 || static_cast<unsigned>(Index) >= Inst.getNumOperands())
+    return nullptr;
+  return &Inst.getOperand(static_cast<unsigned>(Index));
+}
+
+static std::optional<bool> symbolLessCalleePreservesReusableTarget(
+    uint64_t Target, MCRegister TargetRegister, MCRegister ReturnRegister,
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, ArrayRef<SymbolLessReturnRegion> SymbolLessRegions) {
+  for (const SymbolLessReturnRegion &Region : SymbolLessRegions) {
+    if (Region.Entry > std::numeric_limits<uint64_t>::max() - TextAddr ||
+        TextAddr + Region.Entry != Target ||
+        Region.LinkRegister != ReturnRegister || Region.Instructions.empty())
+      continue;
+    for (size_t InstIndex : Region.Instructions)
+      if (InstIndex >= Decoded.size() || !Decoded[InstIndex].DecodeSucceeded ||
+          definesOverlappingRegister(Decoded[InstIndex], LS, TargetRegister))
+        return false;
+    return true;
+  }
+  return std::nullopt;
+}
+
 /// A reusable target value remains valid after a call only when the exact local
 /// callee is fully decoded, returns through the call's link pair, and cannot
 /// transitively or directly clobber the target pair.
@@ -2550,17 +2577,12 @@ static bool calleePreservesReusableTarget(
   if (LS.MRI->regsOverlap(TargetRegister, ReturnRegister))
     return false;
 
-  for (const SymbolLessReturnRegion &Region : SymbolLessRegions) {
-    if (Region.Entry > std::numeric_limits<uint64_t>::max() - TextAddr ||
-        TextAddr + Region.Entry != Target ||
-        Region.LinkRegister != ReturnRegister || Region.Instructions.empty())
-      continue;
-    for (size_t InstIndex : Region.Instructions)
-      if (InstIndex >= Decoded.size() || !Decoded[InstIndex].DecodeSucceeded ||
-          definesOverlappingRegister(Decoded[InstIndex], LS, TargetRegister))
-        return false;
-    return true;
-  }
+  std::optional<bool> SymbolLessPreservation =
+      symbolLessCalleePreservesReusableTarget(Target, TargetRegister,
+                                              ReturnRegister, Decoded, LS,
+                                              TextAddr, SymbolLessRegions);
+  if (SymbolLessPreservation)
+    return *SymbolLessPreservation;
 
   const ElfView::FunctionTextRange *Callee = nullptr;
   for (const ElfView::FunctionTextRange &Range : FunctionRanges)
@@ -2573,10 +2595,19 @@ static bool calleePreservesReusableTarget(
 
   uint64_t CalleeBegin = Callee->Begin - TextAddr;
   uint64_t CalleeEnd = Callee->End - TextAddr;
+  ArrayRef<InternalDecodedInst>::const_iterator Begin = llvm::lower_bound(
+      Decoded, CalleeBegin, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  ArrayRef<InternalDecodedInst>::const_iterator End =
+      std::lower_bound(Begin, Decoded.end(), CalleeEnd,
+                       [](const InternalDecodedInst &DI, uint64_t Offset) {
+                         return DI.Offset < Offset;
+                       });
   bool SawInstruction = false;
-  for (const InternalDecodedInst &DI : Decoded) {
-    if (DI.Offset < CalleeBegin || DI.Offset >= CalleeEnd)
-      continue;
+  for (ArrayRef<InternalDecodedInst>::const_iterator It = Begin; It != End;
+       ++It) {
+    const InternalDecodedInst &DI = *It;
     SawInstruction = true;
     if (!DI.DecodeSucceeded || LS.MIA->isCall(DI.Inst) ||
         definesOverlappingRegister(DI, LS, TargetRegister))
@@ -2614,6 +2645,45 @@ static bool calleePreservesReusableTarget(
   }
   return SawInstruction;
 }
+
+static bool hasSymbolLessReusableTargetPreservationCandidate(
+    size_t InstIndex, ArrayRef<InternalDecodedInst> Decoded,
+    const LLVMState &LS, uint64_t TextAddr, ArrayRef<uint64_t> ReachingTargets,
+    ArrayRef<SymbolLessReturnRegion> SymbolLessRegions) {
+  if (InstIndex >= Decoded.size() || ReachingTargets.empty())
+    return false;
+  const MCOperand *TargetOperand = getAMDGPUNamedOperand(
+      Decoded[InstIndex].Inst, AMDGPU::NamedOperand::Src0);
+  const MCOperand *ReturnOperand = getAMDGPUNamedOperand(
+      Decoded[InstIndex].Inst, AMDGPU::NamedOperand::SDst);
+  if (!TargetOperand || !TargetOperand->isReg() || !TargetOperand->getReg() ||
+      !ReturnOperand || !ReturnOperand->isReg() || !ReturnOperand->getReg())
+    return false;
+  MCRegister TargetRegister(TargetOperand->getReg());
+  MCRegister ReturnRegister(ReturnOperand->getReg());
+  if (LS.MRI->regsOverlap(TargetRegister, ReturnRegister))
+    return false;
+  for (uint64_t Target : ReachingTargets) {
+    std::optional<bool> Preservation = symbolLessCalleePreservesReusableTarget(
+        Target, TargetRegister, ReturnRegister, Decoded, LS, TextAddr,
+        SymbolLessRegions);
+    if (Preservation && *Preservation)
+      return true;
+  }
+  return false;
+}
+
+static bool hasSymbolLessReusableTargetPreservationCandidate(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, ArrayRef<ReachingCallTargets> ReusableCalls,
+    ArrayRef<SymbolLessReturnRegion> SymbolLessRegions) {
+  for (size_t I = 0; I != ReusableCalls.size(); ++I)
+    if (hasSymbolLessReusableTargetPreservationCandidate(
+            I, Decoded, LS, TextAddr, ReusableCalls[I], SymbolLessRegions))
+      return true;
+  return false;
+}
+
 struct ReachingPcUse {
   size_t InstIndex = 0;
   MCRegister Register;
@@ -2628,6 +2698,22 @@ struct FiniteSetPcTransfer {
   uint64_t FunctionBegin = 0;
   uint64_t FunctionEnd = 0;
 };
+
+static bool hasSameFiniteSetPcTransfers(ArrayRef<FiniteSetPcTransfer> LHS,
+                                        ArrayRef<FiniteSetPcTransfer> RHS) {
+  if (LHS.size() != RHS.size())
+    return false;
+  for (size_t I = 0; I != LHS.size(); ++I)
+    if (LHS[I].InstIndex != RHS[I].InstIndex ||
+        LHS[I].SequenceBeginIndex != RHS[I].SequenceBeginIndex ||
+        LHS[I].SequenceEndIndex != RHS[I].SequenceEndIndex ||
+        LHS[I].Target != RHS[I].Target ||
+        LHS[I].LocalTargetIndex != RHS[I].LocalTargetIndex ||
+        LHS[I].FunctionBegin != RHS[I].FunctionBegin ||
+        LHS[I].FunctionEnd != RHS[I].FunctionEnd)
+      return false;
+  return true;
+}
 
 static const ElfView::FunctionTextRange *
 findInnermostFunctionRange(uint64_t Address,
@@ -3080,6 +3166,56 @@ static SmallVector<FiniteSetPcTransfer, 8> selectLeastReachableSetPcCandidates(
   }
 }
 
+static SmallVector<size_t, 2> collectReusablePcSuccessors(
+    size_t I, size_t BeginIndex, size_t EndIndex,
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    const DenseMap<uint64_t, size_t> &OffsetToIndex,
+    const DenseMap<size_t, const FiniteSetPcTransfer *> &FiniteSetPcByInst) {
+  SmallVector<size_t, 2> Successors;
+  const InternalDecodedInst &DI = Decoded[I];
+  if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+      DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode || LS.MIA->isReturn(DI.Inst))
+    return Successors;
+
+  if (LS.MIA->isCall(DI.Inst)) {
+    if (I + 1 < EndIndex)
+      Successors.push_back(I + 1);
+    return Successors;
+  }
+
+  if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
+      LS.MIA->isIndirectBranch(DI.Inst)) {
+    DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator FiniteSetPc =
+        FiniteSetPcByInst.find(I);
+    if (FiniteSetPc != FiniteSetPcByInst.end() &&
+        FiniteSetPc->second->LocalTargetIndex &&
+        *FiniteSetPc->second->LocalTargetIndex >= BeginIndex &&
+        *FiniteSetPc->second->LocalTargetIndex < EndIndex)
+      Successors.push_back(*FiniteSetPc->second->LocalTargetIndex);
+    // All other indirect jumps or bounded returns leave this
+    // intraprocedural path.
+    return Successors;
+  }
+
+  if (LS.MIA->isBranch(DI.Inst)) {
+    std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+    if (Target) {
+      DenseMap<uint64_t, size_t>::const_iterator TargetIndex =
+          OffsetToIndex.find(*Target);
+      if (TargetIndex != OffsetToIndex.end() &&
+          TargetIndex->second >= BeginIndex && TargetIndex->second < EndIndex)
+        Successors.push_back(TargetIndex->second);
+    }
+    if (!LS.MIA->isUnconditionalBranch(DI.Inst) && I + 1 < EndIndex)
+      Successors.push_back(I + 1);
+    return Successors;
+  }
+
+  if (I + 1 < EndIndex)
+    Successors.push_back(I + 1);
+  return Successors;
+}
+
 /// Resolve uses of an SGPR pair whose value is selected once and reused across
 /// control flow. A monotone intraprocedural solver propagates finite values
 /// from proven get-PC materializations. Any unrecognized pair definition
@@ -3092,8 +3228,18 @@ static std::vector<ReachingCallTargets> resolveReusablePcValuesAtUses(
     ArrayRef<uint64_t> DeclaredEntries,
     ArrayRef<SymbolLessReturnRegion> SymbolLessRegions,
     ArrayRef<ReachingPcUse> Uses,
-    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
-  std::vector<ReachingCallTargets> Resolved(Decoded.size());
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {},
+    std::vector<ReachingCallTargets> Resolved = {}) {
+  // A provisional symbol-less preservation retry changes only the
+  // function/register groups that previously reached such a callee. Retain
+  // every other group's first-pass facts and storage; rebuilding the complete
+  // object-wide result would repeat the dominant corpus cost.
+  bool IsSelectivePreservationRetry =
+      !SymbolLessRegions.empty() && Resolved.size() == Decoded.size();
+  if (!IsSelectivePreservationRetry) {
+    Resolved.clear();
+    Resolved.resize(Decoded.size());
+  }
   SmallVector<ReachingCallGroup, 8> Groups;
   DenseMap<size_t, const FiniteSetPcTransfer *> FiniteSetPcByInst;
   for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
@@ -3133,7 +3279,26 @@ static std::vector<ReachingCallTargets> resolveReusablePcValuesAtUses(
   for (size_t I = 0; I != Decoded.size(); ++I)
     OffsetToIndex[Decoded[I].Offset] = I;
 
-  SmallVector<std::pair<size_t, uint64_t>, 16> DirectEntries;
+  // Index independent entries by their target instruction. For a direct
+  // target, retaining only the minimum and maximum source index is sufficient:
+  // at least one source lies outside a group exactly when either bound does.
+  // This avoids rescanning every object-wide branch for every register group.
+  BitVector DeclaredEntryInstructions(Decoded.size());
+  BitVector PotentialEntryInstructions(Decoded.size());
+  SmallVector<size_t, 16> PotentialEntryIndices;
+  for (uint64_t Entry : DeclaredEntries) {
+    DenseMap<uint64_t, size_t>::const_iterator EntryIndex =
+        OffsetToIndex.find(Entry);
+    if (EntryIndex == OffsetToIndex.end())
+      continue;
+    DeclaredEntryInstructions.set(EntryIndex->second);
+    if (!PotentialEntryInstructions.test(EntryIndex->second)) {
+      PotentialEntryInstructions.set(EntryIndex->second);
+      PotentialEntryIndices.push_back(EntryIndex->second);
+    }
+  }
+
+  DenseMap<size_t, std::pair<size_t, size_t>> DirectEntrySourceBounds;
   for (size_t SourceIndex = 0; SourceIndex != Decoded.size(); ++SourceIndex) {
     const InternalDecodedInst &Source = Decoded[SourceIndex];
     if (!Source.DecodeSucceeded ||
@@ -3142,9 +3307,27 @@ static std::vector<ReachingCallTargets> resolveReusablePcValuesAtUses(
       continue;
     std::optional<uint64_t> Target =
         getDirectTextTarget(Source, LS, TextAddr, TextEnd);
-    if (Target)
-      DirectEntries.emplace_back(SourceIndex, *Target);
+    if (!Target)
+      continue;
+    DenseMap<uint64_t, size_t>::const_iterator TargetIndex =
+        OffsetToIndex.find(*Target);
+    if (TargetIndex == OffsetToIndex.end())
+      continue;
+    if (!PotentialEntryInstructions.test(TargetIndex->second)) {
+      PotentialEntryInstructions.set(TargetIndex->second);
+      PotentialEntryIndices.push_back(TargetIndex->second);
+    }
+    DenseMap<size_t, std::pair<size_t, size_t>>::iterator Bounds =
+        DirectEntrySourceBounds.find(TargetIndex->second);
+    if (Bounds == DirectEntrySourceBounds.end()) {
+      DirectEntrySourceBounds.try_emplace(
+          TargetIndex->second, std::make_pair(SourceIndex, SourceIndex));
+      continue;
+    }
+    Bounds->second.first = std::min(Bounds->second.first, SourceIndex);
+    Bounds->second.second = std::max(Bounds->second.second, SourceIndex);
   }
+  llvm::sort(PotentialEntryIndices);
   DenseMap<std::pair<uint64_t, uint64_t>, bool> CalleePreservation;
 
   for (const ReachingCallGroup &Group : Groups) {
@@ -3162,6 +3345,67 @@ static std::vector<ReachingCallTargets> resolveReusablePcValuesAtUses(
     size_t EndIndex = static_cast<size_t>(End - Decoded.begin());
     if (BeginIndex == EndIndex)
       continue;
+    BitVector CallsInGroup(EndIndex - BeginIndex);
+    for (size_t I : Group.Calls)
+      if (I >= BeginIndex && I < EndIndex)
+        CallsInGroup.set(I - BeginIndex);
+
+    if (IsSelectivePreservationRetry) {
+      bool HasUnresolvedCall = false;
+      for (size_t I : Group.Calls)
+        if (Resolved[I].empty()) {
+          HasUnresolvedCall = true;
+          break;
+        }
+      if (!HasUnresolvedCall)
+        continue;
+
+      // A provisional callee-preservation fact can only change a later use
+      // along a CFG path leaving the exact candidate call. Do not repeat the
+      // group solver when every unresolved use is causally disconnected.
+      SmallVector<size_t, 32> CausalWorklist;
+      BitVector CausalVisited(EndIndex - BeginIndex);
+      for (size_t I : Group.Calls) {
+        if (!hasSymbolLessReusableTargetPreservationCandidate(
+                I, Decoded, LS, TextAddr, Resolved[I], SymbolLessRegions))
+          continue;
+        SmallVector<size_t, 2> Successors =
+            collectReusablePcSuccessors(I, BeginIndex, EndIndex, Decoded, LS,
+                                        OffsetToIndex, FiniteSetPcByInst);
+        for (size_t Successor : Successors)
+          if (!CausalVisited.test(Successor - BeginIndex)) {
+            CausalVisited.set(Successor - BeginIndex);
+            CausalWorklist.push_back(Successor);
+          }
+      }
+
+      bool HasCausalUnresolvedCall = false;
+      while (!CausalWorklist.empty() && !HasCausalUnresolvedCall) {
+        size_t I = CausalWorklist.pop_back_val();
+        if (CallsInGroup.test(I - BeginIndex) && Resolved[I].empty()) {
+          HasCausalUnresolvedCall = true;
+          break;
+        }
+        // A definition of the reusable pair kills every value whose
+        // preservation changed at the candidate call. A later
+        // materialization may establish a new finite value, but that fact is
+        // independent of this preservation retry.
+        if (definesOverlappingRegister(Decoded[I], LS, Group.TargetRegister))
+          continue;
+        SmallVector<size_t, 2> Successors =
+            collectReusablePcSuccessors(I, BeginIndex, EndIndex, Decoded, LS,
+                                        OffsetToIndex, FiniteSetPcByInst);
+        for (size_t Successor : Successors)
+          if (!CausalVisited.test(Successor - BeginIndex)) {
+            CausalVisited.set(Successor - BeginIndex);
+            CausalWorklist.push_back(Successor);
+          }
+      }
+      if (!HasCausalUnresolvedCall)
+        continue;
+      for (size_t I : Group.Calls)
+        Resolved[I].clear();
+    }
 
     DenseMap<size_t, size_t> Starters;
     DenseMap<size_t, uint64_t> Completions;
@@ -3198,21 +3442,18 @@ static std::vector<ReachingCallTargets> resolveReusablePcValuesAtUses(
     // Every declared entry and direct cross-function target is an independent
     // root. An entry into a materialization interior must not inherit the
     // token established by the containing function's ordinary entry path.
-    for (uint64_t Entry : DeclaredEntries) {
-      DenseMap<uint64_t, size_t>::const_iterator EntryIndex =
-          OffsetToIndex.find(Entry);
-      if (EntryIndex != OffsetToIndex.end() &&
-          EntryIndex->second >= BeginIndex && EntryIndex->second < EndIndex)
-        seedUnknownEntry(EntryIndex->second);
-    }
-    for (const std::pair<size_t, uint64_t> &Entry : DirectEntries) {
-      if (Entry.first >= BeginIndex && Entry.first < EndIndex)
-        continue;
-      DenseMap<uint64_t, size_t>::const_iterator TargetIndex =
-          OffsetToIndex.find(Entry.second);
-      if (TargetIndex != OffsetToIndex.end() &&
-          TargetIndex->second >= BeginIndex && TargetIndex->second < EndIndex)
-        seedUnknownEntry(TargetIndex->second);
+    SmallVector<size_t, 16>::const_iterator Entry =
+        llvm::lower_bound(PotentialEntryIndices, BeginIndex);
+    for (; Entry != PotentialEntryIndices.end() && *Entry < EndIndex; ++Entry) {
+      bool IsIndependent = DeclaredEntryInstructions.test(*Entry);
+      DenseMap<size_t, std::pair<size_t, size_t>>::const_iterator Bounds =
+          DirectEntrySourceBounds.find(*Entry);
+      if (Bounds != DirectEntrySourceBounds.end() &&
+          (Bounds->second.first < BeginIndex ||
+           Bounds->second.second >= EndIndex))
+        IsIndependent = true;
+      if (IsIndependent)
+        seedUnknownEntry(*Entry);
     }
 
     while (!Worklist.empty()) {
@@ -3260,7 +3501,7 @@ static std::vector<ReachingCallTargets> resolveReusablePcValuesAtUses(
         State.ActiveMaterializations = std::move(Preserved);
       }
 
-      bool IsReusableCall = llvm::is_contained(Group.Calls, I);
+      bool IsReusableCall = CallsInGroup.test(I - BeginIndex);
       bool HasFiniteState = !State.HasUnknown &&
                             State.ActiveMaterializations.empty() &&
                             !State.Targets.empty();
@@ -3315,44 +3556,9 @@ static std::vector<ReachingCallTargets> resolveReusablePcValuesAtUses(
         State.ActiveMaterializations.clear();
       }
 
-      SmallVector<size_t, 2> Successors;
-      auto appendFallthrough = [&]() {
-        if (I + 1 < EndIndex)
-          Successors.push_back(I + 1);
-      };
-      if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
-          DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
-          LS.MIA->isReturn(DI.Inst)) {
-        // No successor.
-      } else if (LS.MIA->isCall(DI.Inst)) {
-        appendFallthrough();
-      } else if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
-                 LS.MIA->isIndirectBranch(DI.Inst)) {
-        DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator
-            FiniteSetPc = FiniteSetPcByInst.find(I);
-        if (FiniteSetPc != FiniteSetPcByInst.end() &&
-            FiniteSetPc->second->LocalTargetIndex &&
-            *FiniteSetPc->second->LocalTargetIndex >= BeginIndex &&
-            *FiniteSetPc->second->LocalTargetIndex < EndIndex)
-          Successors.push_back(*FiniteSetPc->second->LocalTargetIndex);
-        // All other indirect jumps or bounded returns leave this
-        // intraprocedural path.
-      } else if (LS.MIA->isBranch(DI.Inst)) {
-        std::optional<uint64_t> Target =
-            evaluateDirectControlFlowTarget(DI, LS);
-        if (Target) {
-          DenseMap<uint64_t, size_t>::const_iterator TargetIndex =
-              OffsetToIndex.find(*Target);
-          if (TargetIndex != OffsetToIndex.end() &&
-              TargetIndex->second >= BeginIndex &&
-              TargetIndex->second < EndIndex)
-            Successors.push_back(TargetIndex->second);
-        }
-        if (!LS.MIA->isUnconditionalBranch(DI.Inst))
-          appendFallthrough();
-      } else {
-        appendFallthrough();
-      }
+      SmallVector<size_t, 2> Successors =
+          collectReusablePcSuccessors(I, BeginIndex, EndIndex, Decoded, LS,
+                                      OffsetToIndex, FiniteSetPcByInst);
 
       for (size_t Successor : Successors) {
         if (mergeReachingPcState(Before[Successor - BeginIndex], State) &&
@@ -3374,7 +3580,8 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
     ArrayRef<uint64_t> DeclaredEntries,
     ArrayRef<SymbolLessReturnRegion> SymbolLessRegions,
-    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {},
+    std::vector<ReachingCallTargets> Resolved = {}) {
   SmallVector<ReachingPcUse, 8> Uses;
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &Call = Decoded[I];
@@ -3388,7 +3595,8 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
   }
   return resolveReusablePcValuesAtUses(
       Decoded, LS, TextAddr, TextEnd, FunctionRanges, LocalCalls,
-      DeclaredEntries, SymbolLessRegions, Uses, FiniteSetPcTransfers);
+      DeclaredEntries, SymbolLessRegions, Uses, FiniteSetPcTransfers,
+      std::move(Resolved));
 }
 
 struct KnownCallSite {
@@ -3407,6 +3615,17 @@ struct BoundedSetPcReturn {
   size_t InstIndex = 0;
   SmallVector<uint64_t, 2> Targets;
 };
+
+static bool hasSameBoundedSetPcReturns(ArrayRef<BoundedSetPcReturn> LHS,
+                                       ArrayRef<BoundedSetPcReturn> RHS) {
+  if (LHS.size() != RHS.size())
+    return false;
+  for (size_t I = 0; I != LHS.size(); ++I)
+    if (LHS[I].InstIndex != RHS[I].InstIndex ||
+        LHS[I].Targets != RHS[I].Targets)
+      return false;
+  return true;
+}
 
 struct DirectTargetSource {
   size_t InstIndex = 0;
@@ -4003,12 +4222,14 @@ static BitVector computeFiniteControlFlowReachability(
     ArrayRef<uint64_t> ExternalEntries,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
     const ControlFlowScanIndex &Index,
+    const DenseMap<uint64_t, size_t> &OffsetToIndex,
     ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers,
-    ArrayRef<BoundedSetPcReturn> BoundedReturns) {
-  BitVector Reachable(Decoded.size());
-  DenseMap<uint64_t, size_t> OffsetToIndex;
-  for (size_t I = 0; I != Decoded.size(); ++I)
-    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+    ArrayRef<BoundedSetPcReturn> BoundedReturns,
+    const BitVector *InitialReachable = nullptr) {
+  bool IsIncremental =
+      InitialReachable && InitialReachable->size() == Decoded.size();
+  BitVector Reachable =
+      IsIncremental ? *InitialReachable : BitVector(Decoded.size());
   DenseMap<size_t, const FiniteSetPcTransfer *> TransferByInst;
   for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
     TransferByInst.try_emplace(Transfer.InstIndex, &Transfer);
@@ -4028,15 +4249,29 @@ static BitVector computeFiniteControlFlowReachability(
     if (It != OffsetToIndex.end())
       Worklist.push_back(It->second);
   };
-  for (uint64_t Entry : DeclaredEntries)
-    addOffset(Entry);
-  for (uint64_t Entry : ExternalEntries)
-    addOffset(Entry);
-  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
-    if (Range.Begin >= TextAddr)
-      addOffset(Range.Begin - TextAddr);
-  if (Worklist.empty() && !Decoded.empty())
-    Worklist.push_back(0);
+  if (IsIncremental) {
+    // With unchanged transfer and return edges, a preservation retry only
+    // adds finite call targets. Seed those edges from every previously
+    // reachable call source, then visit only newly reached instructions.
+    for (const KnownCallSite &Call : Index.Calls)
+      if (Reachable.test(Call.InstIndex)) {
+        addOffset(Call.Target);
+        addOffset(Call.Continuation);
+      }
+    for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
+      if (Reachable.test(Call.InstIndex))
+        addOffset(Call.Continuation);
+  } else {
+    for (uint64_t Entry : DeclaredEntries)
+      addOffset(Entry);
+    for (uint64_t Entry : ExternalEntries)
+      addOffset(Entry);
+    for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+      if (Range.Begin >= TextAddr)
+        addOffset(Range.Begin - TextAddr);
+    if (Worklist.empty() && !Decoded.empty())
+      Worklist.push_back(0);
+  }
 
   while (!Worklist.empty()) {
     size_t I = Worklist.pop_back_val();
@@ -4445,6 +4680,7 @@ struct FiniteControlFlowAudit {
   BitVector InvalidSetPcCandidates;
   bool Closed = false;
   bool HasUnboundedIndirectEntries = false;
+  bool HasNonReusableUnboundedIndirectEntries = false;
 };
 
 // Some B0-only vector encodings are intentionally absent from the A0 MC
@@ -4471,14 +4707,17 @@ static FiniteControlFlowAudit auditFiniteIndirectControlFlow(
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
     ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
     const ControlFlowScanIndex &Index,
+    const DenseMap<uint64_t, size_t> &OffsetToIndex,
     ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers,
     ArrayRef<BoundedSetPcReturn> BoundedReturns,
     ArrayRef<SymbolLessReturnRegion> SymbolLessRegions,
     ArrayRef<uint8_t> Text) {
   FiniteControlFlowAudit Audit{BitVector(FiniteSetPcTransfers.size()), true};
-  auto markUnboundedIndirectEntry = [&]() {
+  auto markUnboundedIndirectEntry = [&](bool IsReusableCallSource = false) {
     Audit.Closed = false;
     Audit.HasUnboundedIndirectEntries = true;
+    if (!IsReusableCallSource)
+      Audit.HasNonReusableUnboundedIndirectEntries = true;
   };
 
   for (size_t CandidateIndex = 0; CandidateIndex != FiniteSetPcTransfers.size();
@@ -4621,34 +4860,31 @@ static FiniteControlFlowAudit auditFiniteIndirectControlFlow(
 
   BitVector Reachable = computeFiniteControlFlowReachability(
       Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
-      FunctionRanges, Index, FiniteSetPcTransfers, BoundedReturns);
-  DenseSet<uint64_t> InstructionOffsets;
-  for (const InternalDecodedInst &DI : Decoded)
-    InstructionOffsets.insert(DI.Offset);
+      FunctionRanges, Index, OffsetToIndex, FiniteSetPcTransfers,
+      BoundedReturns);
   for (uint64_t Entry : DeclaredEntries)
-    if (Entry < TextSize && !InstructionOffsets.contains(Entry))
+    if (Entry < TextSize && !OffsetToIndex.contains(Entry))
       markUnboundedIndirectEntry();
   for (uint64_t Entry : ExternalEntries)
-    if (Entry < TextSize && !InstructionOffsets.contains(Entry))
+    if (Entry < TextSize && !OffsetToIndex.contains(Entry))
       markUnboundedIndirectEntry();
   for (const ElfView::FunctionTextRange &Range : FunctionRanges)
     if (Range.Begin >= TextAddr && Range.Begin - TextAddr < TextSize &&
-        !InstructionOffsets.contains(Range.Begin - TextAddr))
+        !OffsetToIndex.contains(Range.Begin - TextAddr))
       markUnboundedIndirectEntry();
   for (const DirectTargetSource &Source : Index.DirectTargetsByTarget)
     if (Reachable.test(Source.InstIndex) && Source.Target < TextSize &&
-        !InstructionOffsets.contains(Source.Target))
+        !OffsetToIndex.contains(Source.Target))
       markUnboundedIndirectEntry();
   for (const KnownCallSite &Call : Index.Calls)
     if (Reachable.test(Call.InstIndex) &&
-        ((!InstructionOffsets.contains(Call.Target) &&
-          Call.Target < TextSize) ||
-         (!InstructionOffsets.contains(Call.Continuation) &&
+        ((!OffsetToIndex.contains(Call.Target) && Call.Target < TextSize) ||
+         (!OffsetToIndex.contains(Call.Continuation) &&
           Call.Continuation < TextSize)))
       markUnboundedIndirectEntry();
   for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
     if (Reachable.test(Call.InstIndex) && Call.Continuation < TextSize &&
-        !InstructionOffsets.contains(Call.Continuation))
+        !OffsetToIndex.contains(Call.Continuation))
       markUnboundedIndirectEntry();
   for (size_t SetPc : Index.SetPcIndices)
     if (Reachable.test(SetPc) && !BoundedSetPc.test(SetPc))
@@ -4667,20 +4903,26 @@ static FiniteControlFlowAudit auditFiniteIndirectControlFlow(
   // exact call target and continuation have been admitted to this same joint
   // audit. Unknown calls remain unbounded in the call-specific loop below.
   for (size_t InstIndex : Index.UnboundedIndirectIndices)
-    if (Reachable.test(InstIndex) && !FiniteCalls.test(InstIndex))
-      markUnboundedIndirectEntry();
+    if (Reachable.test(InstIndex) && !FiniteCalls.test(InstIndex)) {
+      bool IsReusableCall =
+          Decoded[InstIndex].DecodeSucceeded &&
+          Decoded[InstIndex].Inst.getOpcode() == LS.SSwapPcI64Opcode;
+      markUnboundedIndirectEntry(IsReusableCall);
+    }
 
   for (size_t InstIndex : Index.BranchOrCallIndices) {
     if (!Reachable.test(InstIndex) || !LS.MIA->isCall(Decoded[InstIndex].Inst))
       continue;
     if (!FiniteCalls.test(InstIndex))
-      markUnboundedIndirectEntry();
+      markUnboundedIndirectEntry(Decoded[InstIndex].DecodeSucceeded &&
+                                 Decoded[InstIndex].Inst.getOpcode() ==
+                                     LS.SSwapPcI64Opcode);
   }
   for (const BoundedSetPcReturn &Return : BoundedReturns) {
     if (!Reachable.test(Return.InstIndex))
       continue;
     for (uint64_t Target : Return.Targets)
-      if (Target < TextSize && !InstructionOffsets.contains(Target))
+      if (Target < TextSize && !OffsetToIndex.contains(Target))
         markUnboundedIndirectEntry();
   }
   for (int I = Reachable.find_first(); I >= 0; I = Reachable.find_next(I))
@@ -6248,6 +6490,14 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   if (!TextEnd)
     return std::nullopt;
 
+  std::optional<ControlFlowScanIndex> BaseIndex = buildControlFlowScanIndex(
+      Decoded, LS, TextAddr, *TextEnd, FunctionRanges);
+  if (!BaseIndex)
+    return std::nullopt;
+  DenseMap<uint64_t, size_t> DecodedOffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    DecodedOffsetToIndex.try_emplace(Decoded[I].Offset, I);
+
   SmallVector<FiniteSetPcTransfer, 8> AllSetPcCandidates =
       collectFiniteSetPcCandidates(Decoded, LS, TextAddr, *TextEnd,
                                    FunctionRanges);
@@ -6257,10 +6507,16 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   std::vector<ReachingCallTargets> ReusableCalls;
   SmallVector<std::optional<PcMaterializedCallInfo>, 16> MaterializedCalls(
       Decoded.size());
+  for (const auto &Entry : BaseIndex->MaterializedCalls)
+    MaterializedCalls[Entry.first] = Entry.second;
   std::optional<ControlFlowScanIndex> Index;
   SmallVector<BoundedSetPcReturn, 2> BoundedReturns;
   SmallVector<SymbolLessReturnRegion, 8> SymbolLessRegions;
   SmallVector<SymbolLessReturnRegion, 8> PreservingSymbolLessRegions;
+  SmallVector<FiniteSetPcTransfer, 8> PreviousEnabledSetPcTransfers;
+  SmallVector<BoundedSetPcReturn, 2> PreviousFunctionReturns;
+  BitVector PreviousPotentialSetPcSources;
+  BitVector PreviousCandidateReachability;
   bool IndirectControlFlowClosed = false;
   bool HasUnboundedIndirectEntries = false;
   bool RejectedSymbolLessPreservation = false;
@@ -6270,19 +6526,27 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   // closed-world audit removes an edge; never let a rejected edge leave
   // self-supporting call or return facts behind.
   for (;;) {
+    bool IsPreservationRetry = !PreservingSymbolLessRegions.empty();
+    PreviousEnabledSetPcTransfers = EnabledSetPcTransfers;
+    PreviousFunctionReturns = BoundedReturns;
     EnabledSetPcTransfers = selectLeastReachableSetPcCandidates(
         Decoded, LS, DeclaredEntries, ExternalEntries, FunctionRanges, TextAddr,
         AllSetPcCandidates, ProvenSetPcCandidates, RejectedSetPcCandidates);
-    Index = buildControlFlowScanIndex(Decoded, LS, TextAddr, *TextEnd,
-                                      FunctionRanges);
-    if (!Index)
-      return std::nullopt;
-    std::fill(MaterializedCalls.begin(), MaterializedCalls.end(), std::nullopt);
-    for (const auto &Entry : Index->MaterializedCalls)
-      MaterializedCalls[Entry.first] = Entry.second;
+    bool HasSameTransfers =
+        IsPreservationRetry &&
+        hasSameFiniteSetPcTransfers(PreviousEnabledSetPcTransfers,
+                                    EnabledSetPcTransfers);
+    // The decoded instruction scan is invariant across fixed-point retries.
+    // Copy its sparse indexes, then append only iteration-specific reusable
+    // calls and candidate transfers below.
+    Index = *BaseIndex;
     ReusableCalls = resolveReusablePcCallTargets(
         Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls,
-        DeclaredEntries, PreservingSymbolLessRegions, EnabledSetPcTransfers);
+        DeclaredEntries, PreservingSymbolLessRegions, EnabledSetPcTransfers,
+        // Transfer ownership so every non-preservation retry can reuse the
+        // object-sized result allocation and a preservation retry can retain
+        // unaffected groups without copying them.
+        std::move(ReusableCalls));
     if (!addReusableCallsToIndex(Decoded, LS, TextAddr, *TextEnd, ReusableCalls,
                                  *Index))
       return std::nullopt;
@@ -6290,10 +6554,12 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     finalizeCallContinuationIndex(*Index);
     BitVector PotentialSetPcSources = computeFiniteControlFlowReachability(
         Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
-        FunctionRanges, *Index, EnabledSetPcTransfers,
-        /*BoundedReturns=*/ArrayRef<BoundedSetPcReturn>{});
+        FunctionRanges, *Index, DecodedOffsetToIndex, EnabledSetPcTransfers,
+        /*BoundedReturns=*/ArrayRef<BoundedSetPcReturn>{},
+        HasSameTransfers ? &PreviousPotentialSetPcSources : nullptr);
     addPotentialFiniteSetPcTransfersToIndex(Decoded, AllSetPcCandidates,
                                             PotentialSetPcSources, *Index);
+    PreviousPotentialSetPcSources = std::move(PotentialSetPcSources);
 
     std::optional<SmallVector<BoundedSetPcReturn, 2>> FunctionReturns =
         collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,
@@ -6302,9 +6568,14 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     if (!FunctionReturns)
       return std::nullopt;
     BoundedReturns = std::move(*FunctionReturns);
+    bool HasSameFunctionReturns =
+        HasSameTransfers &&
+        hasSameBoundedSetPcReturns(PreviousFunctionReturns, BoundedReturns);
     BitVector CandidateReachability = computeFiniteControlFlowReachability(
         Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
-        FunctionRanges, *Index, EnabledSetPcTransfers, BoundedReturns);
+        FunctionRanges, *Index, DecodedOffsetToIndex, EnabledSetPcTransfers,
+        BoundedReturns,
+        HasSameFunctionReturns ? &PreviousCandidateReachability : nullptr);
     bool AddedCandidate = false;
     for (size_t I = 0; I != AllSetPcCandidates.size(); ++I) {
       if (RejectedSetPcCandidates.test(I) || ProvenSetPcCandidates.test(I) ||
@@ -6315,13 +6586,11 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     }
     if (AddedCandidate)
       continue;
-    BitVector ReachableCallSources = computeFiniteControlFlowReachability(
-        Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
-        FunctionRanges, *Index, EnabledSetPcTransfers, BoundedReturns);
     SymbolLessRegions = collectSymbolLessReturnRegions(
         Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
         ExternalEntries, *Index, EnabledSetPcTransfers, BoundedReturns,
-        ReachableCallSources);
+        CandidateReachability);
+    PreviousCandidateReachability = std::move(CandidateReachability);
     SmallVector<BoundedSetPcReturn, 2> AllBoundedReturns = BoundedReturns;
     for (const SymbolLessReturnRegion &Region : SymbolLessRegions)
       for (size_t Return : Region.Returns) {
@@ -6331,8 +6600,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       }
     FiniteControlFlowAudit Audit = auditFiniteIndirectControlFlow(
         Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
-        ExternalEntries, *Index, EnabledSetPcTransfers, AllBoundedReturns,
-        SymbolLessRegions, Text);
+        ExternalEntries, *Index, DecodedOffsetToIndex, EnabledSetPcTransfers,
+        AllBoundedReturns, SymbolLessRegions, Text);
     if (Audit.InvalidSetPcCandidates.any()) {
       PreservingSymbolLessRegions.clear();
       RejectedSymbolLessPreservation = false;
@@ -6352,13 +6621,18 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       ProvenSetPcCandidates.reset();
       continue;
     }
-    if (!Audit.Closed && PreservingSymbolLessRegions.empty() &&
-        !RejectedSymbolLessPreservation && !SymbolLessRegions.empty()) {
+    if (!Audit.Closed && !Audit.HasNonReusableUnboundedIndirectEntries &&
+        PreservingSymbolLessRegions.empty() &&
+        !RejectedSymbolLessPreservation &&
+        hasSymbolLessReusableTargetPreservationCandidate(
+            Decoded, LS, TextAddr, ReusableCalls, SymbolLessRegions)) {
       // Symbol-less leaves and reusable target preservation form a bounded
       // fixed point: later calls keep the first audit open until the already
       // proven leaf is allowed to preserve their target pair. Try those local
-      // facts provisionally, then require the expanded audit below to close
-      // and reproduce every preservation proof before retaining them.
+      // facts provisionally only when every open source is a reusable call:
+      // preserving a target cannot close an independent set-PC, branch, or
+      // undecoded entry. Require the expanded audit below to close and
+      // reproduce every preservation proof before retaining them.
       PreservingSymbolLessRegions = SymbolLessRegions;
       continue;
     }
@@ -6380,8 +6654,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       AllBoundedReturns = BoundedReturns;
       Audit = auditFiniteIndirectControlFlow(
           Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
-          ExternalEntries, *Index, EnabledSetPcTransfers, AllBoundedReturns,
-          SymbolLessRegions, Text);
+          ExternalEntries, *Index, DecodedOffsetToIndex, EnabledSetPcTransfers,
+          AllBoundedReturns, SymbolLessRegions, Text);
     }
     if (!Audit.Closed && !EnabledSetPcTransfers.empty()) {
       PreservingSymbolLessRegions.clear();
@@ -6405,7 +6679,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       RejectedSymbolLessPreservation = true;
       continue;
     }
-    if (Audit.Closed && !RejectedSymbolLessPreservation &&
+    if (Audit.Closed && !PreservingSymbolLessRegions.empty() &&
+        !RejectedSymbolLessPreservation &&
         !hasSameSymbolLessPreservationProofs(PreservingSymbolLessRegions,
                                              SymbolLessRegions)) {
       PreservingSymbolLessRegions = SymbolLessRegions;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -6513,8 +6513,37 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       Info.Targets.insert(*Continuation);
     }
   }
-  for (const BoundedSetPcReturn &Return : BoundedReturns)
-    Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
+  DenseSet<uint64_t> DecodedOffsets;
+  for (const InternalDecodedInst &DI : Decoded)
+    if (DI.DecodeSucceeded)
+      DecodedOffsets.insert(DI.Offset);
+  for (const BoundedSetPcReturn &Return : BoundedReturns) {
+    uint64_t ReturnOffset = Decoded[Return.InstIndex].Offset;
+    SmallVector<uint64_t, 2> LocalTargets;
+    for (uint64_t Target : Return.Targets) {
+      if (Target >= TextSize)
+        continue;
+      if (!DecodedOffsets.contains(Target)) {
+        log() << "hotswap: audited bounded return at 0x"
+              << utohexstr(ReturnOffset) << " has non-boundary local target 0x"
+              << utohexstr(Target) << "\n";
+        return std::nullopt;
+      }
+      LocalTargets.push_back(Target);
+    }
+    llvm::sort(LocalTargets);
+    LocalTargets.erase(std::unique(LocalTargets.begin(), LocalTargets.end()),
+                       LocalTargets.end());
+    auto Inserted =
+        Info.BoundedIndirectTargets.try_emplace(ReturnOffset, LocalTargets);
+    if (!Inserted.second && Inserted.first->second != LocalTargets) {
+      log() << "hotswap: conflicting audited target sets for bounded return at "
+               "0x"
+            << utohexstr(ReturnOffset) << "\n";
+      return std::nullopt;
+    }
+    Info.BoundedIndirectTransfers.insert(ReturnOffset);
+  }
   if (!AbiEntrySet && !IndirectControlFlowClosed && HasUnboundedIndirectEntries)
     Info.HasUnboundedIndirectEntries = true;
   return Info;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1632,6 +1632,209 @@ unsafeIncomingNumberedSgprsInRange(ArrayRef<InternalDecodedInst> Decoded,
   return Unsafe;
 }
 
+struct BatchedSgprContinuationAnalysis {
+  uint64_t FunctionBegin = 0;
+  uint64_t FunctionEnd = 0;
+  size_t BeginIndex = 0;
+  size_t InstructionCount = 0;
+  unsigned RegisterCount = 0;
+  unsigned WordsPerRow = 0;
+  std::vector<uint64_t> UnsafeRows;
+
+  std::optional<BitVector> query(ArrayRef<InternalDecodedInst> Decoded,
+                                 uint64_t Continuation) const {
+    if (Continuation < FunctionBegin || Continuation >= FunctionEnd)
+      return std::nullopt;
+    auto Begin = Decoded.begin() + BeginIndex;
+    auto End = Begin + InstructionCount;
+    auto It = llvm::lower_bound(
+        ArrayRef<InternalDecodedInst>(Begin, End), Continuation,
+        [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
+    if (It == ArrayRef<InternalDecodedInst>(Begin, End).end() ||
+        It->Offset != Continuation)
+      return std::nullopt;
+    size_t LocalIndex = It - Begin;
+    const uint64_t *Row = UnsafeRows.data() + LocalIndex * WordsPerRow;
+    BitVector Result(RegisterCount);
+    for (unsigned Register = 0; Register != RegisterCount; ++Register)
+      if ((Row[Register / 64] >> (Register % 64)) & 1)
+        Result.set(Register);
+    return Result;
+  }
+};
+
+static std::optional<BatchedSgprContinuationAnalysis>
+computeBatchedSgprContinuationAnalysis(ArrayRef<InternalDecodedInst> Decoded,
+                                       const LLVMState &LS,
+                                       uint64_t FunctionBegin,
+                                       uint64_t FunctionEnd,
+                                       ArrayRef<MCRegister> NumberedSgprs) {
+  if (!LS.MIA || FunctionBegin >= FunctionEnd)
+    return std::nullopt;
+  auto Begin =
+      llvm::lower_bound(Decoded, FunctionBegin,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  auto End = llvm::lower_bound(
+      Decoded, FunctionEnd, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  if (Begin == End)
+    return std::nullopt;
+
+  BatchedSgprContinuationAnalysis Result;
+  Result.FunctionBegin = FunctionBegin;
+  Result.FunctionEnd = FunctionEnd;
+  Result.BeginIndex = Begin - Decoded.begin();
+  Result.InstructionCount = End - Begin;
+  Result.RegisterCount = NumberedSgprs.size();
+  Result.WordsPerRow = (Result.RegisterCount + 63) / 64;
+  if (Result.WordsPerRow == 0)
+    return Result;
+  if (Result.InstructionCount >
+      std::numeric_limits<size_t>::max() / Result.WordsPerRow)
+    return std::nullopt;
+  size_t WordCount = Result.InstructionCount * Result.WordsPerRow;
+
+  std::vector<uint64_t> UsesRows(WordCount);
+  std::vector<uint64_t> DefsRows(WordCount);
+  Result.UnsafeRows.assign(WordCount, 0);
+  std::vector<SmallVector<size_t, 2>> Successors(Result.InstructionCount);
+  std::vector<SmallVector<size_t, 2>> Predecessors(Result.InstructionCount);
+  BitVector OpaqueSuccessor(Result.InstructionCount);
+
+  auto FindLocalIndex = [&](uint64_t Offset) -> std::optional<size_t> {
+    if (Offset < FunctionBegin || Offset >= FunctionEnd)
+      return std::nullopt;
+    auto It =
+        llvm::lower_bound(ArrayRef<InternalDecodedInst>(Begin, End), Offset,
+                          [](const InternalDecodedInst &DI, uint64_t Target) {
+                            return DI.Offset < Target;
+                          });
+    if (It == ArrayRef<InternalDecodedInst>(Begin, End).end() ||
+        It->Offset != Offset)
+      return std::nullopt;
+    return It - Begin;
+  };
+  auto AddSuccessor = [&](size_t From, uint64_t Offset) {
+    std::optional<size_t> To = FindLocalIndex(Offset);
+    if (!To) {
+      OpaqueSuccessor.set(From);
+      return;
+    }
+    if (!llvm::is_contained(Successors[From], *To)) {
+      Successors[From].push_back(*To);
+      Predecessors[*To].push_back(From);
+    }
+  };
+  auto StoreBits = [&](uint64_t *Row, const BitVector &Bits) {
+    for (int Bit = Bits.find_first(); Bit >= 0; Bit = Bits.find_next(Bit))
+      Row[static_cast<unsigned>(Bit) / 64] |=
+          uint64_t{1} << (static_cast<unsigned>(Bit) % 64);
+  };
+
+  for (size_t I = 0; I != Result.InstructionCount; ++I) {
+    const InternalDecodedInst &DI = Begin[I];
+    uint64_t *Uses = UsesRows.data() + I * Result.WordsPerRow;
+    uint64_t *Defs = DefsRows.data() + I * Result.WordsPerRow;
+    if (!DI.DecodeSucceeded || DI.Offset < FunctionBegin ||
+        DI.Offset >= FunctionEnd) {
+      OpaqueSuccessor.set(I);
+      continue;
+    }
+
+    BitVector UsesBits(Result.RegisterCount);
+    BitVector DefsBits(Result.RegisterCount);
+    getNumberedSgprUsesAndDefs(DI, LS, NumberedSgprs, UsesBits, DefsBits);
+    StoreBits(Uses, UsesBits);
+    StoreBits(Defs, DefsBits);
+
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode)
+      continue;
+    if (LS.MIA->isCall(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
+        LS.MIA->isReturn(DI.Inst)) {
+      OpaqueSuccessor.set(I);
+      continue;
+    }
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (Target)
+        AddSuccessor(I, *Target);
+      else
+        OpaqueSuccessor.set(I);
+      if (LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
+               !LS.MIA->isBarrier(DI.Inst)) {
+      OpaqueSuccessor.set(I);
+      continue;
+    }
+
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "batched SGPR liveness fallthrough");
+    if (Fallthrough)
+      AddSuccessor(I, *Fallthrough);
+    else
+      OpaqueSuccessor.set(I);
+  }
+
+  SmallVector<size_t, 32> Worklist;
+  Worklist.reserve(Result.InstructionCount);
+  BitVector Queued(Result.InstructionCount, true);
+  for (size_t I = 0; I != Result.InstructionCount; ++I)
+    Worklist.push_back(I);
+  while (!Worklist.empty()) {
+    size_t I = Worklist.pop_back_val();
+    Queued.reset(I);
+    const uint64_t *Uses = UsesRows.data() + I * Result.WordsPerRow;
+    const uint64_t *Defs = DefsRows.data() + I * Result.WordsPerRow;
+    uint64_t *Unsafe = Result.UnsafeRows.data() + I * Result.WordsPerRow;
+    bool Changed = false;
+    for (unsigned Word = 0; Word != Result.WordsPerRow; ++Word) {
+      uint64_t SuccessorUnsafe =
+          OpaqueSuccessor.test(I) ? std::numeric_limits<uint64_t>::max() : 0;
+      for (size_t Successor : Successors[I])
+        SuccessorUnsafe |=
+            Result.UnsafeRows[Successor * Result.WordsPerRow + Word];
+      uint64_t NewUnsafe = Uses[Word] | (SuccessorUnsafe & ~Defs[Word]);
+      if (Word + 1 == Result.WordsPerRow && Result.RegisterCount % 64 != 0)
+        NewUnsafe &= (uint64_t{1} << (Result.RegisterCount % 64)) - 1;
+      uint64_t Added = NewUnsafe & ~Unsafe[Word];
+      if (Added != 0) {
+        Unsafe[Word] |= Added;
+        Changed = true;
+      }
+    }
+    if (!Changed)
+      continue;
+    for (size_t Predecessor : Predecessors[I])
+      if (!Queued.test(Predecessor)) {
+        Queued.set(Predecessor);
+        Worklist.push_back(Predecessor);
+      }
+  }
+  return Result;
+}
+
+BatchedSgprContinuationTestResult runBatchedSgprContinuationAnalysisForTest(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t FunctionBegin, uint64_t FunctionEnd,
+    ArrayRef<uint64_t> Continuations, ArrayRef<MCRegister> NumberedSgprs) {
+  BatchedSgprContinuationTestResult Result;
+  std::optional<BatchedSgprContinuationAnalysis> Analysis =
+      computeBatchedSgprContinuationAnalysis(Decoded, LS, FunctionBegin,
+                                             FunctionEnd, NumberedSgprs);
+  Result.Analyses = 1;
+  for (uint64_t Continuation : Continuations)
+    Result.Queries.push_back(Analysis ? Analysis->query(Decoded, Continuation)
+                                      : std::nullopt);
+  return Result;
+}
+
 void noteCurrentTextMutation(PatchContext &Ctx) {
   if (Ctx.TextMutationGeneration == std::numeric_limits<uint64_t>::max()) {
     Ctx.CurrentFunctionSgprLivenessCache.clear();
@@ -1657,6 +1860,21 @@ bool isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx,
 }
 
 static std::optional<unsigned>
+selectLocallyDeadSgprPair(unsigned MaxSgprs, const BitVector &Unsafe) {
+  if (MaxSgprs < 2 || Unsafe.size() < MaxSgprs)
+    return std::nullopt;
+  unsigned Base = (MaxSgprs - 2) & ~1u;
+  for (;;) {
+    if (!Unsafe.test(Base) && !Unsafe.test(Base + 1))
+      return Base;
+    if (Base == 0)
+      break;
+    Base -= 2;
+  }
+  return std::nullopt;
+}
+
+static std::optional<unsigned>
 findLocallyDeadSgprPair(PatchContext &Ctx, uint64_t InstOffset,
                         uint32_t InstSize, ArrayRef<uint8_t> Replacement) {
   if (Ctx.Config.MaxSgprs < 2)
@@ -1672,16 +1890,7 @@ findLocallyDeadSgprPair(PatchContext &Ctx, uint64_t InstOffset,
 
   BitVector Unsafe = *ReplacementIncoming;
   Unsafe |= *ContinuationLive;
-  unsigned Base = (Ctx.Config.MaxSgprs - 2) & ~1u;
-  for (;;) {
-    if (!Unsafe.test(Base) && !Unsafe.test(Base + 1)) {
-      return Base;
-    }
-    if (Base == 0)
-      break;
-    Base -= 2;
-  }
-  return std::nullopt;
+  return selectLocallyDeadSgprPair(Ctx.Config.MaxSgprs, Unsafe);
 }
 
 struct FarReturnScratch {
@@ -8741,6 +8950,7 @@ assignLongBranchGateways(PatchContext &Ctx,
           Ctx.DirectControlFlow.BoundedIndirectTransfers);
   DenseMap<std::pair<uint64_t, uint64_t>, std::optional<DenseSet<uint64_t>>>
       PromotionVccNeedsCache;
+  uint64_t PromotionSgprContinuationAnalyses = 0;
   using PromotionRange = std::pair<uint64_t, uint64_t>;
   std::set<PromotionRange> PromotionReservedRanges;
   auto ReservePromotionRange = [&](uint64_t Begin, uint64_t End) {
@@ -8935,9 +9145,15 @@ assignLongBranchGateways(PatchContext &Ctx,
         Replacement.resize(UseVcc ? BestVccReplacementSize
                                   : MinimumReplacementSize);
         std::optional<unsigned> Scratch;
-        if (!UseVcc)
+        if (!UseVcc) {
+          size_t CachedFunctionsBefore =
+              Ctx.CurrentFunctionSgprLivenessCache.size();
           Scratch = findLocallyDeadSgprPair(Ctx, Start, Replacement.size(),
                                             Replacement);
+          PromotionSgprContinuationAnalyses +=
+              Ctx.CurrentFunctionSgprLivenessCache.size() -
+              CachedFunctionsBefore;
+        }
         if (!Scratch && !UseVcc) {
           PromotionStillPossible.reset(Index);
           continue;
@@ -9279,6 +9495,9 @@ assignLongBranchGateways(PatchContext &Ctx,
                std::chrono::steady_clock::now() - ForwardBranchPlanStart)
                .count()
         << " ms\n";
+  if (PromotionSgprContinuationAnalyses != 0)
+    log() << "hotswap: batched promotion SGPR continuation analysis built "
+          << PromotionSgprContinuationAnalyses << " function cache(s)\n";
 
   if (!Pending.empty()) {
     const PendingGateway &P = Pending.front();

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -4404,6 +4404,24 @@ struct FiniteControlFlowAudit {
   bool HasUnboundedIndirectEntries = false;
 };
 
+// Some B0-only vector encodings are intentionally absent from the A0 MC
+// decoder used by hotswap. The legacy VOP3 encoding has the exact six-bit
+// major 0x34 (Inst[31:26]): it cannot transfer control or write the scalar
+// MODE register. An undecoded instance therefore remains opaque to dataflow,
+// but it is not an object-wide indirect-entry source. Keep this whitelist on
+// the exact encoding class; every other undecoded encoding retains the
+// fail-closed behavior.
+static bool
+isProvablyNonControlFlowUndecodedVectorInst(const InternalDecodedInst &DI,
+                                            ArrayRef<uint8_t> Text) {
+  if (DI.DecodeSucceeded || DI.Offset > Text.size() ||
+      MinInstSize > Text.size() - DI.Offset)
+    return false;
+  uint32_t Word =
+      support::endian::read32le(Text.data() + static_cast<size_t>(DI.Offset));
+  return (Word & 0xfc000000u) == (0x34u << 26);
+}
+
 static FiniteControlFlowAudit auditFiniteIndirectControlFlow(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextSize,
@@ -4412,7 +4430,8 @@ static FiniteControlFlowAudit auditFiniteIndirectControlFlow(
     const ControlFlowScanIndex &Index,
     ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers,
     ArrayRef<BoundedSetPcReturn> BoundedReturns,
-    ArrayRef<SymbolLessReturnRegion> SymbolLessRegions) {
+    ArrayRef<SymbolLessReturnRegion> SymbolLessRegions,
+    ArrayRef<uint8_t> Text) {
   FiniteControlFlowAudit Audit{BitVector(FiniteSetPcTransfers.size()), true};
   auto markUnboundedIndirectEntry = [&]() {
     Audit.Closed = false;
@@ -4622,7 +4641,9 @@ static FiniteControlFlowAudit auditFiniteIndirectControlFlow(
         markUnboundedIndirectEntry();
   }
   for (int I = Reachable.find_first(); I >= 0; I = Reachable.find_next(I))
-    if (!Decoded[static_cast<size_t>(I)].DecodeSucceeded)
+    if (!Decoded[static_cast<size_t>(I)].DecodeSucceeded &&
+        !isProvablyNonControlFlowUndecodedVectorInst(
+            Decoded[static_cast<size_t>(I)], Text))
       markUnboundedIndirectEntry();
   return Audit;
 }
@@ -6266,7 +6287,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     FiniteControlFlowAudit Audit = auditFiniteIndirectControlFlow(
         Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
         ExternalEntries, *Index, EnabledSetPcTransfers, AllBoundedReturns,
-        SymbolLessRegions);
+        SymbolLessRegions, Text);
     if (Audit.InvalidSetPcCandidates.any()) {
       for (size_t I = 0; I != EnabledSetPcTransfers.size(); ++I) {
         if (!Audit.InvalidSetPcCandidates.test(I))
@@ -6294,7 +6315,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       Audit = auditFiniteIndirectControlFlow(
           Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
           ExternalEntries, *Index, EnabledSetPcTransfers, AllBoundedReturns,
-          SymbolLessRegions);
+          SymbolLessRegions, Text);
     }
     if (!Audit.Closed && !EnabledSetPcTransfers.empty()) {
       for (const FiniteSetPcTransfer &Enabled : EnabledSetPcTransfers)

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1643,8 +1643,9 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
       !MakeDelta.Inst.getOperand(2).isImm())
     return std::nullopt;
   MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
-  if (LS.MRI->regsOverlap(DeltaReg, Pair) ||
-      AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
+  if (LS.MRI->regsOverlap(DeltaReg, Pair))
+    return std::nullopt;
+  if (AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
       !AddLow.Inst.getOperand(1).isReg() ||
       !AddLow.Inst.getOperand(0).getReg() ||
       AddLow.Inst.getOperand(0).getReg() !=
@@ -1667,20 +1668,8 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
       !LS.MRI->regsOverlap(Low, Pair) || !LS.MRI->regsOverlap(High, Pair))
     return std::nullopt;
 
-  std::optional<uint32_t> FirstAddend;
-  if (MakeDelta.Inst.getOperand(1).isImm()) {
-    FirstAddend = static_cast<uint32_t>(MakeDelta.Inst.getOperand(1).getImm());
-  } else if (MakeDelta.Size == 2 * MinInstSize &&
-             MakeDelta.Offset <= Text.size() &&
-             MakeDelta.Size <= Text.size() - MakeDelta.Offset &&
-             Text[MakeDelta.Offset] == 0xff) {
-    // The disassembler represents a SOP2 literal source as its literal
-    // register marker, not as an immediate operand. Require the gfx12 SOP2
-    // src0 literal selector before interpreting the final dword as that
-    // literal; an ordinary register source is not a constant displacement.
-    FirstAddend = support::endian::read32le(Text.data() + MakeDelta.Offset +
-                                            MakeDelta.Size - MinInstSize);
-  }
+  std::optional<uint32_t> FirstAddend =
+      evaluateAbsoluteUint32Operand(MakeDelta.Inst.getOperand(1));
   if (!FirstAddend)
     return std::nullopt;
   uint32_t Delta = *FirstAddend +
@@ -1695,69 +1684,336 @@ struct ReachingCallGroup {
   SmallVector<size_t, 8> Calls;
 };
 
-static std::optional<uint64_t>
-getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
-                    uint64_t TextAddr, uint64_t TextEnd);
+struct FiniteSetPcTransfer {
+  size_t InstIndex = 0;
+  size_t SequenceBeginIndex = 0;
+  size_t SequenceEndIndex = 0;
+  uint64_t Target = 0;
+  std::optional<size_t> LocalTargetIndex;
+  uint64_t FunctionBegin = 0;
+  uint64_t FunctionEnd = 0;
+};
 
-/// A reusable target value remains valid after a call only when the exact local
-/// callee is fully decoded, returns through the call's link pair, and cannot
-/// transitively or directly clobber the target pair.
-static bool calleePreservesReusableTarget(
-    uint64_t Target, MCRegister TargetRegister, MCRegister ReturnRegister,
+static const ElfView::FunctionTextRange *
+findInnermostFunctionRange(uint64_t Address,
+                           ArrayRef<ElfView::FunctionTextRange> Ranges) {
+  const ElfView::FunctionTextRange *Best = nullptr;
+  for (const ElfView::FunctionTextRange &Range : Ranges)
+    if (Range.Begin <= Address && Address < Range.End &&
+        (!Best || Range.Begin > Best->Begin ||
+         (Range.Begin == Best->Begin && Range.End < Best->End)))
+      Best = &Range;
+  return Best;
+}
+
+/// Collect exact materialized s_set_pc_i64 transfers. These are candidates,
+/// not proofs: a later closed-world audit must still rule out an alternate
+/// entry into the materialization before the edge can authorize mutation.
+static SmallVector<FiniteSetPcTransfer, 8> collectFiniteSetPcCandidates(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
-  const ElfView::FunctionTextRange *Callee = nullptr;
-  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
-    if (Range.Begin == Target && Range.Begin >= TextAddr &&
-        Range.End > Range.Begin && Range.End <= TextEnd &&
-        (!Callee || Range.End < Callee->End))
-      Callee = &Range;
-  if (!Callee)
-    return false;
+  SmallVector<FiniteSetPcTransfer, 8> Candidates;
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
 
-  uint64_t CalleeBegin = Callee->Begin - TextAddr;
-  uint64_t CalleeEnd = Callee->End - TextAddr;
-  bool SawInstruction = false;
-  for (const InternalDecodedInst &DI : Decoded) {
-    if (DI.Offset < CalleeBegin || DI.Offset >= CalleeEnd)
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &GetPc = Decoded[I];
+    if (!GetPc.DecodeSucceeded ||
+        GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
+        GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+        !GetPc.Inst.getOperand(0).getReg())
       continue;
-    SawInstruction = true;
-    if (!DI.DecodeSucceeded || LS.MIA->isCall(DI.Inst) ||
-        definesOverlappingRegister(DI, LS, TargetRegister))
-      return false;
+    MCRegister Pair(GetPc.Inst.getOperand(0).getReg());
+    std::optional<uint64_t> GetPcAddress = checkedAddUint64(
+        TextAddr, GetPc.Offset, "finite set-PC get-PC address");
+    if (!GetPcAddress)
+      continue;
+    const ElfView::FunctionTextRange *Range =
+        findInnermostFunctionRange(*GetPcAddress, FunctionRanges);
+    if (!Range || Range->Begin < TextAddr || Range->End > TextEnd)
+      continue;
+    ArrayRef<InternalDecodedInst>::const_iterator FunctionEnd =
+        llvm::lower_bound(Decoded, Range->End - TextAddr,
+                          [](const InternalDecodedInst &DI, uint64_t Offset) {
+                            return DI.Offset < Offset;
+                          });
+    size_t FunctionEndIndex =
+        static_cast<size_t>(FunctionEnd - Decoded.begin());
+    auto appendCandidate = [&](size_t SetPcIndex, size_t SequenceEndIndex,
+                               uint64_t Target) {
+      for (size_t J = I; J <= SequenceEndIndex; ++J) {
+        if (!Decoded[J].DecodeSucceeded)
+          return;
+        if (J == SequenceEndIndex)
+          break;
+        std::optional<uint64_t> End =
+            checkedAddUint64(Decoded[J].Offset, Decoded[J].Size,
+                             "finite set-PC materialization instruction end");
+        if (!End || *End != Decoded[J + 1].Offset)
+          return;
+      }
+      std::optional<size_t> LocalTargetIndex;
+      if (Target >= TextAddr && Target < TextEnd) {
+        DenseMap<uint64_t, size_t>::const_iterator LocalTarget =
+            OffsetToIndex.find(Target - TextAddr);
+        // A local transfer to the middle of an instruction is not finite for
+        // purposes of safe rewriting.
+        if (LocalTarget == OffsetToIndex.end())
+          return;
+        LocalTargetIndex = LocalTarget->second;
+      }
+      Candidates.push_back({SetPcIndex, I, SequenceEndIndex, Target,
+                            LocalTargetIndex, Range->Begin - TextAddr,
+                            Range->End - TextAddr});
+    };
 
-    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
-      if (DI.Inst.getNumOperands() != 1 ||
-          !isExactRegisterOperand(DI.Inst, 0, ReturnRegister))
-        return false;
-      continue;
+    std::optional<std::pair<size_t, uint64_t>> Match =
+        matchReusablePcMaterialization(Decoded, I, FunctionEndIndex, Pair, LS,
+                                       TextAddr);
+    if (Match && Match->first + 1 < FunctionEndIndex) {
+      size_t SetPcIndex = Match->first + 1;
+      const InternalDecodedInst &SetPc = Decoded[SetPcIndex];
+      if (SetPc.DecodeSucceeded &&
+          SetPc.Inst.getOpcode() == LS.SSetPcI64Opcode &&
+          SetPc.Inst.getNumOperands() == 1 &&
+          isExactRegisterOperand(SetPc.Inst, 0, Pair))
+        appendCandidate(SetPcIndex, SetPcIndex, Match->second);
     }
+
+    // Tensile also emits a signed-direction materialized jump. The signed
+    // displacement is a link-time constant, but the sequence uses a generic
+    // compare/abs/add-or-sub shape:
+    //
+    //   get_pc Pair
+    //   add_co_i32 Delta, Literal, Imm
+    //   cmp_ge_i32 Delta, 0
+    //   cbranch_scc1 Positive
+    //   abs_i32 Delta, Delta
+    //   sub_co_u32/sub_co_ci_u32 Pair, Pair, Delta
+    //   set_pc Pair
+    // Positive:
+    //   add_co_u32/add_co_ci_u32 Pair, Pair, Delta
+    //   set_pc Pair
+    //
+    // Both set-PC instructions have the same finite target. Keep the entire
+    // shape in one audited materialization interval so an alternate entry
+    // into either arm invalidates both candidates.
+    if (I + 10 >= FunctionEndIndex)
+      continue;
+    const InternalDecodedInst &MakeDelta = Decoded[I + 1];
+    const InternalDecodedInst &Compare = Decoded[I + 2];
+    const InternalDecodedInst &Branch = Decoded[I + 3];
+    const InternalDecodedInst &Abs = Decoded[I + 4];
+    const InternalDecodedInst &SubLow = Decoded[I + 5];
+    const InternalDecodedInst &SubHigh = Decoded[I + 6];
+    const InternalDecodedInst &NegativeSetPc = Decoded[I + 7];
+    const InternalDecodedInst &AddLow = Decoded[I + 8];
+    const InternalDecodedInst &AddHigh = Decoded[I + 9];
+    const InternalDecodedInst &PositiveSetPc = Decoded[I + 10];
+    if (!MakeDelta.DecodeSucceeded || !Compare.DecodeSucceeded ||
+        !Branch.DecodeSucceeded || !Abs.DecodeSucceeded ||
+        !SubLow.DecodeSucceeded || !SubHigh.DecodeSucceeded ||
+        !NegativeSetPc.DecodeSucceeded || !AddLow.DecodeSucceeded ||
+        !AddHigh.DecodeSucceeded || !PositiveSetPc.DecodeSucceeded ||
+        MakeDelta.Mnemonic != "s_add_co_i32" ||
+        MakeDelta.Inst.getNumOperands() != 3 ||
+        !MakeDelta.Inst.getOperand(0).isReg() ||
+        !MakeDelta.Inst.getOperand(0).getReg() ||
+        !MakeDelta.Inst.getOperand(2).isImm())
+      continue;
+    MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
+    if (LS.MRI->regsOverlap(DeltaReg, Pair))
+      continue;
+    if (Compare.Mnemonic != "s_cmp_ge_i32" ||
+        Compare.Inst.getNumOperands() != 2 ||
+        !isExactRegisterOperand(Compare.Inst, 0, DeltaReg) ||
+        !Compare.Inst.getOperand(1).isImm() ||
+        Compare.Inst.getOperand(1).getImm() != 0 ||
+        Branch.Mnemonic != "s_cbranch_scc1" || Abs.Mnemonic != "s_abs_i32" ||
+        Abs.Inst.getNumOperands() != 2 ||
+        !isExactRegisterOperand(Abs.Inst, 0, DeltaReg) ||
+        !isExactRegisterOperand(Abs.Inst, 1, DeltaReg) ||
+        NegativeSetPc.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        NegativeSetPc.Inst.getNumOperands() != 1 ||
+        !isExactRegisterOperand(NegativeSetPc.Inst, 0, Pair) ||
+        PositiveSetPc.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        PositiveSetPc.Inst.getNumOperands() != 1 ||
+        !isExactRegisterOperand(PositiveSetPc.Inst, 0, Pair))
+      continue;
+    std::optional<uint64_t> PositiveLabel =
+        evaluateDirectControlFlowTarget(Branch, LS);
+    if (!PositiveLabel || *PositiveLabel != AddLow.Offset)
+      continue;
+
+    auto matchesPairArithmetic = [&](const InternalDecodedInst &Low,
+                                     const InternalDecodedInst &High,
+                                     StringRef LowMnemonic,
+                                     StringRef HighMnemonic) {
+      if (Low.Mnemonic != LowMnemonic || High.Mnemonic != HighMnemonic ||
+          Low.Inst.getNumOperands() != 3 || !Low.Inst.getOperand(0).isReg() ||
+          !Low.Inst.getOperand(1).isReg() || !Low.Inst.getOperand(0).getReg() ||
+          Low.Inst.getOperand(0).getReg() != Low.Inst.getOperand(1).getReg() ||
+          !isExactRegisterOperand(Low.Inst, 2, DeltaReg) ||
+          High.Inst.getNumOperands() != 3 || !High.Inst.getOperand(0).isReg() ||
+          !High.Inst.getOperand(1).isReg() ||
+          !High.Inst.getOperand(0).getReg() ||
+          High.Inst.getOperand(0).getReg() !=
+              High.Inst.getOperand(1).getReg() ||
+          !High.Inst.getOperand(2).isImm() ||
+          High.Inst.getOperand(2).getImm() != 0)
+        return false;
+      MCRegister LowReg(Low.Inst.getOperand(0).getReg());
+      MCRegister HighReg(High.Inst.getOperand(0).getReg());
+      std::optional<unsigned> LowIndex = numberedSgprIndex(*LS.MRI, LowReg);
+      std::optional<unsigned> HighIndex = numberedSgprIndex(*LS.MRI, HighReg);
+      return LowIndex && HighIndex && *HighIndex == *LowIndex + 1 &&
+             LS.MRI->regsOverlap(LowReg, Pair) &&
+             LS.MRI->regsOverlap(HighReg, Pair);
+    };
+    if (!matchesPairArithmetic(SubLow, SubHigh, "s_sub_co_u32",
+                               "s_sub_co_ci_u32") ||
+        !matchesPairArithmetic(AddLow, AddHigh, "s_add_co_u32",
+                               "s_add_co_ci_u32"))
+      continue;
+
+    std::optional<uint32_t> FirstAddend =
+        evaluateAbsoluteUint32Operand(MakeDelta.Inst.getOperand(1));
+    if (!FirstAddend)
+      continue;
+    uint32_t DeltaBits =
+        *FirstAddend +
+        static_cast<uint32_t>(MakeDelta.Inst.getOperand(2).getImm());
+    int64_t SignedDelta = static_cast<int32_t>(DeltaBits);
+    std::optional<uint64_t> PcValue = checkedAddUint64(
+        *GetPcAddress, GetPc.Size, "signed finite set-PC get-PC value");
+    if (!PcValue)
+      continue;
+    uint64_t Target = *PcValue + static_cast<uint64_t>(SignedDelta);
+    appendCandidate(I + 7, I + 10, Target);
+    appendCandidate(I + 10, I + 10, Target);
+  }
+  llvm::sort(Candidates, [](const FiniteSetPcTransfer &LHS,
+                            const FiniteSetPcTransfer &RHS) {
+    return LHS.InstIndex < RHS.InstIndex;
+  });
+  Candidates.erase(std::unique(Candidates.begin(), Candidates.end(),
+                               [](const FiniteSetPcTransfer &LHS,
+                                  const FiniteSetPcTransfer &RHS) {
+                                 return LHS.InstIndex == RHS.InstIndex;
+                               }),
+                   Candidates.end());
+  return Candidates;
+}
+
+static BitVector computeStaticallyReachableInstructions(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers) {
+  BitVector Reachable(Decoded.size());
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+  DenseMap<size_t, const FiniteSetPcTransfer *> TransferByInst;
+  for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
+    TransferByInst.try_emplace(Transfer.InstIndex, &Transfer);
+
+  SmallVector<size_t, 32> Worklist;
+  auto addRoot = [&](uint64_t Offset) {
+    DenseMap<uint64_t, size_t>::const_iterator It = OffsetToIndex.find(Offset);
+    if (It != OffsetToIndex.end())
+      Worklist.push_back(It->second);
+  };
+  for (uint64_t Entry : DeclaredEntries)
+    addRoot(Entry);
+  for (uint64_t Entry : ExternalEntries)
+    addRoot(Entry);
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin >= TextAddr)
+      addRoot(Range.Begin - TextAddr);
+  if (Worklist.empty() && !Decoded.empty())
+    Worklist.push_back(0);
+
+  while (!Worklist.empty()) {
+    size_t I = Worklist.pop_back_val();
+    if (Reachable.test(I))
+      continue;
+    Reachable.set(I);
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!DI.DecodeSucceeded)
+      continue;
+    auto addOffset = [&](uint64_t Offset) {
+      DenseMap<uint64_t, size_t>::const_iterator It =
+          OffsetToIndex.find(Offset);
+      if (It != OffsetToIndex.end())
+        Worklist.push_back(It->second);
+    };
     if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
         DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
         LS.MIA->isReturn(DI.Inst))
       continue;
-    if (LS.MIA->isIndirectBranch(DI.Inst) ||
-        DI.Inst.getOpcode() == LS.SAddPcI64Opcode)
-      return false;
-
-    bool HasFallthrough = true;
-    if (LS.MIA->isBranch(DI.Inst)) {
-      std::optional<uint64_t> BranchTarget =
-          getDirectTextTarget(DI, LS, TextAddr, TextEnd);
-      if (!BranchTarget || *BranchTarget < CalleeBegin ||
-          *BranchTarget >= CalleeEnd)
-        return false;
-      HasFallthrough = !LS.MIA->isUnconditionalBranch(DI.Inst);
-    }
-    if (!HasFallthrough)
+    if (LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Fallthrough = checkedAddUint64(
+          DI.Offset, DI.Size, "finite set-PC call continuation");
+      if (Fallthrough)
+        addOffset(*Fallthrough);
       continue;
-    std::optional<uint64_t> Fallthrough =
-        checkedAddUint64(DI.Offset, DI.Size, "reusable callee fallthrough");
-    if (!Fallthrough || *Fallthrough >= CalleeEnd)
-      return false;
+    }
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
+        LS.MIA->isIndirectBranch(DI.Inst)) {
+      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator Transfer =
+          TransferByInst.find(I);
+      if (Transfer != TransferByInst.end() &&
+          Transfer->second->LocalTargetIndex)
+        Worklist.push_back(*Transfer->second->LocalTargetIndex);
+      continue;
+    }
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (Target)
+        addOffset(*Target);
+      if (LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    }
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "finite set-PC reachability fallthrough");
+    if (Fallthrough)
+      addOffset(*Fallthrough);
   }
-  return SawInstruction;
+  return Reachable;
+}
+
+static SmallVector<FiniteSetPcTransfer, 8> selectLeastReachableSetPcCandidates(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr,
+    ArrayRef<FiniteSetPcTransfer> AllCandidates,
+    const BitVector &ProvenCandidates, const BitVector &RejectedCandidates) {
+  SmallVector<FiniteSetPcTransfer, 8> Selected;
+  BitVector SelectedBits(AllCandidates.size());
+  for (size_t I = 0; I != AllCandidates.size(); ++I)
+    if (ProvenCandidates.test(I) && !RejectedCandidates.test(I)) {
+      SelectedBits.set(I);
+      Selected.push_back(AllCandidates[I]);
+    }
+  for (;;) {
+    BitVector Reachable = computeStaticallyReachableInstructions(
+        Decoded, LS, DeclaredEntries, ExternalEntries, FunctionRanges, TextAddr,
+        Selected);
+    bool Changed = false;
+    for (size_t I = 0; I != AllCandidates.size(); ++I) {
+      if (RejectedCandidates.test(I) || SelectedBits.test(I) ||
+          !Reachable.test(AllCandidates[I].InstIndex))
+        continue;
+      SelectedBits.set(I);
+      Selected.push_back(AllCandidates[I]);
+      Changed = true;
+    }
+    if (!Changed)
+      return Selected;
+  }
 }
 
 /// Resolve register calls whose target pair is selected once and reused across
@@ -1768,8 +2024,7 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-    ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
-    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint8_t> Text) {
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
   std::vector<ReachingCallTargets> Resolved(Decoded.size());
   SmallVector<ReachingCallGroup, 8> Groups;
   DenseMap<size_t, const FiniteSetPcTransfer *> FiniteSetPcByInst;
@@ -1831,15 +2086,15 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
 
   for (const ReachingCallGroup &Group : Groups) {
     ArrayRef<InternalDecodedInst>::const_iterator Begin =
-        std::lower_bound(Decoded.begin(), Decoded.end(), Group.Begin,
-                         [](const InternalDecodedInst &DI, uint64_t Offset) {
-                           return DI.Offset < Offset;
-                         });
-    ArrayRef<InternalDecodedInst>::const_iterator End =
-        std::lower_bound(Begin, Decoded.end(), Group.End,
-                         [](const InternalDecodedInst &DI, uint64_t Offset) {
-                           return DI.Offset < Offset;
-                         });
+        llvm::lower_bound(Decoded, Group.Begin,
+                          [](const InternalDecodedInst &DI, uint64_t Offset) {
+                            return DI.Offset < Offset;
+                          });
+    ArrayRef<InternalDecodedInst>::const_iterator End = std::lower_bound(
+        Begin, Decoded.end(), Group.End,
+        [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
     size_t BeginIndex = static_cast<size_t>(Begin - Decoded.begin());
     size_t EndIndex = static_cast<size_t>(End - Decoded.begin());
     if (BeginIndex == EndIndex)
@@ -1943,15 +2198,29 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
       }
 
       bool IsReusableCall = llvm::is_contained(Group.Calls, I);
-      bool HasFiniteTargets = IsReusableCall && !State.HasUnknown &&
-                              State.ActiveMaterializations.empty() &&
-                              !State.Targets.empty();
-      if (HasFiniteTargets)
+      bool HasFiniteState = !State.HasUnknown &&
+                            State.ActiveMaterializations.empty() &&
+                            !State.Targets.empty();
+      if (IsReusableCall && HasFiniteState)
         Resolved[I] = State.Targets;
 
-      bool CalleesPreserve =
-          HasFiniteTargets && DI.Inst.getNumOperands() != 0 &&
-          DI.Inst.getOperand(0).isReg() && DI.Inst.getOperand(0).getReg();
+      // The first call after a straight-line materialization is also resolved
+      // by the one-shot matcher. Let that bootstrap call preserve the reaching
+      // value only when both analyses prove the same singleton target through
+      // this exact target pair.
+      bool IsMatchingBootstrapCall = false;
+      if (LocalCalls[I] && HasFiniteState && State.Targets.size() == 1 &&
+          State.Targets.front() == LocalCalls[I]->Target &&
+          DI.Inst.getNumOperands() >= 2) {
+        const MCOperand &TargetOp =
+            DI.Inst.getOperand(DI.Inst.getNumOperands() - 1);
+        IsMatchingBootstrapCall =
+            TargetOp.isReg() && TargetOp.getReg() == Group.TargetRegister;
+      }
+      bool CalleesPreserve = (IsReusableCall || IsMatchingBootstrapCall) &&
+                             HasFiniteState && DI.Inst.getNumOperands() != 0 &&
+                             DI.Inst.getOperand(0).isReg() &&
+                             DI.Inst.getOperand(0).getReg();
       if (CalleesPreserve) {
         MCRegister ReturnRegister(DI.Inst.getOperand(0).getReg());
         uint64_t RegisterKey = static_cast<uint64_t>(Group.TargetRegister.id())
@@ -3388,13 +3657,18 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   if (!TextEnd)
     return std::nullopt;
 
-  SmallVector<std::optional<PcMaterializedCallInfo>, 16> MaterializedCalls(
-      Decoded.size());
-  for (size_t I = 0; I != Decoded.size(); ++I)
-    MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
-  std::vector<ReachingCallTargets> ReusableCalls = resolveReusablePcCallTargets(
-      Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls,
-      DeclaredEntries, Text);
+  SmallVector<FiniteSetPcTransfer, 8> AllSetPcCandidates =
+      collectFiniteSetPcCandidates(Decoded, LS, TextAddr, *TextEnd,
+                                   FunctionRanges);
+  BitVector RejectedSetPcCandidates(AllSetPcCandidates.size());
+  BitVector ProvenSetPcCandidates(AllSetPcCandidates.size());
+  SmallVector<FiniteSetPcTransfer, 8> EnabledSetPcTransfers;
+  std::vector<ReachingCallTargets> ReusableCalls;
+  std::optional<ControlFlowScanIndex> Index;
+  SmallVector<BoundedSetPcReturn, 2> BoundedReturns;
+  SmallVector<SymbolLessReturnRegion, 8> SymbolLessRegions;
+  bool IndirectControlFlowClosed = false;
+  bool HasUnboundedIndirectEntries = false;
 
   // Exact set-PC edges are an optimistic over-approximation used only to
   // discover later finite call targets. Rebuild from scratch whenever the

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -30,6 +30,7 @@
 #include "comgr-env.h"
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
@@ -43,6 +44,7 @@
 #include <cstdio>
 #include <limits>
 #include <mutex>
+#include <tuple>
 
 using namespace llvm;
 
@@ -1990,39 +1992,31 @@ struct ExternalCallContinuation {
   uint64_t Continuation = 0;
 };
 
-struct KnownCallSites {
-  SmallVector<KnownCallSite, 4> Local;
-  SmallVector<ExternalCallContinuation, 4> External;
-};
-
 struct BoundedSetPcReturn {
   size_t InstIndex = 0;
   SmallVector<uint64_t, 2> Targets;
 };
 
-struct DirectTextEntry {
+struct DirectTargetSource {
+  size_t InstIndex = 0;
   uint64_t Target = 0;
-  size_t SourceIndex = 0;
 };
 
-struct KnownCallEntry {
-  uint64_t Entry = 0;
-  size_t CallIndex = 0;
+struct FallthroughEntryInfo {
+  bool Proven = false;
+  uint64_t ChainBegin = 0;
 };
 
-static bool compareDirectTextEntries(const DirectTextEntry &LHS,
-                                     const DirectTextEntry &RHS) {
-  if (LHS.Target != RHS.Target)
-    return LHS.Target < RHS.Target;
-  return LHS.SourceIndex < RHS.SourceIndex;
-}
-
-static bool compareKnownCallEntries(const KnownCallEntry &LHS,
-                                    const KnownCallEntry &RHS) {
-  if (LHS.Entry != RHS.Entry)
-    return LHS.Entry < RHS.Entry;
-  return LHS.CallIndex < RHS.CallIndex;
-}
+struct ControlFlowScanIndex {
+  DenseMap<size_t, PcMaterializedCallInfo> MaterializedCalls;
+  DenseMap<uint64_t, FallthroughEntryInfo> FallthroughEntries;
+  SmallVector<KnownCallSite, 4> Calls;
+  SmallVector<ExternalCallContinuation, 4> ExternalCallContinuations;
+  SmallVector<size_t, 16> SetPcIndices;
+  SmallVector<size_t, 16> BranchOrCallIndices;
+  SmallVector<DirectTargetSource, 16> DirectTargetsByTarget;
+  bool HasUnboundedIndirectEntry = false;
+};
 
 static bool hasPcRelativeOperand(const InternalDecodedInst &DI,
                                  const LLVMState &LS) {
@@ -2064,138 +2058,153 @@ getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
   return AbsoluteTarget - TextAddr;
 }
 
-static std::optional<KnownCallSites> collectKnownCallSites(
-    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-    uint64_t TextAddr, uint64_t TextEnd,
-    ArrayRef<std::optional<PcMaterializedCallInfo>> MaterializedCalls,
-    ArrayRef<ReachingCallTargets> ReusableCalls) {
-  KnownCallSites Calls;
-  uint64_t TextSize = TextEnd - TextAddr;
+static std::optional<ControlFlowScanIndex>
+buildControlFlowScanIndex(ArrayRef<InternalDecodedInst> Decoded,
+                          const LLVMState &LS, uint64_t TextAddr,
+                          uint64_t TextEnd,
+                          ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
+  ControlFlowScanIndex Index;
+  DenseSet<uint64_t> FunctionBegins;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin >= TextAddr && Range.Begin < TextEnd)
+      FunctionBegins.insert(Range.Begin - TextAddr);
+
+  bool FallthroughProven = true;
+  uint64_t FallthroughChainBegin = 0;
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &DI = Decoded[I];
-    std::optional<MCRegister> ReturnRegister = getCallReturnRegister(DI, LS);
-    if (!ReturnRegister)
-      continue;
+    if (I == 0) {
+      FallthroughChainBegin = DI.Offset;
+    } else {
+      const InternalDecodedInst &Predecessor = Decoded[I - 1];
+      bool EndOverflows =
+          Predecessor.Offset >
+          std::numeric_limits<uint64_t>::max() - Predecessor.Size;
+      if (EndOverflows || Predecessor.Offset + Predecessor.Size != DI.Offset ||
+          !Predecessor.DecodeSucceeded) {
+        FallthroughProven = false;
+        FallthroughChainBegin = DI.Offset;
+      } else if (LS.MIA->isBarrier(Predecessor.Inst)) {
+        FallthroughProven = true;
+        FallthroughChainBegin = DI.Offset;
+      }
+    }
+    if (FunctionBegins.contains(DI.Offset))
+      Index.FallthroughEntries.try_emplace(
+          DI.Offset,
+          FallthroughEntryInfo{FallthroughProven, FallthroughChainBegin});
 
-    SmallVector<uint64_t, 8> LocalTargets;
-    bool HasFiniteExternalTarget = false;
-    if (MaterializedCalls[I]) {
-      uint64_t AbsoluteTarget = MaterializedCalls[I]->Target;
-      if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
-        LocalTargets.push_back(AbsoluteTarget - TextAddr);
-      else
-        HasFiniteExternalTarget = true;
-    } else if (!ReusableCalls[I].empty()) {
-      if (llvm::any_of(ReusableCalls[I], [TextAddr, TextEnd](uint64_t Target) {
-            return Target < TextAddr || Target >= TextEnd;
-          }))
-        continue;
-      for (uint64_t AbsoluteTarget : ReusableCalls[I])
-        LocalTargets.push_back(AbsoluteTarget - TextAddr);
-    } else if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
-               DI.Inst.getNumOperands() != 0 &&
-               DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
-      uint64_t AbsoluteTarget = static_cast<uint64_t>(
-          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
-      if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
-        LocalTargets.push_back(AbsoluteTarget - TextAddr);
-      else
-        HasFiniteExternalTarget = true;
-    } else if (hasPcRelativeOperand(DI, LS)) {
-      std::optional<uint64_t> RelativeTarget =
-          evaluateDirectControlFlowTarget(DI, LS);
-      if (RelativeTarget) {
-        if (*RelativeTarget < TextSize)
-          LocalTargets.push_back(*RelativeTarget);
+    std::optional<PcMaterializedCallInfo> Materialized =
+        matchPcMaterializedCall(Decoded, I, LS, TextAddr);
+    if (Materialized)
+      Index.MaterializedCalls.try_emplace(I, *Materialized);
+
+    std::optional<MCRegister> ReturnRegister = getCallReturnRegister(DI, LS);
+    if (ReturnRegister) {
+      std::optional<uint64_t> Target;
+      bool HasFiniteExternalTarget = false;
+      if (Materialized) {
+        uint64_t AbsoluteTarget = Materialized->Target;
+        if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
+          Target = AbsoluteTarget - TextAddr;
         else
           HasFiniteExternalTarget = true;
+      } else if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
+                 DI.Inst.getNumOperands() != 0 &&
+                 DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
+        uint64_t AbsoluteTarget = static_cast<uint64_t>(
+            DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
+        if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
+          Target = AbsoluteTarget - TextAddr;
+        else
+          HasFiniteExternalTarget = true;
+      } else if (hasPcRelativeOperand(DI, LS)) {
+        std::optional<uint64_t> RelativeTarget =
+            evaluateDirectControlFlowTarget(DI, LS);
+        if (RelativeTarget) {
+          if (*RelativeTarget < TextEnd - TextAddr)
+            Target = *RelativeTarget;
+          else
+            HasFiniteExternalTarget = true;
+        }
+      } else {
+        Target = getDirectTextTarget(DI, LS, TextAddr, TextEnd);
       }
-    } else if (std::optional<uint64_t> Target =
-                   getDirectTextTarget(DI, LS, TextAddr, TextEnd)) {
-      LocalTargets.push_back(*Target);
+      if (Target || HasFiniteExternalTarget) {
+        std::optional<uint64_t> Continuation = checkedAddUint64(
+            DI.Offset, DI.Size, "known call continuation address");
+        if (!Continuation)
+          return std::nullopt;
+        uint64_t TextSize = TextEnd - TextAddr;
+        if (*Continuation >= TextSize ||
+            (*Continuation & (MinInstSize - 1)) != 0) {
+          log() << "hotswap: call at 0x" << utohexstr(DI.Offset)
+                << " has no aligned continuation inside .text\n";
+          return std::nullopt;
+        }
+        if (Target)
+          Index.Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
+        if (HasFiniteExternalTarget)
+          Index.ExternalCallContinuations.push_back({I, *Continuation});
+      }
     }
-    if (LocalTargets.empty() && !HasFiniteExternalTarget)
+
+    if (DI.DecodeSucceeded && DI.Inst.getOpcode() == LS.SSetPcI64Opcode)
+      Index.SetPcIndices.push_back(I);
+
+    // Set-PC returns are checked separately against BoundedReturnPositions.
+    // MC lowering erases their return pseudo identity, so including them in
+    // this generic bucket would make even a proven bounded return look like
+    // an arbitrary object-wide entry.
+    if (DI.DecodeSucceeded && DI.Inst.getOpcode() != LS.SSetPcI64Opcode &&
+        !LS.MIA->isReturn(DI.Inst) &&
+        (LS.MIA->isIndirectBranch(DI.Inst) ||
+         DI.Inst.getOpcode() == LS.SAddPcI64Opcode))
+      Index.HasUnboundedIndirectEntry = true;
+
+    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+        LS.MIA->isReturn(DI.Inst))
       continue;
+    Index.BranchOrCallIndices.push_back(I);
 
-    std::optional<uint64_t> Continuation =
-        checkedAddUint64(DI.Offset, DI.Size, "known call continuation address");
-    if (!Continuation)
-      return std::nullopt;
-    // A returning call must have a local, aligned continuation. In
-    // particular, the byte just past the final .text instruction is not a
-    // target inside .text and must never enter DirectControlFlowInfo::Targets.
-    // Reject the complete proof instead of silently treating a malformed or
-    // non-returning call as an ordinary finite call.
-    if (*Continuation >= TextSize || (*Continuation & (MinInstSize - 1)) != 0) {
-      log() << "hotswap: call at 0x" << utohexstr(DI.Offset)
-            << " has no aligned continuation inside .text\n";
-      return std::nullopt;
-    }
-    for (uint64_t Target : LocalTargets)
-      Calls.Local.push_back({I, Target, *Continuation, *ReturnRegister});
-    if (HasFiniteExternalTarget)
-      Calls.External.push_back({I, *Continuation});
+    std::optional<uint64_t> DirectTarget =
+        getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+    if (DirectTarget)
+      Index.DirectTargetsByTarget.push_back({I, *DirectTarget});
   }
-  return Calls;
+  llvm::sort(Index.DirectTargetsByTarget,
+             [](const DirectTargetSource &LHS, const DirectTargetSource &RHS) {
+               return std::tie(LHS.Target, LHS.InstIndex) <
+                      std::tie(RHS.Target, RHS.InstIndex);
+             });
+  return Index;
 }
 
-static size_t findDecodedIndexAtOrAfter(ArrayRef<InternalDecodedInst> Decoded,
-                                        uint64_t Offset) {
-  return std::lower_bound(Decoded.begin(), Decoded.end(), Offset,
-                          [](const InternalDecodedInst &DI, uint64_t Value) {
-                            return DI.Offset < Value;
-                          }) -
-         Decoded.begin();
-}
-
-static bool isSetPcReturnCandidate(const InternalDecodedInst &DI,
-                                   const LLVMState &LS) {
-  // AMDGPUMCInstLower lowers S_SETPC_B64_return to S_SETPC_B64, so the
-  // decoded instruction no longer carries MIA::isReturn identity. Recover
-  // only the bounded local-function form from its call/link dataflow.
-  return DI.DecodeSucceeded && DI.Inst.getOpcode() == LS.SSetPcI64Opcode &&
-         DI.Inst.getNumOperands() == 1 && DI.Inst.getOperand(0).isReg() &&
-         DI.Inst.getOperand(0).getReg();
-}
-
-static bool hasUnprovenFallthroughEntry(
-    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-    uint64_t FunctionBegin, uint64_t ReturnOffset,
-    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<KnownCallSite> Calls,
-    ArrayRef<ExternalCallContinuation> ExternalCalls,
-    ArrayRef<KnownCallEntry> CallEntries,
-    ArrayRef<DirectTextEntry> DirectEntries) {
+static bool hasUnprovenFallthroughEntry(ArrayRef<InternalDecodedInst> Decoded,
+                                        uint64_t FunctionBegin,
+                                        uint64_t ReturnOffset,
+                                        ArrayRef<uint64_t> DeclaredEntries,
+                                        const ControlFlowScanIndex &Index) {
   if (FunctionBegin == 0)
     return false;
 
-  size_t BeginIndex = findDecodedIndexAtOrAfter(Decoded, FunctionBegin);
-  if (BeginIndex == Decoded.size() ||
-      Decoded[BeginIndex].Offset != FunctionBegin) {
+  DenseMap<uint64_t, FallthroughEntryInfo>::const_iterator Fallthrough =
+      Index.FallthroughEntries.find(FunctionBegin);
+  if (Fallthrough == Index.FallthroughEntries.end()) {
     log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
           << " is not a bounded return: function entry at 0x"
           << utohexstr(FunctionBegin) << " is not an instruction boundary\n";
     return true;
   }
 
-  uint64_t ChainBegin = FunctionBegin;
-  size_t PredecessorIndex = BeginIndex;
-  while (PredecessorIndex != 0) {
-    const InternalDecodedInst &Predecessor = Decoded[PredecessorIndex - 1];
-    std::optional<uint64_t> PredecessorEnd = checkedAddUint64(
-        Predecessor.Offset, Predecessor.Size, "fallthrough predecessor end");
-    if (!PredecessorEnd || *PredecessorEnd != ChainBegin ||
-        !Predecessor.DecodeSucceeded) {
-      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
-            << " is not a bounded return: fallthrough into function entry "
-               "at 0x"
-            << utohexstr(FunctionBegin) << " is unprovable\n";
-      return true;
-    }
-    if (LS.MIA->isBarrier(Predecessor.Inst))
-      break;
-    ChainBegin = Predecessor.Offset;
-    --PredecessorIndex;
+  if (!Fallthrough->second.Proven) {
+    log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+          << " is not a bounded return: fallthrough into function entry "
+             "at 0x"
+          << utohexstr(FunctionBegin) << " is unprovable\n";
+    return true;
   }
+  uint64_t ChainBegin = Fallthrough->second.ChainBegin;
 
   if (ChainBegin == FunctionBegin)
     return false;
@@ -2211,25 +2220,27 @@ static bool hasUnprovenFallthroughEntry(
     return true;
   }
 
-  ArrayRef<KnownCallEntry>::iterator CallEntry =
-      std::lower_bound(CallEntries.begin(), CallEntries.end(), ChainBegin,
-                       [](const KnownCallEntry &Indexed, uint64_t Offset) {
-                         return Indexed.Entry < Offset;
-                       });
-  for (; CallEntry != CallEntries.end() && CallEntry->Entry < FunctionBegin;
-       ++CallEntry) {
-    const KnownCallSite &Call = Calls[CallEntry->CallIndex];
+  for (const KnownCallSite &Call : Index.Calls) {
     uint64_t Source = Decoded[Call.InstIndex].Offset;
     if (Source >= ChainBegin && Source < FunctionBegin)
       continue;
-    log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
-          << " is not a bounded return: call at 0x" << utohexstr(Source)
-          << " enters the fallthrough chain at 0x"
-          << utohexstr(CallEntry->Entry) << "\n";
-    return true;
+    if ((Call.Target >= ChainBegin && Call.Target < FunctionBegin) ||
+        (Call.Continuation >= ChainBegin &&
+         Call.Continuation < FunctionBegin)) {
+      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+            << " is not a bounded return: call at 0x" << utohexstr(Source)
+            << " enters the fallthrough chain at 0x"
+            << utohexstr(Call.Target >= ChainBegin &&
+                                 Call.Target < FunctionBegin
+                             ? Call.Target
+                             : Call.Continuation)
+            << "\n";
+      return true;
+    }
   }
 
-  for (const ExternalCallContinuation &Call : ExternalCalls) {
+  for (const ExternalCallContinuation &Call :
+       Index.ExternalCallContinuations) {
     uint64_t Source = Decoded[Call.InstIndex].Offset;
     if (Call.Continuation >= ChainBegin && Call.Continuation < FunctionBegin) {
       log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
@@ -2240,21 +2251,30 @@ static bool hasUnprovenFallthroughEntry(
     }
   }
 
-  ArrayRef<DirectTextEntry>::iterator DirectEntry =
-      std::lower_bound(DirectEntries.begin(), DirectEntries.end(), ChainBegin,
-                       [](const DirectTextEntry &Indexed, uint64_t Offset) {
-                         return Indexed.Target < Offset;
-                       });
-  for (; DirectEntry != DirectEntries.end() &&
-         DirectEntry->Target < FunctionBegin;
-       ++DirectEntry) {
-    const InternalDecodedInst &Source = Decoded[DirectEntry->SourceIndex];
+  SmallVector<DirectTargetSource, 16>::const_iterator FirstTarget =
+      llvm::lower_bound(Index.DirectTargetsByTarget, ChainBegin,
+                        [](const DirectTargetSource &Source, uint64_t Target) {
+                          return Source.Target < Target;
+                        });
+  size_t FirstSourceIndex = Decoded.size();
+  uint64_t FirstSourceTarget = 0;
+  for (SmallVector<DirectTargetSource, 16>::const_iterator It = FirstTarget;
+       It != Index.DirectTargetsByTarget.end() && It->Target < FunctionBegin;
+       ++It) {
+    const InternalDecodedInst &Source = Decoded[It->InstIndex];
     if (Source.Offset >= ChainBegin && Source.Offset < FunctionBegin)
       continue;
+    if (It->InstIndex < FirstSourceIndex) {
+      FirstSourceIndex = It->InstIndex;
+      FirstSourceTarget = It->Target;
+    }
+  }
+  if (FirstSourceIndex != Decoded.size()) {
     log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
           << " is not a bounded return: control flow at 0x"
-          << utohexstr(Source.Offset) << " enters the fallthrough chain at 0x"
-          << utohexstr(DirectEntry->Target) << "\n";
+          << utohexstr(Decoded[FirstSourceIndex].Offset)
+          << " enters the fallthrough chain at 0x"
+          << utohexstr(FirstSourceTarget) << "\n";
     return true;
   }
   return false;
@@ -2265,18 +2285,9 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
                            const LLVMState &LS, uint64_t TextAddr,
                            uint64_t TextEnd, ArrayRef<uint64_t> DeclaredEntries,
                            ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-                           ArrayRef<KnownCallSite> Calls,
-                           ArrayRef<ExternalCallContinuation> ExternalCalls,
-                           ArrayRef<uint64_t> ExternalEntries) {
-  SmallVector<size_t, 2> ReturnIndices;
-  for (size_t ReturnIndex = 0; ReturnIndex != Decoded.size(); ++ReturnIndex)
-    if (isSetPcReturnCandidate(Decoded[ReturnIndex], LS))
-      ReturnIndices.push_back(ReturnIndex);
-
+                           ArrayRef<uint64_t> ExternalEntries,
+                           const ControlFlowScanIndex &Index) {
   SmallVector<BoundedSetPcReturn, 2> Returns;
-  if (ReturnIndices.empty())
-    return Returns;
-
   SmallVector<uint64_t, 16> SortedDeclaredEntries(DeclaredEntries);
   llvm::sort(SortedDeclaredEntries);
   SortedDeclaredEntries.erase(
@@ -2289,30 +2300,48 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
       std::unique(SortedExternalEntries.begin(), SortedExternalEntries.end()),
       SortedExternalEntries.end());
 
-  SmallVector<DirectTextEntry, 16> DirectEntries;
-  for (size_t SourceIndex = 0; SourceIndex != Decoded.size(); ++SourceIndex)
-    if (std::optional<uint64_t> Target =
-            getDirectTextTarget(Decoded[SourceIndex], LS, TextAddr, TextEnd))
-      DirectEntries.push_back({*Target, SourceIndex});
-  llvm::sort(DirectEntries, compareDirectTextEntries);
-
-  SmallVector<KnownCallEntry, 8> CallsByTarget;
-  SmallVector<KnownCallEntry, 16> CallEntries;
-  for (size_t CallIndex = 0; CallIndex != Calls.size(); ++CallIndex) {
-    const KnownCallSite &Call = Calls[CallIndex];
-    CallsByTarget.push_back({Call.Target, CallIndex});
-    CallEntries.push_back({Call.Target, CallIndex});
-    CallEntries.push_back({Call.Continuation, CallIndex});
+  SmallVector<SmallVector<size_t, 2>, 16> CandidateRanges(
+      Index.SetPcIndices.size());
+  for (size_t RangeIndex = 0; RangeIndex != FunctionRanges.size();
+       ++RangeIndex) {
+    const ElfView::FunctionTextRange &Range = FunctionRanges[RangeIndex];
+    if (Range.End <= Range.Begin)
+      continue;
+    SmallVector<size_t, 16>::const_iterator First = llvm::lower_bound(
+        Index.SetPcIndices, Range.Begin,
+        [&](size_t InstIndex, uint64_t Address) {
+          return TextAddr + Decoded[InstIndex].Offset < Address;
+        });
+    SmallVector<size_t, 16>::const_iterator After = std::lower_bound(
+        First, Index.SetPcIndices.end(), Range.End,
+        [&](size_t InstIndex, uint64_t Address) {
+          return TextAddr + Decoded[InstIndex].Offset < Address;
+        });
+    for (SmallVector<size_t, 16>::const_iterator It = First; It != After;
+         ++It) {
+      size_t Position = static_cast<size_t>(It - Index.SetPcIndices.begin());
+      CandidateRanges[Position].push_back(RangeIndex);
+    }
   }
-  llvm::sort(CallsByTarget, compareKnownCallEntries);
-  llvm::sort(CallEntries, compareKnownCallEntries);
 
-  for (size_t ReturnIndex : ReturnIndices) {
+  for (size_t ReturnPosition = 0; ReturnPosition != Index.SetPcIndices.size();
+       ++ReturnPosition) {
+    size_t ReturnIndex = Index.SetPcIndices[ReturnPosition];
     const InternalDecodedInst &Return = Decoded[ReturnIndex];
+    // AMDGPUMCInstLower lowers S_SETPC_B64_return to S_SETPC_B64, so the
+    // decoded instruction no longer carries MIA::isReturn identity. Recover
+    // only the bounded local-function form from its call/link dataflow.
+    if (!Return.DecodeSucceeded ||
+        Return.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        Return.Inst.getNumOperands() != 1 ||
+        !Return.Inst.getOperand(0).isReg() ||
+        !Return.Inst.getOperand(0).getReg())
+      continue;
     MCRegister ReturnRegister(Return.Inst.getOperand(0).getReg());
 
     bool IsBounded = false;
-    for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+    for (size_t RangeIndex : CandidateRanges[ReturnPosition]) {
+      const ElfView::FunctionTextRange &Range = FunctionRanges[RangeIndex];
       if (Range.Begin < TextAddr || Range.Begin >= TextEnd ||
           Range.End <= Range.Begin || Range.End > TextEnd ||
           (Range.Symbol && Range.Symbol->getBinding() != ELF::STB_LOCAL))
@@ -2334,9 +2363,9 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
         continue;
       }
 
-      for (const ElfView::FunctionTextRange &Alias : FunctionRanges) {
-        if (Return.Offset + TextAddr < Alias.Begin ||
-            Return.Offset + TextAddr >= Alias.End || Alias.Begin == Range.Begin)
+      for (size_t AliasIndex : CandidateRanges[ReturnPosition]) {
+        const ElfView::FunctionTextRange &Alias = FunctionRanges[AliasIndex];
+        if (Alias.Begin == Range.Begin)
           continue;
         log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
               << " is not a bounded return: overlapping function entry at "
@@ -2360,20 +2389,26 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
         continue;
       }
 
-      if (hasUnprovenFallthroughEntry(
-              Decoded, LS, FunctionBegin, Return.Offset, SortedDeclaredEntries,
-              Calls, ExternalCalls, CallEntries, DirectEntries))
+      if (hasUnprovenFallthroughEntry(Decoded, FunctionBegin, Return.Offset,
+                                      SortedDeclaredEntries, Index))
         continue;
 
       // The link pair must retain the value written by the incoming call
       // throughout the function. This includes blocks laid out after the
       // return that may branch back into its epilogue.
-      size_t FunctionInstBegin =
-          findDecodedIndexAtOrAfter(Decoded, FunctionBegin);
-      size_t FunctionInstEnd = findDecodedIndexAtOrAfter(Decoded, FunctionEnd);
-      for (size_t InstIndex = FunctionInstBegin; InstIndex != FunctionInstEnd;
-           ++InstIndex) {
-        const InternalDecodedInst &DI = Decoded[InstIndex];
+      ArrayRef<InternalDecodedInst>::const_iterator FunctionFirst =
+          llvm::lower_bound(Decoded, FunctionBegin,
+                            [](const InternalDecodedInst &DI, uint64_t Offset) {
+                              return DI.Offset < Offset;
+                            });
+      ArrayRef<InternalDecodedInst>::const_iterator FunctionAfter =
+          std::lower_bound(FunctionFirst, Decoded.end(), FunctionEnd,
+                           [](const InternalDecodedInst &DI, uint64_t Offset) {
+                             return DI.Offset < Offset;
+                           });
+      for (ArrayRef<InternalDecodedInst>::const_iterator It = FunctionFirst;
+           It != FunctionAfter; ++It) {
+        const InternalDecodedInst &DI = *It;
         // MC call instructions carry no transitive callee-clobber information.
         // Without interprocedural proof, a nested callee may overwrite the
         // outer link pair even when the call defines a different return pair.
@@ -2398,13 +2433,9 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
         continue;
 
       SmallVector<uint64_t, 2> Targets;
-      SmallVector<KnownCallEntry, 8>::iterator CallAtTarget = std::lower_bound(
-          CallsByTarget.begin(), CallsByTarget.end(),
-          KnownCallEntry{FunctionBegin, 0}, compareKnownCallEntries);
-      for (; CallAtTarget != CallsByTarget.end() &&
-             CallAtTarget->Entry < FunctionEnd;
-           ++CallAtTarget) {
-        const KnownCallSite &Call = Calls[CallAtTarget->CallIndex];
+      for (const KnownCallSite &Call : Index.Calls) {
+        if (Call.Target < FunctionBegin || Call.Target >= FunctionEnd)
+          continue;
         if (Call.Target != FunctionBegin) {
           log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
                 << " is not a bounded return: call at 0x"
@@ -2430,37 +2461,38 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
       // A branch from outside the function would bypass the call link
       // definition. Direct calls to the function entry are allowed only when
       // they were collected above with this exact return register.
-      SmallVector<DirectTextEntry, 16>::iterator DirectEntry = std::lower_bound(
-          DirectEntries.begin(), DirectEntries.end(),
-          DirectTextEntry{FunctionBegin, 0}, compareDirectTextEntries);
-      for (; DirectEntry != DirectEntries.end() &&
-             DirectEntry->Target < FunctionEnd;
-           ++DirectEntry) {
-        size_t SourceIndex = DirectEntry->SourceIndex;
+      SmallVector<DirectTargetSource, 16>::const_iterator FirstTarget =
+          llvm::lower_bound(
+              Index.DirectTargetsByTarget, FunctionBegin,
+              [](const DirectTargetSource &Source, uint64_t Target) {
+                return Source.Target < Target;
+              });
+      size_t FirstUnsafeSourceIndex = Decoded.size();
+      uint64_t FirstUnsafeTarget = 0;
+      for (SmallVector<DirectTargetSource, 16>::const_iterator It = FirstTarget;
+           It != Index.DirectTargetsByTarget.end() && It->Target < FunctionEnd;
+           ++It) {
+        size_t SourceIndex = It->InstIndex;
         const InternalDecodedInst &Source = Decoded[SourceIndex];
         if (Source.Offset >= FunctionBegin && Source.Offset < FunctionEnd)
           continue;
 
         bool IsKnownEntryCall = false;
-        if (LS.MIA->isCall(Source.Inst) &&
-            DirectEntry->Target == FunctionBegin) {
-          ArrayRef<KnownCallSite>::iterator KnownCall =
-              std::lower_bound(Calls.begin(), Calls.end(), SourceIndex,
-                               [](const KnownCallSite &Call, size_t Index) {
-                                 return Call.InstIndex < Index;
-                               });
-          IsKnownEntryCall = KnownCall != Calls.end() &&
-                             KnownCall->InstIndex == SourceIndex &&
-                             KnownCall->ReturnRegister == ReturnRegister;
+        if (LS.MIA->isCall(Source.Inst) && It->Target == FunctionBegin)
+          for (const KnownCallSite &Call : Index.Calls)
+            IsKnownEntryCall |= Call.InstIndex == SourceIndex &&
+                                Call.ReturnRegister == ReturnRegister;
+        if (!IsKnownEntryCall && SourceIndex < FirstUnsafeSourceIndex) {
+          FirstUnsafeSourceIndex = SourceIndex;
+          FirstUnsafeTarget = It->Target;
         }
-        if (!IsKnownEntryCall) {
-          log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
-                << " is not a bounded return: control flow at 0x"
-                << utohexstr(Source.Offset) << " enters at 0x"
-                << utohexstr(DirectEntry->Target) << "\n";
-          Safe = false;
-          break;
-        }
+      }
+      if (FirstUnsafeSourceIndex != Decoded.size()) {
+        log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+              << " is not a bounded return: control flow at 0x"
+              << utohexstr(Decoded[FirstUnsafeSourceIndex].Offset)
+              << " enters at 0x" << utohexstr(FirstUnsafeTarget) << "\n";
+        Safe = false;
       }
       if (!Safe)
         continue;
@@ -2478,54 +2510,41 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
   return Returns;
 }
 
-static const BoundedSetPcReturn *
-findBoundedSetPcReturn(ArrayRef<BoundedSetPcReturn> Returns, size_t InstIndex) {
-  for (const BoundedSetPcReturn &Return : Returns)
-    if (Return.InstIndex == InstIndex)
-      return &Return;
-  return nullptr;
-}
-
 static bool
-hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
-                         const LLVMState &LS, uint64_t TextAddr,
-                         uint64_t TextEnd, ArrayRef<uint64_t> DeclaredEntries,
+hasKnownControlFlowEntry(ArrayRef<uint64_t> DeclaredEntries,
                          ArrayRef<BoundedSetPcReturn> BoundedReturns,
+                         const DenseMap<size_t, size_t> &BoundedReturnPositions,
+                         const ControlFlowScanIndex &Index,
                          uint64_t SequenceStart, uint64_t SequenceEnd) {
   for (uint64_t Entry : DeclaredEntries)
     if (Entry > SequenceStart && Entry <= SequenceEnd)
       return true;
 
-  for (size_t I = 0; I != Decoded.size(); ++I) {
-    const InternalDecodedInst &DI = Decoded[I];
-    if (DI.DecodeSucceeded && DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
-      const BoundedSetPcReturn *Return =
-          findBoundedSetPcReturn(BoundedReturns, I);
-      if (!Return)
+  for (size_t InstIndex : Index.SetPcIndices) {
+    DenseMap<size_t, size_t>::const_iterator It =
+        BoundedReturnPositions.find(InstIndex);
+    if (It == BoundedReturnPositions.end())
+      return true;
+    const BoundedSetPcReturn &Return = BoundedReturns[It->second];
+    for (uint64_t Target : Return.Targets)
+      if (Target > SequenceStart && Target <= SequenceEnd)
         return true;
-      for (uint64_t Target : Return->Targets)
-        if (Target > SequenceStart && Target <= SequenceEnd)
-          return true;
-      continue;
-    }
-
-    // Without bounding an indirect target, it may enter at any instruction in
-    // the materialization. Keep the call unresolved rather than relying on
-    // the indirect transfer's containing function alone.
-    if (DI.DecodeSucceeded && !LS.MIA->isReturn(DI.Inst) &&
-        (LS.MIA->isIndirectBranch(DI.Inst) ||
-         DI.Inst.getOpcode() == LS.SAddPcI64Opcode))
-      return true;
-    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
-        LS.MIA->isReturn(DI.Inst))
-      continue;
-
-    std::optional<uint64_t> RelativeTarget =
-        getDirectTextTarget(DI, LS, TextAddr, TextEnd);
-    if (RelativeTarget && *RelativeTarget > SequenceStart &&
-        *RelativeTarget <= SequenceEnd)
-      return true;
   }
+
+  // Without bounding an indirect target, it may enter at any instruction in
+  // the materialization. Keep the call unresolved rather than relying on the
+  // indirect transfer's containing function alone.
+  if (Index.HasUnboundedIndirectEntry)
+    return true;
+
+  SmallVector<DirectTargetSource, 16>::const_iterator First =
+      llvm::upper_bound(Index.DirectTargetsByTarget, SequenceStart,
+                        [](uint64_t Target, const DirectTargetSource &Source) {
+                          return Target < Source.Target;
+                        });
+  if (First != Index.DirectTargetsByTarget.end() &&
+      First->Target <= SequenceEnd)
+    return true;
   return false;
 }
 
@@ -2547,37 +2566,71 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   if (!TextEnd)
     return std::nullopt;
 
+  std::optional<ControlFlowScanIndex> Index = buildControlFlowScanIndex(
+      Decoded, LS, TextAddr, *TextEnd, FunctionRanges);
+  if (!Index)
+    return std::nullopt;
+
   SmallVector<std::optional<PcMaterializedCallInfo>, 16> MaterializedCalls(
       Decoded.size());
-  for (size_t I = 0; I != Decoded.size(); ++I)
-    MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
+  for (const auto &Entry : Index->MaterializedCalls)
+    MaterializedCalls[Entry.first] = Entry.second;
   std::vector<ReachingCallTargets> ReusableCalls = resolveReusablePcCallTargets(
       Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls,
       DeclaredEntries, Text);
 
-  std::optional<KnownCallSites> Calls = collectKnownCallSites(
-      Decoded, LS, TextAddr, *TextEnd, MaterializedCalls, ReusableCalls);
-  if (!Calls)
-    return std::nullopt;
+  // Reusable targets are intentionally lower priority than an exact canonical
+  // one-shot materialization, matching the established call-site proof. Add
+  // only the non-canonical finite target sets to the sparse call index.
+  for (size_t I = 0; I != ReusableCalls.size(); ++I) {
+    if (ReusableCalls[I].empty() || Index->MaterializedCalls.contains(I))
+      continue;
+    std::optional<MCRegister> ReturnRegister =
+        getCallReturnRegister(Decoded[I], LS);
+    if (!ReturnRegister ||
+        llvm::any_of(ReusableCalls[I], [TextAddr, TextEnd](uint64_t Target) {
+          return Target < TextAddr || Target >= *TextEnd;
+        }))
+      continue;
+    std::optional<uint64_t> Continuation = checkedAddUint64(
+        Decoded[I].Offset, Decoded[I].Size,
+        "known reusable call continuation address");
+    if (!Continuation)
+      return std::nullopt;
+    if (*Continuation >= TextSize ||
+        (*Continuation & (MinInstSize - 1)) != 0) {
+      log() << "hotswap: call at 0x" << utohexstr(Decoded[I].Offset)
+            << " has no aligned continuation inside .text\n";
+      return std::nullopt;
+    }
+    for (uint64_t Target : ReusableCalls[I])
+      Index->Calls.push_back(
+          {I, Target - TextAddr, *Continuation, *ReturnRegister});
+  }
+
   std::optional<SmallVector<BoundedSetPcReturn, 2>> BoundedReturns =
       collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,
-                                 DeclaredEntries, FunctionRanges, Calls->Local,
-                                 Calls->External, ExternalEntries);
+                                 DeclaredEntries, FunctionRanges,
+                                 ExternalEntries, *Index);
   if (!BoundedReturns)
     return std::nullopt;
+  DenseMap<size_t, size_t> BoundedReturnPositions;
+  for (size_t I = 0; I != BoundedReturns->size(); ++I)
+    BoundedReturnPositions.try_emplace((*BoundedReturns)[I].InstIndex, I);
+
   // Canonical one-shot materializations also participate in the reusable
   // reaching-value solver so CFG joins can prove their exact path. Preserve
   // the established fail-closed entry proof once bounded returns are known:
   // an interior alias, fallthrough, or unbounded transfer may still bypass
   // the materialization even when its local dataflow token is exact.
   BitVector LocallyProvenMaterializedCalls(Decoded.size());
-  for (size_t I = 0; I != Decoded.size(); ++I) {
-    if (!MaterializedCalls[I] || ReusableCalls[I].empty())
+  for (const auto &Entry : Index->MaterializedCalls) {
+    size_t I = Entry.first;
+    if (ReusableCalls[I].empty())
       continue;
-    if (hasKnownControlFlowEntry(Decoded, LS, TextAddr, *TextEnd,
-                                 DeclaredEntries, *BoundedReturns,
-                                 MaterializedCalls[I]->SequenceStart,
-                                 MaterializedCalls[I]->SequenceEnd)) {
+    if (hasKnownControlFlowEntry(
+            DeclaredEntries, *BoundedReturns, BoundedReturnPositions, *Index,
+            Entry.second.SequenceStart, Entry.second.SequenceEnd)) {
       ReusableCalls[I].clear();
       continue;
     }
@@ -2590,14 +2643,12 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       Info.Targets.insert(Target);
     Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
   }
-  for (const ExternalCallContinuation &Call : Calls->External)
+  for (const ExternalCallContinuation &Call :
+       Index->ExternalCallContinuations)
     Info.Targets.insert(Call.Continuation);
 
-  for (size_t InstIndex = 0; InstIndex != Decoded.size(); ++InstIndex) {
+  for (size_t InstIndex : Index->BranchOrCallIndices) {
     const InternalDecodedInst &DI = Decoded[InstIndex];
-    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
-        LS.MIA->isReturn(DI.Inst))
-      continue;
     // Existing indirect branches are handled by
     // collectIndirectControlFlowFunctions(), which protects their containing
     // function from source relocation. Calls without a statically resolvable
@@ -2620,13 +2671,15 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
           DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
         Target = static_cast<uint64_t>(
             DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
-      } else if (MaterializedCalls[InstIndex] &&
-                 !hasKnownControlFlowEntry(
-                     Decoded, LS, TextAddr, *TextEnd, DeclaredEntries,
-                     *BoundedReturns,
-                     MaterializedCalls[InstIndex]->SequenceStart,
-                     MaterializedCalls[InstIndex]->SequenceEnd)) {
-        Target = MaterializedCalls[InstIndex]->Target;
+      } else {
+        DenseMap<size_t, PcMaterializedCallInfo>::const_iterator Materialized =
+            Index->MaterializedCalls.find(InstIndex);
+        if (Materialized != Index->MaterializedCalls.end() &&
+            !hasKnownControlFlowEntry(DeclaredEntries, *BoundedReturns,
+                                      BoundedReturnPositions, *Index,
+                                      Materialized->second.SequenceStart,
+                                      Materialized->second.SequenceEnd))
+          Target = Materialized->second.Target;
       }
       bool IsFiniteExternalMaterializedCall =
           MaterializedCalls[InstIndex] &&

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -34,6 +34,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/MC/MCExpr.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/MathExtras.h"
@@ -1571,6 +1572,18 @@ static bool isExactRegisterOperand(const MCInst &Inst, unsigned Index,
          Inst.getOperand(Index).getReg() == Reg;
 }
 
+static std::optional<uint32_t>
+evaluateAbsoluteUint32Operand(const MCOperand &Operand) {
+  if (Operand.isImm())
+    return static_cast<uint32_t>(Operand.getImm());
+  if (!Operand.isExpr())
+    return std::nullopt;
+  int64_t Value = 0;
+  if (!Operand.getExpr()->evaluateAsAbsolute(Value))
+    return std::nullopt;
+  return static_cast<uint32_t>(Value);
+}
+
 /// Recognize the two compiler-emitted ways a reusable register-call target is
 /// materialized. The first is the canonical get-PC/add-nc pair. Tensile also
 /// computes a 32-bit displacement in a temporary and propagates carry into the
@@ -1587,7 +1600,7 @@ static std::optional<std::pair<size_t, uint64_t>>
 matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
                                size_t GetPcIndex, size_t FunctionEndIndex,
                                MCRegister Pair, const LLVMState &LS,
-                               uint64_t TextAddr, ArrayRef<uint8_t> Text) {
+                               uint64_t TextAddr) {
   const InternalDecodedInst &GetPc = Decoded[GetPcIndex];
   if (!GetPc.DecodeSucceeded || GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
       !isExactRegisterOperand(GetPc.Inst, 0, Pair))
@@ -1630,8 +1643,9 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
       !MakeDelta.Inst.getOperand(2).isImm())
     return std::nullopt;
   MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
-  if (LS.MRI->regsOverlap(DeltaReg, Pair) ||
-      AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
+  if (LS.MRI->regsOverlap(DeltaReg, Pair))
+    return std::nullopt;
+  if (AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
       !AddLow.Inst.getOperand(1).isReg() ||
       !AddLow.Inst.getOperand(0).getReg() ||
       AddLow.Inst.getOperand(0).getReg() !=
@@ -1654,20 +1668,8 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
       !LS.MRI->regsOverlap(Low, Pair) || !LS.MRI->regsOverlap(High, Pair))
     return std::nullopt;
 
-  std::optional<uint32_t> FirstAddend;
-  if (MakeDelta.Inst.getOperand(1).isImm()) {
-    FirstAddend = static_cast<uint32_t>(MakeDelta.Inst.getOperand(1).getImm());
-  } else if (MakeDelta.Size == 2 * MinInstSize &&
-             MakeDelta.Offset <= Text.size() &&
-             MakeDelta.Size <= Text.size() - MakeDelta.Offset &&
-             Text[MakeDelta.Offset] == 0xff) {
-    // The disassembler represents a SOP2 literal source as its literal
-    // register marker, not as an immediate operand. Require the gfx12 SOP2
-    // src0 literal selector before interpreting the final dword as that
-    // literal; an ordinary register source is not a constant displacement.
-    FirstAddend = support::endian::read32le(Text.data() + MakeDelta.Offset +
-                                            MakeDelta.Size - MinInstSize);
-  }
+  std::optional<uint32_t> FirstAddend =
+      evaluateAbsoluteUint32Operand(MakeDelta.Inst.getOperand(1));
   if (!FirstAddend)
     return std::nullopt;
   uint32_t Delta = *FirstAddend +
@@ -1682,69 +1684,336 @@ struct ReachingCallGroup {
   SmallVector<size_t, 8> Calls;
 };
 
-static std::optional<uint64_t>
-getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
-                    uint64_t TextAddr, uint64_t TextEnd);
+struct FiniteSetPcTransfer {
+  size_t InstIndex = 0;
+  size_t SequenceBeginIndex = 0;
+  size_t SequenceEndIndex = 0;
+  uint64_t Target = 0;
+  std::optional<size_t> LocalTargetIndex;
+  uint64_t FunctionBegin = 0;
+  uint64_t FunctionEnd = 0;
+};
 
-/// A reusable target value remains valid after a call only when the exact local
-/// callee is fully decoded, returns through the call's link pair, and cannot
-/// transitively or directly clobber the target pair.
-static bool calleePreservesReusableTarget(
-    uint64_t Target, MCRegister TargetRegister, MCRegister ReturnRegister,
+static const ElfView::FunctionTextRange *
+findInnermostFunctionRange(uint64_t Address,
+                           ArrayRef<ElfView::FunctionTextRange> Ranges) {
+  const ElfView::FunctionTextRange *Best = nullptr;
+  for (const ElfView::FunctionTextRange &Range : Ranges)
+    if (Range.Begin <= Address && Address < Range.End &&
+        (!Best || Range.Begin > Best->Begin ||
+         (Range.Begin == Best->Begin && Range.End < Best->End)))
+      Best = &Range;
+  return Best;
+}
+
+/// Collect exact materialized s_set_pc_i64 transfers. These are candidates,
+/// not proofs: a later closed-world audit must still rule out an alternate
+/// entry into the materialization before the edge can authorize mutation.
+static SmallVector<FiniteSetPcTransfer, 8> collectFiniteSetPcCandidates(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
-  const ElfView::FunctionTextRange *Callee = nullptr;
-  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
-    if (Range.Begin == Target && Range.Begin >= TextAddr &&
-        Range.End > Range.Begin && Range.End <= TextEnd &&
-        (!Callee || Range.End < Callee->End))
-      Callee = &Range;
-  if (!Callee)
-    return false;
+  SmallVector<FiniteSetPcTransfer, 8> Candidates;
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
 
-  uint64_t CalleeBegin = Callee->Begin - TextAddr;
-  uint64_t CalleeEnd = Callee->End - TextAddr;
-  bool SawInstruction = false;
-  for (const InternalDecodedInst &DI : Decoded) {
-    if (DI.Offset < CalleeBegin || DI.Offset >= CalleeEnd)
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &GetPc = Decoded[I];
+    if (!GetPc.DecodeSucceeded ||
+        GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
+        GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+        !GetPc.Inst.getOperand(0).getReg())
       continue;
-    SawInstruction = true;
-    if (!DI.DecodeSucceeded || LS.MIA->isCall(DI.Inst) ||
-        definesOverlappingRegister(DI, LS, TargetRegister))
-      return false;
+    MCRegister Pair(GetPc.Inst.getOperand(0).getReg());
+    std::optional<uint64_t> GetPcAddress = checkedAddUint64(
+        TextAddr, GetPc.Offset, "finite set-PC get-PC address");
+    if (!GetPcAddress)
+      continue;
+    const ElfView::FunctionTextRange *Range =
+        findInnermostFunctionRange(*GetPcAddress, FunctionRanges);
+    if (!Range || Range->Begin < TextAddr || Range->End > TextEnd)
+      continue;
+    ArrayRef<InternalDecodedInst>::const_iterator FunctionEnd =
+        llvm::lower_bound(Decoded, Range->End - TextAddr,
+                          [](const InternalDecodedInst &DI, uint64_t Offset) {
+                            return DI.Offset < Offset;
+                          });
+    size_t FunctionEndIndex =
+        static_cast<size_t>(FunctionEnd - Decoded.begin());
+    auto appendCandidate = [&](size_t SetPcIndex, size_t SequenceEndIndex,
+                               uint64_t Target) {
+      for (size_t J = I; J <= SequenceEndIndex; ++J) {
+        if (!Decoded[J].DecodeSucceeded)
+          return;
+        if (J == SequenceEndIndex)
+          break;
+        std::optional<uint64_t> End =
+            checkedAddUint64(Decoded[J].Offset, Decoded[J].Size,
+                             "finite set-PC materialization instruction end");
+        if (!End || *End != Decoded[J + 1].Offset)
+          return;
+      }
+      std::optional<size_t> LocalTargetIndex;
+      if (Target >= TextAddr && Target < TextEnd) {
+        DenseMap<uint64_t, size_t>::const_iterator LocalTarget =
+            OffsetToIndex.find(Target - TextAddr);
+        // A local transfer to the middle of an instruction is not finite for
+        // purposes of safe rewriting.
+        if (LocalTarget == OffsetToIndex.end())
+          return;
+        LocalTargetIndex = LocalTarget->second;
+      }
+      Candidates.push_back({SetPcIndex, I, SequenceEndIndex, Target,
+                            LocalTargetIndex, Range->Begin - TextAddr,
+                            Range->End - TextAddr});
+    };
 
-    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
-      if (DI.Inst.getNumOperands() != 1 ||
-          !isExactRegisterOperand(DI.Inst, 0, ReturnRegister))
-        return false;
-      continue;
+    std::optional<std::pair<size_t, uint64_t>> Match =
+        matchReusablePcMaterialization(Decoded, I, FunctionEndIndex, Pair, LS,
+                                       TextAddr);
+    if (Match && Match->first + 1 < FunctionEndIndex) {
+      size_t SetPcIndex = Match->first + 1;
+      const InternalDecodedInst &SetPc = Decoded[SetPcIndex];
+      if (SetPc.DecodeSucceeded &&
+          SetPc.Inst.getOpcode() == LS.SSetPcI64Opcode &&
+          SetPc.Inst.getNumOperands() == 1 &&
+          isExactRegisterOperand(SetPc.Inst, 0, Pair))
+        appendCandidate(SetPcIndex, SetPcIndex, Match->second);
     }
+
+    // Tensile also emits a signed-direction materialized jump. The signed
+    // displacement is a link-time constant, but the sequence uses a generic
+    // compare/abs/add-or-sub shape:
+    //
+    //   get_pc Pair
+    //   add_co_i32 Delta, Literal, Imm
+    //   cmp_ge_i32 Delta, 0
+    //   cbranch_scc1 Positive
+    //   abs_i32 Delta, Delta
+    //   sub_co_u32/sub_co_ci_u32 Pair, Pair, Delta
+    //   set_pc Pair
+    // Positive:
+    //   add_co_u32/add_co_ci_u32 Pair, Pair, Delta
+    //   set_pc Pair
+    //
+    // Both set-PC instructions have the same finite target. Keep the entire
+    // shape in one audited materialization interval so an alternate entry
+    // into either arm invalidates both candidates.
+    if (I + 10 >= FunctionEndIndex)
+      continue;
+    const InternalDecodedInst &MakeDelta = Decoded[I + 1];
+    const InternalDecodedInst &Compare = Decoded[I + 2];
+    const InternalDecodedInst &Branch = Decoded[I + 3];
+    const InternalDecodedInst &Abs = Decoded[I + 4];
+    const InternalDecodedInst &SubLow = Decoded[I + 5];
+    const InternalDecodedInst &SubHigh = Decoded[I + 6];
+    const InternalDecodedInst &NegativeSetPc = Decoded[I + 7];
+    const InternalDecodedInst &AddLow = Decoded[I + 8];
+    const InternalDecodedInst &AddHigh = Decoded[I + 9];
+    const InternalDecodedInst &PositiveSetPc = Decoded[I + 10];
+    if (!MakeDelta.DecodeSucceeded || !Compare.DecodeSucceeded ||
+        !Branch.DecodeSucceeded || !Abs.DecodeSucceeded ||
+        !SubLow.DecodeSucceeded || !SubHigh.DecodeSucceeded ||
+        !NegativeSetPc.DecodeSucceeded || !AddLow.DecodeSucceeded ||
+        !AddHigh.DecodeSucceeded || !PositiveSetPc.DecodeSucceeded ||
+        MakeDelta.Mnemonic != "s_add_co_i32" ||
+        MakeDelta.Inst.getNumOperands() != 3 ||
+        !MakeDelta.Inst.getOperand(0).isReg() ||
+        !MakeDelta.Inst.getOperand(0).getReg() ||
+        !MakeDelta.Inst.getOperand(2).isImm())
+      continue;
+    MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
+    if (LS.MRI->regsOverlap(DeltaReg, Pair))
+      continue;
+    if (Compare.Mnemonic != "s_cmp_ge_i32" ||
+        Compare.Inst.getNumOperands() != 2 ||
+        !isExactRegisterOperand(Compare.Inst, 0, DeltaReg) ||
+        !Compare.Inst.getOperand(1).isImm() ||
+        Compare.Inst.getOperand(1).getImm() != 0 ||
+        Branch.Mnemonic != "s_cbranch_scc1" || Abs.Mnemonic != "s_abs_i32" ||
+        Abs.Inst.getNumOperands() != 2 ||
+        !isExactRegisterOperand(Abs.Inst, 0, DeltaReg) ||
+        !isExactRegisterOperand(Abs.Inst, 1, DeltaReg) ||
+        NegativeSetPc.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        NegativeSetPc.Inst.getNumOperands() != 1 ||
+        !isExactRegisterOperand(NegativeSetPc.Inst, 0, Pair) ||
+        PositiveSetPc.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        PositiveSetPc.Inst.getNumOperands() != 1 ||
+        !isExactRegisterOperand(PositiveSetPc.Inst, 0, Pair))
+      continue;
+    std::optional<uint64_t> PositiveLabel =
+        evaluateDirectControlFlowTarget(Branch, LS);
+    if (!PositiveLabel || *PositiveLabel != AddLow.Offset)
+      continue;
+
+    auto matchesPairArithmetic = [&](const InternalDecodedInst &Low,
+                                     const InternalDecodedInst &High,
+                                     StringRef LowMnemonic,
+                                     StringRef HighMnemonic) {
+      if (Low.Mnemonic != LowMnemonic || High.Mnemonic != HighMnemonic ||
+          Low.Inst.getNumOperands() != 3 || !Low.Inst.getOperand(0).isReg() ||
+          !Low.Inst.getOperand(1).isReg() || !Low.Inst.getOperand(0).getReg() ||
+          Low.Inst.getOperand(0).getReg() != Low.Inst.getOperand(1).getReg() ||
+          !isExactRegisterOperand(Low.Inst, 2, DeltaReg) ||
+          High.Inst.getNumOperands() != 3 || !High.Inst.getOperand(0).isReg() ||
+          !High.Inst.getOperand(1).isReg() ||
+          !High.Inst.getOperand(0).getReg() ||
+          High.Inst.getOperand(0).getReg() !=
+              High.Inst.getOperand(1).getReg() ||
+          !High.Inst.getOperand(2).isImm() ||
+          High.Inst.getOperand(2).getImm() != 0)
+        return false;
+      MCRegister LowReg(Low.Inst.getOperand(0).getReg());
+      MCRegister HighReg(High.Inst.getOperand(0).getReg());
+      std::optional<unsigned> LowIndex = numberedSgprIndex(*LS.MRI, LowReg);
+      std::optional<unsigned> HighIndex = numberedSgprIndex(*LS.MRI, HighReg);
+      return LowIndex && HighIndex && *HighIndex == *LowIndex + 1 &&
+             LS.MRI->regsOverlap(LowReg, Pair) &&
+             LS.MRI->regsOverlap(HighReg, Pair);
+    };
+    if (!matchesPairArithmetic(SubLow, SubHigh, "s_sub_co_u32",
+                               "s_sub_co_ci_u32") ||
+        !matchesPairArithmetic(AddLow, AddHigh, "s_add_co_u32",
+                               "s_add_co_ci_u32"))
+      continue;
+
+    std::optional<uint32_t> FirstAddend =
+        evaluateAbsoluteUint32Operand(MakeDelta.Inst.getOperand(1));
+    if (!FirstAddend)
+      continue;
+    uint32_t DeltaBits =
+        *FirstAddend +
+        static_cast<uint32_t>(MakeDelta.Inst.getOperand(2).getImm());
+    int64_t SignedDelta = static_cast<int32_t>(DeltaBits);
+    std::optional<uint64_t> PcValue = checkedAddUint64(
+        *GetPcAddress, GetPc.Size, "signed finite set-PC get-PC value");
+    if (!PcValue)
+      continue;
+    uint64_t Target = *PcValue + static_cast<uint64_t>(SignedDelta);
+    appendCandidate(I + 7, I + 10, Target);
+    appendCandidate(I + 10, I + 10, Target);
+  }
+  llvm::sort(Candidates, [](const FiniteSetPcTransfer &LHS,
+                            const FiniteSetPcTransfer &RHS) {
+    return LHS.InstIndex < RHS.InstIndex;
+  });
+  Candidates.erase(std::unique(Candidates.begin(), Candidates.end(),
+                               [](const FiniteSetPcTransfer &LHS,
+                                  const FiniteSetPcTransfer &RHS) {
+                                 return LHS.InstIndex == RHS.InstIndex;
+                               }),
+                   Candidates.end());
+  return Candidates;
+}
+
+static BitVector computeStaticallyReachableInstructions(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers) {
+  BitVector Reachable(Decoded.size());
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+  DenseMap<size_t, const FiniteSetPcTransfer *> TransferByInst;
+  for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
+    TransferByInst.try_emplace(Transfer.InstIndex, &Transfer);
+
+  SmallVector<size_t, 32> Worklist;
+  auto addRoot = [&](uint64_t Offset) {
+    DenseMap<uint64_t, size_t>::const_iterator It = OffsetToIndex.find(Offset);
+    if (It != OffsetToIndex.end())
+      Worklist.push_back(It->second);
+  };
+  for (uint64_t Entry : DeclaredEntries)
+    addRoot(Entry);
+  for (uint64_t Entry : ExternalEntries)
+    addRoot(Entry);
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin >= TextAddr)
+      addRoot(Range.Begin - TextAddr);
+  if (Worklist.empty() && !Decoded.empty())
+    Worklist.push_back(0);
+
+  while (!Worklist.empty()) {
+    size_t I = Worklist.pop_back_val();
+    if (Reachable.test(I))
+      continue;
+    Reachable.set(I);
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!DI.DecodeSucceeded)
+      continue;
+    auto addOffset = [&](uint64_t Offset) {
+      DenseMap<uint64_t, size_t>::const_iterator It =
+          OffsetToIndex.find(Offset);
+      if (It != OffsetToIndex.end())
+        Worklist.push_back(It->second);
+    };
     if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
         DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
         LS.MIA->isReturn(DI.Inst))
       continue;
-    if (LS.MIA->isIndirectBranch(DI.Inst) ||
-        DI.Inst.getOpcode() == LS.SAddPcI64Opcode)
-      return false;
-
-    bool HasFallthrough = true;
-    if (LS.MIA->isBranch(DI.Inst)) {
-      std::optional<uint64_t> BranchTarget =
-          getDirectTextTarget(DI, LS, TextAddr, TextEnd);
-      if (!BranchTarget || *BranchTarget < CalleeBegin ||
-          *BranchTarget >= CalleeEnd)
-        return false;
-      HasFallthrough = !LS.MIA->isUnconditionalBranch(DI.Inst);
-    }
-    if (!HasFallthrough)
+    if (LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Fallthrough = checkedAddUint64(
+          DI.Offset, DI.Size, "finite set-PC call continuation");
+      if (Fallthrough)
+        addOffset(*Fallthrough);
       continue;
-    std::optional<uint64_t> Fallthrough =
-        checkedAddUint64(DI.Offset, DI.Size, "reusable callee fallthrough");
-    if (!Fallthrough || *Fallthrough >= CalleeEnd)
-      return false;
+    }
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
+        LS.MIA->isIndirectBranch(DI.Inst)) {
+      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator Transfer =
+          TransferByInst.find(I);
+      if (Transfer != TransferByInst.end() &&
+          Transfer->second->LocalTargetIndex)
+        Worklist.push_back(*Transfer->second->LocalTargetIndex);
+      continue;
+    }
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (Target)
+        addOffset(*Target);
+      if (LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    }
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "finite set-PC reachability fallthrough");
+    if (Fallthrough)
+      addOffset(*Fallthrough);
   }
-  return SawInstruction;
+  return Reachable;
+}
+
+static SmallVector<FiniteSetPcTransfer, 8> selectLeastReachableSetPcCandidates(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr,
+    ArrayRef<FiniteSetPcTransfer> AllCandidates,
+    const BitVector &ProvenCandidates, const BitVector &RejectedCandidates) {
+  SmallVector<FiniteSetPcTransfer, 8> Selected;
+  BitVector SelectedBits(AllCandidates.size());
+  for (size_t I = 0; I != AllCandidates.size(); ++I)
+    if (ProvenCandidates.test(I) && !RejectedCandidates.test(I)) {
+      SelectedBits.set(I);
+      Selected.push_back(AllCandidates[I]);
+    }
+  for (;;) {
+    BitVector Reachable = computeStaticallyReachableInstructions(
+        Decoded, LS, DeclaredEntries, ExternalEntries, FunctionRanges, TextAddr,
+        Selected);
+    bool Changed = false;
+    for (size_t I = 0; I != AllCandidates.size(); ++I) {
+      if (RejectedCandidates.test(I) || SelectedBits.test(I) ||
+          !Reachable.test(AllCandidates[I].InstIndex))
+        continue;
+      SelectedBits.set(I);
+      Selected.push_back(AllCandidates[I]);
+      Changed = true;
+    }
+    if (!Changed)
+      return Selected;
+  }
 }
 
 /// Resolve register calls whose target pair is selected once and reused across
@@ -1755,10 +2024,12 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-    ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
-    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint8_t> Text) {
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
   std::vector<ReachingCallTargets> Resolved(Decoded.size());
   SmallVector<ReachingCallGroup, 8> Groups;
+  DenseMap<size_t, const FiniteSetPcTransfer *> FiniteSetPcByInst;
+  for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
+    FiniteSetPcByInst.try_emplace(Transfer.InstIndex, &Transfer);
 
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &Call = Decoded[I];
@@ -1834,8 +2105,8 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     DenseMap<size_t, SmallVector<size_t, 2>> Intermediates;
     for (size_t I = BeginIndex; I != EndIndex; ++I) {
       std::optional<std::pair<size_t, uint64_t>> Match =
-          matchReusablePcMaterialization(
-              Decoded, I, EndIndex, Group.TargetRegister, LS, TextAddr, Text);
+          matchReusablePcMaterialization(Decoded, I, EndIndex,
+                                         Group.TargetRegister, LS, TextAddr);
       if (Match) {
         Starters[I] = Match->first;
         Completions[Match->first] = Match->second;
@@ -1991,8 +2262,17 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
         // No successor.
       } else if (LS.MIA->isCall(DI.Inst)) {
         appendFallthrough();
-      } else if (LS.MIA->isIndirectBranch(DI.Inst)) {
-        // An indirect jump or bounded return leaves this intraprocedural path.
+      } else if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
+                 LS.MIA->isIndirectBranch(DI.Inst)) {
+        DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator
+            FiniteSetPc = FiniteSetPcByInst.find(I);
+        if (FiniteSetPc != FiniteSetPcByInst.end() &&
+            FiniteSetPc->second->LocalTargetIndex &&
+            *FiniteSetPc->second->LocalTargetIndex >= BeginIndex &&
+            *FiniteSetPc->second->LocalTargetIndex < EndIndex)
+          Successors.push_back(*FiniteSetPc->second->LocalTargetIndex);
+        // All other indirect jumps or bounded returns leave this
+        // intraprocedural path.
       } else if (LS.MIA->isBranch(DI.Inst)) {
         std::optional<uint64_t> Target =
             evaluateDirectControlFlowTarget(DI, LS);
@@ -2055,6 +2335,16 @@ static bool compareKnownCallEntries(const KnownCallEntry &LHS,
          std::tie(RHS.Entry, RHS.CallIndex);
 }
 
+struct ExternalCallContinuation {
+  size_t InstIndex = 0;
+  uint64_t Continuation = 0;
+};
+
+struct CallContinuationSource {
+  size_t InstIndex = 0;
+  uint64_t Continuation = 0;
+};
+
 struct FallthroughEntryInfo {
   bool Proven = false;
   uint64_t ChainBegin = 0;
@@ -2068,7 +2358,10 @@ struct ControlFlowScanIndex {
   SmallVector<KnownCallEntry, 8> CallsByTarget;
   SmallVector<KnownCallEntry, 16> CallEntries;
   DenseMap<size_t, MCRegister> CallReturnRegistersBySource;
+  SmallVector<CallContinuationSource, 4> CallContinuationsByOffset;
+  SmallVector<ExternalCallContinuation, 4> ExternalCallContinuations;
   SmallVector<size_t, 16> SetPcIndices;
+  SmallVector<size_t, 4> UnboundedIndirectIndices;
   SmallVector<size_t, 16> BranchOrCallIndices;
   SmallVector<DirectTargetSource, 16> DirectTargetsByTarget;
   bool HasUnboundedIndirectEntry = false;
@@ -2233,8 +2526,10 @@ buildControlFlowScanIndex(ArrayRef<InternalDecodedInst> Decoded,
     if (DI.DecodeSucceeded && DI.Inst.getOpcode() != LS.SSetPcI64Opcode &&
         !LS.MIA->isReturn(DI.Inst) &&
         (LS.MIA->isIndirectBranch(DI.Inst) ||
-         DI.Inst.getOpcode() == LS.SAddPcI64Opcode))
+         DI.Inst.getOpcode() == LS.SAddPcI64Opcode)) {
       Index.HasUnboundedIndirectEntry = true;
+      Index.UnboundedIndirectIndices.push_back(I);
+    }
 
     if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
         LS.MIA->isReturn(DI.Inst))
@@ -2413,7 +2708,6 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
       continue;
     MCRegister ReturnRegister(Return.Inst.getOperand(0).getReg());
 
-    bool IsBounded = false;
     for (size_t RangeIndex : CandidateRanges[ReturnPosition]) {
       const ElfView::FunctionTextRange &Range = FunctionRanges[RangeIndex];
       if (Range.Begin < TextAddr || Range.Begin >= TextEnd ||
@@ -2506,6 +2800,45 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
       if (!Safe)
         continue;
 
+      // A call that returns into this function does not supply its link pair
+      // at the function entry. Reject continuations at the exact entry as
+      // well as in the interior; the earlier fallthrough-chain check only
+      // covers bytes laid out before FunctionBegin.
+      SmallVector<CallContinuationSource, 4>::const_iterator Continuation =
+          llvm::lower_bound(
+              Index.CallContinuationsByOffset, FunctionBegin,
+              [](const CallContinuationSource &Source, uint64_t Offset) {
+                return Source.Continuation < Offset;
+              });
+      if (Continuation != Index.CallContinuationsByOffset.end() &&
+          Continuation->Continuation < FunctionEnd) {
+        log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+              << " is not a bounded return: call at 0x"
+              << utohexstr(Decoded[Continuation->InstIndex].Offset)
+              << " returns into the function at 0x"
+              << utohexstr(Continuation->Continuation) << "\n";
+        Safe = false;
+      }
+      if (!Safe)
+        continue;
+      SmallVector<ExternalCallContinuation, 4>::const_iterator
+          ExternalContinuation = llvm::lower_bound(
+              Index.ExternalCallContinuations, FunctionBegin,
+              [](const ExternalCallContinuation &Source, uint64_t Offset) {
+                return Source.Continuation < Offset;
+              });
+      if (ExternalContinuation != Index.ExternalCallContinuations.end() &&
+          ExternalContinuation->Continuation < FunctionEnd) {
+        log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+              << " is not a bounded return: external call at 0x"
+              << utohexstr(Decoded[ExternalContinuation->InstIndex].Offset)
+              << " returns into the function at 0x"
+              << utohexstr(ExternalContinuation->Continuation) << "\n";
+        Safe = false;
+      }
+      if (!Safe)
+        continue;
+
       SmallVector<uint64_t, 2> Targets;
       SmallVector<KnownCallEntry, 8>::const_iterator CallAtTarget =
           llvm::lower_bound(Index.CallsByTarget, FunctionBegin,
@@ -2583,14 +2916,623 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
       llvm::sort(Targets);
       Targets.erase(std::unique(Targets.begin(), Targets.end()), Targets.end());
       Returns.push_back({ReturnIndex, std::move(Targets)});
-      IsBounded = true;
       break;
     }
-    if (!IsBounded)
-      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
-            << " remains an unbounded indirect transfer\n";
   }
   return Returns;
+}
+
+static BitVector computeFiniteControlFlowReachability(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries,
+    ArrayRef<uint64_t> ExternalEntries,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    const ControlFlowScanIndex &Index,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers,
+    ArrayRef<BoundedSetPcReturn> BoundedReturns) {
+  BitVector Reachable(Decoded.size());
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+  DenseMap<size_t, const FiniteSetPcTransfer *> TransferByInst;
+  for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
+    TransferByInst.try_emplace(Transfer.InstIndex, &Transfer);
+  DenseMap<size_t, const BoundedSetPcReturn *> ReturnByInst;
+  for (const BoundedSetPcReturn &Return : BoundedReturns)
+    ReturnByInst.try_emplace(Return.InstIndex, &Return);
+  DenseMap<size_t, SmallVector<uint64_t, 2>> CallTargetsByInst;
+  for (const KnownCallSite &Call : Index.Calls) {
+    SmallVector<uint64_t, 2> &Targets = CallTargetsByInst[Call.InstIndex];
+    if (!llvm::is_contained(Targets, Call.Target))
+      Targets.push_back(Call.Target);
+  }
+
+  SmallVector<size_t, 32> Worklist;
+  auto addOffset = [&](uint64_t Offset) {
+    DenseMap<uint64_t, size_t>::const_iterator It = OffsetToIndex.find(Offset);
+    if (It != OffsetToIndex.end())
+      Worklist.push_back(It->second);
+  };
+  for (uint64_t Entry : DeclaredEntries)
+    addOffset(Entry);
+  for (uint64_t Entry : ExternalEntries)
+    addOffset(Entry);
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin >= TextAddr)
+      addOffset(Range.Begin - TextAddr);
+  if (Worklist.empty() && !Decoded.empty())
+    Worklist.push_back(0);
+
+  while (!Worklist.empty()) {
+    size_t I = Worklist.pop_back_val();
+    if (Reachable.test(I))
+      continue;
+    Reachable.set(I);
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!DI.DecodeSucceeded)
+      continue;
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      DenseMap<size_t, const FiniteSetPcTransfer *>::const_iterator Transfer =
+          TransferByInst.find(I);
+      if (Transfer != TransferByInst.end() &&
+          Transfer->second->LocalTargetIndex)
+        Worklist.push_back(*Transfer->second->LocalTargetIndex);
+      DenseMap<size_t, const BoundedSetPcReturn *>::const_iterator Return =
+          ReturnByInst.find(I);
+      if (Return != ReturnByInst.end())
+        for (uint64_t Target : Return->second->Targets)
+          if (Target < TextSize)
+            addOffset(Target);
+      continue;
+    }
+    if (LS.MIA->isCall(DI.Inst)) {
+      DenseMap<size_t, SmallVector<uint64_t, 2>>::const_iterator Targets =
+          CallTargetsByInst.find(I);
+      if (Targets != CallTargetsByInst.end())
+        for (uint64_t Target : Targets->second)
+          addOffset(Target);
+      std::optional<uint64_t> Fallthrough = checkedAddUint64(
+          DI.Offset, DI.Size, "finite call continuation reachability");
+      if (Fallthrough && *Fallthrough < TextSize)
+        addOffset(*Fallthrough);
+      continue;
+    }
+    if (LS.MIA->isIndirectBranch(DI.Inst) ||
+        DI.Inst.getOpcode() == LS.SAddPcI64Opcode)
+      continue;
+    if (LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (Target)
+        addOffset(*Target);
+      if (LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    }
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "finite control-flow reachability fallthrough");
+    if (Fallthrough && *Fallthrough < TextSize)
+      addOffset(*Fallthrough);
+  }
+  return Reachable;
+}
+
+struct SymbolLessReturnRegion {
+  uint64_t Entry = 0;
+  MCRegister LinkRegister;
+  SmallVector<size_t, 16> Instructions;
+  SmallVector<size_t, 2> Returns;
+  SmallVector<uint64_t, 8> Continuations;
+};
+
+static bool instructionMayFallThrough(const InternalDecodedInst &DI,
+                                      const LLVMState &LS) {
+  if (!DI.DecodeSucceeded)
+    return true;
+  if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+      DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+      LS.MIA->isReturn(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst))
+    return false;
+  return !LS.MIA->isBranch(DI.Inst) || !LS.MIA->isUnconditionalBranch(DI.Inst);
+}
+
+/// Prove symbol-less callable regions from finite call targets. This is
+/// intentionally based on forward CFG reachability from a concrete call
+/// target, rather than layout labels or source tails. Every entry into the
+/// resulting region must be one of the calls that supplies the exact link
+/// pair, and the pair must remain untouched until each s_set_pc_i64 return.
+static SmallVector<SymbolLessReturnRegion, 8> collectSymbolLessReturnRegions(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextSize,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    const ControlFlowScanIndex &Index,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers,
+    ArrayRef<BoundedSetPcReturn> PreviouslyBoundedReturns,
+    const BitVector &ReachableCallSources) {
+  struct CallGroup {
+    uint64_t Entry = 0;
+    MCRegister LinkRegister;
+    SmallVector<uint64_t, 8> Continuations;
+  };
+  SmallVector<CallGroup, 8> Groups;
+  DenseMap<std::pair<uint64_t, unsigned>, size_t> GroupPositions;
+  for (const KnownCallSite &Call : Index.Calls) {
+    if (!ReachableCallSources.test(Call.InstIndex))
+      continue;
+    std::pair<uint64_t, unsigned> Key{Call.Target, Call.ReturnRegister.id()};
+    auto Inserted = GroupPositions.try_emplace(Key, Groups.size());
+    if (Inserted.second) {
+      Groups.push_back({Call.Target, Call.ReturnRegister, {}});
+    }
+    Groups[Inserted.first->second].Continuations.push_back(Call.Continuation);
+  }
+
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex.try_emplace(Decoded[I].Offset, I);
+
+  SmallVector<SymbolLessReturnRegion, 8> Regions;
+  for (CallGroup &Group : Groups) {
+    DenseMap<uint64_t, size_t>::const_iterator Entry =
+        OffsetToIndex.find(Group.Entry);
+    if (Entry == OffsetToIndex.end())
+      continue;
+
+    SymbolLessReturnRegion Region;
+    Region.Entry = Group.Entry;
+    Region.LinkRegister = Group.LinkRegister;
+    llvm::sort(Group.Continuations);
+    Group.Continuations.erase(
+        std::unique(Group.Continuations.begin(), Group.Continuations.end()),
+        Group.Continuations.end());
+    Region.Continuations = Group.Continuations;
+
+    SmallVector<size_t, 32> Worklist{Entry->second};
+    BitVector Visited(Decoded.size());
+    bool Safe = true;
+    while (!Worklist.empty() && Safe) {
+      size_t I = Worklist.pop_back_val();
+      if (Visited.test(I))
+        continue;
+      Visited.set(I);
+      Region.Instructions.push_back(I);
+      const InternalDecodedInst &DI = Decoded[I];
+      if (!DI.DecodeSucceeded) {
+        Safe = false;
+        break;
+      }
+      if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+        if (DI.Inst.getNumOperands() != 1 ||
+            !isExactRegisterOperand(DI.Inst, 0, Group.LinkRegister)) {
+          Safe = false;
+          break;
+        }
+        Region.Returns.push_back(I);
+        continue;
+      }
+      if (LS.MIA->isCall(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
+          DI.Inst.getOpcode() == LS.SAddPcI64Opcode ||
+          LS.MIA->isReturn(DI.Inst) ||
+          definesOverlappingRegister(DI, LS, Group.LinkRegister)) {
+        Safe = false;
+        break;
+      }
+      if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+          DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode)
+        continue;
+
+      auto addSuccessor = [&](uint64_t Offset) {
+        DenseMap<uint64_t, size_t>::const_iterator It =
+            OffsetToIndex.find(Offset);
+        if (It == OffsetToIndex.end()) {
+          Safe = false;
+          return;
+        }
+        Worklist.push_back(It->second);
+      };
+      if (LS.MIA->isBranch(DI.Inst)) {
+        std::optional<uint64_t> Target =
+            evaluateDirectControlFlowTarget(DI, LS);
+        if (!Target || *Target >= TextSize) {
+          Safe = false;
+          break;
+        }
+        addSuccessor(*Target);
+        if (!Safe)
+          break;
+        if (LS.MIA->isUnconditionalBranch(DI.Inst))
+          continue;
+      }
+      std::optional<uint64_t> Fallthrough = checkedAddUint64(
+          DI.Offset, DI.Size, "symbol-less return fallthrough");
+      if (!Fallthrough || *Fallthrough >= TextSize) {
+        Safe = false;
+        break;
+      }
+      addSuccessor(*Fallthrough);
+    }
+    if (!Safe || Region.Returns.empty())
+      continue;
+    llvm::sort(Region.Instructions);
+    llvm::sort(Region.Returns);
+
+    auto containsInstructionByte = [&](uint64_t Offset) {
+      for (size_t InstIndex : Region.Instructions) {
+        const InternalDecodedInst &DI = Decoded[InstIndex];
+        std::optional<uint64_t> End = checkedAddUint64(
+            DI.Offset, DI.Size, "symbol-less return instruction end");
+        // Overflow is itself unprovable; conservatively treat the queried
+        // byte as overlapping the claimed region.
+        if (!End || (Offset >= DI.Offset && Offset < *End))
+          return true;
+      }
+      return false;
+    };
+    auto sourceIsInside = [&](size_t InstIndex) {
+      return llvm::is_contained(Region.Instructions, InstIndex);
+    };
+
+    for (uint64_t EntryOffset : DeclaredEntries)
+      if (containsInstructionByte(EntryOffset)) {
+        Safe = false;
+        break;
+      }
+    if (!Safe)
+      continue;
+    for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+      if (Range.Begin < TextAddr || Range.Begin - TextAddr >= TextSize)
+        continue;
+      uint64_t EntryOffset = Range.Begin - TextAddr;
+      if (EntryOffset != Region.Entry && containsInstructionByte(EntryOffset)) {
+        Safe = false;
+        break;
+      }
+    }
+    if (!Safe)
+      continue;
+    for (uint64_t EntryOffset : ExternalEntries)
+      if (containsInstructionByte(EntryOffset)) {
+        Safe = false;
+        break;
+      }
+    if (!Safe)
+      continue;
+
+    // Reject layout fallthrough from outside the reachable region.
+    for (size_t InstIndex : Region.Instructions) {
+      if (InstIndex == 0)
+        continue;
+      const InternalDecodedInst &DI = Decoded[InstIndex];
+      const InternalDecodedInst &Predecessor = Decoded[InstIndex - 1];
+      std::optional<uint64_t> PredecessorEnd =
+          checkedAddUint64(Predecessor.Offset, Predecessor.Size,
+                           "symbol-less return predecessor end");
+      if (sourceIsInside(InstIndex - 1))
+        continue;
+      if (!Predecessor.DecodeSucceeded || !PredecessorEnd ||
+          *PredecessorEnd != DI.Offset ||
+          instructionMayFallThrough(Predecessor, LS)) {
+        Safe = false;
+        break;
+      }
+    }
+    if (!Safe)
+      continue;
+
+    for (const KnownCallSite &Call : Index.Calls) {
+      bool TargetInside = containsInstructionByte(Call.Target);
+      bool ContinuationInside = containsInstructionByte(Call.Continuation);
+      if (!TargetInside && !ContinuationInside)
+        continue;
+      if (sourceIsInside(Call.InstIndex)) {
+        Safe = false;
+        break;
+      }
+      if (ContinuationInside || Call.Target != Region.Entry ||
+          Call.ReturnRegister != Region.LinkRegister) {
+        Safe = false;
+        break;
+      }
+    }
+    if (!Safe)
+      continue;
+    for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
+      if (containsInstructionByte(Call.Continuation)) {
+        Safe = false;
+        break;
+      }
+    if (!Safe)
+      continue;
+
+    for (const DirectTargetSource &Source : Index.DirectTargetsByTarget) {
+      if (!containsInstructionByte(Source.Target) ||
+          sourceIsInside(Source.InstIndex))
+        continue;
+      bool IsEntryCall = false;
+      for (const KnownCallSite &Call : Index.Calls)
+        IsEntryCall |= Call.InstIndex == Source.InstIndex &&
+                       Call.Target == Region.Entry &&
+                       Call.ReturnRegister == Region.LinkRegister;
+      if (!IsEntryCall) {
+        Safe = false;
+        break;
+      }
+    }
+    if (!Safe)
+      continue;
+
+    for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers) {
+      if (!Transfer.LocalTargetIndex ||
+          !llvm::is_contained(Region.Instructions,
+                              *Transfer.LocalTargetIndex) ||
+          sourceIsInside(Transfer.InstIndex))
+        continue;
+      Safe = false;
+      break;
+    }
+    if (!Safe)
+      continue;
+    for (const BoundedSetPcReturn &Return : PreviouslyBoundedReturns) {
+      if (sourceIsInside(Return.InstIndex))
+        continue;
+      for (uint64_t Target : Return.Targets)
+        if (containsInstructionByte(Target)) {
+          Safe = false;
+          break;
+        }
+      if (!Safe)
+        break;
+    }
+    if (Safe)
+      Regions.push_back(std::move(Region));
+  }
+
+  // Two independently inferred call entries may not claim a shared body.
+  BitVector Claimed(Decoded.size());
+  BitVector Overlap(Regions.size());
+  for (size_t I = 0; I != Regions.size(); ++I)
+    for (size_t InstIndex : Regions[I].Instructions) {
+      if (Claimed.test(InstIndex)) {
+        Overlap.set(I);
+        for (size_t J = 0; J != I; ++J)
+          if (llvm::is_contained(Regions[J].Instructions, InstIndex))
+            Overlap.set(J);
+      }
+      Claimed.set(InstIndex);
+    }
+  SmallVector<SymbolLessReturnRegion, 8> Disjoint;
+  for (size_t I = 0; I != Regions.size(); ++I)
+    if (!Overlap.test(I))
+      Disjoint.push_back(std::move(Regions[I]));
+  return Disjoint;
+}
+
+struct FiniteControlFlowAudit {
+  BitVector InvalidSetPcCandidates;
+  bool Closed = false;
+  bool HasUnboundedIndirectEntries = false;
+};
+
+static FiniteControlFlowAudit auditFiniteIndirectControlFlow(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextSize,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint64_t> ExternalEntries,
+    const ControlFlowScanIndex &Index,
+    ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers,
+    ArrayRef<BoundedSetPcReturn> BoundedReturns,
+    ArrayRef<SymbolLessReturnRegion> SymbolLessRegions) {
+  FiniteControlFlowAudit Audit{BitVector(FiniteSetPcTransfers.size()), true};
+  auto markUnboundedIndirectEntry = [&]() {
+    Audit.Closed = false;
+    Audit.HasUnboundedIndirectEntries = true;
+  };
+
+  for (size_t CandidateIndex = 0; CandidateIndex != FiniteSetPcTransfers.size();
+       ++CandidateIndex) {
+    const FiniteSetPcTransfer &Candidate = FiniteSetPcTransfers[CandidateIndex];
+    uint64_t SequenceStart = Decoded[Candidate.SequenceBeginIndex].Offset;
+    std::optional<uint64_t> SequenceEnd =
+        checkedAddUint64(Decoded[Candidate.SequenceEndIndex].Offset,
+                         Decoded[Candidate.SequenceEndIndex].Size,
+                         "finite set-PC materialization end");
+    auto isInteriorByte = [&](uint64_t Offset) {
+      return !SequenceEnd || (Offset > SequenceStart && Offset < *SequenceEnd);
+    };
+    auto sourceIsSequence = [&](size_t InstIndex) {
+      return InstIndex >= Candidate.SequenceBeginIndex &&
+             InstIndex <= Candidate.SequenceEndIndex;
+    };
+    bool Safe = true;
+    for (uint64_t Entry : DeclaredEntries)
+      if (isInteriorByte(Entry)) {
+        Safe = false;
+        break;
+      }
+    if (Safe)
+      for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+        if (Range.Begin >= TextAddr && isInteriorByte(Range.Begin - TextAddr)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (uint64_t Entry : ExternalEntries)
+        if (isInteriorByte(Entry)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (const DirectTargetSource &Source : Index.DirectTargetsByTarget)
+        if (isInteriorByte(Source.Target) &&
+            !sourceIsSequence(Source.InstIndex)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (const KnownCallSite &Call : Index.Calls)
+        if ((isInteriorByte(Call.Target) ||
+             isInteriorByte(Call.Continuation)) &&
+            !sourceIsSequence(Call.InstIndex)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (const ExternalCallContinuation &Call :
+           Index.ExternalCallContinuations)
+        if (isInteriorByte(Call.Continuation) &&
+            !sourceIsSequence(Call.InstIndex)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
+        if (Transfer.LocalTargetIndex &&
+            isInteriorByte(Decoded[*Transfer.LocalTargetIndex].Offset)) {
+          Safe = false;
+          break;
+        }
+    if (Safe)
+      for (const BoundedSetPcReturn &Return : BoundedReturns) {
+        for (uint64_t TargetOffset : Return.Targets) {
+          if (isInteriorByte(TargetOffset)) {
+            Safe = false;
+            break;
+          }
+        }
+        if (!Safe)
+          break;
+      }
+    if (!Safe)
+      Audit.InvalidSetPcCandidates.set(CandidateIndex);
+  }
+
+  if (Audit.InvalidSetPcCandidates.any()) {
+    Audit.Closed = false;
+    return Audit;
+  }
+
+  BitVector BoundedSetPc(Decoded.size());
+  for (const FiniteSetPcTransfer &Transfer : FiniteSetPcTransfers)
+    BoundedSetPc.set(Transfer.InstIndex);
+  for (const BoundedSetPcReturn &Return : BoundedReturns)
+    BoundedSetPc.set(Return.InstIndex);
+  for (const SymbolLessReturnRegion &Region : SymbolLessRegions)
+    for (size_t Return : Region.Returns)
+      BoundedSetPc.set(Return);
+
+  // Symbol-less regions are inferred together so large mutually independent
+  // helper families can reach a fixed point. Validate that joint proof before
+  // treating any provisional return as bounded: each provisional source must
+  // have exactly one owning region, and a return owned by another region (or
+  // by a symbol-backed function) may not enter any byte of this region.
+  DenseMap<size_t, unsigned> ProvisionalOwners;
+  DenseMap<size_t, unsigned> PublishedProvisionalReturns;
+  for (const SymbolLessReturnRegion &Region : SymbolLessRegions)
+    for (size_t Return : Region.Returns) {
+      ++ProvisionalOwners[Return];
+      if (!llvm::is_contained(Region.Instructions, Return))
+        markUnboundedIndirectEntry();
+    }
+  for (const BoundedSetPcReturn &Return : BoundedReturns)
+    if (ProvisionalOwners.contains(Return.InstIndex))
+      ++PublishedProvisionalReturns[Return.InstIndex];
+  for (const auto &Owner : ProvisionalOwners)
+    if (Owner.second != 1 ||
+        PublishedProvisionalReturns.lookup(Owner.first) != 1)
+      markUnboundedIndirectEntry();
+
+  for (const SymbolLessReturnRegion &Region : SymbolLessRegions) {
+    auto containsInstructionByte = [&](uint64_t Offset) {
+      for (size_t InstIndex : Region.Instructions) {
+        const InternalDecodedInst &DI = Decoded[InstIndex];
+        std::optional<uint64_t> End = checkedAddUint64(
+            DI.Offset, DI.Size, "symbol-less joint audit instruction end");
+        if (!End || (Offset >= DI.Offset && Offset < *End))
+          return true;
+      }
+      return false;
+    };
+    for (const BoundedSetPcReturn &Return : BoundedReturns) {
+      if (llvm::is_contained(Region.Instructions, Return.InstIndex)) {
+        if (!llvm::is_contained(Region.Returns, Return.InstIndex))
+          markUnboundedIndirectEntry();
+        continue;
+      }
+      for (uint64_t Target : Return.Targets)
+        if (containsInstructionByte(Target)) {
+          markUnboundedIndirectEntry();
+          break;
+        }
+    }
+  }
+
+  BitVector Reachable = computeFiniteControlFlowReachability(
+      Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
+      FunctionRanges, Index, FiniteSetPcTransfers, BoundedReturns);
+  DenseSet<uint64_t> InstructionOffsets;
+  for (const InternalDecodedInst &DI : Decoded)
+    InstructionOffsets.insert(DI.Offset);
+  for (uint64_t Entry : DeclaredEntries)
+    if (Entry < TextSize && !InstructionOffsets.contains(Entry))
+      markUnboundedIndirectEntry();
+  for (uint64_t Entry : ExternalEntries)
+    if (Entry < TextSize && !InstructionOffsets.contains(Entry))
+      markUnboundedIndirectEntry();
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin >= TextAddr && Range.Begin - TextAddr < TextSize &&
+        !InstructionOffsets.contains(Range.Begin - TextAddr))
+      markUnboundedIndirectEntry();
+  for (const DirectTargetSource &Source : Index.DirectTargetsByTarget)
+    if (Reachable.test(Source.InstIndex) && Source.Target < TextSize &&
+        !InstructionOffsets.contains(Source.Target))
+      markUnboundedIndirectEntry();
+  for (const KnownCallSite &Call : Index.Calls)
+    if (Reachable.test(Call.InstIndex) &&
+        ((!InstructionOffsets.contains(Call.Target) &&
+          Call.Target < TextSize) ||
+         (!InstructionOffsets.contains(Call.Continuation) &&
+          Call.Continuation < TextSize)))
+      markUnboundedIndirectEntry();
+  for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
+    if (Reachable.test(Call.InstIndex) && Call.Continuation < TextSize &&
+        !InstructionOffsets.contains(Call.Continuation))
+      markUnboundedIndirectEntry();
+  for (size_t SetPc : Index.SetPcIndices)
+    if (Reachable.test(SetPc) && !BoundedSetPc.test(SetPc))
+      markUnboundedIndirectEntry();
+
+  for (size_t InstIndex : Index.UnboundedIndirectIndices)
+    if (Reachable.test(InstIndex))
+      markUnboundedIndirectEntry();
+
+  // Every call is also an indirect entry source until either a finite local
+  // target or a finite external target has been recorded for it.
+  BitVector FiniteCalls(Decoded.size());
+  for (const KnownCallSite &Call : Index.Calls)
+    FiniteCalls.set(Call.InstIndex);
+  for (const ExternalCallContinuation &Call : Index.ExternalCallContinuations)
+    FiniteCalls.set(Call.InstIndex);
+  for (size_t InstIndex : Index.BranchOrCallIndices) {
+    if (!Reachable.test(InstIndex) || !LS.MIA->isCall(Decoded[InstIndex].Inst))
+      continue;
+    if (!FiniteCalls.test(InstIndex))
+      markUnboundedIndirectEntry();
+  }
+  for (const BoundedSetPcReturn &Return : BoundedReturns) {
+    if (!Reachable.test(Return.InstIndex))
+      continue;
+    for (uint64_t Target : Return.Targets)
+      if (Target < TextSize && !InstructionOffsets.contains(Target))
+        markUnboundedIndirectEntry();
+  }
+  for (int I = Reachable.find_first(); I >= 0; I = Reachable.find_next(I))
+    if (!Decoded[static_cast<size_t>(I)].DecodeSucceeded)
+      markUnboundedIndirectEntry();
+  return Audit;
 }
 
 static bool
@@ -2631,6 +3573,72 @@ hasKnownControlFlowEntry(ArrayRef<uint64_t> DeclaredEntries,
   return false;
 }
 
+static bool addReusableCallsToIndex(ArrayRef<InternalDecodedInst> Decoded,
+                                    const LLVMState &LS, uint64_t TextAddr,
+                                    uint64_t TextEnd,
+                                    ArrayRef<ReachingCallTargets> ReusableCalls,
+                                    ControlFlowScanIndex &Index) {
+  for (size_t I = 0; I != ReusableCalls.size(); ++I) {
+    if (ReusableCalls[I].empty() || Index.MaterializedCalls.contains(I))
+      continue;
+    std::optional<MCRegister> ReturnRegister =
+        getCallReturnRegister(Decoded[I], LS);
+    if (!ReturnRegister)
+      continue;
+    std::optional<uint64_t> Continuation =
+        checkedAddUint64(Decoded[I].Offset, Decoded[I].Size,
+                         "known reusable call continuation address");
+    if (!Continuation)
+      return false;
+    bool HasExternalTarget = false;
+    for (uint64_t Target : ReusableCalls[I])
+      if (Target >= TextAddr && Target < TextEnd) {
+        Index.Calls.push_back(
+            {I, Target - TextAddr, *Continuation, *ReturnRegister});
+      } else {
+        HasExternalTarget = true;
+      }
+    if (HasExternalTarget)
+      Index.ExternalCallContinuations.push_back({I, *Continuation});
+  }
+  return true;
+}
+
+static void finalizeCallContinuationIndex(ControlFlowScanIndex &Index) {
+  Index.CallContinuationsByOffset.clear();
+  for (const KnownCallSite &Call : Index.Calls)
+    Index.CallContinuationsByOffset.push_back(
+        {Call.InstIndex, Call.Continuation});
+  llvm::sort(
+      Index.CallContinuationsByOffset,
+      [](const CallContinuationSource &LHS, const CallContinuationSource &RHS) {
+        return std::tie(LHS.Continuation, LHS.InstIndex) <
+               std::tie(RHS.Continuation, RHS.InstIndex);
+      });
+  llvm::sort(Index.ExternalCallContinuations,
+             [](const ExternalCallContinuation &LHS,
+                const ExternalCallContinuation &RHS) {
+               return std::tie(LHS.Continuation, LHS.InstIndex) <
+                      std::tie(RHS.Continuation, RHS.InstIndex);
+             });
+}
+
+static void
+addPotentialFiniteSetPcTransfersToIndex(ArrayRef<InternalDecodedInst> Decoded,
+                                        ArrayRef<FiniteSetPcTransfer> Transfers,
+                                        const BitVector &Reachable,
+                                        ControlFlowScanIndex &Index) {
+  for (const FiniteSetPcTransfer &Transfer : Transfers)
+    if (Reachable.test(Transfer.InstIndex) && Transfer.LocalTargetIndex)
+      Index.DirectTargetsByTarget.push_back(
+          {Transfer.InstIndex, Decoded[*Transfer.LocalTargetIndex].Offset});
+  llvm::sort(Index.DirectTargetsByTarget,
+             [](const DirectTargetSource &LHS, const DirectTargetSource &RHS) {
+               return std::tie(LHS.Target, LHS.InstIndex) <
+                      std::tie(RHS.Target, RHS.InstIndex);
+             });
+}
+
 /// Collect statically known direct branch and call destinations so an interior
 /// entry point is never swallowed by coalescing.
 std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
@@ -2649,58 +3657,138 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   if (!TextEnd)
     return std::nullopt;
 
-  std::optional<ControlFlowScanIndex> Index = buildControlFlowScanIndex(
-      Decoded, LS, TextAddr, *TextEnd, FunctionRanges);
-  if (!Index)
-    return std::nullopt;
+  SmallVector<FiniteSetPcTransfer, 8> AllSetPcCandidates =
+      collectFiniteSetPcCandidates(Decoded, LS, TextAddr, *TextEnd,
+                                   FunctionRanges);
+  BitVector RejectedSetPcCandidates(AllSetPcCandidates.size());
+  BitVector ProvenSetPcCandidates(AllSetPcCandidates.size());
+  SmallVector<FiniteSetPcTransfer, 8> EnabledSetPcTransfers;
+  std::vector<ReachingCallTargets> ReusableCalls;
+  std::optional<ControlFlowScanIndex> Index;
+  SmallVector<BoundedSetPcReturn, 2> BoundedReturns;
+  SmallVector<SymbolLessReturnRegion, 8> SymbolLessRegions;
+  bool IndirectControlFlowClosed = false;
+  bool HasUnboundedIndirectEntries = false;
 
-  SmallVector<std::optional<PcMaterializedCallInfo>, 16> MaterializedCalls(
-      Decoded.size());
-  for (const auto &Entry : Index->MaterializedCalls)
-    MaterializedCalls[Entry.first] = Entry.second;
-  std::vector<ReachingCallTargets> ReusableCalls = resolveReusablePcCallTargets(
-      Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls,
-      DeclaredEntries, Text);
+  // Exact set-PC edges are an optimistic over-approximation used only to
+  // discover later finite call targets. Rebuild from scratch whenever the
+  // closed-world audit removes an edge; never let a rejected edge leave
+  // self-supporting call or return facts behind.
+  for (;;) {
+    EnabledSetPcTransfers = selectLeastReachableSetPcCandidates(
+        Decoded, LS, DeclaredEntries, ExternalEntries, FunctionRanges, TextAddr,
+        AllSetPcCandidates, ProvenSetPcCandidates, RejectedSetPcCandidates);
+    ReusableCalls = resolveReusablePcCallTargets(
+        Decoded, LS, TextAddr, *TextEnd, FunctionRanges, EnabledSetPcTransfers);
+    Index = buildControlFlowScanIndex(Decoded, LS, TextAddr, *TextEnd,
+                                      FunctionRanges);
+    if (!Index || !addReusableCallsToIndex(Decoded, LS, TextAddr, *TextEnd,
+                                           ReusableCalls, *Index))
+      return std::nullopt;
+    indexKnownCalls(*Index);
+    finalizeCallContinuationIndex(*Index);
+    BitVector PotentialSetPcSources = computeFiniteControlFlowReachability(
+        Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
+        FunctionRanges, *Index, EnabledSetPcTransfers,
+        /*BoundedReturns=*/ArrayRef<BoundedSetPcReturn>{});
+    addPotentialFiniteSetPcTransfersToIndex(Decoded, AllSetPcCandidates,
+                                            PotentialSetPcSources, *Index);
 
-  // Reusable targets are intentionally lower priority than an exact canonical
-  // one-shot materialization, matching the established call-site proof. Add
-  // only the non-canonical finite target sets to the sparse call index.
-  for (size_t I = 0; I != ReusableCalls.size(); ++I) {
-    if (ReusableCalls[I].empty() || Index->MaterializedCalls.contains(I))
-      continue;
-    std::optional<MCRegister> ReturnRegister =
-        getCallReturnRegister(Decoded[I], LS);
-    if (!ReturnRegister ||
-        llvm::any_of(ReusableCalls[I], [TextAddr, TextEnd](uint64_t Target) {
-          return Target < TextAddr || Target >= *TextEnd;
-        }))
-      continue;
-    std::optional<uint64_t> Continuation = checkedAddUint64(
-        Decoded[I].Offset, Decoded[I].Size,
-        "known reusable call continuation address");
-    if (!Continuation)
+    std::optional<SmallVector<BoundedSetPcReturn, 2>> FunctionReturns =
+        collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,
+                                   DeclaredEntries, FunctionRanges,
+                                   ExternalEntries, *Index);
+    if (!FunctionReturns)
       return std::nullopt;
-    if (*Continuation >= TextSize ||
-        (*Continuation & (MinInstSize - 1)) != 0) {
-      log() << "hotswap: call at 0x" << utohexstr(Decoded[I].Offset)
-            << " has no aligned continuation inside .text\n";
-      return std::nullopt;
+    BoundedReturns = std::move(*FunctionReturns);
+    BitVector CandidateReachability = computeFiniteControlFlowReachability(
+        Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
+        FunctionRanges, *Index, EnabledSetPcTransfers, BoundedReturns);
+    bool AddedCandidate = false;
+    for (size_t I = 0; I != AllSetPcCandidates.size(); ++I) {
+      if (RejectedSetPcCandidates.test(I) || ProvenSetPcCandidates.test(I) ||
+          !CandidateReachability.test(AllSetPcCandidates[I].InstIndex))
+        continue;
+      ProvenSetPcCandidates.set(I);
+      AddedCandidate = true;
     }
-    for (uint64_t Target : ReusableCalls[I])
-      Index->Calls.push_back(
-          {I, Target - TextAddr, *Continuation, *ReturnRegister});
+    if (AddedCandidate)
+      continue;
+    BitVector ReachableCallSources = computeFiniteControlFlowReachability(
+        Decoded, LS, TextAddr, TextSize, DeclaredEntries, ExternalEntries,
+        FunctionRanges, *Index, EnabledSetPcTransfers, BoundedReturns);
+    SymbolLessRegions = collectSymbolLessReturnRegions(
+        Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
+        ExternalEntries, *Index, EnabledSetPcTransfers, BoundedReturns,
+        ReachableCallSources);
+    SmallVector<BoundedSetPcReturn, 2> AllBoundedReturns = BoundedReturns;
+    for (const SymbolLessReturnRegion &Region : SymbolLessRegions)
+      for (size_t Return : Region.Returns) {
+        SmallVector<uint64_t, 2> Targets(Region.Continuations.begin(),
+                                         Region.Continuations.end());
+        AllBoundedReturns.push_back({Return, std::move(Targets)});
+      }
+    FiniteControlFlowAudit Audit = auditFiniteIndirectControlFlow(
+        Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
+        ExternalEntries, *Index, EnabledSetPcTransfers, AllBoundedReturns,
+        SymbolLessRegions);
+    if (Audit.InvalidSetPcCandidates.any()) {
+      for (size_t I = 0; I != EnabledSetPcTransfers.size(); ++I) {
+        if (!Audit.InvalidSetPcCandidates.test(I))
+          continue;
+        for (size_t J = 0; J != AllSetPcCandidates.size(); ++J)
+          if (AllSetPcCandidates[J].InstIndex ==
+              EnabledSetPcTransfers[I].InstIndex) {
+            RejectedSetPcCandidates.set(J);
+          }
+      }
+      // Every dynamic proof is conditional on the complete edge set used to
+      // reach it. A downstream candidate may have been reachable only through
+      // a just-rejected candidate, so rediscover the least fixed point from
+      // roots rather than retaining sticky proof bits.
+      ProvenSetPcCandidates.reset();
+      continue;
+    }
+    if (!Audit.Closed && !SymbolLessRegions.empty()) {
+      // Symbol-less returns depend on a closed object-wide entry proof. If
+      // any reachable entry source remains open, discard those inferred
+      // regions before finalizing; unlike symbol-backed local returns, they
+      // have no independent function boundary to constrain provenance.
+      SymbolLessRegions.clear();
+      AllBoundedReturns = BoundedReturns;
+      Audit = auditFiniteIndirectControlFlow(
+          Decoded, LS, TextAddr, TextSize, FunctionRanges, DeclaredEntries,
+          ExternalEntries, *Index, EnabledSetPcTransfers, AllBoundedReturns,
+          SymbolLessRegions);
+    }
+    if (!Audit.Closed && !EnabledSetPcTransfers.empty()) {
+      for (const FiniteSetPcTransfer &Enabled : EnabledSetPcTransfers)
+        for (size_t J = 0; J != AllSetPcCandidates.size(); ++J)
+          if (AllSetPcCandidates[J].InstIndex == Enabled.InstIndex) {
+            RejectedSetPcCandidates.set(J);
+          }
+      ProvenSetPcCandidates.reset();
+      continue;
+    }
+    IndirectControlFlowClosed = Audit.Closed;
+    HasUnboundedIndirectEntries = Audit.HasUnboundedIndirectEntries;
+    if (!Audit.Closed)
+      AllBoundedReturns.clear();
+    BoundedReturns = std::move(AllBoundedReturns);
+    break;
+  }
+
+  for (const FiniteSetPcTransfer &Transfer : EnabledSetPcTransfers) {
+    SmallVector<uint64_t, 2> Targets;
+    if (Transfer.LocalTargetIndex)
+      Targets.push_back(Decoded[*Transfer.LocalTargetIndex].Offset);
+    BoundedReturns.push_back({Transfer.InstIndex, std::move(Targets)});
   }
   indexKnownCalls(*Index);
 
-  std::optional<SmallVector<BoundedSetPcReturn, 2>> BoundedReturns =
-      collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,
-                                 DeclaredEntries, FunctionRanges,
-                                 ExternalEntries, *Index);
-  if (!BoundedReturns)
-    return std::nullopt;
   DenseMap<size_t, size_t> BoundedReturnPositions;
-  for (size_t I = 0; I != BoundedReturns->size(); ++I)
-    BoundedReturnPositions.try_emplace((*BoundedReturns)[I].InstIndex, I);
+  for (size_t I = 0; I != BoundedReturns.size(); ++I)
+    BoundedReturnPositions.try_emplace(BoundedReturns[I].InstIndex, I);
 
   // Canonical one-shot materializations also participate in the reusable
   // reaching-value solver so CFG joins can prove their exact path. Preserve
@@ -2713,7 +3801,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     if (ReusableCalls[I].empty())
       continue;
     if (hasKnownControlFlowEntry(
-            DeclaredEntries, *BoundedReturns, BoundedReturnPositions, *Index,
+            DeclaredEntries, BoundedReturns, BoundedReturnPositions, *Index,
             Entry.second.SequenceStart, Entry.second.SequenceEnd)) {
       ReusableCalls[I].clear();
       continue;
@@ -2722,7 +3810,13 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   }
 
   DirectControlFlowInfo Info;
-  for (const BoundedSetPcReturn &Return : *BoundedReturns) {
+  for (uint64_t Entry : DeclaredEntries)
+    if (Entry < TextSize)
+      Info.Targets.insert(Entry);
+  for (uint64_t Entry : ExternalEntries)
+    if (Entry < TextSize)
+      Info.Targets.insert(Entry);
+  for (const BoundedSetPcReturn &Return : BoundedReturns)
     for (uint64_t Target : Return.Targets)
       Info.Targets.insert(Target);
     Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
@@ -2759,7 +3853,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
         DenseMap<size_t, PcMaterializedCallInfo>::const_iterator Materialized =
             Index->MaterializedCalls.find(InstIndex);
         if (Materialized != Index->MaterializedCalls.end() &&
-            !hasKnownControlFlowEntry(DeclaredEntries, *BoundedReturns,
+            !hasKnownControlFlowEntry(DeclaredEntries, BoundedReturns,
                                       BoundedReturnPositions, *Index,
                                       Materialized->second.SequenceStart,
                                       Materialized->second.SequenceEnd))
@@ -2839,8 +3933,10 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       Info.Targets.insert(*Continuation);
     }
   }
-  for (const BoundedSetPcReturn &Return : *BoundedReturns)
+  for (const BoundedSetPcReturn &Return : BoundedReturns)
     Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
+  if (!IndirectControlFlowClosed && HasUnboundedIndirectEntries)
+    Info.HasUnboundedIndirectEntries = true;
   return Info;
 }
 
@@ -3796,16 +4892,17 @@ assignLongBranchGateways(PatchContext &Ctx,
   // sequence consumes the tail. Shared dispatch and VCC preservation likewise
   // reserve the second dword. Relays are object-wide: unlike an arbitrary NOP
   // sled they cannot be reached by the owning function's original fallthrough.
-  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
-    const Trampoline &T = Ctx.OutTrampolines[I];
-    if (T.OriginalSize < 2 * MinInstSize || T.UsesDirectSetPCForward ||
-        T.UsesSharedDispatcherForward)
-      continue;
-    uint64_t Tail = T.OriginalOffset + MinInstSize;
-    SourceTailIslandOwners[Tail] = I;
-    Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
-                        std::numeric_limits<uint64_t>::max()});
-  }
+  if (!Ctx.DirectControlFlow.HasUnboundedIndirectEntries)
+    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+      const Trampoline &T = Ctx.OutTrampolines[I];
+      if (T.OriginalSize < 2 * MinInstSize || T.UsesDirectSetPCForward ||
+          T.UsesSharedDispatcherForward || T.LongBranchPreservesVcc)
+        continue;
+      uint64_t Tail = T.OriginalOffset + MinInstSize;
+      SourceTailIslandOwners[Tail] = I;
+      Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
+                          std::numeric_limits<uint64_t>::max()});
+    }
 
   for (PendingGateway &P : Pending) {
     const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2563,13 +2563,6 @@ buildControlFlowScanIndex(ArrayRef<InternalDecodedInst> Decoded,
             DI.Offset, DI.Size, "known call continuation address");
         if (!Continuation)
           return std::nullopt;
-        uint64_t TextSize = TextEnd - TextAddr;
-        if (*Continuation >= TextSize ||
-            (*Continuation & (MinInstSize - 1)) != 0) {
-          log() << "hotswap: call at 0x" << utohexstr(DI.Offset)
-                << " has no aligned continuation inside .text\n";
-          return std::nullopt;
-        }
         if (Target)
           Index.Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
         if (HasFiniteExternalTarget)
@@ -3913,11 +3906,17 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       if (!LS.MIA->isCall(DI.Inst))
         continue;
       std::optional<uint64_t> Target;
+      bool IsFiniteExternalMaterializedCall =
+          MaterializedCalls[InstIndex] &&
+          (MaterializedCalls[InstIndex]->Target < TextAddr ||
+           MaterializedCalls[InstIndex]->Target >= *TextEnd);
       if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
           DI.Inst.getNumOperands() != 0 &&
           DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
         Target = static_cast<uint64_t>(
             DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
+      } else if (IsFiniteExternalMaterializedCall) {
+        Target = MaterializedCalls[InstIndex]->Target;
       } else {
         DenseMap<size_t, PcMaterializedCallInfo>::const_iterator Materialized =
             Index->MaterializedCalls.find(InstIndex);
@@ -3928,10 +3927,6 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
                                       Materialized->second.SequenceEnd))
           Target = Materialized->second.Target;
       }
-      bool IsFiniteExternalMaterializedCall =
-          MaterializedCalls[InstIndex] &&
-          (MaterializedCalls[InstIndex]->Target < TextAddr ||
-           MaterializedCalls[InstIndex]->Target >= *TextEnd);
       if (!ReusableCalls[InstIndex].empty() &&
           !IsFiniteExternalMaterializedCall) {
         if (llvm::any_of(ReusableCalls[InstIndex],

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -792,6 +792,365 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
   return true;
 }
 
+bool instructionReadsRegister(const InternalDecodedInst &DI,
+                              const LLVMState &LS, MCRegister Register) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  // A tied use makes its corresponding explicit def a read/modify/write
+  // operand. Some MCInst producers materialize a duplicate use operand while
+  // others only retain the destination operand, so consult the descriptor
+  // instead of relying on the decoded operand list to contain that duplicate.
+  for (unsigned Def = 0; Def != DefCount; ++Def) {
+    bool HasTiedUse = false;
+    for (unsigned Use = Desc.getNumDefs(); Use != Desc.getNumOperands();
+         ++Use) {
+      if (Desc.getOperandConstraint(Use, MCOI::TIED_TO) ==
+          static_cast<int>(Def)) {
+        HasTiedUse = true;
+        break;
+      }
+    }
+    if (!HasTiedUse)
+      continue;
+    const MCOperand &Operand = DI.Inst.getOperand(Def);
+    if (Operand.isReg() && Operand.getReg() &&
+        LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+      return true;
+  }
+  unsigned FixedOperandCount =
+      std::min(Desc.getNumOperands(), DI.Inst.getNumOperands());
+  for (unsigned I = DefCount; I != FixedOperandCount; ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (Operand.isReg() && Operand.getReg() &&
+        LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+      return true;
+  }
+  if (!Desc.variadicOpsAreDefs()) {
+    for (unsigned I = FixedOperandCount; I != DI.Inst.getNumOperands(); ++I) {
+      const MCOperand &Operand = DI.Inst.getOperand(I);
+      if (Operand.isReg() && Operand.getReg() &&
+          LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+        return true;
+    }
+  }
+  for (MCPhysReg ImplicitUse : Desc.implicit_uses())
+    if (LS.MRI->regsOverlap(MCRegister(ImplicitUse), Register))
+      return true;
+  return false;
+}
+
+static void addTrackedSgprBits(const LLVMState &LS, MCRegister Register,
+                               unsigned MaxSgprs, BitVector &Bits,
+                               bool &Valid) {
+  if (!Register.isValid())
+    return;
+  SmallVector<MCRegister, 8> Candidates;
+  Candidates.push_back(Register);
+  for (MCPhysReg Subregister : LS.MRI->subregs(Register))
+    Candidates.push_back(MCRegister(Subregister));
+  // A decoded operand can name a low/high subregister directly. Its scalar
+  // numbered SGPR then appears among its super-registers rather than subregs.
+  for (MCPhysReg Superregister : LS.MRI->superregs(Register))
+    Candidates.push_back(MCRegister(Superregister));
+
+  for (MCRegister Candidate : Candidates) {
+    std::optional<unsigned> Index = numberedSgprIndex(*LS.MRI, Candidate);
+    if (!Index)
+      continue;
+    if (*Index >= MaxSgprs) {
+      Valid = false;
+      continue;
+    }
+    Bits.set(*Index);
+  }
+  if (isVccRegister(LS, Register))
+    Bits.set(MaxSgprs);
+}
+
+static bool collectTrackedSgprUsesAndDefs(const InternalDecodedInst &DI,
+                                          const LLVMState &LS,
+                                          unsigned MaxSgprs, BitVector &Uses,
+                                          BitVector &Defs) {
+  if (!DI.DecodeSucceeded || !LS.MCII || !LS.MRI)
+    return false;
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  unsigned FixedOperandCount =
+      std::min(Desc.getNumOperands(), DI.Inst.getNumOperands());
+  bool Valid = true;
+
+  for (unsigned I = 0; I != DefCount; ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (!Operand.isReg() || !Operand.getReg())
+      continue;
+    MCRegister Register(Operand.getReg());
+    addTrackedSgprBits(LS, Register, MaxSgprs, Defs, Valid);
+    for (unsigned Use = Desc.getNumDefs(); Use != Desc.getNumOperands();
+         ++Use) {
+      if (Desc.getOperandConstraint(Use, MCOI::TIED_TO) != static_cast<int>(I))
+        continue;
+      addTrackedSgprBits(LS, Register, MaxSgprs, Uses, Valid);
+      break;
+    }
+  }
+  for (unsigned I = DefCount; I != FixedOperandCount; ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (Operand.isReg() && Operand.getReg())
+      addTrackedSgprBits(LS, MCRegister(Operand.getReg()), MaxSgprs, Uses,
+                         Valid);
+  }
+  for (unsigned I = FixedOperandCount; I != DI.Inst.getNumOperands(); ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (!Operand.isReg() || !Operand.getReg())
+      continue;
+    addTrackedSgprBits(LS, MCRegister(Operand.getReg()), MaxSgprs,
+                       Desc.variadicOpsAreDefs() ? Defs : Uses, Valid);
+  }
+  for (MCPhysReg Register : Desc.implicit_uses())
+    addTrackedSgprBits(LS, MCRegister(Register), MaxSgprs, Uses, Valid);
+  for (MCPhysReg Register : Desc.implicit_defs())
+    addTrackedSgprBits(LS, MCRegister(Register), MaxSgprs, Defs, Valid);
+  return Valid;
+}
+
+std::optional<BitVector>
+getReplacementIncomingSgprs(ArrayRef<uint8_t> Replacement, const LLVMState &LS,
+                            unsigned MaxSgprs) {
+  if (MaxSgprs == std::numeric_limits<unsigned>::max())
+    return std::nullopt;
+  const unsigned TrackedSgprs = MaxSgprs + 1;
+  BitVector Incoming(TrackedSgprs);
+  BitVector Defined(TrackedSgprs);
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Replacement.data(), Replacement.size(), LS, Decoded))
+    return std::nullopt;
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (!DI.DecodeSucceeded || !LS.MIA ||
+        LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
+      return std::nullopt;
+    BitVector Uses(TrackedSgprs);
+    BitVector Defs(TrackedSgprs);
+    if (!collectTrackedSgprUsesAndDefs(DI, LS, MaxSgprs, Uses, Defs))
+      return std::nullopt;
+    Uses.reset(Defined);
+    Incoming |= Uses;
+    Defined |= Defs;
+  }
+  return Incoming;
+}
+
+bool replacementNeedsIncomingRegister(ArrayRef<uint8_t> Replacement,
+                                      const LLVMState &LS,
+                                      MCRegister Register) {
+  constexpr unsigned MaxTrackedSgprs = 106;
+  std::optional<BitVector> Incoming =
+      getReplacementIncomingSgprs(Replacement, LS, MaxTrackedSgprs);
+  if (!Incoming)
+    return true;
+  BitVector RegisterBits(MaxTrackedSgprs + 1);
+  bool Valid = true;
+  addTrackedSgprBits(LS, Register, MaxTrackedSgprs, RegisterBits, Valid);
+  return !Valid || RegisterBits.none() || Incoming->anyCommon(RegisterBits);
+}
+
+static bool addCurrentFunctionLivenessSuccessor(
+    size_t From, uint64_t Offset,
+    const DenseMap<uint64_t, size_t> &InstructionIndices,
+    std::vector<SmallVector<size_t, 2>> &Successors,
+    std::vector<SmallVector<size_t, 2>> &Predecessors) {
+  DenseMap<uint64_t, size_t>::const_iterator Target =
+      InstructionIndices.find(Offset);
+  if (Target == InstructionIndices.end())
+    return false;
+  Successors[From].push_back(Target->second);
+  Predecessors[Target->second].push_back(From);
+  return true;
+}
+
+static CurrentFunctionSgprLiveness buildCurrentFunctionSgprLiveness(
+    PatchContext &Ctx, const ElfView::FunctionTextRange &FunctionRange) {
+  CurrentFunctionSgprLiveness Result;
+  Result.Generation = Ctx.TextMutationGeneration;
+  Result.MaxSgprs = Ctx.Config.MaxSgprs;
+  if (!Ctx.LS.MIA || FunctionRange.End < FunctionRange.Begin ||
+      FunctionRange.Begin > Ctx.TextSize ||
+      FunctionRange.End - FunctionRange.Begin >
+          Ctx.TextSize - FunctionRange.Begin ||
+      Ctx.Config.MaxSgprs == std::numeric_limits<unsigned>::max())
+    return Result;
+
+  std::vector<InternalDecodedInst> Decoded;
+  uint64_t FunctionSize = FunctionRange.End - FunctionRange.Begin;
+  if (!decodeTextSection(Ctx.Text + FunctionRange.Begin, FunctionSize, Ctx.LS,
+                         Decoded))
+    return Result;
+
+  uint64_t ExpectedOffset = FunctionRange.Begin;
+  for (InternalDecodedInst &DI : Decoded) {
+    DI.Offset += FunctionRange.Begin;
+    if (!DI.DecodeSucceeded || DI.Size == 0 || DI.Offset != ExpectedOffset)
+      return Result;
+    std::optional<uint64_t> Next = checkedAddUint64(
+        DI.Offset, DI.Size, "current-function SGPR liveness decode");
+    if (!Next || *Next > FunctionRange.End)
+      return Result;
+    ExpectedOffset = *Next;
+  }
+  if (ExpectedOffset != FunctionRange.End || Decoded.empty())
+    return Result;
+
+  const unsigned TrackedSgprs = Ctx.Config.MaxSgprs + 1;
+  const size_t InstructionCount = Decoded.size();
+  std::vector<BitVector> Uses(InstructionCount, BitVector(TrackedSgprs));
+  std::vector<BitVector> Defs(InstructionCount, BitVector(TrackedSgprs));
+  std::vector<SmallVector<size_t, 2>> Successors(InstructionCount);
+  std::vector<SmallVector<size_t, 2>> Predecessors(InstructionCount);
+  BitVector HasUnknownSuccessor(InstructionCount);
+
+  for (size_t I = 0; I != InstructionCount; ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    Result.InstructionIndices.try_emplace(DI.Offset, I);
+    if (!collectTrackedSgprUsesAndDefs(DI, Ctx.LS, Ctx.Config.MaxSgprs, Uses[I],
+                                       Defs[I]))
+      return Result;
+  }
+
+  for (size_t I = 0; I != InstructionCount; ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.Inst.getOpcode() == Ctx.LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == Ctx.LS.SEndPgmSavedOpcode)
+      continue;
+    if (Ctx.LS.MIA->isCall(DI.Inst) || Ctx.LS.MIA->isIndirectBranch(DI.Inst) ||
+        Ctx.LS.MIA->isReturn(DI.Inst) ||
+        StringRef(DI.Mnemonic).starts_with("s_rfe")) {
+      HasUnknownSuccessor.set(I);
+      continue;
+    }
+    if (Ctx.LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target =
+          evaluateDirectControlFlowTarget(DI, Ctx.LS);
+      if (!Target)
+        HasUnknownSuccessor.set(I);
+      else if (!addCurrentFunctionLivenessSuccessor(I, *Target,
+                                                    Result.InstructionIndices,
+                                                    Successors, Predecessors))
+        HasUnknownSuccessor.set(I);
+      if (Ctx.LS.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI) &&
+               !Ctx.LS.MIA->isBarrier(DI.Inst)) {
+      HasUnknownSuccessor.set(I);
+      continue;
+    }
+
+    std::optional<uint64_t> Fallthrough = checkedAddUint64(
+        DI.Offset, DI.Size, "current-function SGPR liveness fallthrough");
+    if (!Fallthrough)
+      HasUnknownSuccessor.set(I);
+    else if (!addCurrentFunctionLivenessSuccessor(I, *Fallthrough,
+                                                  Result.InstructionIndices,
+                                                  Successors, Predecessors))
+      HasUnknownSuccessor.set(I);
+  }
+
+  // Each worklist transfer and successor union costs
+  // O(ceil(R / word-size)), where R is the configured tracked SGPR count.
+  // Computing all registers together avoids rebuilding and walking this CFG
+  // once per scratch-register candidate.
+  Result.LiveBefore.assign(InstructionCount, BitVector(TrackedSgprs));
+  std::vector<BitVector> LiveAfter(InstructionCount, BitVector(TrackedSgprs));
+  BitVector AllLive(TrackedSgprs, true);
+  SmallVector<size_t, 32> Worklist;
+  BitVector InWorklist(InstructionCount, true);
+  for (size_t I = InstructionCount; I != 0; --I)
+    Worklist.push_back(I - 1);
+
+  while (!Worklist.empty()) {
+    size_t I = Worklist.pop_back_val();
+    InWorklist.reset(I);
+    BitVector NewAfter(TrackedSgprs);
+    if (HasUnknownSuccessor.test(I))
+      NewAfter = AllLive;
+    for (size_t Successor : Successors[I])
+      NewAfter |= Result.LiveBefore[Successor];
+
+    BitVector NewBefore = NewAfter;
+    NewBefore.reset(Defs[I]);
+    NewBefore |= Uses[I];
+    if (NewAfter == LiveAfter[I] && NewBefore == Result.LiveBefore[I])
+      continue;
+    LiveAfter[I] = std::move(NewAfter);
+    Result.LiveBefore[I] = std::move(NewBefore);
+    for (size_t Predecessor : Predecessors[I]) {
+      if (InWorklist.test(Predecessor))
+        continue;
+      InWorklist.set(Predecessor);
+      Worklist.push_back(Predecessor);
+    }
+  }
+  Result.Valid = true;
+  return Result;
+}
+
+std::optional<BitVector> getLiveSgprsAtContinuation(PatchContext &Ctx,
+                                                    uint64_t InstOffset,
+                                                    uint32_t InstSize) {
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!FunctionRange)
+    return std::nullopt;
+  using FunctionKey = std::pair<uint64_t, uint64_t>;
+  FunctionKey Key{FunctionRange->Begin, FunctionRange->End};
+  DenseMap<FunctionKey, CurrentFunctionSgprLiveness>::iterator Cached =
+      Ctx.CurrentFunctionSgprLivenessCache.find(Key);
+  if (Cached == Ctx.CurrentFunctionSgprLivenessCache.end() ||
+      Cached->second.Generation != Ctx.TextMutationGeneration ||
+      Cached->second.MaxSgprs != Ctx.Config.MaxSgprs) {
+    CurrentFunctionSgprLiveness Current =
+        buildCurrentFunctionSgprLiveness(Ctx, *FunctionRange);
+    Cached = Ctx.CurrentFunctionSgprLivenessCache
+                 .insert_or_assign(Key, std::move(Current))
+                 .first;
+  }
+  if (!Cached->second.Valid)
+    return std::nullopt;
+
+  std::optional<uint64_t> Continuation =
+      checkedAddUint64(InstOffset, InstSize, "SGPR liveness continuation");
+  if (!Continuation)
+    return std::nullopt;
+  DenseMap<uint64_t, size_t>::const_iterator Index =
+      Cached->second.InstructionIndices.find(*Continuation);
+  if (Index == Cached->second.InstructionIndices.end())
+    return std::nullopt;
+  return Cached->second.LiveBefore[Index->second];
+}
+
+void noteCurrentTextMutation(PatchContext &Ctx) {
+  if (Ctx.TextMutationGeneration == std::numeric_limits<uint64_t>::max()) {
+    Ctx.CurrentFunctionSgprLivenessCache.clear();
+    Ctx.TextMutationGeneration = 0;
+    return;
+  }
+  ++Ctx.TextMutationGeneration;
+}
+
+bool isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx,
+                                            uint64_t InstOffset,
+                                            uint32_t InstSize,
+                                            MCRegister Register) {
+  std::optional<BitVector> Live =
+      getLiveSgprsAtContinuation(Ctx, InstOffset, InstSize);
+  if (!Live)
+    return false;
+  BitVector RegisterBits(Ctx.Config.MaxSgprs + 1);
+  bool Valid = true;
+  addTrackedSgprBits(Ctx.LS, Register, Ctx.Config.MaxSgprs, RegisterBits,
+                     Valid);
+  return Valid && RegisterBits.any() && !Live->anyCommon(RegisterBits);
+}
+
 static std::optional<SafeSgprScratchBlock>
 reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset) {
   std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
@@ -3505,6 +3864,7 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       if (*P == 0)
         continue;
       Patched += *P;
+      noteCurrentTextMutation(Ctx);
       break;
     }
   }
@@ -3531,6 +3891,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     HazardScope.addPatches(P);
     HazardScope.finish();
     Patched += P;
+    if (P != 0)
+      noteCurrentTextMutation(Ctx);
   }
   if (Config.RunB0A0Patches && VT.applyVop3px2Src2Fix) {
     HotswapProfile::Scope Vop3Scope =
@@ -3539,6 +3901,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     Vop3Scope.addPatches(P);
     Vop3Scope.finish();
     Patched += P;
+    if (P != 0)
+      noteCurrentTextMutation(Ctx);
   }
 
   if (!OutTrampolines.empty()) {

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -6417,11 +6417,11 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
           MaterializedCalls[InstIndex] &&
           (MaterializedCalls[InstIndex]->Target < TextAddr ||
            MaterializedCalls[InstIndex]->Target >= *TextEnd) &&
-          !hasKnownControlFlowEntry(
-              DeclaredEntries, BoundedReturns, BoundedReturnPositions, *Index,
-              HasUnboundedIndirectEntries,
-              MaterializedCalls[InstIndex]->SequenceStart,
-              MaterializedCalls[InstIndex]->SequenceEnd);
+          !hasKnownControlFlowEntry(DeclaredEntries, BoundedReturns,
+                                    BoundedReturnPositions, *Index,
+                                    HasUnboundedIndirectEntries,
+                                    MaterializedCalls[InstIndex]->SequenceStart,
+                                    MaterializedCalls[InstIndex]->SequenceEnd);
       if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
           DI.Inst.getNumOperands() != 0 &&
           DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
@@ -6534,8 +6534,9 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     llvm::sort(LocalTargets);
     LocalTargets.erase(std::unique(LocalTargets.begin(), LocalTargets.end()),
                        LocalTargets.end());
-    auto Inserted =
-        Info.BoundedIndirectTargets.try_emplace(ReturnOffset, LocalTargets);
+    std::pair<DenseMap<uint64_t, SmallVector<uint64_t, 2>>::iterator, bool>
+        Inserted =
+            Info.BoundedIndirectTargets.try_emplace(ReturnOffset, LocalTargets);
     if (!Inserted.second && Inserted.first->second != LocalTargets) {
       log() << "hotswap: conflicting audited target sets for bounded return at "
                "0x"

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -6352,7 +6352,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       ProvenSetPcCandidates.reset();
       continue;
     }
-    if (PreservingSymbolLessRegions.empty() &&
+    if (!Audit.Closed && PreservingSymbolLessRegions.empty() &&
         !RejectedSymbolLessPreservation && !SymbolLessRegions.empty()) {
       // Symbol-less leaves and reusable target preservation form a bounded
       // fixed point: later calls keep the first audit open until the already

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1227,7 +1227,8 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
       !MakeDelta.Inst.getOperand(2).isImm())
     return std::nullopt;
   MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
-  if (AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
+  if (LS.MRI->regsOverlap(DeltaReg, Pair) ||
+      AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
       !AddLow.Inst.getOperand(1).isReg() ||
       !AddLow.Inst.getOperand(0).getReg() ||
       AddLow.Inst.getOperand(0).getReg() !=
@@ -1253,12 +1254,14 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
   std::optional<uint32_t> FirstAddend;
   if (MakeDelta.Inst.getOperand(1).isImm()) {
     FirstAddend = static_cast<uint32_t>(MakeDelta.Inst.getOperand(1).getImm());
-  } else if (MakeDelta.Size >= 2 * MinInstSize &&
+  } else if (MakeDelta.Size == 2 * MinInstSize &&
              MakeDelta.Offset <= Text.size() &&
-             MakeDelta.Size <= Text.size() - MakeDelta.Offset) {
+             MakeDelta.Size <= Text.size() - MakeDelta.Offset &&
+             Text[MakeDelta.Offset] == 0xff) {
     // The disassembler represents a SOP2 literal source as its literal
-    // register marker, not as an immediate operand. The literal dword is the
-    // final dword in this otherwise exact compiler-emitted instruction.
+    // register marker, not as an immediate operand. Require the gfx12 SOP2
+    // src0 literal selector before interpreting the final dword as that
+    // literal; an ordinary register source is not a constant displacement.
     FirstAddend = support::endian::read32le(Text.data() + MakeDelta.Offset +
                                             MakeDelta.Size - MinInstSize);
   }
@@ -1276,6 +1279,71 @@ struct ReachingCallGroup {
   SmallVector<size_t, 8> Calls;
 };
 
+static std::optional<uint64_t>
+getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
+                    uint64_t TextAddr, uint64_t TextEnd);
+
+/// A reusable target value remains valid after a call only when the exact local
+/// callee is fully decoded, returns through the call's link pair, and cannot
+/// transitively or directly clobber the target pair.
+static bool calleePreservesReusableTarget(
+    uint64_t Target, MCRegister TargetRegister, MCRegister ReturnRegister,
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextEnd,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
+  const ElfView::FunctionTextRange *Callee = nullptr;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin == Target && Range.Begin >= TextAddr &&
+        Range.End > Range.Begin && Range.End <= TextEnd &&
+        (!Callee || Range.End < Callee->End))
+      Callee = &Range;
+  if (!Callee)
+    return false;
+
+  uint64_t CalleeBegin = Callee->Begin - TextAddr;
+  uint64_t CalleeEnd = Callee->End - TextAddr;
+  bool SawInstruction = false;
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (DI.Offset < CalleeBegin || DI.Offset >= CalleeEnd)
+      continue;
+    SawInstruction = true;
+    if (!DI.DecodeSucceeded || LS.MIA->isCall(DI.Inst) ||
+        definesOverlappingRegister(DI, LS, TargetRegister))
+      return false;
+
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      if (DI.Inst.getNumOperands() != 1 ||
+          !isExactRegisterOperand(DI.Inst, 0, ReturnRegister))
+        return false;
+      continue;
+    }
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+    if (LS.MIA->isIndirectBranch(DI.Inst) ||
+        DI.Inst.getOpcode() == LS.SAddPcI64Opcode)
+      return false;
+
+    bool HasFallthrough = true;
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> BranchTarget =
+          getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+      if (!BranchTarget || *BranchTarget < CalleeBegin ||
+          *BranchTarget >= CalleeEnd)
+        return false;
+      HasFallthrough = !LS.MIA->isUnconditionalBranch(DI.Inst);
+    }
+    if (!HasFallthrough)
+      continue;
+    std::optional<uint64_t> Fallthrough =
+        checkedAddUint64(DI.Offset, DI.Size, "reusable callee fallthrough");
+    if (!Fallthrough || *Fallthrough >= CalleeEnd)
+      return false;
+  }
+  return SawInstruction;
+}
+
 /// Resolve register calls whose target pair is selected once and reused across
 /// control flow. A monotone intraprocedural solver propagates finite target
 /// sets from proven get-PC materializations. Any unrecognized pair definition
@@ -1285,7 +1353,7 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
     ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
-    ArrayRef<uint8_t> Text) {
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint8_t> Text) {
   std::vector<ReachingCallTargets> Resolved(Decoded.size());
   SmallVector<ReachingCallGroup, 8> Groups;
 
@@ -1329,14 +1397,33 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
   for (size_t I = 0; I != Decoded.size(); ++I)
     OffsetToIndex[Decoded[I].Offset] = I;
 
+  SmallVector<std::pair<size_t, uint64_t>, 16> DirectEntries;
+  for (size_t SourceIndex = 0; SourceIndex != Decoded.size(); ++SourceIndex) {
+    const InternalDecodedInst &Source = Decoded[SourceIndex];
+    if (!Source.DecodeSucceeded ||
+        (!LS.MIA->isBranch(Source.Inst) && !LS.MIA->isCall(Source.Inst)) ||
+        LS.MIA->isReturn(Source.Inst))
+      continue;
+    std::optional<uint64_t> Target =
+        getDirectTextTarget(Source, LS, TextAddr, TextEnd);
+    if (Target)
+      DirectEntries.emplace_back(SourceIndex, *Target);
+  }
+  DenseMap<std::pair<uint64_t, uint64_t>, bool> CalleePreservation;
+
   for (const ReachingCallGroup &Group : Groups) {
-    size_t BeginIndex = 0;
-    while (BeginIndex != Decoded.size() &&
-           Decoded[BeginIndex].Offset < Group.Begin)
-      ++BeginIndex;
-    size_t EndIndex = BeginIndex;
-    while (EndIndex != Decoded.size() && Decoded[EndIndex].Offset < Group.End)
-      ++EndIndex;
+    ArrayRef<InternalDecodedInst>::const_iterator Begin =
+        std::lower_bound(Decoded.begin(), Decoded.end(), Group.Begin,
+                         [](const InternalDecodedInst &DI, uint64_t Offset) {
+                           return DI.Offset < Offset;
+                         });
+    ArrayRef<InternalDecodedInst>::const_iterator End =
+        std::lower_bound(Begin, Decoded.end(), Group.End,
+                         [](const InternalDecodedInst &DI, uint64_t Offset) {
+                           return DI.Offset < Offset;
+                         });
+    size_t BeginIndex = static_cast<size_t>(Begin - Decoded.begin());
+    size_t EndIndex = static_cast<size_t>(End - Decoded.begin());
     if (BeginIndex == EndIndex)
       continue;
 
@@ -1359,12 +1446,38 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
       continue;
 
     std::vector<ReachingPcState> Before(EndIndex - BeginIndex);
-    Before.front().Reached = true;
-    Before.front().HasUnknown = true;
     SmallVector<size_t, 32> Worklist;
     BitVector Queued(EndIndex - BeginIndex);
-    Worklist.push_back(BeginIndex);
-    Queued.set(0);
+    auto seedUnknownEntry = [&](size_t Index) {
+      ReachingPcState &Entry = Before[Index - BeginIndex];
+      Entry.Reached = true;
+      Entry.HasUnknown = true;
+      if (!Queued.test(Index - BeginIndex)) {
+        Worklist.push_back(Index);
+        Queued.set(Index - BeginIndex);
+      }
+    };
+    seedUnknownEntry(BeginIndex);
+
+    // Every declared entry and direct cross-function target is an independent
+    // root. An entry into a materialization interior must not inherit the
+    // token established by the containing function's ordinary entry path.
+    for (uint64_t Entry : DeclaredEntries) {
+      DenseMap<uint64_t, size_t>::const_iterator EntryIndex =
+          OffsetToIndex.find(Entry);
+      if (EntryIndex != OffsetToIndex.end() &&
+          EntryIndex->second >= BeginIndex && EntryIndex->second < EndIndex)
+        seedUnknownEntry(EntryIndex->second);
+    }
+    for (const std::pair<size_t, uint64_t> &Entry : DirectEntries) {
+      if (Entry.first >= BeginIndex && Entry.first < EndIndex)
+        continue;
+      DenseMap<uint64_t, size_t>::const_iterator TargetIndex =
+          OffsetToIndex.find(Entry.second);
+      if (TargetIndex != OffsetToIndex.end() &&
+          TargetIndex->second >= BeginIndex && TargetIndex->second < EndIndex)
+        seedUnknownEntry(TargetIndex->second);
+    }
 
     while (!Worklist.empty()) {
       size_t I = Worklist.pop_back_val();
@@ -1411,9 +1524,45 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
         State.ActiveMaterializations = std::move(Preserved);
       }
 
-      if (llvm::is_contained(Group.Calls, I) && !State.HasUnknown &&
-          State.ActiveMaterializations.empty() && !State.Targets.empty())
+      bool IsReusableCall = llvm::is_contained(Group.Calls, I);
+      bool HasFiniteTargets = IsReusableCall && !State.HasUnknown &&
+                              State.ActiveMaterializations.empty() &&
+                              !State.Targets.empty();
+      if (HasFiniteTargets)
         Resolved[I] = State.Targets;
+
+      bool CalleesPreserve =
+          HasFiniteTargets && DI.Inst.getNumOperands() != 0 &&
+          DI.Inst.getOperand(0).isReg() && DI.Inst.getOperand(0).getReg();
+      if (CalleesPreserve) {
+        MCRegister ReturnRegister(DI.Inst.getOperand(0).getReg());
+        uint64_t RegisterKey = static_cast<uint64_t>(Group.TargetRegister.id())
+                                   << 32 |
+                               ReturnRegister.id();
+        for (uint64_t Target : State.Targets) {
+          std::pair<uint64_t, uint64_t> Key{Target, RegisterKey};
+          DenseMap<std::pair<uint64_t, uint64_t>, bool>::iterator Cached =
+              CalleePreservation.find(Key);
+          if (Cached == CalleePreservation.end())
+            Cached =
+                CalleePreservation
+                    .try_emplace(Key, calleePreservesReusableTarget(
+                                          Target, Group.TargetRegister,
+                                          ReturnRegister, Decoded, LS, TextAddr,
+                                          TextEnd, FunctionRanges))
+                    .first;
+          CalleesPreserve &= Cached->second;
+        }
+      }
+
+      if (LS.MIA->isCall(DI.Inst) && !CalleesPreserve) {
+        // MC call operands do not describe transitive clobbers. Carry the
+        // finite set past this call only after proving every exact local
+        // target preserves the reusable target pair.
+        State.HasUnknown = true;
+        State.Targets.clear();
+        State.ActiveMaterializations.clear();
+      }
 
       SmallVector<size_t, 2> Successors;
       auto appendFallthrough = [&]() {
@@ -1986,7 +2135,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   for (size_t I = 0; I != Decoded.size(); ++I)
     MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
   std::vector<ReachingCallTargets> ReusableCalls = resolveReusablePcCallTargets(
-      Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls, Text);
+      Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls,
+      DeclaredEntries, Text);
 
   std::optional<SmallVector<KnownCallSite, 4>> Calls = collectKnownCallSites(
       Decoded, LS, TextAddr, *TextEnd, MaterializedCalls, ReusableCalls);

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2087,12 +2087,12 @@ static std::optional<KnownCallSites> collectKnownCallSites(
       else
         HasFiniteExternalTarget = true;
     } else if (!ReusableCalls[I].empty()) {
-      for (uint64_t AbsoluteTarget : ReusableCalls[I]) {
-        if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
-          LocalTargets.push_back(AbsoluteTarget - TextAddr);
-        else
-          HasFiniteExternalTarget = true;
-      }
+      if (llvm::any_of(ReusableCalls[I], [TextAddr, TextEnd](uint64_t Target) {
+            return Target < TextAddr || Target >= TextEnd;
+          }))
+        continue;
+      for (uint64_t AbsoluteTarget : ReusableCalls[I])
+        LocalTargets.push_back(AbsoluteTarget - TextAddr);
     } else if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
                DI.Inst.getNumOperands() != 0 &&
                DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
@@ -2612,21 +2612,22 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
         Target = MaterializedCalls[InstIndex]->Target;
       }
       if (!ReusableCalls[InstIndex].empty()) {
-        size_t LocalTargetCount = 0;
-        size_t ExternalTargetCount = 0;
-        for (uint64_t ReusableTarget : ReusableCalls[InstIndex]) {
-          if (ReusableTarget >= TextAddr && ReusableTarget < *TextEnd) {
-            Info.Targets.insert(ReusableTarget - TextAddr);
-            ++LocalTargetCount;
-          } else {
-            ++ExternalTargetCount;
-          }
+        if (llvm::any_of(ReusableCalls[InstIndex],
+                         [TextAddr, TextEnd](uint64_t ReusableTarget) {
+                           return ReusableTarget < TextAddr ||
+                                  ReusableTarget >= *TextEnd;
+                         })) {
+          log() << "hotswap: unresolved call target at 0x"
+                << utohexstr(DI.Offset) << " (reusable target outside .text)\n";
+          Info.HasUnresolvedTargets = true;
+          continue;
         }
+        for (uint64_t ReusableTarget : ReusableCalls[InstIndex])
+          Info.Targets.insert(ReusableTarget - TextAddr);
         Info.BoundedIndirectTransfers.insert(DI.Offset);
         log() << "hotswap: resolved reusable PC-materialized call at 0x"
-              << utohexstr(DI.Offset) << " to " << LocalTargetCount
-              << " local and " << ExternalTargetCount
-              << " finite external target(s)\n";
+              << utohexstr(DI.Offset) << " to "
+              << ReusableCalls[InstIndex].size() << " target(s)\n";
         continue;
       }
       if (!Target) {

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2843,12 +2843,22 @@ static amd_comgr_status_t retargetCodeObjectImpl(
           << "parseable ELF64 (" << toString(ViewOrErr.takeError()) << ").\n";
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
   }
-  if (ViewOrErr->textSize() == 0) {
-    log() << "hotswap: error: retargetCodeObject: input ELF has empty "
-          << ".text section; nothing to rewrite.\n";
-    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
-  }
   ElfView &Elf = *ViewOrErr;
+  if (ViewOrErr->textSize() == 0) {
+    if (!Elf.isValidDataOnlyObject()) {
+      log() << "hotswap: error: retargetCodeObject: empty .text does not "
+               "describe a valid data-only code object.\n";
+      return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+    std::unique_ptr<WritableMemoryBuffer> Result =
+        copyOutputBuffer(ElfData, ElfSize, "data-only");
+    if (!Result)
+      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+    Out = std::move(Result);
+    log() << "hotswap: accepted data-only code object with empty .text; "
+             "returning a byte-identical copy.\n";
+    return AMD_COMGR_STATUS_SUCCESS;
+  }
   if (Prof)
     Profile.add(HotswapMetric::ElfParse, profNowNs() - ParseT0, 0);
 

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1525,15 +1525,29 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
       }
 
       bool IsReusableCall = llvm::is_contained(Group.Calls, I);
-      bool HasFiniteTargets = IsReusableCall && !State.HasUnknown &&
-                              State.ActiveMaterializations.empty() &&
-                              !State.Targets.empty();
-      if (HasFiniteTargets)
+      bool HasFiniteState = !State.HasUnknown &&
+                            State.ActiveMaterializations.empty() &&
+                            !State.Targets.empty();
+      if (IsReusableCall && HasFiniteState)
         Resolved[I] = State.Targets;
 
-      bool CalleesPreserve =
-          HasFiniteTargets && DI.Inst.getNumOperands() != 0 &&
-          DI.Inst.getOperand(0).isReg() && DI.Inst.getOperand(0).getReg();
+      // The first call after a straight-line materialization is also resolved
+      // by the one-shot matcher. Let that bootstrap call preserve the reaching
+      // value only when both analyses prove the same singleton target through
+      // this exact target pair.
+      bool IsMatchingBootstrapCall = false;
+      if (LocalCalls[I] && HasFiniteState && State.Targets.size() == 1 &&
+          State.Targets.front() == LocalCalls[I]->Target &&
+          DI.Inst.getNumOperands() >= 2) {
+        const MCOperand &TargetOp =
+            DI.Inst.getOperand(DI.Inst.getNumOperands() - 1);
+        IsMatchingBootstrapCall =
+            TargetOp.isReg() && TargetOp.getReg() == Group.TargetRegister;
+      }
+      bool CalleesPreserve = (IsReusableCall || IsMatchingBootstrapCall) &&
+                             HasFiniteState && DI.Inst.getNumOperands() != 0 &&
+                             DI.Inst.getOperand(0).isReg() &&
+                             DI.Inst.getOperand(0).getReg();
       if (CalleesPreserve) {
         MCRegister ReturnRegister(DI.Inst.getOperand(0).getReg());
         uint64_t RegisterKey = static_cast<uint64_t>(Group.TargetRegister.id())

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2526,6 +2526,14 @@ struct ReachingCallGroup {
   SmallVector<size_t, 8> Calls;
 };
 
+struct SymbolLessReturnRegion {
+  uint64_t Entry = 0;
+  MCRegister LinkRegister;
+  SmallVector<size_t, 16> Instructions;
+  SmallVector<size_t, 2> Returns;
+  SmallVector<uint64_t, 8> Continuations;
+};
+
 static std::optional<uint64_t>
 getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
                     uint64_t TextAddr, uint64_t TextEnd);
@@ -2537,7 +2545,23 @@ static bool calleePreservesReusableTarget(
     uint64_t Target, MCRegister TargetRegister, MCRegister ReturnRegister,
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
-    ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<SymbolLessReturnRegion> SymbolLessRegions) {
+  if (LS.MRI->regsOverlap(TargetRegister, ReturnRegister))
+    return false;
+
+  for (const SymbolLessReturnRegion &Region : SymbolLessRegions) {
+    if (Region.Entry > std::numeric_limits<uint64_t>::max() - TextAddr ||
+        TextAddr + Region.Entry != Target ||
+        Region.LinkRegister != ReturnRegister || Region.Instructions.empty())
+      continue;
+    for (size_t InstIndex : Region.Instructions)
+      if (InstIndex >= Decoded.size() || !Decoded[InstIndex].DecodeSucceeded ||
+          definesOverlappingRegister(Decoded[InstIndex], LS, TargetRegister))
+        return false;
+    return true;
+  }
+
   const ElfView::FunctionTextRange *Callee = nullptr;
   for (const ElfView::FunctionTextRange &Range : FunctionRanges)
     if (Range.Begin == Target && Range.Begin >= TextAddr &&
@@ -3065,7 +3089,9 @@ static std::vector<ReachingCallTargets> resolveReusablePcValuesAtUses(
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
     ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
-    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<ReachingPcUse> Uses,
+    ArrayRef<uint64_t> DeclaredEntries,
+    ArrayRef<SymbolLessReturnRegion> SymbolLessRegions,
+    ArrayRef<ReachingPcUse> Uses,
     ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
   std::vector<ReachingCallTargets> Resolved(Decoded.size());
   SmallVector<ReachingCallGroup, 8> Groups;
@@ -3273,7 +3299,8 @@ static std::vector<ReachingCallTargets> resolveReusablePcValuesAtUses(
                     .try_emplace(Key, calleePreservesReusableTarget(
                                           Target, Group.TargetRegister,
                                           ReturnRegister, Decoded, LS, TextAddr,
-                                          TextEnd, FunctionRanges))
+                                          TextEnd, FunctionRanges,
+                                          SymbolLessRegions))
                     .first;
           CalleesPreserve &= Cached->second;
         }
@@ -3346,6 +3373,7 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
     ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
     ArrayRef<uint64_t> DeclaredEntries,
+    ArrayRef<SymbolLessReturnRegion> SymbolLessRegions,
     ArrayRef<FiniteSetPcTransfer> FiniteSetPcTransfers = {}) {
   SmallVector<ReachingPcUse, 8> Uses;
   for (size_t I = 0; I != Decoded.size(); ++I) {
@@ -3360,7 +3388,7 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
   }
   return resolveReusablePcValuesAtUses(
       Decoded, LS, TextAddr, TextEnd, FunctionRanges, LocalCalls,
-      DeclaredEntries, Uses, FiniteSetPcTransfers);
+      DeclaredEntries, SymbolLessRegions, Uses, FiniteSetPcTransfers);
 }
 
 struct KnownCallSite {
@@ -4067,14 +4095,6 @@ static BitVector computeFiniteControlFlowReachability(
   return Reachable;
 }
 
-struct SymbolLessReturnRegion {
-  uint64_t Entry = 0;
-  MCRegister LinkRegister;
-  SmallVector<size_t, 16> Instructions;
-  SmallVector<size_t, 2> Returns;
-  SmallVector<uint64_t, 8> Continuations;
-};
-
 static bool instructionMayFallThrough(const InternalDecodedInst &DI,
                                       const LLVMState &LS) {
   if (!DI.DecodeSucceeded)
@@ -4396,6 +4416,29 @@ static SmallVector<SymbolLessReturnRegion, 8> collectSymbolLessReturnRegions(
     if (!Region.Instructions.empty())
       Disjoint.push_back(std::move(Region));
   return Disjoint;
+}
+
+static bool
+hasSameSymbolLessPreservationProof(ArrayRef<SymbolLessReturnRegion> Regions,
+                                   const SymbolLessReturnRegion &Required) {
+  for (const SymbolLessReturnRegion &Region : Regions)
+    if (Region.Entry == Required.Entry &&
+        Region.LinkRegister == Required.LinkRegister &&
+        Region.Instructions == Required.Instructions &&
+        Region.Returns == Required.Returns)
+      return true;
+  return false;
+}
+
+static bool
+hasSameSymbolLessPreservationProofs(ArrayRef<SymbolLessReturnRegion> LHS,
+                                    ArrayRef<SymbolLessReturnRegion> RHS) {
+  if (LHS.size() != RHS.size())
+    return false;
+  for (const SymbolLessReturnRegion &Region : LHS)
+    if (!hasSameSymbolLessPreservationProof(RHS, Region))
+      return false;
+  return true;
 }
 
 struct FiniteControlFlowAudit {
@@ -6217,8 +6260,10 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   std::optional<ControlFlowScanIndex> Index;
   SmallVector<BoundedSetPcReturn, 2> BoundedReturns;
   SmallVector<SymbolLessReturnRegion, 8> SymbolLessRegions;
+  SmallVector<SymbolLessReturnRegion, 8> PreservingSymbolLessRegions;
   bool IndirectControlFlowClosed = false;
   bool HasUnboundedIndirectEntries = false;
+  bool RejectedSymbolLessPreservation = false;
 
   // Exact set-PC edges are an optimistic over-approximation used only to
   // discover later finite call targets. Rebuild from scratch whenever the
@@ -6237,7 +6282,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       MaterializedCalls[Entry.first] = Entry.second;
     ReusableCalls = resolveReusablePcCallTargets(
         Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls,
-        DeclaredEntries, EnabledSetPcTransfers);
+        DeclaredEntries, PreservingSymbolLessRegions, EnabledSetPcTransfers);
     if (!addReusableCallsToIndex(Decoded, LS, TextAddr, *TextEnd, ReusableCalls,
                                  *Index))
       return std::nullopt;
@@ -6289,6 +6334,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
         ExternalEntries, *Index, EnabledSetPcTransfers, AllBoundedReturns,
         SymbolLessRegions, Text);
     if (Audit.InvalidSetPcCandidates.any()) {
+      PreservingSymbolLessRegions.clear();
+      RejectedSymbolLessPreservation = false;
       for (size_t I = 0; I != EnabledSetPcTransfers.size(); ++I) {
         if (!Audit.InvalidSetPcCandidates.test(I))
           continue;
@@ -6305,6 +6352,25 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       ProvenSetPcCandidates.reset();
       continue;
     }
+    if (PreservingSymbolLessRegions.empty() &&
+        !RejectedSymbolLessPreservation && !SymbolLessRegions.empty()) {
+      // Symbol-less leaves and reusable target preservation form a bounded
+      // fixed point: later calls keep the first audit open until the already
+      // proven leaf is allowed to preserve their target pair. Try those local
+      // facts provisionally, then require the expanded audit below to close
+      // and reproduce every preservation proof before retaining them.
+      PreservingSymbolLessRegions = SymbolLessRegions;
+      continue;
+    }
+    if (!Audit.Closed && !PreservingSymbolLessRegions.empty()) {
+      // A preservation fact may expose more calls and therefore more entry
+      // edges. Keep it only when the expanded graph remains independently
+      // closed; otherwise rerun without the assumption and do not rediscover
+      // the same self-supporting fact.
+      PreservingSymbolLessRegions.clear();
+      RejectedSymbolLessPreservation = true;
+      continue;
+    }
     if (!Audit.Closed && !SymbolLessRegions.empty()) {
       // Symbol-less returns depend on a closed object-wide entry proof. If
       // any reachable entry source remains open, discard those inferred
@@ -6318,12 +6384,31 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
           SymbolLessRegions, Text);
     }
     if (!Audit.Closed && !EnabledSetPcTransfers.empty()) {
+      PreservingSymbolLessRegions.clear();
+      RejectedSymbolLessPreservation = false;
       for (const FiniteSetPcTransfer &Enabled : EnabledSetPcTransfers)
         for (size_t J = 0; J != AllSetPcCandidates.size(); ++J)
           if (AllSetPcCandidates[J].InstIndex == Enabled.InstIndex) {
             RejectedSetPcCandidates.set(J);
           }
       ProvenSetPcCandidates.reset();
+      continue;
+    }
+    bool LostPreservationProof = false;
+    for (const SymbolLessReturnRegion &Region : PreservingSymbolLessRegions)
+      if (!hasSameSymbolLessPreservationProof(SymbolLessRegions, Region)) {
+        LostPreservationProof = true;
+        break;
+      }
+    if (LostPreservationProof) {
+      PreservingSymbolLessRegions.clear();
+      RejectedSymbolLessPreservation = true;
+      continue;
+    }
+    if (Audit.Closed && !RejectedSymbolLessPreservation &&
+        !hasSameSymbolLessPreservationProofs(PreservingSymbolLessRegions,
+                                             SymbolLessRegions)) {
+      PreservingSymbolLessRegions = SymbolLessRegions;
       continue;
     }
     IndirectControlFlowClosed = Audit.Closed;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -410,19 +410,19 @@ truncateNopSledsAtDirectTargets(std::vector<NopSled> &Sleds,
   return true;
 }
 
-std::optional<SmallVector<uint8_t>> encodeSetPCLongBranch(const LLVMState &LS,
-                                                          uint64_t FromOffset,
-                                                          uint64_t TargetOffset,
-                                                          unsigned SgprBase) {
-  if ((SgprBase & 1u) != 0) {
+std::optional<SmallVector<uint8_t>>
+encodeSetPCLongBranch(const LLVMState &LS, uint64_t FromOffset,
+                      uint64_t TargetOffset, unsigned SgprBase, bool UseVcc) {
+  if (!UseVcc && (SgprBase & 1u) != 0) {
     log() << "hotswap: error: set-PC long branch requires an aligned "
              "SGPR pair, got s"
           << SgprBase << "\n";
     return std::nullopt;
   }
 
-  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
-                           std::to_string(SgprBase + 1) + "]";
+  const std::string Pair = UseVcc ? "vcc"
+                                  : "s[" + std::to_string(SgprBase) + ":" +
+                                        std::to_string(SgprBase + 1) + "]";
   SmallVector<uint8_t> GetPc = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
   if (GetPc.empty())
     return std::nullopt;
@@ -493,10 +493,68 @@ getSetPcLongBranchLayoutSize(uint64_t FromOffset, uint64_t TargetOffset) {
   return SetPcReturnReserveBytes;
 }
 
+static std::optional<SmallVector<uint8_t>>
+encodeSetPcGateway(const LLVMState &LS, uint64_t FromOffset,
+                   uint64_t TargetOffset, unsigned SgprBase, bool UseVcc,
+                   bool PreserveVcc) {
+  SmallVector<uint8_t> Bytes;
+  uint64_t SetPcOffset = FromOffset;
+  if (PreserveVcc) {
+    if (!UseVcc) {
+      log() << "hotswap: error: VCC-preserving gateway does not use VCC\n";
+      return std::nullopt;
+    }
+    Bytes = assembleSingleInst(
+        "s_mov_b32 s" + std::to_string(SgprBase) + ", vcc_lo", LS);
+    if (Bytes.size() != VccMoveBytes)
+      return std::nullopt;
+    std::optional<uint64_t> Offset = checkedAddUint64(
+        FromOffset, Bytes.size(), "VCC-preserving set-PC gateway offset");
+    if (!Offset)
+      return std::nullopt;
+    SetPcOffset = *Offset;
+  }
+
+  std::optional<SmallVector<uint8_t>> SetPc =
+      encodeSetPCLongBranch(LS, SetPcOffset, TargetOffset, SgprBase, UseVcc);
+  if (!SetPc)
+    return std::nullopt;
+  Bytes.append(SetPc->begin(), SetPc->end());
+  return Bytes;
+}
+
+static std::optional<uint32_t>
+getSetPcGatewayLayoutSize(uint64_t FromOffset, uint64_t TargetOffset,
+                          unsigned SgprBase, bool UseVcc,
+                          bool PreserveVcc) {
+  if (PreserveVcc && !UseVcc)
+    return std::nullopt;
+  if (!UseVcc && (SgprBase & 1u) != 0)
+    return std::nullopt;
+
+  uint64_t SetPcOffset = FromOffset;
+  uint32_t PrefixBytes = 0;
+  if (PreserveVcc) {
+    std::optional<uint64_t> Offset = checkedAddUint64(
+        FromOffset, VccMoveBytes,
+        "VCC-preserving set-PC gateway layout offset");
+    if (!Offset)
+      return std::nullopt;
+    SetPcOffset = *Offset;
+    PrefixBytes = VccMoveBytes;
+  }
+
+  std::optional<uint32_t> SetPcBytes =
+      getSetPcLongBranchLayoutSize(SetPcOffset, TargetOffset);
+  if (!SetPcBytes)
+    return std::nullopt;
+  return PrefixBytes + *SetPcBytes;
+}
+
 Expected<std::optional<EncodedSetPcGateway>>
 findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                         uint64_t FromOffset, uint64_t TargetOffset,
-                        unsigned SgprBase) {
+                        unsigned SgprBase, bool UseVcc, bool PreserveVcc) {
   NopSled *Best = nullptr;
   uint32_t BestLayoutSize = 0;
   uint64_t BestUsableEnd = 0;
@@ -514,8 +572,9 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
       continue;
 
     std::optional<uint32_t> LayoutSize =
-        getSetPcLongBranchLayoutSize(Sled.WritePos, TargetOffset);
-    if ((SgprBase & 1u) != 0 || !LayoutSize)
+        getSetPcGatewayLayoutSize(Sled.WritePos, TargetOffset, SgprBase,
+                                  UseVcc, PreserveVcc);
+    if (!LayoutSize)
       return createStringError(
           Twine("failed to encode set-PC gateway at candidate offset 0x") +
           utohexstr(Sled.WritePos));
@@ -530,7 +589,8 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
   if (!Best)
     return std::nullopt;
   std::optional<SmallVector<uint8_t>> BestBytes =
-      encodeSetPCLongBranch(LS, Best->WritePos, TargetOffset, SgprBase);
+      encodeSetPcGateway(LS, Best->WritePos, TargetOffset, SgprBase, UseVcc,
+                         PreserveVcc);
   if (!BestBytes)
     return createStringError(
         Twine("failed to encode set-PC gateway at candidate offset 0x") +
@@ -543,6 +603,71 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
         " bytes, encoded " + Twine(BestBytes->size()) + " bytes");
   return std::optional<EncodedSetPcGateway>(
       EncodedSetPcGateway{Best, std::move(*BestBytes)});
+}
+
+/// Split a live-VCC gateway across an eight-byte nearby save/branch segment
+/// and a 16-byte get-PC/add/set-PC segment. This serves functions whose safe
+/// padding is fragmented too finely for the ordinary contiguous 20-byte
+/// sequence, while preserving SCC and saving VCC before it is used as the
+/// target pair.
+std::optional<EncodedSplitVccGateway>
+findSplitVccGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
+                    uint64_t FromOffset, uint64_t TargetOffset,
+                    unsigned SaveSgpr) {
+  constexpr uint64_t PrimaryBytes = 2 * MinInstSize;
+  constexpr uint64_t SecondaryBytes = SetPcForwardSequenceBytes - MinInstSize;
+  SmallVector<size_t, 32> PrimaryCandidates;
+  for (size_t I = 0; I != Gateways.size(); ++I) {
+    const NopSled &Sled = Gateways[I];
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    if (Sled.GatewayOnly || FromOffset < Sled.FunctionStart ||
+        FromOffset >= Sled.FunctionEnd || Sled.WritePos > UsableEnd ||
+        PrimaryBytes > UsableEnd - Sled.WritePos ||
+        !isSBranchReachable(FromOffset, Sled.WritePos))
+      continue;
+    PrimaryCandidates.push_back(I);
+  }
+  llvm::sort(PrimaryCandidates, [&](size_t LHS, size_t RHS) {
+    uint64_t L = Gateways[LHS].WritePos;
+    uint64_t R = Gateways[RHS].WritePos;
+    uint64_t LDistance = FromOffset > L ? FromOffset - L : L - FromOffset;
+    uint64_t RDistance = FromOffset > R ? FromOffset - R : R - FromOffset;
+    return LDistance < RDistance;
+  });
+
+  for (size_t PrimaryIndex : PrimaryCandidates) {
+    const NopSled &Primary = Gateways[PrimaryIndex];
+    uint64_t PrimaryOffset = Primary.WritePos;
+    for (size_t SecondaryIndex = 0; SecondaryIndex != Gateways.size();
+         ++SecondaryIndex) {
+      if (SecondaryIndex == PrimaryIndex)
+        continue;
+      const NopSled &Secondary = Gateways[SecondaryIndex];
+      uint64_t UsableEnd = std::min(Secondary.End, Secondary.FunctionEnd);
+      if (FromOffset < Secondary.FunctionStart ||
+          FromOffset >= Secondary.FunctionEnd ||
+          Secondary.WritePos > UsableEnd ||
+          SecondaryBytes > UsableEnd - Secondary.WritePos ||
+          (PrimaryOffset < Secondary.WritePos + SecondaryBytes &&
+           Secondary.WritePos < PrimaryOffset + PrimaryBytes) ||
+          !isSBranchReachable(PrimaryOffset + MinInstSize, Secondary.WritePos))
+        continue;
+      std::optional<SmallVector<uint8_t>> SetPc = encodeSetPCLongBranch(
+          LS, Secondary.WritePos, TargetOffset, SaveSgpr, /*UseVcc=*/true);
+      if (!SetPc || SetPc->size() > SecondaryBytes)
+        continue;
+      SmallVector<uint8_t> Save = assembleSingleInst(
+          "s_mov_b32 s" + std::to_string(SaveSgpr) + ", vcc_lo", LS);
+      SmallVector<uint8_t> Branch =
+          LS.encodeSBranch(PrimaryOffset + MinInstSize, Secondary.WritePos);
+      if (Save.size() != MinInstSize || Branch.size() != MinInstSize)
+        continue;
+      Save.append(Branch);
+      return EncodedSplitVccGateway{PrimaryIndex, SecondaryIndex,
+                                    std::move(Save), std::move(*SetPc)};
+    }
+  }
+  return std::nullopt;
 }
 
 static std::optional<unsigned> numberedSgprIndex(const MCRegisterInfo &MRI,
@@ -644,7 +769,8 @@ summarizeSafeSgprUsage(PatchContext &Ctx,
 
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
-                         unsigned Alignment, StringRef Context) {
+                         unsigned Alignment, StringRef Context,
+                         bool ReportNoSpace) {
   if (Count == 0 || Alignment == 0 || (Alignment & (Alignment - 1)) != 0) {
     log() << "hotswap: error: " << Context
           << ": invalid global SGPR block request (count=" << Count
@@ -741,8 +867,10 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
   }
   unsigned Base = (HighWatermark + Alignment - 1) & ~(Alignment - 1);
   if (Base > Ctx.Config.MaxSgprs || Count > Ctx.Config.MaxSgprs - Base) {
-    log() << "hotswap: error: " << Context << ": no aligned block of " << Count
-          << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs << "\n";
+    if (ReportNoSpace)
+      log() << "hotswap: error: " << Context << ": no aligned block of "
+            << Count << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs
+            << "\n";
     return std::nullopt;
   }
   return SafeSgprScratchBlock{Base, Count};
@@ -1185,26 +1313,69 @@ findLocallyDeadSgprPair(PatchContext &Ctx, uint64_t InstOffset,
   return std::nullopt;
 }
 
-static std::optional<SafeSgprScratchBlock>
-reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
-                     ArrayRef<uint8_t> Replacement) {
+struct FarReturnScratch {
+  bool Available = false;
+  unsigned SgprBase = 0;
+  bool UseVcc = false;
+  bool PreserveVcc = false;
+};
+
+static FarReturnScratch reserveSafeFarReturn(PatchContext &Ctx,
+                                             uint64_t InstOffset,
+                                             uint32_t InstSize,
+                                             ArrayRef<uint8_t> Replacement) {
   std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
-      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return");
+      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return",
+      /*ReportNoSpace=*/false);
   if (Scratch) {
     if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch,
                                     "safe far return"))
-      return std::nullopt;
-    return Scratch;
+      return {};
+    return FarReturnScratch{/*Available=*/true, Scratch->Base,
+                            /*UseVcc=*/false, /*PreserveVcc=*/false};
   }
 
-  std::optional<unsigned> LocalPair =
-      findLocallyDeadSgprPair(Ctx, InstOffset, InstSize, Replacement);
-  if (!LocalPair)
-    return std::nullopt;
-  log() << "hotswap: safe far return: reusing locally dead s[" << *LocalPair
-        << ":" << *LocalPair + 1 << "] at 0x" << utohexstr(InstOffset)
-        << "\n";
-  return SafeSgprScratchBlock{*LocalPair, 2};
+  if (Ctx.LS.VCCRegister.isValid() &&
+      !replacementNeedsIncomingRegister(Replacement, Ctx.LS,
+                                        Ctx.LS.VCCRegister) &&
+      isRegisterDefinitelyDeadAtContinuation(Ctx, InstOffset, InstSize,
+                                             Ctx.LS.VCCRegister)) {
+    log() << "hotswap: safe far return: reusing dead VCC at 0x"
+          << utohexstr(InstOffset) << "\n";
+    return FarReturnScratch{/*Available=*/true, /*SgprBase=*/0,
+                            /*UseVcc=*/true, /*PreserveVcc=*/false};
+  }
+
+  if (std::optional<unsigned> LocalPair =
+          findLocallyDeadSgprPair(Ctx, InstOffset, InstSize, Replacement)) {
+    log() << "hotswap: safe far return: reusing locally dead s[" << *LocalPair
+          << ":" << *LocalPair + 1 << "] at 0x" << utohexstr(InstOffset)
+          << "\n";
+    return FarReturnScratch{/*Available=*/true, *LocalPair,
+                            /*UseVcc=*/false, /*PreserveVcc=*/false};
+  }
+
+  std::string Owner =
+      Ctx.Elf.findKernelAtAddress(InstOffset + Ctx.Elf.textAddr());
+  std::optional<unsigned> WavefrontSize =
+      Owner.empty() ? std::nullopt : Ctx.Elf.getKernelWavefrontSize(Owner);
+  if (WavefrontSize == 32 && InstSize >= 2 * MinInstSize) {
+    std::optional<SafeSgprScratchBlock> Save = findSafeSgprScratchBlock(
+        Ctx, InstOffset, /*Count=*/1, /*Alignment=*/1,
+        "VCC-preserving far return", /*ReportNoSpace=*/false);
+    if (Save) {
+      log() << "hotswap: safe far return: deferring live wave32 VCC_LO "
+               "preservation in s"
+            << Save->Base << " at 0x" << utohexstr(InstOffset) << "\n";
+      return FarReturnScratch{/*Available=*/true, Save->Base,
+                              /*UseVcc=*/true, /*PreserveVcc=*/true};
+    }
+  }
+
+  log() << "hotswap: safe far return: no register pair at 0x"
+        << utohexstr(InstOffset)
+        << "; deferring to the s_branch island planner\n";
+  return {};
 }
 
 bool isSBranchReachable(uint64_t From, uint64_t To) {
@@ -1255,9 +1426,21 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   const bool Far = !(isSBranchReachable(InstOffset, *PoolStart) &&
                      isSBranchReachable(*ShortBackFrom, *ReturnTo));
 
-  uint64_t ReturnReserve = Far ? SetPcReturnReserveBytes : MinInstSize;
+  FarReturnScratch Scratch;
+  if (Far)
+    Scratch = reserveSafeFarReturn(Ctx, InstOffset, InstSize, Replacement);
+  uint64_t ReturnReserve = MinInstSize;
+  uint64_t BodyPrefix = 0;
+  if (Far && Scratch.Available) {
+    ReturnReserve = Scratch.PreserveVcc ? VccPreservingReturnReserveBytes
+                                        : SetPcReturnReserveBytes;
+    BodyPrefix = Scratch.PreserveVcc ? VccRestoreSequenceBytes : 0;
+  }
   std::optional<uint64_t> TrampolineSize = checkedAddUint64(
-      Replacement.size(), ReturnReserve, "queued trampoline size");
+      Replacement.size(), BodyPrefix, "queued trampoline body size");
+  if (TrampolineSize)
+    TrampolineSize = checkedAddUint64(*TrampolineSize, ReturnReserve,
+                                      "queued trampoline size");
   if (!TrampolineSize)
     return false;
   std::optional<uint64_t> QueuedBytes =
@@ -1269,6 +1452,17 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   Trampoline T;
   T.OriginalOffset = InstOffset;
   T.OriginalSize = InstSize;
+  if (Scratch.PreserveVcc) {
+    SmallVector<std::string, 2> RestoreLines;
+    RestoreLines.push_back("s_mov_b32 vcc_lo, s" +
+                           std::to_string(Scratch.SgprBase));
+    RestoreLines.push_back("s_delay_alu instid0(SALU_CYCLE_1)");
+    SmallVector<uint8_t> Restore =
+        assembleInstructions(joinAsmLines(RestoreLines), Ctx.LS);
+    if (Restore.size() != VccRestoreSequenceBytes)
+      return false;
+    T.Bytes.append(Restore.begin(), Restore.end());
+  }
   T.Bytes.insert(T.Bytes.end(), Replacement.begin(), Replacement.end());
   if (std::optional<ElfView::FunctionTextRange> Range =
           Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset)) {
@@ -1290,14 +1484,12 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
     if (InstSize < MinInstSize)
       return declineFar(Twine(InstSize) + " B, smaller than " +
                         Twine(MinInstSize) + " B forward branch");
-    std::optional<SafeSgprScratchBlock> Scratch =
-        reserveSafeFarReturn(Ctx, InstOffset, InstSize, Replacement);
-    if (!Scratch)
-      return declineFar("no safe SGPR pair for set-PC return");
-    T.Bytes.insert(T.Bytes.end(), SetPcReturnReserveBytes, uint8_t{0});
+    T.Bytes.insert(T.Bytes.end(), ReturnReserve, uint8_t{0});
     T.Long = true;
-    T.UsesSetPCBack = true;
-    T.LongBranchSgprBase = Scratch->Base;
+    T.UsesSetPCBack = Scratch.Available;
+    T.LongBranchSgprBase = Scratch.SgprBase;
+    T.LongBranchUsesVcc = Scratch.UseVcc;
+    T.LongBranchPreservesVcc = Scratch.PreserveVcc;
     Ctx.Profile.count(HotswapMetric::JumpLong);
     Ctx.OutTrampolines.emplace_back(std::move(T));
     Ctx.QueuedTrampolineBytes = *QueuedBytes;
@@ -4064,15 +4256,22 @@ mergeAdjacentLongTrampolines(std::vector<Trampoline> &Trampolines,
       Trampoline &Prev = Merged.back();
       std::optional<uint64_t> PrevEnd = checkedAddUint64(
           Prev.OriginalOffset, Prev.OriginalSize, "adjacent trampoline end");
+      uint32_t BackReserve = Prev.LongBranchPreservesVcc
+                                 ? VccPreservingReturnReserveBytes
+                                 : SetPcReturnReserveBytes;
+      uint32_t BodyPrefix =
+          Prev.LongBranchPreservesVcc ? VccRestoreSequenceBytes : 0;
       Adjacent = PrevEnd && *PrevEnd == T.OriginalOffset && Prev.Long &&
                  T.Long && Prev.UsesSetPCBack && T.UsesSetPCBack &&
+                 Prev.LongBranchPreservesVcc == T.LongBranchPreservesVcc &&
                  Prev.LongBranchSgprBase == T.LongBranchSgprBase &&
+                 Prev.LongBranchUsesVcc == T.LongBranchUsesVcc &&
                  Prev.HasFunctionRange && T.HasFunctionRange &&
                  Prev.FunctionStart == T.FunctionStart &&
                  Prev.FunctionEnd == T.FunctionEnd &&
                  !DirectBranchTargets.contains(T.OriginalOffset) &&
-                 Prev.Bytes.size() >= SetPcReturnReserveBytes &&
-                 T.Bytes.size() >= SetPcReturnReserveBytes;
+                 Prev.Bytes.size() >= BackReserve &&
+                 T.Bytes.size() >= BackReserve + BodyPrefix;
     }
 
     if (!Adjacent) {
@@ -4086,8 +4285,13 @@ mergeAdjacentLongTrampolines(std::vector<Trampoline> &Trampolines,
       Merged.emplace_back(std::move(T));
       continue;
     }
-    Prev.Bytes.resize(Prev.Bytes.size() - SetPcReturnReserveBytes);
-    Prev.Bytes.append(T.Bytes.begin(), T.Bytes.end());
+    uint32_t BackReserve = Prev.LongBranchPreservesVcc
+                               ? VccPreservingReturnReserveBytes
+                               : SetPcReturnReserveBytes;
+    size_t BodyPrefix =
+        Prev.LongBranchPreservesVcc ? VccRestoreSequenceBytes : 0;
+    Prev.Bytes.resize(Prev.Bytes.size() - BackReserve);
+    Prev.Bytes.append(T.Bytes.begin() + BodyPrefix, T.Bytes.end());
     Prev.OriginalSize += T.OriginalSize;
     ++MergeCount;
   }
@@ -4105,6 +4309,43 @@ static void appendPoolBranchIslands(std::vector<Trampoline> &Trampolines) {
     T.Bytes.append(PoolBranchIslandBytes, uint8_t{0});
     T.HasPoolBranchIsland = true;
   }
+}
+
+/// Live-VCC preservation can be selected for an original eight-byte site so
+/// adjacent patched sites can merge into a restore+delay landing. If
+/// coalescing cannot prove at least that 12-byte source window, fall back to
+/// the registerless route before gateway planning. Ordinary straight-line
+/// expansion deliberately skips these candidates: growing their pool bodies
+/// after initial layout could invalidate a later short-branch classification.
+static bool finalizeDeferredVccPreservation(PatchContext &Ctx) {
+  for (Trampoline &T : Ctx.OutTrampolines) {
+    if (!T.LongBranchPreservesVcc)
+      continue;
+    if (T.Bytes.size() <
+        VccRestoreSequenceBytes + VccPreservingReturnReserveBytes) {
+      log() << "hotswap: error: deferred live-VCC trampoline at 0x"
+            << utohexstr(T.OriginalOffset) << " is truncated\n";
+      return false;
+    }
+    if (T.OriginalSize < VccPreservingSourceBytes) {
+      T.Bytes.erase(T.Bytes.begin(), T.Bytes.begin() + VccRestoreSequenceBytes);
+      T.Bytes.resize(T.Bytes.size() - VccPreservingReturnReserveBytes);
+      T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
+      T.UsesSetPCBack = false;
+      T.LongBranchSgprBase = 0;
+      T.LongBranchUsesVcc = false;
+      T.LongBranchPreservesVcc = false;
+      log() << "hotswap: deferred live-VCC preservation at 0x"
+            << utohexstr(T.OriginalOffset)
+            << " fell back to a registerless far return\n";
+      continue;
+    }
+    SafeSgprScratchBlock Save{T.LongBranchSgprBase, 1};
+    if (!commitSafeSgprScratchBlock(Ctx, T.OriginalOffset, Save,
+                                    "activated VCC-preserving far return"))
+      return false;
+  }
+  return true;
 }
 
 static bool isEndProgram(const InternalDecodedInst &DI, const LLVMState &LS) {
@@ -4216,7 +4457,8 @@ collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
 /// Grow undersized far-site windows only through proven straight-line code.
 /// Patched neighbors are merged; ordinary instructions are copied verbatim
 /// into the trampoline body and retain their original order. This is bounded
-/// to the 20 bytes required by the gfx12 SCC-neutral forward sequence.
+/// to the source bytes required by the selected gfx12 set-PC sequence and, for
+/// a live wave32 VCC, its restore landing pad.
 static void
 expandStraightLineTrampolines(PatchContext &Ctx,
                               const DenseSet<uint64_t> &DirectBranchTargets) {
@@ -4235,8 +4477,13 @@ expandStraightLineTrampolines(PatchContext &Ctx,
         IndirectControlFlowFunctions.contains(
             Ctx.OutTrampolines[I].FunctionStart))
       continue;
-    while (Ctx.OutTrampolines[I].Long &&
-           Ctx.OutTrampolines[I].OriginalSize < SetPcForwardSequenceBytes) {
+    if (Ctx.OutTrampolines[I].LongBranchPreservesVcc)
+      continue;
+    while (Ctx.OutTrampolines[I].Long && Ctx.OutTrampolines[I].UsesSetPCBack &&
+           Ctx.OutTrampolines[I].OriginalSize <
+               (Ctx.OutTrampolines[I].LongBranchPreservesVcc
+                    ? VccPreservingReturnReserveBytes + VccLandingPadBytes
+                    : SetPcForwardSequenceBytes)) {
       Trampoline &T = Ctx.OutTrampolines[I];
       std::optional<uint64_t> End = checkedAddUint64(
           T.OriginalOffset, T.OriginalSize, "straight-line expansion end");
@@ -4245,9 +4492,13 @@ expandStraightLineTrampolines(PatchContext &Ctx,
 
       if (I + 1 < Ctx.OutTrampolines.size() &&
           Ctx.OutTrampolines[I + 1].OriginalOffset == *End) {
+        if (T.LongBranchPreservesVcc)
+          break;
         Trampoline &Next = Ctx.OutTrampolines[I + 1];
         if (!Next.Long || !Next.UsesSetPCBack ||
             Next.LongBranchSgprBase != T.LongBranchSgprBase ||
+            Next.LongBranchUsesVcc != T.LongBranchUsesVcc ||
+            Next.LongBranchPreservesVcc != T.LongBranchPreservesVcc ||
             !T.HasFunctionRange || !Next.HasFunctionRange ||
             T.FunctionStart != Next.FunctionStart ||
             T.FunctionEnd != Next.FunctionEnd ||
@@ -4269,21 +4520,27 @@ expandStraightLineTrampolines(PatchContext &Ctx,
       if (!Current)
         break;
       const InternalDecodedInst &DI = *Current;
+      uint32_t BackReserve = T.LongBranchPreservesVcc
+                                 ? VccPreservingReturnReserveBytes
+                                 : SetPcReturnReserveBytes;
       std::optional<ElfView::FunctionTextRange> Range =
           Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
       if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
           Range->End != T.FunctionEnd ||
           !isSafeStraightLineRelocation(DI, Ctx.LS, Protected) ||
-          T.Bytes.size() < SetPcReturnReserveBytes)
+          T.Bytes.size() < BackReserve)
         break;
 
-      T.Bytes.insert(T.Bytes.end() - SetPcReturnReserveBytes,
-                     Ctx.Text + DI.Offset, Ctx.Text + DI.Offset + DI.Size);
+      T.Bytes.insert(T.Bytes.end() - BackReserve, Ctx.Text + DI.Offset,
+                     Ctx.Text + DI.Offset + DI.Size);
       T.OriginalSize += DI.Size;
     }
 
-    while (Ctx.OutTrampolines[I].Long &&
-           Ctx.OutTrampolines[I].OriginalSize < SetPcForwardSequenceBytes) {
+    while (Ctx.OutTrampolines[I].Long && Ctx.OutTrampolines[I].UsesSetPCBack &&
+           Ctx.OutTrampolines[I].OriginalSize <
+               (Ctx.OutTrampolines[I].LongBranchPreservesVcc
+                    ? VccPreservingReturnReserveBytes + VccLandingPadBytes
+                    : SetPcForwardSequenceBytes)) {
       Trampoline &T = Ctx.OutTrampolines[I];
       if (DirectBranchTargets.contains(T.OriginalOffset))
         break;
@@ -4310,7 +4567,9 @@ expandStraightLineTrampolines(PatchContext &Ctx,
       if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
           Range->End != T.FunctionEnd)
         break;
-      T.Bytes.insert(T.Bytes.begin(), Ctx.Text + DI.Offset,
+      size_t BodyPrefix =
+          T.LongBranchPreservesVcc ? VccRestoreSequenceBytes : 0;
+      T.Bytes.insert(T.Bytes.begin() + BodyPrefix, Ctx.Text + DI.Offset,
                      Ctx.Text + DI.Offset + DI.Size);
       T.OriginalOffset = DI.Offset;
       T.OriginalSize += DI.Size;
@@ -4384,10 +4643,51 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
   return Sleds;
 }
 
+/// Gateway sleds are decoded before adjacent trampoline sites are coalesced.
+/// Remove every final source interval from those earlier views, then callers
+/// may add back only the explicitly unreachable source-tail subranges. This
+/// prevents two independently-derived sleds from aliasing the same bytes.
+static void subtractTrampolineSources(std::vector<NopSled> &Gateways,
+                                      ArrayRef<Trampoline> Trampolines) {
+  SmallVector<std::pair<uint64_t, uint64_t>, 64> Sources;
+  for (const Trampoline &T : Trampolines) {
+    std::optional<uint64_t> End = checkedAddUint64(
+        T.OriginalOffset, T.OriginalSize, "gateway source interval");
+    if (End)
+      Sources.push_back({T.OriginalOffset, *End});
+  }
+  llvm::sort(Sources);
+
+  std::vector<NopSled> Filtered;
+  for (const NopSled &Sled : Gateways) {
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    if (Sled.WritePos >= UsableEnd)
+      continue;
+    uint64_t Cursor = Sled.WritePos;
+    for (const auto &[SourceBegin, SourceEnd] : Sources) {
+      if (SourceEnd <= Cursor)
+        continue;
+      if (SourceBegin >= UsableEnd)
+        break;
+      if (SourceBegin > Cursor)
+        Filtered.push_back({Cursor, std::min(SourceBegin, UsableEnd), Cursor,
+                            Sled.FunctionStart, Sled.FunctionEnd});
+      Cursor = std::max(Cursor, SourceEnd);
+      if (Cursor >= UsableEnd)
+        break;
+    }
+    if (Cursor < UsableEnd)
+      Filtered.push_back(
+          {Cursor, UsableEnd, Cursor, Sled.FunctionStart, Sled.FunctionEnd});
+  }
+  Gateways = std::move(Filtered);
+}
+
 Expected<uint64_t>
 countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
                                 uint64_t FromOffset, uint64_t TargetOffset,
-                                unsigned SgprBase, uint64_t MaxSlots) {
+                                unsigned SgprBase, uint64_t MaxSlots,
+                                bool UseVcc, bool PreserveVcc) {
   uint64_t Slots = 0;
   for (const NopSled &Sled : Gateways) {
     if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
@@ -4402,8 +4702,9 @@ countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
         break;
 
       std::optional<uint32_t> LayoutSize =
-          getSetPcLongBranchLayoutSize(Candidate, TargetOffset);
-      if ((SgprBase & 1u) != 0 || !LayoutSize)
+          getSetPcGatewayLayoutSize(Candidate, TargetOffset, SgprBase, UseVcc,
+                                    PreserveVcc);
+      if (!LayoutSize)
         return createStringError(
             Twine("invalid set-PC gateway while counting candidate "
                   "offset 0x") +
@@ -4437,8 +4738,8 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
     uint64_t BestOffset = 0;
     for (size_t I = 0; I != Gateways.size(); ++I) {
       NopSled &Sled = Gateways[I];
-      if (UsedSleds.contains(I) || FromOffset < Sled.FunctionStart ||
-          FromOffset >= Sled.FunctionEnd)
+      if (Sled.GatewayOnly || UsedSleds.contains(I) ||
+          FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
         continue;
       uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
       bool MakesProgress =
@@ -4487,6 +4788,90 @@ static SmallVector<uint8_t> encodeScc1Branch(const LLVMState &LS,
   return assembleSingleInst("s_cbranch_scc1 " + std::to_string(DwordDelta), LS);
 }
 
+bool sourceHasUniqueFunctionRange(
+    const Trampoline &T,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges, uint64_t TextAddr) {
+  if (!T.HasFunctionRange)
+    return false;
+  std::optional<uint64_t> SourceEnd = checkedAddUint64(
+      T.OriginalOffset, T.OriginalSize, "source-tail unique function end");
+  if (!SourceEnd)
+    return false;
+
+  SmallVector<std::pair<uint64_t, uint64_t>, 2> DistinctCoveringRanges;
+  bool MatchesSelectedRange = false;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+    if (Range.Begin < TextAddr || Range.End < TextAddr)
+      continue;
+    uint64_t Begin = Range.Begin - TextAddr;
+    uint64_t End = Range.End - TextAddr;
+    if (Begin > T.OriginalOffset || End < *SourceEnd)
+      continue;
+    std::pair<uint64_t, uint64_t> Bounds{Begin, End};
+    if (!llvm::is_contained(DistinctCoveringRanges, Bounds))
+      DistinctCoveringRanges.push_back(Bounds);
+    MatchesSelectedRange |=
+        Begin == T.FunctionStart && End == T.FunctionEnd;
+    if (DistinctCoveringRanges.size() > 1)
+      return false;
+  }
+  return DistinctCoveringRanges.size() == 1 && MatchesSelectedRange;
+}
+
+bool isSafeSourceTailRange(const Trampoline &T,
+                           const DirectControlFlowInfo &ControlFlow,
+                           bool HasUniqueFunctionRange, uint64_t Begin,
+                           uint64_t End) {
+  if (ControlFlow.HasUnresolvedTargets ||
+      ControlFlow.HasUnboundedIndirectEntries || !HasUniqueFunctionRange ||
+      Begin >= End)
+    return false;
+  std::optional<uint64_t> FirstTailByte = checkedAddUint64(
+      T.OriginalOffset, MinInstSize, "source-tail first byte");
+  std::optional<uint64_t> SourceEnd = checkedAddUint64(
+      T.OriginalOffset, T.OriginalSize, "source-tail source end");
+  if (!FirstTailByte || !SourceEnd || Begin < *FirstTailByte ||
+      End > *SourceEnd)
+    return false;
+  // These intervals are at most a handful of instruction dwords. Checking
+  // every byte also catches an unusually-aligned declared alias rather than
+  // assuming every protected entry is four-byte aligned.
+  for (uint64_t Offset = Begin; Offset != End; ++Offset)
+    if (ControlFlow.Targets.contains(Offset))
+      return false;
+  return true;
+}
+
+static SmallVector<uint8_t> encodeDirectCall(const LLVMState &LS,
+                                             uint64_t FromOffset,
+                                             uint64_t TargetOffset,
+                                             StringRef ReturnPair) {
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(FromOffset, MinInstSize, "direct call PC base");
+  if (!PcBase)
+    return {};
+  uint64_t ByteDistance =
+      TargetOffset >= *PcBase ? TargetOffset - *PcBase : *PcBase - TargetOffset;
+  if ((ByteDistance & (MinInstSize - 1)) != 0)
+    return {};
+  uint64_t DwordDistance = ByteDistance / MinInstSize;
+  int64_t DwordDelta = 0;
+  if (TargetOffset >= *PcBase) {
+    if (DwordDistance > static_cast<uint64_t>(BranchOffsetMax))
+      return {};
+    DwordDelta = static_cast<int64_t>(DwordDistance);
+  } else {
+    const uint64_t MaxBackward =
+        static_cast<uint64_t>(-static_cast<int64_t>(BranchOffsetMin));
+    if (DwordDistance > MaxBackward)
+      return {};
+    DwordDelta = -static_cast<int64_t>(DwordDistance);
+  }
+  std::string Asm =
+      "s_call_i64 " + ReturnPair.str() + ", " + std::to_string(DwordDelta);
+  return assembleSingleInst(Asm, LS);
+}
+
 /// Plan common far gateways before the final pool layout. An 8-byte source
 /// cannot hold the 20-byte SCC-neutral set-PC sequence, but it can preserve
 /// its identity without touching SCC:
@@ -4517,7 +4902,8 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
     if (!Next)
       return false;
     TP = *Next;
-    if (!T.Long || T.OriginalSize < 2 * MinInstSize ||
+    if (!T.Long || T.UsesMirroredStubForward ||
+        T.OriginalSize < 2 * MinInstSize ||
         isSBranchReachable(T.OriginalOffset, ThisTP))
       continue;
     std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
@@ -4543,8 +4929,20 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
   // The ordinary planner is simpler and uses fewer scratch registers for
   // small objects. Shared dispatch is a capacity mechanism for dense far-site
   // workloads, not a replacement for individual gateways.
+  log() << "hotswap: shared planner considering " << Candidates.size()
+        << " source site(s) across " << TextGateways.size()
+        << " gateway/relay window(s)\n";
   if (Candidates.size() < 8)
     return true;
+
+  const std::vector<ElfView::FunctionTextRange> FunctionRanges =
+      Ctx.Elf.functionTextRanges();
+  auto HasSafeTail = [&](const Trampoline &T, uint64_t Begin, uint64_t End) {
+    bool HasUniqueFunctionRange = sourceHasUniqueFunctionRange(
+        T, FunctionRanges, Ctx.Elf.textAddr());
+    return isSafeSourceTailRange(T, Ctx.DirectControlFlow,
+                                 HasUniqueFunctionRange, Begin, End);
+  };
 
   BitVector Assigned(Ctx.OutTrampolines.size());
   SmallVector<SmallVector<size_t, 32>, 8> Groups;
@@ -4558,7 +4956,7 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
     uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
     for (size_t I = 0; I != TextGateways.size(); ++I) {
       const NopSled &Sled = TextGateways[I];
-      uint64_t From = SeedT.OriginalOffset + MinInstSize;
+      uint64_t From = SeedT.OriginalOffset;
       if (SeedT.OriginalOffset < Sled.FunctionStart ||
           SeedT.OriginalOffset >= Sled.FunctionEnd)
         continue;
@@ -4576,10 +4974,14 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
     }
     uint64_t GatewayOffset = 0;
     uint64_t SecondaryGatewayOffset = 0;
+    uint64_t GatewayFunctionStart = 0;
+    uint64_t GatewayFunctionEnd = std::numeric_limits<uint64_t>::max();
     std::vector<NopSled> WorkingGateways;
     SmallVector<uint64_t, 4> SeedIslands;
     if (SledIndex != TextGateways.size()) {
       GatewayOffset = TextGateways[SledIndex].WritePos;
+      GatewayFunctionStart = TextGateways[SledIndex].FunctionStart;
+      GatewayFunctionEnd = TextGateways[SledIndex].FunctionEnd;
       WorkingGateways = TextGateways;
       WorkingGateways[SledIndex].WritePos += SetPcForwardSequenceBytes;
     } else {
@@ -4587,19 +4989,23 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
       for (size_t I = 0; I != TextGateways.size(); ++I) {
         const NopSled &Sled = TextGateways[I];
         uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-        if (Sled.WritePos > UsableEnd ||
+        if (SeedT.OriginalOffset < Sled.FunctionStart ||
+            SeedT.OriginalOffset >= Sled.FunctionEnd ||
+            Sled.WritePos > UsableEnd ||
             SetPcForwardSequenceBytes > UsableEnd - Sled.WritePos)
           continue;
         std::vector<NopSled> Trial = TextGateways;
         uint64_t TrialGateway = Trial[I].WritePos;
         Trial[I].WritePos += SetPcForwardSequenceBytes;
         std::optional<SmallVector<uint64_t, 4>> Islands =
-            allocateForwardBranchIslands(
-                Trial, SeedT.OriginalOffset + MinInstSize, TrialGateway);
+            allocateForwardBranchIslands(Trial, SeedT.OriginalOffset,
+                                         TrialGateway);
         if (!Islands || Islands->empty() || Islands->size() >= BestIslandCount)
           continue;
         BestIslandCount = Islands->size();
         GatewayOffset = TrialGateway;
+        GatewayFunctionStart = Sled.FunctionStart;
+        GatewayFunctionEnd = Sled.FunctionEnd;
         WorkingGateways = std::move(Trial);
         SeedIslands = std::move(*Islands);
       }
@@ -4611,7 +5017,7 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
              ++I) {
           const NopSled &First = TextGateways[I];
           uint64_t FirstEnd = std::min(First.End, First.FunctionEnd);
-          uint64_t SourceBranch = SeedT.OriginalOffset + MinInstSize;
+          uint64_t SourceBranch = SeedT.OriginalOffset;
           if (SeedT.OriginalOffset < First.FunctionStart ||
               SeedT.OriginalOffset >= First.FunctionEnd ||
               First.WritePos > FirstEnd ||
@@ -4634,6 +5040,10 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
             WorkingGateways = FirstReserved;
             SecondaryGatewayOffset = WorkingGateways[J].WritePos;
             WorkingGateways[J].WritePos += 4 * MinInstSize;
+            GatewayFunctionStart =
+                std::max(First.FunctionStart, Second.FunctionStart);
+            GatewayFunctionEnd =
+                std::min(First.FunctionEnd, Second.FunctionEnd);
             break;
           }
         }
@@ -4652,11 +5062,14 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
           C.ScratchBase != Seed.ScratchBase)
         continue;
       const Trampoline &T = Ctx.OutTrampolines[C.Index];
+      if (T.OriginalOffset < GatewayFunctionStart ||
+          T.OriginalOffset >= GatewayFunctionEnd)
+        continue;
       uint64_t ProposedSpan =
           8 + 28 * (Members.size() + 1) + GroupBodyBytes + T.Bytes.size();
       if (ProposedSpan > MaxDispatcherSpan)
         continue;
-      uint64_t From = T.OriginalOffset + MinInstSize;
+      uint64_t From = T.OriginalOffset;
       SmallVector<uint64_t, 4> Islands;
       if (C.Index == Seed.Index && !SeedIslands.empty()) {
         Islands = SeedIslands;
@@ -4672,40 +5085,53 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
     SmallVector<std::pair<uint64_t, size_t>, 32> RelayAnchors;
     for (size_t Index : Members) {
       LocalMembers.insert(Index);
-      RelayAnchors.push_back(
-          {Ctx.OutTrampolines[Index].OriginalOffset + MinInstSize, Index});
+      const Trampoline &T = Ctx.OutTrampolines[Index];
+      uint64_t Tail = T.OriginalOffset + MinInstSize;
+      if (HasSafeTail(T, Tail, Tail + MinInstSize))
+        RelayAnchors.push_back({Tail, Index});
     }
     llvm::sort(RelayAnchors);
-    for (const Candidate &C : Candidates) {
-      if (Members.size() == MaxGroupSites || Assigned.test(C.Index) ||
-          LocalMembers.contains(C.Index) || C.ScratchBase != Seed.ScratchBase)
-        continue;
-      const Trampoline &T = Ctx.OutTrampolines[C.Index];
-      uint64_t ProposedSpan =
-          8 + 28 * (Members.size() + 1) + GroupBodyBytes + T.Bytes.size();
-      if (ProposedSpan > MaxDispatcherSpan)
-        continue;
-      uint64_t From = T.OriginalOffset + MinInstSize;
-      auto It =
-          llvm::lower_bound(RelayAnchors, std::make_pair(From, size_t{0}));
-      std::optional<uint64_t> Relay;
-      if (It != RelayAnchors.end() && isSBranchReachable(From, It->first))
-        Relay = It->first;
-      if (It != RelayAnchors.begin()) {
-        --It;
-        if (isSBranchReachable(From, It->first))
+    bool AddedRelayMember;
+    do {
+      AddedRelayMember = false;
+      for (const Candidate &C : Candidates) {
+        if (Members.size() == MaxGroupSites || Assigned.test(C.Index) ||
+            LocalMembers.contains(C.Index) ||
+            C.ScratchBase != Seed.ScratchBase)
+          continue;
+        const Trampoline &T = Ctx.OutTrampolines[C.Index];
+        if (T.OriginalOffset < GatewayFunctionStart ||
+            T.OriginalOffset >= GatewayFunctionEnd)
+          continue;
+        uint64_t ProposedSpan =
+            8 + 28 * (Members.size() + 1) + GroupBodyBytes + T.Bytes.size();
+        if (ProposedSpan > MaxDispatcherSpan)
+          continue;
+        uint64_t From = T.OriginalOffset;
+        auto It =
+            llvm::lower_bound(RelayAnchors, std::make_pair(From, size_t{0}));
+        std::optional<uint64_t> Relay;
+        if (It != RelayAnchors.end() && isSBranchReachable(From, It->first))
           Relay = It->first;
+        if (It != RelayAnchors.begin()) {
+          --It;
+          if (isSBranchReachable(From, It->first))
+            Relay = It->first;
+        }
+        if (!Relay)
+          continue;
+        Members.push_back(C.Index);
+        LocalMembers.insert(C.Index);
+        MemberRelays[C.Index] = *Relay;
+        GroupBodyBytes += T.Bytes.size();
+        uint64_t Tail = T.OriginalOffset + MinInstSize;
+        if (HasSafeTail(T, Tail, Tail + MinInstSize))
+          RelayAnchors.insert(
+              llvm::lower_bound(RelayAnchors, std::make_pair(Tail, C.Index)),
+              {Tail, C.Index});
+        AddedRelayMember = true;
       }
-      if (!Relay)
-        continue;
-      Members.push_back(C.Index);
-      LocalMembers.insert(C.Index);
-      MemberRelays[C.Index] = *Relay;
-      GroupBodyBytes += T.Bytes.size();
-      RelayAnchors.insert(
-          llvm::lower_bound(RelayAnchors, std::make_pair(From, C.Index)),
-          {From, C.Index});
-    }
+    } while (AddedRelayMember && Members.size() != MaxGroupSites);
     // A single site with a normal 20-byte gateway gains nothing from the
     // dispatcher and would unnecessarily consume two extra SGPRs. Leave it to
     // the established direct planner. A split 8+16-byte gateway is retained
@@ -4778,6 +5204,295 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
   log() << "hotswap: planned " << Groups.size()
         << " shared far-dispatch gateway group(s) for " << Assigned.count()
         << " source site(s)\n";
+  return true;
+}
+
+/// Plan a relocation-neutral shared gateway for far sites that have only the
+/// pair already reserved for their return edge. Each source records its own PC
+/// and branches to a common SCC-neutral add/set-PC sequence:
+///
+///   s_call_i64 Pair, CommonGateway
+///
+/// The call records source S+4 without touching SCC. The common delta maps it
+/// to a sparse pool stub at
+/// StubBase + (S - MinSource). Thus the load bias cancels without a dispatcher
+/// classifier or another scratch pair. The stub branches to S's trampoline
+/// body. Sources are grouped only when their sparse prefix plus bodies stays
+/// within short-branch range.
+static bool planMirroredStubGateways(PatchContext &Ctx,
+                                     std::vector<NopSled> &TextGateways) {
+  const auto PlanStart = std::chrono::steady_clock::now();
+  struct Candidate {
+    size_t Index = 0;
+    unsigned PairBase = 0;
+    bool UsesVcc = false;
+  };
+  SmallVector<Candidate, 64> Candidates;
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
+    uint64_t ThisTP = TP;
+    std::optional<uint64_t> Next =
+        checkedAddUint64(TP, T.Bytes.size(), "mirrored-stub pool layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+    if (!T.Long || !T.UsesSetPCBack || T.LongBranchPreservesVcc ||
+        T.UsesSharedDispatcherForward || T.UsesMirroredStubForward ||
+        T.OriginalSize < 2 * MinInstSize ||
+        isSBranchReachable(T.OriginalOffset, ThisTP))
+      continue;
+    std::optional<SmallVector<uint8_t>> Direct =
+        encodeSetPCLongBranch(Ctx.LS, T.OriginalOffset, ThisTP,
+                              T.LongBranchSgprBase, T.LongBranchUsesVcc);
+    if (Direct && Direct->size() <= T.OriginalSize)
+      continue;
+    Candidates.push_back({I, T.LongBranchSgprBase, T.LongBranchUsesVcc});
+  }
+  if (Candidates.empty())
+    return true;
+  log() << "hotswap: affine planner considering " << Candidates.size()
+        << " pair-only source site(s) across " << TextGateways.size()
+        << " gateway/relay window(s)\n";
+  // Two sources are the first point where one 12-byte text gateway replaces
+  // multiple ordinary gateways and therefore adds real text-space capacity.
+  constexpr size_t MinSharedSites = 2;
+  if (Candidates.size() < MinSharedSites)
+    return true;
+
+  // The sparse stub is after .text and within 4 GiB, so its positive delta
+  // uses the eight-byte literal32 form of s_add_nc_u64 plus four-byte set-PC.
+  constexpr uint64_t GatewayReserve = 3 * MinInstSize;
+  constexpr uint64_t MaxGroupSpan = 120 * 1024;
+  constexpr size_t MaxGroupSites = 1024;
+  BitVector Assigned(Ctx.OutTrampolines.size());
+  SmallVector<SmallVector<size_t, 32>, 8> Groups;
+  uint64_t DirectGatewayGroups = 0;
+  uint64_t IslandGatewayGroups = 0;
+  uint32_t GroupBase = 1;
+  for (const Trampoline &T : Ctx.OutTrampolines)
+    GroupBase = std::max(GroupBase, T.MirroredStubGroup + 1);
+
+  // Prefer high-address seeds. Their gateway and pool are usually close, and
+  // lower sources can reuse their unreachable second dword as a safe relay.
+  llvm::stable_sort(Candidates,
+                    [&](const Candidate &LHS, const Candidate &RHS) {
+                      return Ctx.OutTrampolines[LHS.Index].OriginalOffset >
+                             Ctx.OutTrampolines[RHS.Index].OriginalOffset;
+                    });
+
+  for (const Candidate &Seed : Candidates) {
+    if (Assigned.test(Seed.Index))
+      continue;
+    const Trampoline &SeedT = Ctx.OutTrampolines[Seed.Index];
+
+    uint64_t GatewayOffset = 0;
+    uint64_t GatewayFunctionStart = 0;
+    uint64_t GatewayFunctionEnd = std::numeric_limits<uint64_t>::max();
+    std::vector<NopSled> WorkingGateways;
+    bool GatewayReservedInText = false;
+    SmallVector<uint64_t, 4> SeedIslands;
+    uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
+
+    // Dense objects can expose tens of thousands of one-dword relays. Find a
+    // directly reachable gateway without cloning that entire vector for every
+    // candidate. A direct route is always preferable to an island chain, so
+    // only use the copying fallback when no such gateway exists.
+    size_t DirectSledIndex = TextGateways.size();
+    uint64_t From = SeedT.OriginalOffset;
+    for (size_t I = 0; I != TextGateways.size(); ++I) {
+      const NopSled &Sled = TextGateways[I];
+      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+      if (From < Sled.FunctionStart || From >= Sled.FunctionEnd ||
+          Sled.WritePos > UsableEnd ||
+          GatewayReserve > UsableEnd - Sled.WritePos ||
+          !isSBranchReachable(From, Sled.WritePos))
+        continue;
+      uint64_t Distance =
+          From > Sled.WritePos ? From - Sled.WritePos : Sled.WritePos - From;
+      if (Distance >= BestDistance)
+        continue;
+      DirectSledIndex = I;
+      BestDistance = Distance;
+    }
+    if (DirectSledIndex != TextGateways.size()) {
+      // The group always contains its seed once a direct gateway has been
+      // found, so this reservation cannot need rollback. Commit it in place
+      // instead of copying every relay window into a trial vector.
+      GatewayOffset = TextGateways[DirectSledIndex].WritePos;
+      GatewayFunctionStart = TextGateways[DirectSledIndex].FunctionStart;
+      GatewayFunctionEnd = TextGateways[DirectSledIndex].FunctionEnd;
+      TextGateways[DirectSledIndex].WritePos += GatewayReserve;
+      GatewayReservedInText = true;
+    }
+
+    if (!GatewayReservedInText) {
+      SmallVector<size_t, 32> GatewayCandidates;
+      for (size_t I = 0; I != TextGateways.size(); ++I) {
+        const NopSled &Sled = TextGateways[I];
+        uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+        if (From < Sled.FunctionStart || From >= Sled.FunctionEnd ||
+            Sled.WritePos > UsableEnd ||
+            GatewayReserve > UsableEnd - Sled.WritePos)
+          continue;
+        GatewayCandidates.push_back(I);
+      }
+      llvm::sort(GatewayCandidates, [&](size_t LHS, size_t RHS) {
+        uint64_t L = TextGateways[LHS].WritePos;
+        uint64_t R = TextGateways[RHS].WritePos;
+        uint64_t LDistance = From > L ? From - L : L - From;
+        uint64_t RDistance = From > R ? From - R : R - From;
+        return LDistance < RDistance;
+      });
+
+      // Failed island allocation rolls its own reservations back, so one
+      // trial vector is enough for every possible gateway. This avoids the
+      // quadratic full-vector cloning that dense corpus objects otherwise
+      // trigger.
+      std::vector<NopSled> Trial = TextGateways;
+      for (size_t I : GatewayCandidates) {
+        uint64_t TrialGateway = Trial[I].WritePos;
+        Trial[I].WritePos += GatewayReserve;
+        std::optional<SmallVector<uint64_t, 4>> Allocated =
+            allocateForwardBranchIslands(Trial, From, TrialGateway);
+        if (!Allocated) {
+          Trial[I].WritePos -= GatewayReserve;
+          continue;
+        }
+        GatewayOffset = TrialGateway;
+        GatewayFunctionStart = TextGateways[I].FunctionStart;
+        GatewayFunctionEnd = TextGateways[I].FunctionEnd;
+        WorkingGateways = std::move(Trial);
+        SeedIslands = std::move(*Allocated);
+        break;
+      }
+    }
+    if (!GatewayReservedInText && WorkingGateways.empty())
+      continue;
+    SmallVector<size_t, 32> Members;
+    DenseMap<size_t, SmallVector<uint64_t, 4>> MemberIslands;
+    uint64_t MinSource = SeedT.OriginalOffset;
+    uint64_t MaxSource = SeedT.OriginalOffset;
+    uint64_t GroupBodyBytes = 0;
+    auto FitsGroup = [&](const Trampoline &T) {
+      uint64_t NewMin = std::min(MinSource, T.OriginalOffset);
+      uint64_t NewMax = std::max(MaxSource, T.OriginalOffset);
+      uint64_t Prefix = NewMax - NewMin + MinInstSize;
+      return Prefix <= MaxGroupSpan &&
+             GroupBodyBytes <= MaxGroupSpan - Prefix &&
+             T.Bytes.size() <= MaxGroupSpan - Prefix - GroupBodyBytes;
+    };
+    auto AddMember = [&](size_t Index) {
+      const Trampoline &T = Ctx.OutTrampolines[Index];
+      Members.push_back(Index);
+      MinSource = std::min(MinSource, T.OriginalOffset);
+      MaxSource = std::max(MaxSource, T.OriginalOffset);
+      GroupBodyBytes += T.Bytes.size();
+    };
+
+    AddMember(Seed.Index);
+    if (!SeedIslands.empty())
+      MemberIslands[Seed.Index] = SeedIslands;
+    for (const Candidate &C : Candidates) {
+      if (C.Index == Seed.Index || Members.size() == MaxGroupSites ||
+          Assigned.test(C.Index) || C.PairBase != Seed.PairBase ||
+          C.UsesVcc != Seed.UsesVcc)
+        continue;
+      const Trampoline &T = Ctx.OutTrampolines[C.Index];
+      if (T.OriginalOffset < GatewayFunctionStart ||
+          T.OriginalOffset >= GatewayFunctionEnd || !FitsGroup(T))
+        continue;
+      uint64_t From = T.OriginalOffset;
+      if (!isSBranchReachable(From, GatewayOffset))
+        continue;
+      AddMember(C.Index);
+    }
+
+    // Small affine groups only replace established ordinary gateways with a
+    // larger sparse pool prefix. Preserve those simpler paths and reserve
+    // mirrored stubs for dense cases where sharing materially adds capacity.
+    if (Members.size() < MinSharedSites) {
+      if (GatewayReservedInText)
+        TextGateways[DirectSledIndex].WritePos -= GatewayReserve;
+      continue;
+    }
+
+    if (GatewayReservedInText) {
+      ++DirectGatewayGroups;
+    } else {
+      TextGateways = std::move(WorkingGateways);
+      ++IslandGatewayGroups;
+    }
+    uint32_t Group = GroupBase + Groups.size();
+    for (size_t Index : Members) {
+      Trampoline &T = Ctx.OutTrampolines[Index];
+      T.UsesMirroredStubForward = true;
+      T.MirroredStubGroup = Group;
+      T.MirroredStubGatewayOffset = GatewayOffset;
+      DenseMap<size_t, SmallVector<uint64_t, 4>>::iterator Islands =
+          MemberIslands.find(Index);
+      if (Islands != MemberIslands.end()) {
+        T.ForwardBranchIslands = std::move(Islands->second);
+        T.ForwardBranchTargetOffset = GatewayOffset;
+      }
+      Assigned.set(Index);
+    }
+    Groups.push_back(std::move(Members));
+  }
+
+  if (Groups.empty())
+    return true;
+
+  // Preserve the pool offsets of unclaimed trampolines. The earlier planners
+  // may have proved their ordinary short edges using those offsets; inserting
+  // a sparse prefix ahead of them could invalidate that proof. Mirrored groups
+  // can sit at the end because their common gateway uses a full 64-bit delta.
+  std::vector<Trampoline> Reordered;
+  Reordered.reserve(Ctx.OutTrampolines.size());
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I)
+    if (!Assigned.test(I))
+      Reordered.push_back(std::move(Ctx.OutTrampolines[I]));
+  for (const SmallVector<size_t, 32> &Group : Groups)
+    for (size_t Index : Group)
+      Reordered.push_back(std::move(Ctx.OutTrampolines[Index]));
+  Ctx.OutTrampolines = std::move(Reordered);
+
+  for (size_t I = 0; I != Ctx.OutTrampolines.size();) {
+    Trampoline &First = Ctx.OutTrampolines[I];
+    if (!First.UsesMirroredStubForward) {
+      ++I;
+      continue;
+    }
+    uint32_t Group = First.MirroredStubGroup;
+    size_t Count = 0;
+    uint64_t MinSource = First.OriginalOffset;
+    uint64_t MaxSource = First.OriginalOffset;
+    while (I + Count != Ctx.OutTrampolines.size() &&
+           Ctx.OutTrampolines[I + Count].UsesMirroredStubForward &&
+           Ctx.OutTrampolines[I + Count].MirroredStubGroup == Group) {
+      MinSource =
+          std::min(MinSource, Ctx.OutTrampolines[I + Count].OriginalOffset);
+      MaxSource =
+          std::max(MaxSource, Ctx.OutTrampolines[I + Count].OriginalOffset);
+      ++Count;
+    }
+    uint64_t Prefix = MaxSource - MinSource + MinInstSize;
+    if (Prefix > std::numeric_limits<uint32_t>::max())
+      return false;
+    First.PoolEntryPrefixBytes = static_cast<uint32_t>(Prefix);
+    First.Bytes.insert(First.Bytes.begin(), Prefix, uint8_t{0});
+    I += Count;
+  }
+
+  log() << "hotswap: planned " << Groups.size()
+        << " mirrored-stub gateway group(s) for " << Assigned.count()
+        << " pair-only source site(s) (" << DirectGatewayGroups
+        << " direct gateway group(s), " << IslandGatewayGroups
+        << " island gateway group(s), "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - PlanStart)
+               .count()
+        << " ms)\n";
   return true;
 }
 
@@ -4923,24 +5638,411 @@ static bool emitSharedDispatchers(PatchContext &Ctx) {
   return true;
 }
 
+static std::optional<SmallVector<uint64_t, 4>>
+allocateBackwardBranchIslands(std::vector<NopSled> &Gateways,
+                              uint64_t OwnerOffset, uint64_t FromOffset,
+                              uint64_t TargetOffset) {
+  struct Allocation {
+    size_t SledIndex = 0;
+    uint64_t PreviousWritePos = 0;
+  };
+  SmallVector<Allocation, 4> Allocations;
+  SmallVector<uint64_t, 4> Islands;
+  DenseSet<size_t> UsedSleds;
+  uint64_t Current = FromOffset;
+
+  while (!isSBranchReachable(Current, TargetOffset)) {
+    size_t BestIndex = Gateways.size();
+    uint64_t BestOffset = std::numeric_limits<uint64_t>::max();
+    for (size_t I = 0; I != Gateways.size(); ++I) {
+      NopSled &Sled = Gateways[I];
+      if (Sled.GatewayOnly || UsedSleds.contains(I) ||
+          OwnerOffset < Sled.FunctionStart || OwnerOffset >= Sled.FunctionEnd)
+        continue;
+      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+      if (Sled.WritePos <= TargetOffset || Sled.WritePos >= Current ||
+          Sled.WritePos > UsableEnd ||
+          MinInstSize > UsableEnd - Sled.WritePos ||
+          !isSBranchReachable(Current, Sled.WritePos))
+        continue;
+      if (BestIndex == Gateways.size() || Sled.WritePos < BestOffset) {
+        BestIndex = I;
+        BestOffset = Sled.WritePos;
+      }
+    }
+
+    if (BestIndex == Gateways.size()) {
+      for (size_t I = Allocations.size(); I != 0; --I) {
+        const Allocation &A = Allocations[I - 1];
+        Gateways[A.SledIndex].WritePos = A.PreviousWritePos;
+      }
+      return std::nullopt;
+    }
+
+    NopSled &Best = Gateways[BestIndex];
+    Allocations.push_back({BestIndex, Best.WritePos});
+    Islands.push_back(Best.WritePos);
+    Current = Best.WritePos;
+    Best.WritePos += MinInstSize;
+    UsedSleds.insert(BestIndex);
+  }
+  return Islands;
+}
+
+static bool emitMirroredStubGateways(PatchContext &Ctx) {
+  DenseMap<uint32_t, SmallVector<size_t, 32>> Groups;
+  SmallVector<uint64_t, 64> PoolOffsets;
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    PoolOffsets.push_back(TP);
+    Trampoline &T = Ctx.OutTrampolines[I];
+    if (T.UsesMirroredStubForward)
+      Groups[T.MirroredStubGroup].push_back(I);
+    std::optional<uint64_t> Next =
+        checkedAddUint64(TP, T.Bytes.size(), "mirrored-stub final layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+  }
+
+  for (auto &KV : Groups) {
+    ArrayRef<size_t> Members = KV.second;
+    if (Members.empty())
+      continue;
+    Trampoline &Owner = Ctx.OutTrampolines[Members.front()];
+    uint64_t StubBase = PoolOffsets[Members.front()];
+    auto fail = [&](const Twine &Reason) {
+      log() << "hotswap: error: mirrored-stub group " << KV.first << " at 0x"
+            << utohexstr(StubBase) << ": " << Reason << "\n";
+      return false;
+    };
+
+    uint64_t MinSource = Owner.OriginalOffset;
+    for (size_t Member : Members)
+      MinSource =
+          std::min(MinSource, Ctx.OutTrampolines[Member].OriginalOffset);
+    std::optional<uint64_t> SourcePc = checkedAddUint64(
+        MinSource, MinInstSize, "mirrored-stub minimum source PC");
+    if (!SourcePc)
+      return false;
+    const std::string Pair =
+        Owner.LongBranchUsesVcc
+            ? "vcc"
+            : "s[" + std::to_string(Owner.LongBranchSgprBase) + ":" +
+                  std::to_string(Owner.LongBranchSgprBase + 1) + "]";
+    if (StubBase < *SourcePc)
+      return fail("common gateway target precedes its source-PC base");
+    uint64_t Delta = StubBase - *SourcePc;
+    if (Delta > std::numeric_limits<uint32_t>::max())
+      return fail("common gateway delta does not fit literal32");
+    SmallVector<std::string, 2> GatewayLines;
+    GatewayLines.push_back("s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" +
+                           utohexstr(Delta));
+    GatewayLines.push_back("s_set_pc_i64 " + Pair);
+    Owner.ForwardGatewayBytes =
+        assembleInstructions(joinAsmLines(GatewayLines), Ctx.LS);
+    if (Owner.ForwardGatewayBytes.empty() ||
+        Owner.ForwardGatewayBytes.size() > 3 * MinInstSize)
+      return fail("common add/set-PC gateway encoding failed");
+    Owner.HasForwardGateway = true;
+    Owner.ForwardGatewayOffset = Owner.MirroredStubGatewayOffset;
+
+    if (Owner.PoolEntryPrefixBytes < MinInstSize ||
+        Owner.PoolEntryPrefixBytes > Owner.Bytes.size())
+      return fail("sparse stub prefix reservation is invalid");
+    for (uint64_t Offset = 0;
+         Offset + MinInstSize <= Owner.PoolEntryPrefixBytes;
+         Offset += MinInstSize)
+      std::memcpy(Owner.Bytes.data() + Offset, Ctx.LS.SNopBytes.data(),
+                  MinInstSize);
+
+    for (size_t Member : Members) {
+      const Trampoline &T = Ctx.OutTrampolines[Member];
+      uint64_t StubDisplacement = T.OriginalOffset - MinSource;
+      if (StubDisplacement > Owner.PoolEntryPrefixBytes - MinInstSize ||
+          StubDisplacement + MinInstSize > Owner.Bytes.size())
+        return fail("source-selected stub lies outside the sparse prefix");
+      uint64_t BodyOffset = PoolOffsets[Member] + T.PoolEntryPrefixBytes;
+      SmallVector<uint8_t> Branch =
+          Ctx.LS.encodeSBranch(StubBase + StubDisplacement, BodyOffset);
+      if (Branch.size() != MinInstSize)
+        return fail("source-selected body branch is out of range");
+      std::memcpy(Owner.Bytes.data() + StubDisplacement, Branch.data(),
+                  Branch.size());
+    }
+  }
+  return true;
+}
+
 static bool
 assignLongBranchGateways(PatchContext &Ctx,
                          const DenseSet<uint64_t> &DirectBranchTargets,
                          bool AllowTextGateways) {
   std::vector<NopSled> Gateways;
+  DenseMap<uint64_t, size_t> PoolIslandOwners;
+  DenseMap<uint64_t, size_t> SourceTailIslandOwners;
+  DenseMap<uint64_t, size_t> SourceTailGatewayOwners;
+  DenseMap<uint64_t, uint64_t> EarlySourceTailOwnerOffsets;
+  DenseMap<uint64_t, uint64_t> EarlySourceGatewayOwnerOffsets;
+  const std::vector<ElfView::FunctionTextRange> FunctionRanges =
+      Ctx.Elf.functionTextRanges();
+  auto HasSafeTail = [&](const Trampoline &T, uint64_t Begin, uint64_t End) {
+    bool HasUniqueFunctionRange = sourceHasUniqueFunctionRange(
+        T, FunctionRanges, Ctx.Elf.textAddr());
+    return isSafeSourceTailRange(T, Ctx.DirectControlFlow,
+                                 HasUniqueFunctionRange, Begin, End);
+  };
   if (AllowTextGateways) {
     Gateways = buildExternalGatewaySleds(
         Ctx.Decoded, Ctx.LS, Ctx.Elf, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
         DirectBranchTargets);
     for (const NopSled &Sled : Ctx.NopSleds)
       Gateways.push_back(Sled);
-    if (!planSharedDispatchGateways(Ctx, Gateways) ||
-        !emitSharedDispatchers(Ctx))
+    subtractTrampolineSources(Gateways, Ctx.OutTrampolines);
+
+    // Keep one 12-byte tail from each safe padding window available for the
+    // pair-only affine gateway. The four-register planner otherwise consumes
+    // these scarce tails as one-dword branch islands before it discovers the
+    // pair-only residuals. Its 20-byte gateways continue to use the prefix.
+    bool HasPairOnlyAffineDemand = false;
+    uint64_t CandidateTP = Ctx.PoolBaseOffset;
+    for (const Trampoline &T : Ctx.OutTrampolines) {
+      uint64_t ThisTP = CandidateTP;
+      std::optional<uint64_t> Next = checkedAddUint64(
+          CandidateTP, T.Bytes.size(), "affine reserve demand pool layout");
+      if (!Next)
+        return false;
+      CandidateTP = *Next;
+      if (!T.Long || !T.UsesSetPCBack || T.LongBranchPreservesVcc ||
+          T.UsesSharedDispatcherForward || T.UsesMirroredStubForward ||
+          T.OriginalSize < 2 * MinInstSize ||
+          isSBranchReachable(T.OriginalOffset, ThisTP))
+        continue;
+      std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
+          Ctx.LS, T.OriginalOffset, ThisTP, T.LongBranchSgprBase,
+          T.LongBranchUsesVcc);
+      if (Direct && Direct->size() <= T.OriginalSize)
+        continue;
+      if (!findSafeSgprScratchBlock(
+              Ctx, T.OriginalOffset, /*Count=*/4, /*Alignment=*/2,
+              "affine reserve demand", /*ReportNoSpace=*/false)) {
+        HasPairOnlyAffineDemand = true;
+        break;
+      }
+    }
+
+    std::vector<NopSled> MirroredGatewayReserves;
+    if (HasPairOnlyAffineDemand) {
+      constexpr uint64_t ReserveBytes = 3 * MinInstSize;
+      for (NopSled &Sled : Gateways) {
+        uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+        if (Sled.WritePos > UsableEnd ||
+            ReserveBytes > UsableEnd - Sled.WritePos)
+          continue;
+        uint64_t ReserveStart = UsableEnd - ReserveBytes;
+        MirroredGatewayReserves.push_back({ReserveStart, UsableEnd,
+                                           ReserveStart, Sled.FunctionStart,
+                                           Sled.FunctionEnd});
+        Sled.End = ReserveStart;
+      }
+    }
+
+    const auto SharedPlanStart = std::chrono::steady_clock::now();
+    if (!planSharedDispatchGateways(Ctx, Gateways))
       return false;
+    log() << "hotswap: shared gateway planning took "
+          << std::chrono::duration_cast<std::chrono::milliseconds>(
+                 std::chrono::steady_clock::now() - SharedPlanStart)
+                 .count()
+          << " ms\n";
+    Gateways.insert(Gateways.end(), MirroredGatewayReserves.begin(),
+                    MirroredGatewayReserves.end());
+
+    // Shared-dispatch sources can also use one-dword direct calls: their link
+    // pair is exactly the source-PC identity consumed by the dispatcher. Keep
+    // tails that the shared planner already selected as relays on that route,
+    // and expose every other tail to the later affine planner.
+    DenseSet<uint64_t> RequiredSharedRelayTails;
+    for (const Trampoline &T : Ctx.OutTrampolines)
+      if (T.UsesSharedDispatcherForward && T.SharedDispatcherRelayOffset != 0)
+        RequiredSharedRelayTails.insert(T.SharedDispatcherRelayOffset);
+    for (Trampoline &T : Ctx.OutTrampolines) {
+      if (!T.UsesSharedDispatcherForward || T.OriginalSize < 2 * MinInstSize ||
+          T.LongBranchPreservesVcc)
+        continue;
+      uint64_t Tail = T.OriginalOffset + MinInstSize;
+      if (!HasSafeTail(T, Tail, Tail + MinInstSize))
+        continue;
+      uint64_t Route =
+          T.SharedDispatcherRelayOffset    ? T.SharedDispatcherRelayOffset
+          : T.ForwardBranchIslands.empty() ? T.SharedDispatcherGatewayOffset
+                                           : T.ForwardBranchIslands.front();
+      if (RequiredSharedRelayTails.contains(Tail)) {
+        T.HasSourceTailBranchIsland = true;
+        T.SourceTailBranchIslandOffset = Tail;
+        T.SourceTailBranchTargetOffset = Route;
+        continue;
+      }
+      EarlySourceTailOwnerOffsets[Tail] = T.OriginalOffset;
+      Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
+                          std::numeric_limits<uint64_t>::max()});
+    }
+
+    // Shared-dispatch sources reserve one direct call in their first dword,
+    // while their second dword remains available as an independent relay.
+    // Expose up to five dwords after that relay: three hold an affine gateway,
+    // while five can hold the save-VCC + set-PC sequence needed by live-VCC
+    // sources. A five-dword window has only eight bytes left after an affine
+    // allocation, so every source owner still hosts at most one gateway.
+    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+      const Trampoline &T = Ctx.OutTrampolines[I];
+      constexpr uint64_t ForwardBytes = 2 * MinInstSize;
+      constexpr uint64_t AffineGatewayBytes = 3 * MinInstSize;
+      constexpr uint64_t VccGatewayBytes = 5 * MinInstSize;
+      if (!T.UsesSharedDispatcherForward ||
+          T.OriginalSize < ForwardBytes + AffineGatewayBytes)
+        continue;
+      uint64_t GatewayBytes = T.OriginalSize >= ForwardBytes + VccGatewayBytes
+                                  ? VccGatewayBytes
+                                  : AffineGatewayBytes;
+      uint64_t Start = T.OriginalOffset + ForwardBytes;
+      if (!HasSafeTail(T, Start, Start + GatewayBytes))
+        continue;
+      EarlySourceGatewayOwnerOffsets[Start] = T.OriginalOffset;
+      Gateways.push_back({Start, Start + GatewayBytes, Start, 0,
+                          std::numeric_limits<uint64_t>::max(),
+                          /*GatewayOnly=*/true});
+    }
+
+    // s_call_i64 records source+4 in the reserved pair and transfers control
+    // in one dword. Expose the now-unreachable second dword of every affine
+    // candidate as an object-wide relay before planning; this lets isolated
+    // pairs share a registerless path to a 12-byte gateway.
+    CandidateTP = Ctx.PoolBaseOffset;
+    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+      const Trampoline &T = Ctx.OutTrampolines[I];
+      uint64_t ThisTP = CandidateTP;
+      std::optional<uint64_t> Next = checkedAddUint64(
+          CandidateTP, T.Bytes.size(), "affine candidate pool layout");
+      if (!Next)
+        return false;
+      CandidateTP = *Next;
+      if (!T.Long || !T.UsesSetPCBack || T.LongBranchPreservesVcc ||
+          T.UsesSharedDispatcherForward || T.OriginalSize < 2 * MinInstSize ||
+          isSBranchReachable(T.OriginalOffset, ThisTP))
+        continue;
+      std::optional<SmallVector<uint8_t>> Direct =
+          encodeSetPCLongBranch(Ctx.LS, T.OriginalOffset, ThisTP,
+                                T.LongBranchSgprBase, T.LongBranchUsesVcc);
+      if (Direct && Direct->size() <= T.OriginalSize)
+        continue;
+      uint64_t Tail = T.OriginalOffset + MinInstSize;
+      if (!HasSafeTail(T, Tail, Tail + MinInstSize))
+        continue;
+      EarlySourceTailOwnerOffsets[Tail] = T.OriginalOffset;
+      Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
+                          std::numeric_limits<uint64_t>::max()});
+    }
+
+    // A registerless far source always emits a one-dword branch. Its remaining
+    // tail is therefore safe before the ordinary planner runs and can bridge a
+    // pair-only source to a 12-byte affine gateway. Unlike arbitrary padding,
+    // these relays are unreachable by original fallthrough and are valid
+    // object-wide.
+    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+      const Trampoline &T = Ctx.OutTrampolines[I];
+      if (T.UsesSetPCBack || T.LongBranchPreservesVcc ||
+          T.UsesSharedDispatcherForward || T.OriginalSize < 2 * MinInstSize)
+        continue;
+      uint64_t Tail = T.OriginalOffset + MinInstSize;
+      if (HasSafeTail(T, Tail, Tail + MinInstSize)) {
+        EarlySourceTailOwnerOffsets[Tail] = T.OriginalOffset;
+        Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
+                            std::numeric_limits<uint64_t>::max()});
+      }
+      constexpr uint64_t GatewayStart = 2 * MinInstSize;
+      constexpr uint64_t GatewayBytes = 5 * MinInstSize;
+      if (T.OriginalSize >= GatewayStart + GatewayBytes) {
+        uint64_t Start = T.OriginalOffset + GatewayStart;
+        if (!HasSafeTail(T, Start, Start + GatewayBytes))
+          continue;
+        EarlySourceGatewayOwnerOffsets[Start] = T.OriginalOffset;
+        Gateways.push_back({Start, Start + GatewayBytes, Start, 0,
+                            std::numeric_limits<uint64_t>::max(),
+                            /*GatewayOnly=*/true});
+      }
+    }
+
+    if (!planMirroredStubGateways(Ctx, Gateways))
+      return false;
+    DenseMap<uint64_t, size_t> TrampolineAtOriginalOffset;
+    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I)
+      TrampolineAtOriginalOffset[Ctx.OutTrampolines[I].OriginalOffset] = I;
+    for (const auto &KV : EarlySourceTailOwnerOffsets) {
+      DenseMap<uint64_t, size_t>::const_iterator Owner =
+          TrampolineAtOriginalOffset.find(KV.second);
+      if (Owner != TrampolineAtOriginalOffset.end())
+        SourceTailIslandOwners[KV.first] = Owner->second;
+    }
+    for (const auto &KV : EarlySourceGatewayOwnerOffsets) {
+      DenseMap<uint64_t, size_t>::const_iterator Owner =
+          TrampolineAtOriginalOffset.find(KV.second);
+      if (Owner != TrampolineAtOriginalOffset.end())
+        SourceTailGatewayOwners[KV.first] = Owner->second;
+    }
+    for (const Trampoline &T : Ctx.OutTrampolines) {
+      if (!T.UsesMirroredStubForward)
+        continue;
+      for (size_t I = 0; I != T.ForwardBranchIslands.size(); ++I) {
+        uint64_t From = T.ForwardBranchIslands[I];
+        DenseMap<uint64_t, size_t>::const_iterator Owner =
+            SourceTailIslandOwners.find(From);
+        if (Owner == SourceTailIslandOwners.end())
+          continue;
+        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+        if (OwnerT.UsesSetPCBack && !OwnerT.UsesMirroredStubForward &&
+            !OwnerT.UsesSharedDispatcherForward) {
+          log() << "hotswap: error: affine relay owner at 0x"
+                << utohexstr(OwnerT.OriginalOffset)
+                << " did not receive a mirrored route\n";
+          return false;
+        }
+        uint64_t To = I + 1 == T.ForwardBranchIslands.size()
+                          ? T.ForwardBranchTargetOffset
+                          : T.ForwardBranchIslands[I + 1];
+        if (OwnerT.HasSourceTailBranchIsland &&
+            OwnerT.SourceTailBranchTargetOffset != To) {
+          log() << "hotswap: error: affine source tail at 0x" << utohexstr(From)
+                << " has conflicting relay targets\n";
+          return false;
+        }
+        OwnerT.HasSourceTailBranchIsland = true;
+        OwnerT.SourceTailBranchIslandOffset = From;
+        OwnerT.SourceTailBranchTargetOffset = To;
+      }
+    }
+    for (const Trampoline &T : Ctx.OutTrampolines) {
+      if (!T.UsesMirroredStubForward)
+        continue;
+      DenseMap<uint64_t, size_t>::const_iterator Owner =
+          SourceTailGatewayOwners.find(T.MirroredStubGatewayOffset);
+      if (Owner == SourceTailGatewayOwners.end())
+        continue;
+      Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+      OwnerT.HasSourceTailGateway = true;
+      OwnerT.SourceTailGatewayOffset = T.MirroredStubGatewayOffset;
+      OwnerT.SourceTailGatewayBytes = 3 * MinInstSize;
+    }
+    const auto DispatcherEmitStart = std::chrono::steady_clock::now();
+    if (!emitSharedDispatchers(Ctx) || !emitMirroredStubGateways(Ctx))
+      return false;
+    log() << "hotswap: shared/affine gateway emission took "
+          << std::chrono::duration_cast<std::chrono::milliseconds>(
+                 std::chrono::steady_clock::now() - DispatcherEmitStart)
+                 .count()
+          << " ms\n";
   }
 
-  DenseMap<uint64_t, size_t> PoolIslandOwners;
-  DenseMap<uint64_t, size_t> SourceTailIslandOwners;
   uint64_t IslandLayoutOffset = Ctx.PoolBaseOffset;
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     Trampoline &T = Ctx.OutTrampolines[I];
@@ -4965,6 +6067,8 @@ assignLongBranchGateways(PatchContext &Ctx,
     uint64_t InitialCandidateSlots = 0;
   };
   std::vector<PendingGateway> Pending;
+  const auto OrdinaryPlanStart = std::chrono::steady_clock::now();
+  uint64_t ReturnBranchIslandChains = 0;
   uint64_t TrampOffset = Ctx.PoolBaseOffset;
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     Trampoline &T = Ctx.OutTrampolines[I];
@@ -4976,22 +6080,43 @@ assignLongBranchGateways(PatchContext &Ctx,
     TrampOffset = *Next;
     if (!T.Long)
       continue;
-    if (T.UsesSharedDispatcherForward)
+    if (T.UsesSharedDispatcherForward || T.UsesMirroredStubForward)
       continue;
 
     if (isSBranchReachable(T.OriginalOffset, TP)) {
       T.UsesShortBranchForward = true;
+      if (T.LongBranchPreservesVcc)
+        std::memcpy(T.Bytes.data(), Ctx.LS.SNopBytes.data(), MinInstSize);
       continue;
     }
-    std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
-        Ctx.LS, T.OriginalOffset, TP, T.LongBranchSgprBase);
-    if (Direct && Direct->size() <= T.OriginalSize) {
-      T.UsesDirectSetPCForward = true;
-      T.DirectSetPCForwardBytes = std::move(*Direct);
-      continue;
+    if (T.UsesSetPCBack) {
+      std::optional<SmallVector<uint8_t>> Direct =
+          T.LongBranchPreservesVcc
+              ? encodeSetPcGateway(Ctx.LS, T.OriginalOffset, TP,
+                                   T.LongBranchSgprBase, T.LongBranchUsesVcc,
+                                   /*PreserveVcc=*/true)
+              : encodeSetPCLongBranch(Ctx.LS, T.OriginalOffset, TP,
+                                      T.LongBranchSgprBase,
+                                      T.LongBranchUsesVcc);
+      uint64_t RequiredSourceBytes =
+          Direct ? Direct->size() +
+                       (T.LongBranchPreservesVcc ? VccLandingPadBytes : 0)
+                 : 0;
+      if (Direct && RequiredSourceBytes <= T.OriginalSize) {
+        T.UsesDirectSetPCForward = true;
+        T.DirectSetPCForwardBytes = std::move(*Direct);
+        continue;
+      }
     }
     Pending.push_back({I, TP, 0});
   }
+  log() << "hotswap: ordinary gateway planner collected " << Pending.size()
+        << " pending site(s) across " << Gateways.size()
+        << " gateway/relay window(s) in "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - OrdinaryPlanStart)
+               .count()
+        << " ms\n";
 
   // Once a source is replaced by a one-dword branch, the remainder of its
   // original instruction window is unreachable and can provide a safe relay.
@@ -4999,23 +6124,74 @@ assignLongBranchGateways(PatchContext &Ctx,
   // sequence consumes the tail. Shared dispatch and VCC preservation likewise
   // reserve the second dword. Relays are object-wide: unlike an arbitrary NOP
   // sled they cannot be reached by the owning function's original fallthrough.
-  if (!Ctx.DirectControlFlow.HasUnboundedIndirectEntries)
-    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
-      const Trampoline &T = Ctx.OutTrampolines[I];
-      if (T.OriginalSize < 2 * MinInstSize || T.UsesDirectSetPCForward ||
-          T.UsesSharedDispatcherForward)
-        continue;
-      uint64_t Tail = T.OriginalOffset + MinInstSize;
-      SourceTailIslandOwners[Tail] = I;
-      Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
-                          std::numeric_limits<uint64_t>::max()});
-    }
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    const Trampoline &T = Ctx.OutTrampolines[I];
+    if (!AllowTextGateways ||
+        Ctx.DirectControlFlow.HasUnboundedIndirectEntries ||
+        T.OriginalSize < 2 * MinInstSize ||
+        T.UsesDirectSetPCForward ||
+        T.UsesSharedDispatcherForward || T.UsesMirroredStubForward ||
+        T.LongBranchPreservesVcc)
+      continue;
+    uint64_t Tail = T.OriginalOffset + MinInstSize;
+    if (SourceTailIslandOwners.contains(Tail) ||
+        !HasSafeTail(T, Tail, Tail + MinInstSize))
+      continue;
+    SourceTailIslandOwners[Tail] = I;
+    Gateways.push_back({Tail, Tail + MinInstSize, Tail, 0,
+                        std::numeric_limits<uint64_t>::max()});
+  }
 
+  // Forward-mode selection above exposes every source that will execute a
+  // one-dword branch. Allocate registerless returns only now, so they can use
+  // the complete set of unreachable source tails. Returns retain first access
+  // to those relays before ordinary forward gateways and island chains.
+  TrampOffset = Ctx.PoolBaseOffset;
+  for (Trampoline &T : Ctx.OutTrampolines) {
+    std::optional<uint64_t> Next = checkedAddUint64(
+        TrampOffset, T.Bytes.size(), "return-island trampoline layout");
+    if (!Next)
+      return false;
+    TrampOffset = *Next;
+    if (!T.Long || T.UsesSetPCBack)
+      continue;
+    const uint64_t TrailingIsland =
+        T.HasPoolBranchIsland ? PoolBranchIslandBytes : 0;
+    if (T.Bytes.size() < TrailingIsland + MinInstSize) {
+      log() << "hotswap: error: registerless return reservation is "
+               "truncated at 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      return false;
+    }
+    uint64_t BackSlot = *Next - TrailingIsland - MinInstSize;
+    std::optional<uint64_t> ReturnTo =
+        checkedAddUint64(T.OriginalOffset, T.OriginalSize,
+                         "registerless trampoline return target");
+    if (!ReturnTo)
+      return false;
+    std::optional<SmallVector<uint64_t, 4>> ReturnIslands =
+        allocateBackwardBranchIslands(Gateways, T.OriginalOffset, BackSlot,
+                                      *ReturnTo);
+    if (!ReturnIslands) {
+      log() << "hotswap: error: no safe return s_branch island chain for far "
+               "site 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      return false;
+    }
+    T.ReturnBranchIslands = std::move(*ReturnIslands);
+    T.ReturnBranchTargetOffset = *ReturnTo;
+    ReturnBranchIslandChains += !T.ReturnBranchIslands.empty();
+  }
+
+  const auto CandidateCountStart = std::chrono::steady_clock::now();
   for (PendingGateway &P : Pending) {
     const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    if (!T.UsesSetPCBack)
+      continue;
     Expected<uint64_t> CandidateSlots = countReachableSetPcGatewaySlots(
         Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
-        T.LongBranchSgprBase, Pending.size());
+        T.LongBranchSgprBase, Pending.size(), T.LongBranchUsesVcc,
+        T.LongBranchPreservesVcc);
     if (!CandidateSlots) {
       log() << "hotswap: error: failed to count gateways for far site 0x"
             << utohexstr(T.OriginalOffset) << ": "
@@ -5024,6 +6200,11 @@ assignLongBranchGateways(PatchContext &Ctx,
     }
     P.InitialCandidateSlots = *CandidateSlots;
   }
+  log() << "hotswap: ordinary gateway candidate counting took "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - CandidateCountStart)
+               .count()
+        << " ms\n";
 
   std::stable_sort(Pending.begin(), Pending.end(),
                    [](const PendingGateway &LHS, const PendingGateway &RHS) {
@@ -5034,11 +6215,18 @@ assignLongBranchGateways(PatchContext &Ctx,
   std::vector<PendingGateway> StillPending;
   StillPending.reserve(Pending.size());
   uint64_t AssignedGateways = 0;
+  uint64_t AssignedSplitVccGateways = 0;
   for (const PendingGateway &P : Pending) {
     Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    if (!T.UsesSetPCBack) {
+      StillPending.push_back(P);
+      continue;
+    }
     Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
         findNearestSetPcGateway(Gateways, Ctx.LS, T.OriginalOffset,
-                                P.TargetOffset, T.LongBranchSgprBase);
+                                P.TargetOffset, T.LongBranchSgprBase,
+                                T.LongBranchUsesVcc,
+                                T.LongBranchPreservesVcc);
     if (!GatewayOrErr) {
       log() << "hotswap: error: failed to plan gateway for far site 0x"
             << utohexstr(T.OriginalOffset) << ": "
@@ -5047,12 +6235,64 @@ assignLongBranchGateways(PatchContext &Ctx,
     }
     std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
     if (!Gateway) {
+      if (T.LongBranchPreservesVcc) {
+        std::optional<EncodedSplitVccGateway> Split =
+            findSplitVccGateway(Gateways, Ctx.LS, T.OriginalOffset,
+                                P.TargetOffset, T.LongBranchSgprBase);
+        if (Split) {
+          NopSled &Primary = Gateways[Split->PrimaryIndex];
+          NopSled &Secondary = Gateways[Split->SecondaryIndex];
+          T.HasForwardGateway = true;
+          T.ForwardGatewayOffset = Primary.WritePos;
+          T.ForwardGatewayBytes = std::move(Split->PrimaryBytes);
+          T.SharedDispatcherSecondaryGatewayOffset = Secondary.WritePos;
+          T.SecondaryForwardGatewayBytes = std::move(Split->SecondaryBytes);
+          DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
+              SourceTailGatewayOwners.find(
+                  T.SharedDispatcherSecondaryGatewayOffset);
+          if (SourceOwner != SourceTailGatewayOwners.end()) {
+            Trampoline &OwnerT = Ctx.OutTrampolines[SourceOwner->second];
+            if (OwnerT.HasSourceTailGateway) {
+              log() << "hotswap: error: split VCC source-tail gateway at 0x"
+                    << utohexstr(T.SharedDispatcherSecondaryGatewayOffset)
+                    << " has conflicting allocations\n";
+              return false;
+            }
+            OwnerT.HasSourceTailGateway = true;
+            OwnerT.SourceTailGatewayOffset =
+                T.SharedDispatcherSecondaryGatewayOffset;
+            OwnerT.SourceTailGatewayBytes =
+                T.SecondaryForwardGatewayBytes.size();
+          }
+          Primary.WritePos += T.ForwardGatewayBytes.size();
+          Secondary.WritePos += T.SecondaryForwardGatewayBytes.size();
+          ++AssignedGateways;
+          ++AssignedSplitVccGateways;
+          continue;
+        }
+      }
       StillPending.push_back(P);
       continue;
     }
     T.HasForwardGateway = true;
     T.ForwardGatewayOffset = Gateway->Sled->WritePos;
     T.ForwardGatewayBytes = std::move(Gateway->Bytes);
+    DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
+        SourceTailGatewayOwners.find(T.ForwardGatewayOffset);
+    if (SourceOwner != SourceTailGatewayOwners.end()) {
+      Trampoline &OwnerT = Ctx.OutTrampolines[SourceOwner->second];
+      if (OwnerT.HasSourceTailGateway &&
+          (OwnerT.SourceTailGatewayOffset != T.ForwardGatewayOffset ||
+           OwnerT.SourceTailGatewayBytes != T.ForwardGatewayBytes.size())) {
+        log() << "hotswap: error: source-tail gateway at 0x"
+              << utohexstr(T.ForwardGatewayOffset)
+              << " has conflicting allocations\n";
+        return false;
+      }
+      OwnerT.HasSourceTailGateway = true;
+      OwnerT.SourceTailGatewayOffset = T.ForwardGatewayOffset;
+      OwnerT.SourceTailGatewayBytes = T.ForwardGatewayBytes.size();
+    }
     Gateway->Sled->WritePos += T.ForwardGatewayBytes.size();
     ++AssignedGateways;
   }
@@ -5072,6 +6312,8 @@ assignLongBranchGateways(PatchContext &Ctx,
     }
     T.ForwardBranchIslands = std::move(*Islands);
     T.ForwardBranchTargetOffset = P.TargetOffset;
+    if (T.LongBranchPreservesVcc)
+      std::memcpy(T.Bytes.data(), Ctx.LS.SNopBytes.data(), MinInstSize);
     ++BranchIslandChains;
   }
   Pending = std::move(StillPending);
@@ -5079,17 +6321,31 @@ assignLongBranchGateways(PatchContext &Ctx,
   if (!Pending.empty()) {
     const PendingGateway &P = Pending.front();
     const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
-    log() << "hotswap: error: no safe short-branch gateway for far site 0x"
-          << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
-          << " initial candidate slot(s))\n";
+    if (!T.UsesSetPCBack)
+      log() << "hotswap: error: no safe forward s_branch island chain for "
+               "registerless far site 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+    else
+      log() << "hotswap: error: no safe short-branch gateway for far site 0x"
+            << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
+            << " initial candidate slot(s), source_bytes=" << T.OriginalSize
+            << ", setpc_back=" << T.UsesSetPCBack
+            << ", preserve_vcc=" << T.LongBranchPreservesVcc
+            << ", use_vcc=" << T.LongBranchUsesVcc << ")\n";
     return false;
   }
   if (AssignedGateways != 0)
     log() << "hotswap: assigned " << AssignedGateways
           << " SCC-neutral forward gateway(s)\n";
+  if (AssignedSplitVccGateways != 0)
+    log() << "hotswap: assigned " << AssignedSplitVccGateways
+          << " split VCC-preserving gateway(s)\n";
   if (BranchIslandChains != 0)
     log() << "hotswap: assigned " << BranchIslandChains
           << " forward s_branch island chain(s)\n";
+  if (ReturnBranchIslandChains != 0)
+    log() << "hotswap: assigned " << ReturnBranchIslandChains
+          << " return s_branch island chain(s)\n";
 
   for (Trampoline &T : Ctx.OutTrampolines) {
     if (T.HasForwardGateway) {
@@ -5407,9 +6663,13 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       expandStraightLineTrampolines(Ctx, ControlFlow->Targets);
       mergeAdjacentLongTrampolines(OutTrampolines, ControlFlow->Targets);
     }
+    if (!finalizeDeferredVccPreservation(Ctx))
+      return std::nullopt;
     appendPoolBranchIslands(OutTrampolines);
+    bool AllowTextGateways = !ControlFlow->HasUnresolvedTargets &&
+                             !ControlFlow->HasUnboundedIndirectEntries;
     if (!assignLongBranchGateways(Ctx, ControlFlow->Targets,
-                                  !ControlFlow->HasUnresolvedTargets))
+                                  AllowTextGateways))
       return std::nullopt;
   }
 
@@ -5555,13 +6815,10 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
       return false;
     TrampOffset = *NextTrampOffset;
 
-    if (T.Long && !T.UsesSetPCBack) {
-      log() << "hotswap: error: far trampoline lacks safe set-PC return at 0x"
-            << utohexstr(T.OriginalOffset) << "\n";
-      return false;
-    }
     const uint32_t BackReserve =
-        T.UsesSetPCBack ? SetPcReturnReserveBytes : MinInstSize;
+        T.LongBranchPreservesVcc
+            ? VccPreservingReturnReserveBytes
+            : (T.UsesSetPCBack ? SetPcReturnReserveBytes : MinInstSize);
     const uint32_t TrailingIsland =
         T.HasPoolBranchIsland ? PoolBranchIslandBytes : 0;
     if (T.Bytes.size() < BackReserve + TrailingIsland) {
@@ -5578,11 +6835,35 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
       return false;
 
     std::optional<SmallVector<uint8_t>> BrBack;
-    if (T.UsesSetPCBack) {
-      BrBack =
-          encodeSetPCLongBranch(LS, BackSlot, *ReturnTo, T.LongBranchSgprBase);
+    if (T.LongBranchPreservesVcc) {
+      SmallVector<uint8_t> Save = assembleSingleInst(
+          "s_mov_b32 s" + std::to_string(T.LongBranchSgprBase) + ", vcc_lo",
+          LS);
+      std::optional<uint64_t> SetPcOffset = checkedAddUint64(
+          BackSlot, Save.size(), "VCC-preserving return set-PC offset");
+      uint64_t LandingDisplacement = T.UsesDirectSetPCForward
+                                         ? T.DirectSetPCForwardBytes.size()
+                                         : MinInstSize;
+      std::optional<uint64_t> Landing =
+          checkedAddUint64(T.OriginalOffset, LandingDisplacement,
+                           "VCC-preserving return landing offset");
+      if (Save.size() != VccMoveBytes || !SetPcOffset || !Landing)
+        return false;
+      std::optional<SmallVector<uint8_t>> SetPc = encodeSetPCLongBranch(
+          LS, *SetPcOffset, *Landing, T.LongBranchSgprBase, /*UseVcc=*/true);
+      if (SetPc) {
+        Save.append(SetPc->begin(), SetPc->end());
+        BrBack = std::move(Save);
+      }
+    } else if (T.UsesSetPCBack) {
+      BrBack = encodeSetPCLongBranch(LS, BackSlot, *ReturnTo,
+                                     T.LongBranchSgprBase, T.LongBranchUsesVcc);
     } else {
-      SmallVector<uint8_t> ShortBranch = LS.encodeSBranch(BackSlot, *ReturnTo);
+      uint64_t BranchTarget = T.ReturnBranchIslands.empty()
+                                  ? *ReturnTo
+                                  : T.ReturnBranchIslands.front();
+      SmallVector<uint8_t> ShortBranch =
+          LS.encodeSBranch(BackSlot, BranchTarget);
       if (!ShortBranch.empty())
         BrBack = std::move(ShortBranch);
     }
@@ -5603,18 +6884,25 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
         const std::string Pair =
             "s[" + std::to_string(T.SharedDispatcherSgprBase) + ":" +
             std::to_string(T.SharedDispatcherSgprBase + 1) + "]";
-        BrFwd = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
-        if (BrFwd.size() != MinInstSize)
-          return false;
         uint64_t BranchTarget =
             T.SharedDispatcherRelayOffset    ? T.SharedDispatcherRelayOffset
             : T.ForwardBranchIslands.empty() ? T.SharedDispatcherGatewayOffset
                                              : T.ForwardBranchIslands.front();
-        SmallVector<uint8_t> Branch =
-            LS.encodeSBranch(T.OriginalOffset + BrFwd.size(), BranchTarget);
-        if (Branch.size() != MinInstSize)
+        BrFwd = encodeDirectCall(LS, T.OriginalOffset, BranchTarget, Pair);
+        if (BrFwd.size() != MinInstSize)
           return false;
-        BrFwd.append(Branch);
+      } else if (T.UsesMirroredStubForward) {
+        const std::string Pair =
+            T.LongBranchUsesVcc
+                ? "vcc"
+                : "s[" + std::to_string(T.LongBranchSgprBase) + ":" +
+                      std::to_string(T.LongBranchSgprBase + 1) + "]";
+        uint64_t BranchTarget = T.ForwardBranchIslands.empty()
+                                    ? T.MirroredStubGatewayOffset
+                                    : T.ForwardBranchIslands.front();
+        BrFwd = encodeDirectCall(LS, T.OriginalOffset, BranchTarget, Pair);
+        if (BrFwd.size() != MinInstSize)
+          return false;
       } else if (T.UsesShortBranchForward) {
         BrFwd = LS.encodeSBranch(T.OriginalOffset, TP);
       } else if (!T.ForwardBranchIslands.empty()) {
@@ -5638,14 +6926,61 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
       return false;
     }
     std::memcpy(Text + T.OriginalOffset, BrFwd.data(), BrFwd.size());
+    uint32_t PadStart = BrFwd.size();
+    if (T.LongBranchPreservesVcc) {
+      uint64_t LandingDisplacement =
+          T.UsesDirectSetPCForward ? BrFwd.size() : MinInstSize;
+      if ((!T.UsesDirectSetPCForward && BrFwd.size() != MinInstSize) ||
+          LandingDisplacement > T.OriginalSize ||
+          VccLandingPadBytes > T.OriginalSize - LandingDisplacement) {
+        log() << "hotswap: error: VCC-preserving source window is invalid at "
+                 "0x"
+              << utohexstr(T.OriginalOffset) << "\n";
+        return false;
+      }
+      SmallVector<std::string, 2> RestoreLines;
+      RestoreLines.push_back("s_mov_b32 vcc_lo, s" +
+                             std::to_string(T.LongBranchSgprBase));
+      RestoreLines.push_back("s_delay_alu instid0(SALU_CYCLE_1)");
+      SmallVector<uint8_t> Restore =
+          assembleInstructions(joinAsmLines(RestoreLines), LS);
+      if (Restore.size() != VccRestoreSequenceBytes) {
+        log() << "hotswap: error: failed to encode VCC restore landing at 0x"
+              << utohexstr(T.OriginalOffset + LandingDisplacement) << "\n";
+        return false;
+      }
+      std::memcpy(Text + T.OriginalOffset + LandingDisplacement, Restore.data(),
+                  Restore.size());
+      PadStart = LandingDisplacement + VccLandingPadBytes;
+    }
+    if (T.HasSourceTailGateway) {
+      std::optional<uint64_t> GatewayEnd =
+          checkedAddUint64(T.SourceTailGatewayOffset, T.SourceTailGatewayBytes,
+                           "source-tail gateway end");
+      std::optional<uint64_t> SourceEnd = checkedAddUint64(
+          T.OriginalOffset, T.OriginalSize, "source-tail gateway source end");
+      if (!GatewayEnd || !SourceEnd ||
+          T.SourceTailGatewayOffset < T.OriginalOffset + PadStart ||
+          *GatewayEnd > *SourceEnd) {
+        log() << "hotswap: error: source-tail gateway overlaps the forward "
+                 "sequence at 0x"
+              << utohexstr(T.OriginalOffset) << "\n";
+        return false;
+      }
+    }
     // Pad the tail of the replaced slot with cached s_nop bytes.
-    for (uint32_t I = BrFwd.size(); I + MinInstSize <= T.OriginalSize;
-         I += MinInstSize)
+    for (uint32_t I = PadStart; I + MinInstSize <= T.OriginalSize;
+         I += MinInstSize) {
+      uint64_t Offset = T.OriginalOffset + I;
+      if (T.HasSourceTailGateway && Offset >= T.SourceTailGatewayOffset &&
+          Offset - T.SourceTailGatewayOffset < T.SourceTailGatewayBytes)
+        continue;
       std::memcpy(Text + T.OriginalOffset + I, LS.SNopBytes.data(),
                   MinInstSize);
+    }
     if (T.HasSourceTailBranchIsland) {
       if (T.SourceTailBranchIslandOffset < T.OriginalOffset ||
-          T.SourceTailBranchIslandOffset - T.OriginalOffset < BrFwd.size() ||
+          T.SourceTailBranchIslandOffset - T.OriginalOffset < PadStart ||
           T.SourceTailBranchIslandOffset - T.OriginalOffset >
               T.OriginalSize - MinInstSize) {
         log() << "hotswap: error: source-tail branch island overlaps the "

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1777,7 +1777,7 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
                           [](const InternalDecodedInst &DI, uint64_t Offset) {
                             return DI.Offset < Offset;
                           });
-    ArrayRef<InternalDecodedInst>::const_iterator End = llvm::lower_bound(
+    ArrayRef<InternalDecodedInst>::const_iterator End = std::lower_bound(
         Begin, Decoded.end(), Group.End,
         [](const InternalDecodedInst &DI, uint64_t Offset) {
           return DI.Offset < Offset;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2002,6 +2002,17 @@ struct DirectTargetSource {
   uint64_t Target = 0;
 };
 
+struct KnownCallEntry {
+  uint64_t Entry = 0;
+  size_t CallIndex = 0;
+};
+
+static bool compareKnownCallEntries(const KnownCallEntry &LHS,
+                                    const KnownCallEntry &RHS) {
+  return std::tie(LHS.Entry, LHS.CallIndex) <
+         std::tie(RHS.Entry, RHS.CallIndex);
+}
+
 struct FallthroughEntryInfo {
   bool Proven = false;
   uint64_t ChainBegin = 0;
@@ -2012,11 +2023,32 @@ struct ControlFlowScanIndex {
   DenseMap<uint64_t, FallthroughEntryInfo> FallthroughEntries;
   SmallVector<KnownCallSite, 4> Calls;
   SmallVector<ExternalCallContinuation, 4> ExternalCallContinuations;
+  SmallVector<KnownCallEntry, 8> CallsByTarget;
+  SmallVector<KnownCallEntry, 16> CallEntries;
+  DenseMap<size_t, MCRegister> CallReturnRegistersBySource;
   SmallVector<size_t, 16> SetPcIndices;
   SmallVector<size_t, 16> BranchOrCallIndices;
   SmallVector<DirectTargetSource, 16> DirectTargetsByTarget;
   bool HasUnboundedIndirectEntry = false;
 };
+
+static void indexKnownCalls(ControlFlowScanIndex &Index) {
+  Index.CallsByTarget.clear();
+  Index.CallEntries.clear();
+  Index.CallReturnRegistersBySource.clear();
+  Index.CallsByTarget.reserve(Index.Calls.size());
+  Index.CallEntries.reserve(Index.Calls.size() * 2);
+  for (size_t CallIndex = 0; CallIndex != Index.Calls.size(); ++CallIndex) {
+    const KnownCallSite &Call = Index.Calls[CallIndex];
+    Index.CallsByTarget.push_back({Call.Target, CallIndex});
+    Index.CallEntries.push_back({Call.Target, CallIndex});
+    Index.CallEntries.push_back({Call.Continuation, CallIndex});
+    Index.CallReturnRegistersBySource.try_emplace(Call.InstIndex,
+                                                  Call.ReturnRegister);
+  }
+  llvm::sort(Index.CallsByTarget, compareKnownCallEntries);
+  llvm::sort(Index.CallEntries, compareKnownCallEntries);
+}
 
 static bool hasPcRelativeOperand(const InternalDecodedInst &DI,
                                  const LLVMState &LS) {
@@ -2220,23 +2252,23 @@ static bool hasUnprovenFallthroughEntry(ArrayRef<InternalDecodedInst> Decoded,
     return true;
   }
 
-  for (const KnownCallSite &Call : Index.Calls) {
+  SmallVector<KnownCallEntry, 16>::const_iterator CallEntry =
+      llvm::lower_bound(Index.CallEntries, ChainBegin,
+                        [](const KnownCallEntry &Indexed, uint64_t Offset) {
+                          return Indexed.Entry < Offset;
+                        });
+  for (;
+       CallEntry != Index.CallEntries.end() && CallEntry->Entry < FunctionBegin;
+       ++CallEntry) {
+    const KnownCallSite &Call = Index.Calls[CallEntry->CallIndex];
     uint64_t Source = Decoded[Call.InstIndex].Offset;
     if (Source >= ChainBegin && Source < FunctionBegin)
       continue;
-    if ((Call.Target >= ChainBegin && Call.Target < FunctionBegin) ||
-        (Call.Continuation >= ChainBegin &&
-         Call.Continuation < FunctionBegin)) {
-      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
-            << " is not a bounded return: call at 0x" << utohexstr(Source)
-            << " enters the fallthrough chain at 0x"
-            << utohexstr(Call.Target >= ChainBegin &&
-                                 Call.Target < FunctionBegin
-                             ? Call.Target
-                             : Call.Continuation)
-            << "\n";
-      return true;
-    }
+    log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+          << " is not a bounded return: call at 0x" << utohexstr(Source)
+          << " enters the fallthrough chain at 0x"
+          << utohexstr(CallEntry->Entry) << "\n";
+    return true;
   }
 
   for (const ExternalCallContinuation &Call :
@@ -2433,9 +2465,15 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
         continue;
 
       SmallVector<uint64_t, 2> Targets;
-      for (const KnownCallSite &Call : Index.Calls) {
-        if (Call.Target < FunctionBegin || Call.Target >= FunctionEnd)
-          continue;
+      SmallVector<KnownCallEntry, 8>::const_iterator CallAtTarget =
+          llvm::lower_bound(Index.CallsByTarget, FunctionBegin,
+                            [](const KnownCallEntry &Indexed, uint64_t Offset) {
+                              return Indexed.Entry < Offset;
+                            });
+      for (; CallAtTarget != Index.CallsByTarget.end() &&
+             CallAtTarget->Entry < FunctionEnd;
+           ++CallAtTarget) {
+        const KnownCallSite &Call = Index.Calls[CallAtTarget->CallIndex];
         if (Call.Target != FunctionBegin) {
           log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
                 << " is not a bounded return: call at 0x"
@@ -2478,10 +2516,13 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
           continue;
 
         bool IsKnownEntryCall = false;
-        if (LS.MIA->isCall(Source.Inst) && It->Target == FunctionBegin)
-          for (const KnownCallSite &Call : Index.Calls)
-            IsKnownEntryCall |= Call.InstIndex == SourceIndex &&
-                                Call.ReturnRegister == ReturnRegister;
+        if (LS.MIA->isCall(Source.Inst) && It->Target == FunctionBegin) {
+          DenseMap<size_t, MCRegister>::const_iterator KnownCall =
+              Index.CallReturnRegistersBySource.find(SourceIndex);
+          IsKnownEntryCall =
+              KnownCall != Index.CallReturnRegistersBySource.end() &&
+              KnownCall->second == ReturnRegister;
+        }
         if (!IsKnownEntryCall && SourceIndex < FirstUnsafeSourceIndex) {
           FirstUnsafeSourceIndex = SourceIndex;
           FirstUnsafeTarget = It->Target;
@@ -2607,6 +2648,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       Index->Calls.push_back(
           {I, Target - TextAddr, *Continuation, *ReturnRegister});
   }
+  indexKnownCalls(*Index);
 
   std::optional<SmallVector<BoundedSetPcReturn, 2>> BoundedReturns =
       collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -687,6 +687,123 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
       EncodedSetPcGateway{Best, std::move(*BestBytes)});
 }
 
+/// Find one contiguous wave32 live-VCC gateway that serves both directions of
+/// an isolated source. The source branches to the prefix, which saves VCC and
+/// uses it to reach the pool. The pool returns directly to the suffix, which
+/// restores VCC and branches to ReturnTo. The intervening scalar branch issues
+/// for one cycle, satisfying the same one-cycle SALU dependency that requires
+/// an explicit s_delay_alu on the fallthrough restore path. See the
+/// SIInstrInfo::getNumWaitStates default in SIInstrInfo.cpp and the
+/// State.advance call in AMDGPUInsertDelayAlu.cpp.
+static Expected<std::optional<EncodedSetPcGateway>>
+findNearestVccRoundTripGateway(std::vector<NopSled> &Gateways,
+                               const LLVMState &LS, uint64_t FromOffset,
+                               uint64_t TargetOffset, uint64_t ReturnTo,
+                               unsigned SaveSgpr,
+                               const DenseSet<uint64_t> *Occupied) {
+  NopSled *Best = nullptr;
+  SmallVector<uint8_t> BestBytes;
+  uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
+
+  SmallVector<uint8_t> Restore =
+      assembleSingleInst("s_mov_b32 vcc_lo, s" + std::to_string(SaveSgpr), LS);
+  if (Restore.size() != VccMoveBytes)
+    return createStringError("failed to assemble round-trip VCC restore");
+
+  for (NopSled &Sled : Gateways) {
+    if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
+      continue;
+    uint64_t Candidate = Sled.WritePos;
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    uint64_t Distance = Candidate > FromOffset ? Candidate - FromOffset
+                                               : FromOffset - Candidate;
+    if (Candidate > UsableEnd || Distance >= MaxSledDistance ||
+        Distance >= BestDistance || !isSBranchReachable(FromOffset, Candidate))
+      continue;
+
+    std::optional<SmallVector<uint8_t>> Forward =
+        encodeSetPcGateway(LS, Candidate, TargetOffset, SaveSgpr,
+                           /*UseVcc=*/true, /*PreserveVcc=*/true);
+    if (!Forward)
+      return createStringError(
+          Twine("failed to encode round-trip VCC gateway at 0x") +
+          utohexstr(Candidate));
+    std::optional<uint64_t> ReturnBranchOffset =
+        checkedAddUint64(Candidate, Forward->size() + Restore.size(),
+                         "round-trip VCC gateway return branch");
+    if (!ReturnBranchOffset)
+      return createStringError("round-trip VCC gateway offset overflow");
+    if (!isSBranchReachable(*ReturnBranchOffset, ReturnTo))
+      continue;
+    SmallVector<uint8_t> ReturnBranch =
+        LS.encodeSBranch(*ReturnBranchOffset, ReturnTo);
+    if (ReturnBranch.size() != MinInstSize)
+      continue;
+
+    SmallVector<uint8_t> Bytes = std::move(*Forward);
+    Bytes.append(Restore.begin(), Restore.end());
+    Bytes.append(ReturnBranch.begin(), ReturnBranch.end());
+    if (Bytes.size() > UsableEnd - Candidate ||
+        gatewayRangeIsOccupied(Candidate, Bytes.size(), Occupied))
+      continue;
+    Best = &Sled;
+    BestBytes = std::move(Bytes);
+    BestDistance = Distance;
+  }
+
+  if (!Best)
+    return std::nullopt;
+  return std::optional<EncodedSetPcGateway>(
+      EncodedSetPcGateway{Best, std::move(BestBytes)});
+}
+
+static Expected<std::optional<EncodedSetPcGateway>>
+findNearestVccRestoreGateway(std::vector<NopSled> &Gateways,
+                             const LLVMState &LS, uint64_t OwnerOffset,
+                             uint64_t ReturnTo, unsigned SaveSgpr,
+                             const DenseSet<uint64_t> *Occupied) {
+  NopSled *Best = nullptr;
+  SmallVector<uint8_t> BestBytes;
+  uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
+
+  SmallVector<uint8_t> Restore =
+      assembleSingleInst("s_mov_b32 vcc_lo, s" + std::to_string(SaveSgpr), LS);
+  if (Restore.size() != VccMoveBytes)
+    return createStringError("failed to assemble split VCC restore gateway");
+
+  for (NopSled &Sled : Gateways) {
+    if (OwnerOffset < Sled.FunctionStart || OwnerOffset >= Sled.FunctionEnd)
+      continue;
+    uint64_t Candidate = Sled.WritePos;
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    std::optional<uint64_t> BranchOffset = checkedAddUint64(
+        Candidate, Restore.size(), "split VCC restore gateway branch");
+    if (Candidate > UsableEnd || !BranchOffset ||
+        !isSBranchReachable(*BranchOffset, ReturnTo))
+      continue;
+    uint64_t Distance =
+        Candidate > ReturnTo ? Candidate - ReturnTo : ReturnTo - Candidate;
+    if (Distance >= BestDistance)
+      continue;
+    SmallVector<uint8_t> Branch = LS.encodeSBranch(*BranchOffset, ReturnTo);
+    if (Branch.size() != MinInstSize)
+      continue;
+    SmallVector<uint8_t> Bytes = Restore;
+    Bytes.append(Branch.begin(), Branch.end());
+    if (Bytes.size() > UsableEnd - Candidate ||
+        gatewayRangeIsOccupied(Candidate, Bytes.size(), Occupied))
+      continue;
+    Best = &Sled;
+    BestBytes = std::move(Bytes);
+    BestDistance = Distance;
+  }
+
+  if (!Best)
+    return std::nullopt;
+  return std::optional<EncodedSetPcGateway>(
+      EncodedSetPcGateway{Best, std::move(BestBytes)});
+}
+
 /// Split a live-VCC gateway across an eight-byte nearby save/branch segment
 /// and a 16-byte get-PC/add/set-PC segment. This serves functions whose safe
 /// padding is fragmented too finely for the ordinary contiguous 20-byte
@@ -7062,8 +7179,8 @@ static void appendPoolBranchIslands(std::vector<Trampoline> &Trampolines) {
 
 /// Live-VCC preservation can be selected for an original eight-byte site so
 /// adjacent patched sites can merge into a restore+delay landing. If
-/// coalescing cannot prove at least that 12-byte source window, fall back to
-/// the registerless route before gateway planning. Ordinary straight-line
+/// coalescing cannot prove at least that 12-byte source window, preserve VCC
+/// through a nearby round-trip gateway instead. Ordinary straight-line
 /// expansion deliberately skips these candidates: growing their pool bodies
 /// after initial layout could invalidate a later short-branch classification.
 static bool finalizeDeferredVccPreservation(PatchContext &Ctx) {
@@ -7077,17 +7194,10 @@ static bool finalizeDeferredVccPreservation(PatchContext &Ctx) {
       return false;
     }
     if (T.OriginalSize < VccPreservingSourceBytes) {
-      T.Bytes.erase(T.Bytes.begin(), T.Bytes.begin() + VccRestoreSequenceBytes);
-      T.Bytes.resize(T.Bytes.size() - VccPreservingReturnReserveBytes);
-      T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
-      T.UsesSetPCBack = false;
-      T.LongBranchSgprBase = 0;
-      T.LongBranchUsesVcc = false;
-      T.LongBranchPreservesVcc = false;
+      T.UsesVccRestoreGateway = true;
       log() << "hotswap: deferred live-VCC preservation at 0x"
             << utohexstr(T.OriginalOffset)
-            << " fell back to a registerless far return\n";
-      continue;
+            << " will use a round-trip restore gateway\n";
     }
     SafeSgprScratchBlock Save{T.LongBranchSgprBase, 1};
     if (!commitSafeSgprScratchBlock(Ctx, T.OriginalOffset, Save,
@@ -7479,6 +7589,8 @@ struct BranchIslandFailure {
   uint64_t TargetOffset = 0;
   uint64_t CorridorOffset = 0;
   bool Forward = false;
+  uint64_t MinimumCapacityBytes = 0;
+  bool PreferNearestCandidate = false;
 };
 
 using BranchIslandPromoter = std::function<bool(const BranchIslandFailure &)>;
@@ -9745,6 +9857,7 @@ assignLongBranchGateways(PatchContext &Ctx,
   DenseMap<uint64_t, uint64_t> EarlySourceGatewayOwnerOffsets;
   DenseMap<uint64_t, uint64_t> ReservedBackboneOwnerOffsets;
   DenseMap<uint64_t, uint64_t> LateDirectSuffixOwnerOffsets;
+  DenseMap<uint64_t, SmallVector<NopSled, 3>> ReservedVccRoundTripCapacity;
   DenseSet<uint64_t> ForceOneDwordForwardSources;
   const std::vector<ElfView::FunctionTextRange> FunctionRanges =
       Ctx.Elf.functionTextRanges();
@@ -9767,6 +9880,148 @@ assignLongBranchGateways(PatchContext &Ctx,
       log() << "hotswap: exposed " << Ctx.LocalReplacementSourceTails.size()
             << " unreachable local-replacement source-tail branch slot(s)\n";
     subtractTrampolineSources(Gateways, Ctx.OutTrampolines);
+
+    // Live-VCC eight-byte sites are more constrained than pair-only affine
+    // sources: each needs either one 28-byte round-trip gateway or disjoint
+    // 8-byte, 16-byte, and 8-byte pieces. Reserve those physical ranges before
+    // shared/affine planning, but add them back only when their owner reaches
+    // ordinary gateway selection so unrelated routes cannot consume them.
+    uint64_t ReservedVccRoundTripSites = 0;
+    uint64_t ReservedSplitVccRoundTripSites = 0;
+    struct VccRoundTripReservationCandidate {
+      size_t TrampolineIndex = 0;
+      uint64_t StableContiguousCandidates = 0;
+    };
+    SmallVector<VccRoundTripReservationCandidate, 64> ReservationOrder;
+    for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+      const Trampoline &T = Ctx.OutTrampolines[I];
+      if (!T.UsesVccRestoreGateway)
+        continue;
+      uint64_t Candidates = 0;
+      for (const NopSled &Sled : Gateways) {
+        if (T.OriginalOffset < Sled.FunctionStart ||
+            T.OriginalOffset >= Sled.FunctionEnd)
+          continue;
+        uint64_t Candidate = Sled.WritePos;
+        uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+        uint64_t Distance = Candidate > T.OriginalOffset
+                                ? Candidate - T.OriginalOffset
+                                : T.OriginalOffset - Candidate;
+        if (Candidate > UsableEnd || Distance >= MaxSledDistance ||
+            !isSBranchReachable(T.OriginalOffset, Candidate))
+          continue;
+        std::optional<uint32_t> ForwardBytes = getSetPcGatewayLayoutSize(
+            Candidate, Ctx.PoolBaseOffset, T.LongBranchSgprBase,
+            /*UseVcc=*/true, /*PreserveVcc=*/true);
+        if (!ForwardBytes)
+          return false;
+        uint64_t TotalBytes = *ForwardBytes + VccMoveBytes + MinInstSize;
+        std::optional<uint64_t> ReturnBranch =
+            checkedAddUint64(Candidate, *ForwardBytes + VccMoveBytes,
+                             "ranked round-trip VCC return branch");
+        std::optional<uint64_t> ReturnTo =
+            checkedAddUint64(T.OriginalOffset, T.OriginalSize,
+                             "ranked round-trip VCC return target");
+        if (ReturnBranch && ReturnTo && TotalBytes <= UsableEnd - Candidate &&
+            isSBranchReachable(*ReturnBranch, *ReturnTo))
+          ++Candidates;
+      }
+      ReservationOrder.push_back({I, Candidates});
+    }
+    llvm::stable_sort(
+        ReservationOrder, [&](const VccRoundTripReservationCandidate &LHS,
+                              const VccRoundTripReservationCandidate &RHS) {
+          if (LHS.StableContiguousCandidates != RHS.StableContiguousCandidates)
+            return LHS.StableContiguousCandidates <
+                   RHS.StableContiguousCandidates;
+          return Ctx.OutTrampolines[LHS.TrampolineIndex].OriginalOffset <
+                 Ctx.OutTrampolines[RHS.TrampolineIndex].OriginalOffset;
+        });
+
+    for (const VccRoundTripReservationCandidate &Candidate : ReservationOrder) {
+      const Trampoline &T = Ctx.OutTrampolines[Candidate.TrampolineIndex];
+      std::optional<uint64_t> ReturnTo =
+          checkedAddUint64(T.OriginalOffset, T.OriginalSize,
+                           "reserved round-trip VCC return target");
+      if (!ReturnTo)
+        return false;
+
+      Expected<std::optional<EncodedSetPcGateway>> ContiguousOrErr =
+          findNearestVccRoundTripGateway(
+              Gateways, Ctx.LS, T.OriginalOffset, Ctx.PoolBaseOffset, *ReturnTo,
+              T.LongBranchSgprBase, /*Occupied=*/nullptr);
+      if (!ContiguousOrErr) {
+        log() << "hotswap: error: failed to reserve round-trip VCC gateway "
+                 "for far site 0x"
+              << utohexstr(T.OriginalOffset) << ": "
+              << toString(ContiguousOrErr.takeError()) << "\n";
+        return false;
+      }
+      std::optional<EncodedSetPcGateway> Contiguous =
+          std::move(*ContiguousOrErr);
+      if (Contiguous) {
+        NopSled &Sled = *Contiguous->Sled;
+        uint64_t Begin = Sled.WritePos;
+        uint64_t End = Begin + Contiguous->Bytes.size();
+        ReservedVccRoundTripCapacity[T.OriginalOffset].push_back(
+            {Begin, End, Begin, Sled.FunctionStart, Sled.FunctionEnd,
+             Sled.GatewayOnly});
+        Sled.WritePos = End;
+        ++ReservedVccRoundTripSites;
+        continue;
+      }
+
+      std::optional<EncodedSplitVccGateway> Split = findSplitVccGateway(
+          Gateways, Ctx.LS, T.OriginalOffset, Ctx.PoolBaseOffset,
+          T.LongBranchSgprBase, /*Occupied=*/nullptr);
+      if (!Split)
+        continue;
+      NopSled &Primary = Gateways[Split->PrimaryIndex];
+      NopSled &Secondary = Gateways[Split->SecondaryIndex];
+      DenseSet<uint64_t> SplitOccupied;
+      for (uint64_t Offset = 0; Offset < Split->PrimaryBytes.size();
+           Offset += MinInstSize)
+        SplitOccupied.insert(Primary.WritePos + Offset);
+      for (uint64_t Offset = 0; Offset < Split->SecondaryBytes.size();
+           Offset += MinInstSize)
+        SplitOccupied.insert(Secondary.WritePos + Offset);
+      Expected<std::optional<EncodedSetPcGateway>> RestoreOrErr =
+          findNearestVccRestoreGateway(Gateways, Ctx.LS, T.OriginalOffset,
+                                       *ReturnTo, T.LongBranchSgprBase,
+                                       &SplitOccupied);
+      if (!RestoreOrErr) {
+        log() << "hotswap: error: failed to reserve split VCC restore gateway "
+                 "for far site 0x"
+              << utohexstr(T.OriginalOffset) << ": "
+              << toString(RestoreOrErr.takeError()) << "\n";
+        return false;
+      }
+      std::optional<EncodedSetPcGateway> Restore = std::move(*RestoreOrErr);
+      if (!Restore)
+        continue;
+
+      SmallVector<NopSled, 3> &Capacity =
+          ReservedVccRoundTripCapacity[T.OriginalOffset];
+      SmallVector<std::pair<NopSled *, uint64_t>, 3> Reservations{
+          {&Primary, Split->PrimaryBytes.size()},
+          {&Secondary, Split->SecondaryBytes.size()},
+          {Restore->Sled, Restore->Bytes.size()}};
+      for (const std::pair<NopSled *, uint64_t> &Reservation : Reservations) {
+        NopSled &Sled = *Reservation.first;
+        uint64_t Begin = Sled.WritePos;
+        uint64_t Size = Reservation.second;
+        uint64_t End = Begin + Size;
+        Capacity.push_back({Begin, End, Begin, Sled.FunctionStart,
+                            Sled.FunctionEnd, Sled.GatewayOnly});
+        Sled.WritePos = End;
+      }
+      ++ReservedVccRoundTripSites;
+      ++ReservedSplitVccRoundTripSites;
+    }
+    if (ReservedVccRoundTripSites != 0)
+      log() << "hotswap: reserved early gateway capacity for "
+            << ReservedVccRoundTripSites << " isolated live-VCC source(s) ("
+            << ReservedSplitVccRoundTripSites << " split)\n";
 
     // Keep one 12-byte tail from each safe padding window available for the
     // pair-only affine gateway. The four-register planner otherwise consumes
@@ -10127,7 +10382,7 @@ assignLongBranchGateways(PatchContext &Ctx,
     if (T.UsesSharedDispatcherForward || T.UsesMirroredStubForward)
       continue;
 
-    if (isSBranchReachable(T.OriginalOffset, TP)) {
+    if (isSBranchReachable(T.OriginalOffset, TP) && !T.UsesVccRestoreGateway) {
       T.UsesShortBranchForward = true;
       if (T.LongBranchPreservesVcc)
         std::memcpy(T.Bytes.data(), Ctx.LS.SNopBytes.data(), MinInstSize);
@@ -10362,15 +10617,14 @@ assignLongBranchGateways(PatchContext &Ctx,
   uint64_t PromotedBranchCapacityRelays = 0;
   SmallVector<std::pair<size_t, uint64_t>, 8> ReturnPromotionBranchOnlyRanges;
   bool PlanningRegisterlessReturns = true;
-  constexpr uint64_t MinBranchCapacitySourceBytes =
-      SetPcForwardSequenceBytes + MinInstSize;
   auto PromoteBranchCapacityRelay =
       [&](const BranchIslandFailure &Failure) -> bool {
     auto [SearchBegin, SearchEnd] = branchPromotionSearchRangeForTest(
         Failure.CurrentOffset, Failure.CorridorOffset, Failure.Forward);
     if (SearchBegin >= SearchEnd)
       return false;
-    auto TryPromote = [&](bool AllowLocalPair) -> bool {
+    std::function<bool(bool, bool)> TryPromote =
+        [&](bool AllowLocalPair, bool AllowPreservedVcc) -> bool {
       auto Begin =
           llvm::lower_bound(Ctx.Decoded, SearchBegin,
                             [](const InternalDecodedInst &DI, uint64_t Offset) {
@@ -10386,8 +10640,8 @@ assignLongBranchGateways(PatchContext &Ctx,
       std::optional<size_t> PreviousIndex;
       while (true) {
         int CandidateIndex = findNextPromotionCandidateIndex(
-            PromotionStillPossible, BeginIndex, EndIndex, Failure.Forward,
-            PreviousIndex);
+            PromotionStillPossible, BeginIndex, EndIndex,
+            Failure.Forward && !Failure.PreferNearestCandidate, PreviousIndex);
         if (CandidateIndex < 0)
           break;
         size_t Index = static_cast<size_t>(CandidateIndex);
@@ -10404,6 +10658,18 @@ assignLongBranchGateways(PatchContext &Ctx,
           PromotionStillPossible.reset(Index);
           continue;
         }
+        std::optional<uint32_t> PreservedDirectSize =
+            getSetPcGatewayLayoutSize(Start, PoolEndOffset, /*SgprBase=*/0,
+                                      /*UseVcc=*/true,
+                                      /*PreserveVcc=*/true);
+        if (!PreservedDirectSize) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        const uint64_t MinBranchCapacitySourceBytes =
+            *ProbeDirectSize + MinInstSize;
+        const uint64_t MinPreservedVccPromotionSourceBytes =
+            *PreservedDirectSize + VccLandingPadBytes + MinInstSize;
         uint64_t Tail = Start + *ProbeDirectSize;
         bool MakesReachableProgress =
             Failure.Forward
@@ -10431,7 +10697,12 @@ assignLongBranchGateways(PatchContext &Ctx,
                         MinInstSize
                 ? std::numeric_limits<uint32_t>::max() - *ProbeDirectSize
                 : RemainingRelayDemand * MinInstSize;
+        DemandBytes = std::max(DemandBytes, Failure.MinimumCapacityBytes);
         uint64_t DesiredSourceBytes = *ProbeDirectSize + DemandBytes;
+        if (Failure.MinimumCapacityBytes != 0)
+          DesiredSourceBytes = std::max(
+              DesiredSourceBytes, *PreservedDirectSize + VccLandingPadBytes +
+                                      Failure.MinimumCapacityBytes);
         DesiredSourceBytes =
             std::max(DesiredSourceBytes, MinBranchCapacitySourceBytes);
         DesiredSourceBytes =
@@ -10462,7 +10733,6 @@ assignLongBranchGateways(PatchContext &Ctx,
               checkedAddUint64(Member->Offset, Member->Size,
                                "promoted branch-capacity member end");
           if (!MemberEnd || *MemberEnd > Function->End ||
-              Replacement.size() + Member->Size > DesiredSourceBytes ||
               OverlapsPromotionRange(Member->Offset, *MemberEnd))
             break;
 
@@ -10490,13 +10760,35 @@ assignLongBranchGateways(PatchContext &Ctx,
           PromotionStillPossible.reset(Index);
           continue;
         }
+        if (Failure.MinimumCapacityBytes != 0 &&
+            BestVccReplacementSize <
+                *ProbeDirectSize + Failure.MinimumCapacityBytes)
+          BestVccReplacementSize = 0;
         bool UseVcc = BestVccReplacementSize != 0;
-        if (!UseVcc && !AllowLocalPair)
-          continue;
-        Replacement.resize(UseVcc ? BestVccReplacementSize
-                                  : MinimumReplacementSize);
+        bool PreserveVcc = false;
         std::optional<unsigned> Scratch;
-        if (!UseVcc) {
+        if (UseVcc) {
+          Replacement.resize(BestVccReplacementSize);
+        } else if (AllowPreservedVcc &&
+                   Replacement.size() >= MinPreservedVccPromotionSourceBytes) {
+          std::string Owner = findKernelOwnerAtTextOffset(Ctx, Start);
+          std::optional<unsigned> WavefrontSize =
+              Owner.empty() ? std::nullopt
+                            : Ctx.Elf.getKernelWavefrontSize(Owner);
+          if (WavefrontSize == 32)
+            if (std::optional<SafeSgprScratchBlock> Save =
+                    findSafeSgprScratchBlock(
+                        Ctx, Start, /*Count=*/1, /*Alignment=*/1,
+                        "promoted VCC-preserving branch capacity",
+                        /*ReportNoSpace=*/false)) {
+              Scratch = Save->Base;
+              UseVcc = true;
+              PreserveVcc = true;
+            }
+          if (!PreserveVcc)
+            continue;
+        } else if (AllowLocalPair) {
+          Replacement.resize(MinimumReplacementSize);
           size_t CachedFunctionsBefore =
               Ctx.CurrentFunctionSgprLivenessCache.size();
           Scratch = findLocallyDeadSgprPair(Ctx, Start, Replacement.size(),
@@ -10504,12 +10796,53 @@ assignLongBranchGateways(PatchContext &Ctx,
           PromotionSgprContinuationAnalyses +=
               Ctx.CurrentFunctionSgprLivenessCache.size() -
               CachedFunctionsBefore;
+        } else {
+          continue;
         }
         if (!Scratch && !UseVcc) {
           PromotionStillPossible.reset(Index);
           continue;
         }
+
+        std::optional<SmallVector<uint8_t>> Direct =
+            PreserveVcc
+                ? encodeSetPcGateway(Ctx.LS, Start, PoolEndOffset, *Scratch,
+                                     /*UseVcc=*/true,
+                                     /*PreserveVcc=*/true)
+                : encodeSetPCLongBranch(Ctx.LS, Start, PoolEndOffset,
+                                        Scratch.value_or(0), UseVcc);
+        std::optional<uint32_t> DirectLayout =
+            PreserveVcc
+                ? getSetPcGatewayLayoutSize(Start, PoolEndOffset, *Scratch,
+                                            /*UseVcc=*/true,
+                                            /*PreserveVcc=*/true)
+                : ProbeDirectSize;
+        if (!Direct || !DirectLayout || Direct->size() != *DirectLayout) {
+          PromotionStillPossible.reset(Index);
+          continue;
+        }
+        std::optional<uint64_t> SourceTail = checkedAddUint64(
+            Start, Direct->size() + (PreserveVcc ? VccLandingPadBytes : 0),
+            "promoted branch-capacity source tail");
+        if (!SourceTail)
+          return false;
+        Tail = *SourceTail;
+        MakesReachableProgress =
+            Failure.Forward
+                ? Tail > Failure.CurrentOffset &&
+                      Tail < Failure.CorridorOffset &&
+                      Tail < Failure.TargetOffset &&
+                      isSBranchReachable(Failure.CurrentOffset, Tail)
+                : Tail < Failure.CurrentOffset &&
+                      Tail > Failure.CorridorOffset &&
+                      Tail > Failure.TargetOffset &&
+                      isSBranchReachable(Failure.CurrentOffset, Tail);
+        if (!MakesReachableProgress || Tail >= Start + Replacement.size())
+          continue;
+
         uint64_t End = Start + Replacement.size();
+        if (Failure.MinimumCapacityBytes > End - Tail)
+          continue;
         Trampoline Promoted;
         Promoted.OriginalOffset = Start;
         Promoted.OriginalSize = Replacement.size();
@@ -10520,28 +10853,38 @@ assignLongBranchGateways(PatchContext &Ctx,
           PromotionStillPossible.reset(Index);
           continue;
         }
-        std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
-            Ctx.LS, Start, PoolEndOffset, Scratch.value_or(0), UseVcc);
-        if (!Direct || Direct->size() != *ProbeDirectSize) {
-          PromotionStillPossible.reset(Index);
-          continue;
-        }
         if (Scratch) {
-          SafeSgprScratchBlock ScratchBlock{*Scratch, 2};
+          SafeSgprScratchBlock ScratchBlock{*Scratch, PreserveVcc ? 1u : 2u};
           if (!commitSafeSgprScratchBlock(
                   Ctx, Start, ScratchBlock,
-                  "promoted branch-capacity trampoline SGPR pair")) {
+                  PreserveVcc
+                      ? "promoted VCC-preserving branch-capacity trampoline"
+                      : "promoted branch-capacity trampoline SGPR pair")) {
             PromotionStillPossible.reset(Index);
             continue;
           }
         }
+        if (PreserveVcc) {
+          SmallVector<std::string, 2> RestoreLines;
+          RestoreLines.push_back("s_mov_b32 vcc_lo, s" +
+                                 std::to_string(*Scratch));
+          RestoreLines.push_back("s_delay_alu instid0(SALU_CYCLE_1)");
+          SmallVector<uint8_t> Restore =
+              assembleInstructions(joinAsmLines(RestoreLines), Ctx.LS);
+          if (Restore.size() != VccRestoreSequenceBytes)
+            return false;
+          Promoted.Bytes.append(Restore.begin(), Restore.end());
+        }
         Promoted.Bytes.append(Replacement.begin(), Replacement.end());
-        Promoted.Bytes.append(SetPcReturnReserveBytes, uint8_t{0});
+        Promoted.Bytes.append(PreserveVcc ? VccPreservingReturnReserveBytes
+                                          : SetPcReturnReserveBytes,
+                              uint8_t{0});
         Promoted.Bytes.append(PoolBranchIslandBytes, uint8_t{0});
         Promoted.Long = true;
         Promoted.UsesSetPCBack = true;
         Promoted.LongBranchSgprBase = Scratch.value_or(0);
         Promoted.LongBranchUsesVcc = UseVcc;
+        Promoted.LongBranchPreservesVcc = PreserveVcc;
         Promoted.UsesDirectSetPCForward = true;
         Promoted.DirectSetPCForwardBytes = std::move(*Direct);
         Promoted.HasPoolBranchIsland = true;
@@ -10589,21 +10932,36 @@ assignLongBranchGateways(PatchContext &Ctx,
                 << ") to provide " << (Failure.Forward ? "forward" : "return")
                 << "-capacity relay window [0x" << utohexstr(Tail) << ",0x"
                 << utohexstr(End) << ") with " << (End - Tail) / MinInstSize
-                << " slot(s) using " << (UseVcc ? "VCC" : "a local SGPR pair")
+                << " slot(s) using "
+                << (PreserveVcc ? "preserved VCC"
+                                : (UseVcc ? "VCC" : "a local SGPR pair"))
                 << " (promotion " << PromotedBranchCapacityRelays << ")\n";
         return true;
       }
       return false;
     };
-    if (TryPromote(/*AllowLocalPair=*/false))
+    if (TryPromote(/*AllowLocalPair=*/false,
+                   /*AllowPreservedVcc=*/false))
       return true;
-    return TryPromote(/*AllowLocalPair=*/true);
+    if (TryPromote(/*AllowLocalPair=*/false,
+                   /*AllowPreservedVcc=*/true))
+      return true;
+    return TryPromote(/*AllowLocalPair=*/true,
+                      /*AllowPreservedVcc=*/false);
   };
 
   const auto ReturnBranchPlanStart = std::chrono::steady_clock::now();
+  struct RegisterlessReturnPlan {
+    size_t TrampolineIndex = 0;
+    uint64_t BackSlot = 0;
+    uint64_t ReturnTo = 0;
+    uint64_t ChainTarget = 0;
+  };
+  SmallVector<RegisterlessReturnPlan, 64> RegisterlessReturnPlans;
   TrampOffset = Ctx.PoolBaseOffset;
-  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
-    Trampoline &T = Ctx.OutTrampolines[I];
+  const size_t OriginalTrampolineCount = Ctx.OutTrampolines.size();
+  for (size_t I = 0; I != OriginalTrampolineCount; ++I) {
+    const Trampoline &T = Ctx.OutTrampolines[I];
     std::optional<uint64_t> Next = checkedAddUint64(
         TrampOffset, T.Bytes.size(), "return-island trampoline layout");
     if (!Next)
@@ -10625,35 +10983,55 @@ assignLongBranchGateways(PatchContext &Ctx,
                          "registerless trampoline return target");
     if (!ReturnTo)
       return false;
+    uint64_t ChainTarget = ReservedReturnTails.lookup(I);
+    RegisterlessReturnPlans.push_back(
+        {I, BackSlot, *ReturnTo, ChainTarget ? ChainTarget : *ReturnTo});
+  }
+
+  // Nearer return targets have shorter, more constrained corridors and must
+  // retain first access to the scarce branch heads nearest the pool. Planning
+  // low-address returns first lets their longer chains consume those heads,
+  // then strands a later target even though the reverse order admits both.
+  llvm::stable_sort(
+      RegisterlessReturnPlans,
+      [](const RegisterlessReturnPlan &LHS, const RegisterlessReturnPlan &RHS) {
+        if (LHS.ChainTarget != RHS.ChainTarget)
+          return LHS.ChainTarget > RHS.ChainTarget;
+        return LHS.BackSlot > RHS.BackSlot;
+      });
+
+  for (const RegisterlessReturnPlan &Plan : RegisterlessReturnPlans) {
+    const Trampoline &T = Ctx.OutTrampolines[Plan.TrampolineIndex];
     uint64_t OwnerOffset = T.OriginalOffset;
     uint32_t OwnerSize = T.OriginalSize;
     bool OwnerPreservesVcc = T.LongBranchPreservesVcc;
     bool OwnerUsesShared = T.UsesSharedDispatcherForward;
     bool OwnerUsesMirrored = T.UsesMirroredStubForward;
-    uint64_t ChainTarget = ReservedReturnTails.lookup(I);
     BranchIslandFailure Failure;
     std::optional<SmallVector<uint64_t, 4>> ReturnIslands =
-        allocateBackwardBranchIslands(Gateways, OwnerOffset, BackSlot,
-                                      ChainTarget ? ChainTarget : *ReturnTo,
-                                      &Failure, &BranchGatewayHeads,
-                                      &OccupiedBranchGatewaySlots,
-                                      PromoteBranchCapacityRelay);
+        allocateBackwardBranchIslands(
+            Gateways, OwnerOffset, Plan.BackSlot, Plan.ChainTarget, &Failure,
+            &BranchGatewayHeads, &OccupiedBranchGatewaySlots,
+            PromoteBranchCapacityRelay);
     if (!ReturnIslands) {
       log() << "hotswap: error: no safe return s_branch island chain for far "
                "site 0x"
             << utohexstr(OwnerOffset) << " (size=" << OwnerSize
-            << ", pool-back-slot=0x" << utohexstr(BackSlot) << ", return-to=0x"
-            << utohexstr(*ReturnTo) << ", reserved-tail=0x"
-            << utohexstr(ChainTarget) << ", preserve-vcc=" << OwnerPreservesVcc
+            << ", pool-back-slot=0x" << utohexstr(Plan.BackSlot)
+            << ", return-to=0x" << utohexstr(Plan.ReturnTo)
+            << ", reserved-tail=0x"
+            << utohexstr(Plan.ChainTarget == Plan.ReturnTo ? uint64_t{0}
+                                                           : Plan.ChainTarget)
+            << ", preserve-vcc=" << OwnerPreservesVcc
             << ", shared=" << OwnerUsesShared
             << ", mirrored=" << OwnerUsesMirrored << ")\n";
       return false;
     }
-    if (ChainTarget)
-      ReturnIslands->push_back(ChainTarget);
-    Trampoline &Planned = Ctx.OutTrampolines[I];
+    if (Plan.ChainTarget != Plan.ReturnTo)
+      ReturnIslands->push_back(Plan.ChainTarget);
+    Trampoline &Planned = Ctx.OutTrampolines[Plan.TrampolineIndex];
     Planned.ReturnBranchIslands = std::move(*ReturnIslands);
-    Planned.ReturnBranchTargetOffset = *ReturnTo;
+    Planned.ReturnBranchTargetOffset = Plan.ReturnTo;
     ReturnBranchIslandChains += !Planned.ReturnBranchIslands.empty();
     if (RemainingRelayDemand)
       --RemainingRelayDemand;
@@ -10686,6 +11064,13 @@ assignLongBranchGateways(PatchContext &Ctx,
     const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
     if (!T.UsesSetPCBack)
       continue;
+    // A round-trip gateway has the strictest layout in this phase. Give it
+    // first access to candidate windows; its exact fit is checked while
+    // encoding the forward and return halves together below.
+    if (T.UsesVccRestoreGateway) {
+      P.InitialCandidateSlots = 0;
+      continue;
+    }
     Expected<uint64_t> CandidateSlots = countReachableSetPcGatewaySlots(
         Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
         T.LongBranchSgprBase, Pending.size(), T.LongBranchUsesVcc,
@@ -10724,11 +11109,29 @@ assignLongBranchGateways(PatchContext &Ctx,
       StillPending.push_back(P);
       continue;
     }
+    if (T.UsesVccRestoreGateway) {
+      DenseMap<uint64_t, SmallVector<NopSled, 3>>::iterator Reserved =
+          ReservedVccRoundTripCapacity.find(T.OriginalOffset);
+      if (Reserved != ReservedVccRoundTripCapacity.end()) {
+        Gateways.insert(Gateways.end(), Reserved->second.begin(),
+                        Reserved->second.end());
+        ReservedVccRoundTripCapacity.erase(Reserved);
+      }
+    }
+    std::optional<uint64_t> ReturnTo =
+        checkedAddUint64(T.OriginalOffset, T.OriginalSize,
+                         "round-trip VCC gateway return target");
+    if (!ReturnTo)
+      return false;
     Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
-        findNearestSetPcGateway(Gateways, Ctx.LS, T.OriginalOffset,
-                                P.TargetOffset, T.LongBranchSgprBase,
-                                T.LongBranchUsesVcc, T.LongBranchPreservesVcc,
-                                &OccupiedBranchGatewaySlots);
+        T.UsesVccRestoreGateway
+            ? findNearestVccRoundTripGateway(
+                  Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset, *ReturnTo,
+                  T.LongBranchSgprBase, &OccupiedBranchGatewaySlots)
+            : findNearestSetPcGateway(
+                  Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
+                  T.LongBranchSgprBase, T.LongBranchUsesVcc,
+                  T.LongBranchPreservesVcc, &OccupiedBranchGatewaySlots);
     if (!GatewayOrErr) {
       log() << "hotswap: error: failed to plan gateway for far site 0x"
             << utohexstr(T.OriginalOffset) << ": "
@@ -10737,7 +11140,82 @@ assignLongBranchGateways(PatchContext &Ctx,
     }
     std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
     if (!Gateway) {
-      if (T.LongBranchPreservesVcc) {
+      if (T.UsesVccRestoreGateway) {
+        std::optional<EncodedSplitVccGateway> Split = findSplitVccGateway(
+            Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
+            T.LongBranchSgprBase, &OccupiedBranchGatewaySlots);
+        if (Split) {
+          NopSled &Primary = Gateways[Split->PrimaryIndex];
+          NopSled &Secondary = Gateways[Split->SecondaryIndex];
+          DenseSet<uint64_t> SplitOccupied = OccupiedBranchGatewaySlots;
+          for (uint64_t Offset = 0; Offset < Split->PrimaryBytes.size();
+               Offset += MinInstSize)
+            SplitOccupied.insert(Primary.WritePos + Offset);
+          for (uint64_t Offset = 0; Offset < Split->SecondaryBytes.size();
+               Offset += MinInstSize)
+            SplitOccupied.insert(Secondary.WritePos + Offset);
+          Expected<std::optional<EncodedSetPcGateway>> RestoreOrErr =
+              findNearestVccRestoreGateway(Gateways, Ctx.LS, T.OriginalOffset,
+                                           *ReturnTo, T.LongBranchSgprBase,
+                                           &SplitOccupied);
+          if (!RestoreOrErr) {
+            log() << "hotswap: error: failed to plan split restore gateway "
+                     "for far site 0x"
+                  << utohexstr(T.OriginalOffset) << ": "
+                  << toString(RestoreOrErr.takeError()) << "\n";
+            return false;
+          }
+          std::optional<EncodedSetPcGateway> Restore = std::move(*RestoreOrErr);
+          if (Restore) {
+            T.HasForwardGateway = true;
+            T.ForwardGatewayOffset = Primary.WritePos;
+            T.ForwardGatewayBytes = std::move(Split->PrimaryBytes);
+            T.SharedDispatcherSecondaryGatewayOffset = Secondary.WritePos;
+            T.SecondaryForwardGatewayBytes = std::move(Split->SecondaryBytes);
+            T.VccRestoreGatewayOffset = Restore->Sled->WritePos;
+            T.VccRestoreGatewayBytes = std::move(Restore->Bytes);
+
+            std::function<bool(uint64_t, uint32_t)> ClaimSourceGateway =
+                [&](uint64_t Offset, uint32_t Size) -> bool {
+              DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
+                  SourceTailGatewayOwners.find(Offset);
+              if (SourceOwner == SourceTailGatewayOwners.end())
+                return true;
+              Trampoline &OwnerT = Ctx.OutTrampolines[SourceOwner->second];
+              if (OwnerT.HasSourceTailGateway) {
+                log() << "hotswap: error: split VCC source-tail gateway at 0x"
+                      << utohexstr(Offset) << " has conflicting allocations\n";
+                return false;
+              }
+              OwnerT.HasSourceTailGateway = true;
+              OwnerT.SourceTailGatewayOffset = Offset;
+              OwnerT.SourceTailGatewayBytes = Size;
+              return true;
+            };
+            if (!ClaimSourceGateway(T.SharedDispatcherSecondaryGatewayOffset,
+                                    T.SecondaryForwardGatewayBytes.size()) ||
+                !ClaimSourceGateway(T.VccRestoreGatewayOffset,
+                                    T.VccRestoreGatewayBytes.size()))
+              return false;
+
+            Primary.WritePos += T.ForwardGatewayBytes.size();
+            Secondary.WritePos += T.SecondaryForwardGatewayBytes.size();
+            Restore->Sled->WritePos += T.VccRestoreGatewayBytes.size();
+            OccupyOrdinaryGateway(T.ForwardGatewayOffset,
+                                  T.ForwardGatewayBytes.size());
+            OccupyOrdinaryGateway(T.SharedDispatcherSecondaryGatewayOffset,
+                                  T.SecondaryForwardGatewayBytes.size());
+            OccupyOrdinaryGateway(T.VccRestoreGatewayOffset,
+                                  T.VccRestoreGatewayBytes.size());
+            ++AssignedGateways;
+            ++AssignedSplitVccGateways;
+            if (RemainingRelayDemand)
+              --RemainingRelayDemand;
+            continue;
+          }
+        }
+      }
+      if (T.LongBranchPreservesVcc && !T.UsesVccRestoreGateway) {
         std::optional<EncodedSplitVccGateway> Split = findSplitVccGateway(
             Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
             T.LongBranchSgprBase, &OccupiedBranchGatewaySlots);
@@ -10785,6 +11263,14 @@ assignLongBranchGateways(PatchContext &Ctx,
     T.HasForwardGateway = true;
     T.ForwardGatewayOffset = Gateway->Sled->WritePos;
     T.ForwardGatewayBytes = std::move(Gateway->Bytes);
+    if (T.UsesVccRestoreGateway) {
+      std::optional<uint32_t> ForwardBytes = getSetPcGatewayLayoutSize(
+          T.ForwardGatewayOffset, P.TargetOffset, T.LongBranchSgprBase,
+          /*UseVcc=*/true, /*PreserveVcc=*/true);
+      if (!ForwardBytes || *ForwardBytes > T.ForwardGatewayBytes.size())
+        return false;
+      T.VccRestoreGatewayOffset = T.ForwardGatewayOffset + *ForwardBytes;
+    }
     DenseMap<uint64_t, size_t>::const_iterator SourceOwner =
         SourceTailGatewayOwners.find(T.ForwardGatewayOffset);
     if (SourceOwner != SourceTailGatewayOwners.end()) {
@@ -10809,6 +11295,89 @@ assignLongBranchGateways(PatchContext &Ctx,
   }
   Pending = std::move(StillPending);
 
+  // The first ordinary pass has now identified every isolated live-VCC source
+  // that lacks stable padding. Simulate exact round-trip reservations in
+  // promoted source windows, adding another window only when prior promoted
+  // capacity cannot serve the current source. Hide the physical windows from
+  // branch islands, then replay each exact owner reservation in the final
+  // retry below.
+  std::vector<NopSled> SimulatedPrePromotedVccCapacity;
+  DenseMap<uint64_t, std::vector<NopSled>> ReservedPrePromotedVccCapacity;
+  uint64_t PrePromotedVccRoundTripGateways = 0;
+  uint64_t PrePromotedVccRoundTripSites = 0;
+  for (const PendingGateway &P : Pending) {
+    const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    if (!T.UsesVccRestoreGateway)
+      continue;
+    uint64_t OwnerOffset = T.OriginalOffset;
+    uint32_t OwnerSize = T.OriginalSize;
+    unsigned SaveSgpr = T.LongBranchSgprBase;
+    std::optional<uint64_t> ReturnTo = checkedAddUint64(
+        OwnerOffset, OwnerSize, "pre-promoted round-trip VCC return target");
+    if (!ReturnTo)
+      return false;
+    Expected<std::optional<EncodedSetPcGateway>> SimulatedOrErr =
+        findNearestVccRoundTripGateway(SimulatedPrePromotedVccCapacity, Ctx.LS,
+                                       OwnerOffset, P.TargetOffset, *ReturnTo,
+                                       SaveSgpr,
+                                       /*Occupied=*/nullptr);
+    if (!SimulatedOrErr) {
+      log() << "hotswap: error: failed to simulate pre-promoted VCC "
+               "capacity for far site 0x"
+            << utohexstr(OwnerOffset) << ": "
+            << toString(SimulatedOrErr.takeError()) << "\n";
+      return false;
+    }
+    std::optional<EncodedSetPcGateway> Simulated = std::move(*SimulatedOrErr);
+    if (!Simulated) {
+      BranchIslandFailure Failure{OwnerOffset,
+                                  P.TargetOffset,
+                                  P.TargetOffset,
+                                  /*Forward=*/true,
+                                  /*MinimumCapacityBytes=*/32,
+                                  /*PreferNearestCandidate=*/true};
+      if (!PromoteBranchCapacityRelay(Failure))
+        continue;
+      size_t SourceGatewayIndex = Gateways.size() - 1;
+      NopSled &SourceGateway = Gateways[SourceGatewayIndex];
+      SimulatedPrePromotedVccCapacity.push_back(SourceGateway);
+      SourceGateway.End = SourceGateway.WritePos;
+      ++PrePromotedVccRoundTripGateways;
+
+      SimulatedOrErr = findNearestVccRoundTripGateway(
+          SimulatedPrePromotedVccCapacity, Ctx.LS, OwnerOffset, P.TargetOffset,
+          *ReturnTo, SaveSgpr,
+          /*Occupied=*/nullptr);
+      if (!SimulatedOrErr) {
+        log() << "hotswap: error: failed to reserve new pre-promoted VCC "
+                 "capacity for far site 0x"
+              << utohexstr(OwnerOffset) << ": "
+              << toString(SimulatedOrErr.takeError()) << "\n";
+        return false;
+      }
+      Simulated = std::move(*SimulatedOrErr);
+      if (!Simulated) {
+        log() << "hotswap: error: exact pre-promoted VCC capacity cannot "
+                 "serve far site 0x"
+              << utohexstr(OwnerOffset) << "\n";
+        return false;
+      }
+    }
+    uint64_t ReservedBegin = Simulated->Sled->WritePos;
+    uint64_t ReservedEnd = ReservedBegin + Simulated->Bytes.size();
+    ReservedPrePromotedVccCapacity[OwnerOffset].push_back(
+        {ReservedBegin, ReservedEnd, ReservedBegin, 0,
+         std::numeric_limits<uint64_t>::max()});
+    Simulated->Sled->WritePos += Simulated->Bytes.size();
+    ++PrePromotedVccRoundTripSites;
+    if (RemainingRelayDemand)
+      --RemainingRelayDemand;
+  }
+  if (PrePromotedVccRoundTripGateways != 0)
+    log() << "hotswap: pre-promoted " << PrePromotedVccRoundTripGateways
+          << " gateway window(s) covering " << PrePromotedVccRoundTripSites
+          << " isolated live-VCC source(s)\n";
+
   for (const auto &[Begin, End] : HiddenReturnPromotionRanges)
     Gateways.push_back(
         {Begin, End, Begin, 0, std::numeric_limits<uint64_t>::max()});
@@ -10820,7 +11389,12 @@ assignLongBranchGateways(PatchContext &Ctx,
   StillPending.reserve(Pending.size());
   const auto ForwardBranchPlanStart = std::chrono::steady_clock::now();
   for (const PendingGateway &P : Pending) {
-    uint64_t OwnerOffset = Ctx.OutTrampolines[P.TrampolineIndex].OriginalOffset;
+    const Trampoline &Unplanned = Ctx.OutTrampolines[P.TrampolineIndex];
+    if (Unplanned.UsesVccRestoreGateway) {
+      StillPending.push_back(P);
+      continue;
+    }
+    uint64_t OwnerOffset = Unplanned.OriginalOffset;
     BranchIslandFailure Failure;
     std::optional<SmallVector<uint64_t, 4>> Islands =
         allocateForwardBranchIslands(Gateways, OwnerOffset, P.TargetOffset,
@@ -10846,6 +11420,212 @@ assignLongBranchGateways(PatchContext &Ctx,
                std::chrono::steady_clock::now() - ForwardBranchPlanStart)
                .count()
         << " ms\n";
+  // Forward island recovery may promote large straight-line source suffixes
+  // after the first variable-width gateway pass. Give isolated live-VCC sites
+  // one final chance to consume that new capacity before reporting failure.
+  uint64_t RetriedVccRoundTripGateways = 0;
+  std::function<bool(uint64_t, uint32_t)> ClaimRetriedSourceGateway =
+      [&](uint64_t Offset, uint32_t Size) -> bool {
+    std::optional<size_t> OwnerIndex;
+    bool IslandOwned = false;
+    DenseMap<uint64_t, size_t>::const_iterator GatewayOwner =
+        SourceTailGatewayOwners.find(Offset);
+    DenseMap<uint64_t, size_t>::const_iterator IslandOwner =
+        SourceTailIslandOwners.find(Offset);
+    if (GatewayOwner != SourceTailGatewayOwners.end())
+      OwnerIndex = GatewayOwner->second;
+    else if (IslandOwner != SourceTailIslandOwners.end()) {
+      OwnerIndex = IslandOwner->second;
+      IslandOwned = true;
+    }
+    if (!OwnerIndex)
+      return true;
+
+    for (uint64_t Relative = 0; Relative < Size; Relative += MinInstSize) {
+      DenseMap<uint64_t, size_t>::const_iterator Owner =
+          SourceTailIslandOwners.find(Offset + Relative);
+      if (Owner != SourceTailIslandOwners.end() && Owner->second != *OwnerIndex)
+        return false;
+    }
+    Trampoline &OwnerT = Ctx.OutTrampolines[*OwnerIndex];
+    if (OwnerT.HasSourceTailGateway) {
+      if (OwnerT.SourceTailGatewayOffset == Offset &&
+          OwnerT.SourceTailGatewayBytes == Size)
+        return true;
+      for (const std::pair<uint64_t, uint32_t> &Existing :
+           OwnerT.AdditionalSourceTailGateways) {
+        uint64_t ExistingOffset = Existing.first;
+        uint32_t ExistingSize = Existing.second;
+        if (ExistingOffset == Offset && ExistingSize == Size)
+          return true;
+        if (Offset < ExistingOffset + ExistingSize &&
+            ExistingOffset < Offset + Size)
+          return false;
+      }
+      if (!IslandOwned || (Offset < OwnerT.SourceTailGatewayOffset +
+                                        OwnerT.SourceTailGatewayBytes &&
+                           OwnerT.SourceTailGatewayOffset < Offset + Size))
+        return false;
+      OwnerT.AdditionalSourceTailGateways.push_back({Offset, Size});
+      return true;
+    }
+    OwnerT.HasSourceTailGateway = true;
+    OwnerT.SourceTailGatewayOffset = Offset;
+    OwnerT.SourceTailGatewayBytes = Size;
+    return true;
+  };
+  std::function<bool()> RetryVccRoundTripGateways = [&]() -> bool {
+    StillPending.clear();
+    StillPending.reserve(Pending.size());
+    for (const PendingGateway &P : Pending) {
+      Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+      if (!T.UsesVccRestoreGateway) {
+        StillPending.push_back(P);
+        continue;
+      }
+      std::optional<uint64_t> ReturnTo =
+          checkedAddUint64(T.OriginalOffset, T.OriginalSize,
+                           "retried round-trip VCC gateway return target");
+      if (!ReturnTo)
+        return false;
+      std::vector<NopSled> OwnerReservedCapacity;
+      std::vector<NopSled> *CandidateGateways = &Gateways;
+      DenseMap<uint64_t, std::vector<NopSled>>::iterator OwnerReservation =
+          ReservedPrePromotedVccCapacity.find(T.OriginalOffset);
+      bool HasOwnerReservation =
+          OwnerReservation != ReservedPrePromotedVccCapacity.end();
+      if (HasOwnerReservation) {
+        OwnerReservedCapacity = std::move(OwnerReservation->second);
+        ReservedPrePromotedVccCapacity.erase(OwnerReservation);
+        CandidateGateways = &OwnerReservedCapacity;
+      }
+      Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
+          findNearestVccRoundTripGateway(
+              *CandidateGateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
+              *ReturnTo, T.LongBranchSgprBase, &OccupiedBranchGatewaySlots);
+      if (!GatewayOrErr) {
+        log() << "hotswap: error: failed to retry round-trip VCC gateway for "
+                 "far site 0x"
+              << utohexstr(T.OriginalOffset) << ": "
+              << toString(GatewayOrErr.takeError()) << "\n";
+        return false;
+      }
+      std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
+      if (HasOwnerReservation && !Gateway) {
+        log() << "hotswap: error: pre-promoted VCC reservation no longer "
+                 "serves far site 0x"
+              << utohexstr(T.OriginalOffset) << "\n";
+        return false;
+      }
+      if (Gateway) {
+        uint64_t Offset = Gateway->Sled->WritePos;
+        std::optional<uint32_t> ForwardBytes = getSetPcGatewayLayoutSize(
+            Offset, P.TargetOffset, T.LongBranchSgprBase,
+            /*UseVcc=*/true, /*PreserveVcc=*/true);
+        if (!ForwardBytes || *ForwardBytes > Gateway->Bytes.size()) {
+          log() << "hotswap: error: retried round-trip gateway layout mismatch "
+                   "at 0x"
+                << utohexstr(Offset) << "\n";
+          return false;
+        }
+        if (!ClaimRetriedSourceGateway(Offset, Gateway->Bytes.size())) {
+          log() << "hotswap: error: retried round-trip source-tail ownership "
+                   "conflict at 0x"
+                << utohexstr(Offset) << "\n";
+          return false;
+        }
+        T.HasForwardGateway = true;
+        T.ForwardGatewayOffset = Offset;
+        T.ForwardGatewayBytes = std::move(Gateway->Bytes);
+        T.VccRestoreGatewayOffset = Offset + *ForwardBytes;
+        Gateway->Sled->WritePos += T.ForwardGatewayBytes.size();
+        OccupyOrdinaryGateway(T.ForwardGatewayOffset,
+                              T.ForwardGatewayBytes.size());
+        ++AssignedGateways;
+        ++RetriedVccRoundTripGateways;
+        if (RemainingRelayDemand)
+          --RemainingRelayDemand;
+        continue;
+      }
+
+      std::optional<EncodedSplitVccGateway> Split = findSplitVccGateway(
+          Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
+          T.LongBranchSgprBase, &OccupiedBranchGatewaySlots);
+      if (!Split) {
+        StillPending.push_back(P);
+        continue;
+      }
+      NopSled &Primary = Gateways[Split->PrimaryIndex];
+      NopSled &Secondary = Gateways[Split->SecondaryIndex];
+      DenseSet<uint64_t> SplitOccupied = OccupiedBranchGatewaySlots;
+      for (uint64_t Offset = 0; Offset < Split->PrimaryBytes.size();
+           Offset += MinInstSize)
+        SplitOccupied.insert(Primary.WritePos + Offset);
+      for (uint64_t Offset = 0; Offset < Split->SecondaryBytes.size();
+           Offset += MinInstSize)
+        SplitOccupied.insert(Secondary.WritePos + Offset);
+      Expected<std::optional<EncodedSetPcGateway>> RestoreOrErr =
+          findNearestVccRestoreGateway(Gateways, Ctx.LS, T.OriginalOffset,
+                                       *ReturnTo, T.LongBranchSgprBase,
+                                       &SplitOccupied);
+      if (!RestoreOrErr) {
+        log() << "hotswap: error: failed to retry split VCC restore gateway "
+                 "for far site 0x"
+              << utohexstr(T.OriginalOffset) << ": "
+              << toString(RestoreOrErr.takeError()) << "\n";
+        return false;
+      }
+      std::optional<EncodedSetPcGateway> Restore = std::move(*RestoreOrErr);
+      if (!Restore) {
+        StillPending.push_back(P);
+        continue;
+      }
+
+      uint64_t PrimaryOffset = Primary.WritePos;
+      uint64_t SecondaryOffset = Secondary.WritePos;
+      uint64_t RestoreOffset = Restore->Sled->WritePos;
+      if (!ClaimRetriedSourceGateway(PrimaryOffset,
+                                     Split->PrimaryBytes.size()) ||
+          !ClaimRetriedSourceGateway(SecondaryOffset,
+                                     Split->SecondaryBytes.size()) ||
+          !ClaimRetriedSourceGateway(RestoreOffset, Restore->Bytes.size())) {
+        log() << "hotswap: error: retried split round-trip source-tail "
+                 "ownership conflict for site 0x"
+              << utohexstr(T.OriginalOffset) << "\n";
+        return false;
+      }
+      T.HasForwardGateway = true;
+      T.ForwardGatewayOffset = PrimaryOffset;
+      T.ForwardGatewayBytes = std::move(Split->PrimaryBytes);
+      T.SharedDispatcherSecondaryGatewayOffset = SecondaryOffset;
+      T.SecondaryForwardGatewayBytes = std::move(Split->SecondaryBytes);
+      T.VccRestoreGatewayOffset = RestoreOffset;
+      T.VccRestoreGatewayBytes = std::move(Restore->Bytes);
+      Primary.WritePos += T.ForwardGatewayBytes.size();
+      Secondary.WritePos += T.SecondaryForwardGatewayBytes.size();
+      Restore->Sled->WritePos += T.VccRestoreGatewayBytes.size();
+      OccupyOrdinaryGateway(T.ForwardGatewayOffset,
+                            T.ForwardGatewayBytes.size());
+      OccupyOrdinaryGateway(T.SharedDispatcherSecondaryGatewayOffset,
+                            T.SecondaryForwardGatewayBytes.size());
+      OccupyOrdinaryGateway(T.VccRestoreGatewayOffset,
+                            T.VccRestoreGatewayBytes.size());
+      ++AssignedGateways;
+      ++AssignedSplitVccGateways;
+      ++RetriedVccRoundTripGateways;
+      if (RemainingRelayDemand)
+        --RemainingRelayDemand;
+    }
+    Pending = std::move(StillPending);
+    return true;
+  };
+  if (!RetryVccRoundTripGateways())
+    return false;
+
+  if (RetriedVccRoundTripGateways != 0)
+    log() << "hotswap: assigned " << RetriedVccRoundTripGateways
+          << " round-trip VCC gateway(s) from promoted capacity\n";
+
   if (PromotionSgprContinuationAnalyses != 0)
     log() << "hotswap: batched promotion SGPR continuation analysis built "
           << PromotionSgprContinuationAnalyses << " function cache(s)\n";
@@ -10903,6 +11683,17 @@ assignLongBranchGateways(PatchContext &Ctx,
         }
         std::memcpy(Ctx.Text + Offset, T.SecondaryForwardGatewayBytes.data(),
                     T.SecondaryForwardGatewayBytes.size());
+      }
+      if (!T.VccRestoreGatewayBytes.empty()) {
+        uint64_t Offset = T.VccRestoreGatewayOffset;
+        if (Offset > Ctx.TextSize ||
+            T.VccRestoreGatewayBytes.size() > Ctx.TextSize - Offset) {
+          log() << "hotswap: error: VCC restore gateway at 0x"
+                << utohexstr(Offset) << " extends past .text.\n";
+          return false;
+        }
+        std::memcpy(Ctx.Text + Offset, T.VccRestoreGatewayBytes.data(),
+                    T.VccRestoreGatewayBytes.size());
       }
     }
     for (size_t I = 0; I != T.ForwardBranchIslands.size(); ++I) {
@@ -11501,8 +12292,10 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
                                          ? T.DirectSetPCForwardBytes.size()
                                          : MinInstSize;
       std::optional<uint64_t> Landing =
-          checkedAddUint64(T.OriginalOffset, LandingDisplacement,
-                           "VCC-preserving return landing offset");
+          T.UsesVccRestoreGateway
+              ? std::optional<uint64_t>(T.VccRestoreGatewayOffset)
+              : checkedAddUint64(T.OriginalOffset, LandingDisplacement,
+                                 "VCC-preserving return landing offset");
       if (Save.size() != VccMoveBytes || !SetPcOffset || !Landing)
         return false;
       std::optional<SmallVector<uint8_t>> SetPc = encodeSetPCLongBranch(
@@ -11583,7 +12376,7 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
     }
     std::memcpy(Text + T.OriginalOffset, BrFwd.data(), BrFwd.size());
     uint32_t PadStart = BrFwd.size();
-    if (T.LongBranchPreservesVcc) {
+    if (T.LongBranchPreservesVcc && !T.UsesVccRestoreGateway) {
       uint64_t LandingDisplacement =
           T.UsesDirectSetPCForward ? BrFwd.size() : MinInstSize;
       if ((!T.UsesDirectSetPCForward && BrFwd.size() != MinInstSize) ||
@@ -11609,15 +12402,44 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
                   Restore.size());
       PadStart = LandingDisplacement + VccLandingPadBytes;
     }
-    if (T.HasSourceTailGateway) {
-      std::optional<uint64_t> GatewayEnd =
-          checkedAddUint64(T.SourceTailGatewayOffset, T.SourceTailGatewayBytes,
-                           "source-tail gateway end");
-      std::optional<uint64_t> SourceEnd = checkedAddUint64(
-          T.OriginalOffset, T.OriginalSize, "source-tail gateway source end");
-      if (!GatewayEnd || !SourceEnd ||
-          T.SourceTailGatewayOffset < T.OriginalOffset + PadStart ||
-          *GatewayEnd > *SourceEnd) {
+    std::function<bool(uint64_t)> IsSourceTailGatewayDword =
+        [&](uint64_t Offset) {
+          if (T.HasSourceTailGateway && Offset >= T.SourceTailGatewayOffset &&
+              Offset - T.SourceTailGatewayOffset < T.SourceTailGatewayBytes)
+            return true;
+          for (const std::pair<uint64_t, uint32_t> &Gateway :
+               T.AdditionalSourceTailGateways) {
+            uint64_t GatewayOffset = Gateway.first;
+            uint32_t GatewayBytes = Gateway.second;
+            if (Offset >= GatewayOffset &&
+                Offset - GatewayOffset < GatewayBytes)
+              return true;
+          }
+          return false;
+        };
+    std::optional<uint64_t> SourceEnd = checkedAddUint64(
+        T.OriginalOffset, T.OriginalSize, "source-tail gateway source end");
+    std::function<bool(uint64_t, uint32_t)> ValidSourceTailGateway =
+        [&](uint64_t Offset, uint32_t Size) {
+          std::optional<uint64_t> GatewayEnd =
+              checkedAddUint64(Offset, Size, "source-tail gateway end");
+          return GatewayEnd && SourceEnd &&
+                 Offset >= T.OriginalOffset + PadStart &&
+                 *GatewayEnd <= *SourceEnd;
+        };
+    if (T.HasSourceTailGateway &&
+        !ValidSourceTailGateway(T.SourceTailGatewayOffset,
+                                T.SourceTailGatewayBytes)) {
+      log() << "hotswap: error: source-tail gateway overlaps the forward "
+               "sequence at 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      return false;
+    }
+    for (const std::pair<uint64_t, uint32_t> &Gateway :
+         T.AdditionalSourceTailGateways) {
+      uint64_t GatewayOffset = Gateway.first;
+      uint32_t GatewayBytes = Gateway.second;
+      if (!ValidSourceTailGateway(GatewayOffset, GatewayBytes)) {
         log() << "hotswap: error: source-tail gateway overlaps the forward "
                  "sequence at 0x"
               << utohexstr(T.OriginalOffset) << "\n";
@@ -11628,8 +12450,7 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
     for (uint32_t I = PadStart; I + MinInstSize <= T.OriginalSize;
          I += MinInstSize) {
       uint64_t Offset = T.OriginalOffset + I;
-      if (T.HasSourceTailGateway && Offset >= T.SourceTailGatewayOffset &&
-          Offset - T.SourceTailGatewayOffset < T.SourceTailGatewayBytes)
+      if (IsSourceTailGatewayDword(Offset))
         continue;
       std::memcpy(Text + T.OriginalOffset + I, LS.SNopBytes.data(),
                   MinInstSize);
@@ -11638,9 +12459,7 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
       if (RelayOffset < T.OriginalOffset ||
           RelayOffset - T.OriginalOffset < PadStart ||
           RelayOffset - T.OriginalOffset > T.OriginalSize - MinInstSize ||
-          (T.HasSourceTailGateway && RelayOffset >= T.SourceTailGatewayOffset &&
-           RelayOffset - T.SourceTailGatewayOffset <
-               T.SourceTailGatewayBytes)) {
+          IsSourceTailGatewayDword(RelayOffset)) {
         log() << "hotswap: error: source-tail branch island overlaps the "
                  "forward sequence at 0x"
               << utohexstr(T.OriginalOffset) << "\n";

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -3929,18 +3929,21 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       }
       if (!ReusableCalls[InstIndex].empty() &&
           !IsFiniteExternalMaterializedCall) {
-        if (llvm::any_of(ReusableCalls[InstIndex],
+        bool HasExternalReusableTarget =
+            llvm::any_of(ReusableCalls[InstIndex],
                          [TextAddr, TextEnd](uint64_t ReusableTarget) {
                            return ReusableTarget < TextAddr ||
                                   ReusableTarget >= *TextEnd;
-                         })) {
+                         });
+        if (HasExternalReusableTarget && !IndirectControlFlowClosed) {
           log() << "hotswap: unresolved call target at 0x"
                 << utohexstr(DI.Offset) << " (reusable target outside .text)\n";
           Info.HasUnresolvedTargets = true;
           continue;
         }
         for (uint64_t ReusableTarget : ReusableCalls[InstIndex])
-          Info.Targets.insert(ReusableTarget - TextAddr);
+          if (ReusableTarget >= TextAddr && ReusableTarget < *TextEnd)
+            Info.Targets.insert(ReusableTarget - TextAddr);
         Info.BoundedIndirectTransfers.insert(DI.Offset);
         if (LocallyProvenMaterializedCalls.test(InstIndex)) {
           log() << "hotswap: resolved PC-materialized call at 0x"

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1986,6 +1986,16 @@ struct KnownCallSite {
   MCRegister ReturnRegister;
 };
 
+struct ExternalCallContinuation {
+  size_t InstIndex = 0;
+  uint64_t Continuation = 0;
+};
+
+struct KnownCallSites {
+  SmallVector<KnownCallSite, 4> Local;
+  SmallVector<ExternalCallContinuation, 4> External;
+};
+
 struct BoundedSetPcReturn {
   size_t InstIndex = 0;
   SmallVector<uint64_t, 2> Targets;
@@ -2055,55 +2065,77 @@ getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
   return AbsoluteTarget - TextAddr;
 }
 
-static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
+static std::optional<KnownCallSites> collectKnownCallSites(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<std::optional<PcMaterializedCallInfo>> MaterializedCalls,
     ArrayRef<ReachingCallTargets> ReusableCalls) {
-  SmallVector<KnownCallSite, 4> Calls;
+  KnownCallSites Calls;
+  uint64_t TextSize = TextEnd - TextAddr;
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &DI = Decoded[I];
     std::optional<MCRegister> ReturnRegister = getCallReturnRegister(DI, LS);
     if (!ReturnRegister)
       continue;
 
+    SmallVector<uint64_t, 8> LocalTargets;
+    bool HasFiniteExternalTarget = false;
     if (MaterializedCalls[I]) {
       uint64_t AbsoluteTarget = MaterializedCalls[I]->Target;
-      if (AbsoluteTarget < TextAddr || AbsoluteTarget >= TextEnd)
-        continue;
-      std::optional<uint64_t> Continuation = checkedAddUint64(
-          DI.Offset, DI.Size, "known call continuation address");
-      if (!Continuation)
-        return std::nullopt;
-      Calls.push_back(
-          {I, AbsoluteTarget - TextAddr, *Continuation, *ReturnRegister});
+      if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
+        LocalTargets.push_back(AbsoluteTarget - TextAddr);
+      else
+        HasFiniteExternalTarget = true;
+    } else if (!ReusableCalls[I].empty()) {
+      for (uint64_t AbsoluteTarget : ReusableCalls[I]) {
+        if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
+          LocalTargets.push_back(AbsoluteTarget - TextAddr);
+        else
+          HasFiniteExternalTarget = true;
+      }
+    } else if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
+               DI.Inst.getNumOperands() != 0 &&
+               DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
+      uint64_t AbsoluteTarget = static_cast<uint64_t>(
+          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
+      if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
+        LocalTargets.push_back(AbsoluteTarget - TextAddr);
+      else
+        HasFiniteExternalTarget = true;
+    } else if (hasPcRelativeOperand(DI, LS)) {
+      std::optional<uint64_t> RelativeTarget =
+          evaluateDirectControlFlowTarget(DI, LS);
+      if (RelativeTarget) {
+        if (*RelativeTarget < TextSize)
+          LocalTargets.push_back(*RelativeTarget);
+        else
+          HasFiniteExternalTarget = true;
+      }
+    } else if (std::optional<uint64_t> Target =
+                   getDirectTextTarget(DI, LS, TextAddr, TextEnd)) {
+      LocalTargets.push_back(*Target);
+    }
+    if (LocalTargets.empty() && !HasFiniteExternalTarget)
       continue;
-    }
 
-    if (!ReusableCalls[I].empty()) {
-      if (llvm::any_of(ReusableCalls[I], [TextAddr, TextEnd](uint64_t Target) {
-            return Target < TextAddr || Target >= TextEnd;
-          }))
-        continue;
-      std::optional<uint64_t> Continuation = checkedAddUint64(
-          DI.Offset, DI.Size, "known call continuation address");
-      if (!Continuation)
-        return std::nullopt;
-      for (uint64_t AbsoluteTarget : ReusableCalls[I])
-        Calls.push_back(
-            {I, AbsoluteTarget - TextAddr, *Continuation, *ReturnRegister});
-      continue;
+    std::optional<uint64_t> Continuation =
+        checkedAddUint64(DI.Offset, DI.Size, "known call continuation address");
+    if (!Continuation)
+      return std::nullopt;
+    // A returning call must have a local, aligned continuation. In
+    // particular, the byte just past the final .text instruction is not a
+    // target inside .text and must never enter DirectControlFlowInfo::Targets.
+    // Reject the complete proof instead of silently treating a malformed or
+    // non-returning call as an ordinary finite call.
+    if (*Continuation >= TextSize || (*Continuation & (MinInstSize - 1)) != 0) {
+      log() << "hotswap: call at 0x" << utohexstr(DI.Offset)
+            << " has no aligned continuation inside .text\n";
+      return std::nullopt;
     }
-
-    std::optional<uint64_t> Target =
-        getDirectTextTarget(DI, LS, TextAddr, TextEnd);
-    if (Target) {
-      std::optional<uint64_t> Continuation = checkedAddUint64(
-          DI.Offset, DI.Size, "known call continuation address");
-      if (!Continuation)
-        return std::nullopt;
-      Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
-    }
+    for (uint64_t Target : LocalTargets)
+      Calls.Local.push_back({I, Target, *Continuation, *ReturnRegister});
+    if (HasFiniteExternalTarget)
+      Calls.External.push_back({I, *Continuation});
   }
   return Calls;
 }
@@ -2131,6 +2163,7 @@ static bool hasUnprovenFallthroughEntry(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t FunctionBegin, uint64_t ReturnOffset,
     ArrayRef<uint64_t> DeclaredEntries, ArrayRef<KnownCallSite> Calls,
+    ArrayRef<ExternalCallContinuation> ExternalCalls,
     ArrayRef<KnownCallEntry> CallEntries,
     ArrayRef<DirectTextEntry> DirectEntries) {
   if (FunctionBegin == 0)
@@ -2197,6 +2230,17 @@ static bool hasUnprovenFallthroughEntry(
     return true;
   }
 
+  for (const ExternalCallContinuation &Call : ExternalCalls) {
+    uint64_t Source = Decoded[Call.InstIndex].Offset;
+    if (Call.Continuation >= ChainBegin && Call.Continuation < FunctionBegin) {
+      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+            << " is not a bounded return: external call at 0x"
+            << utohexstr(Source) << " returns into the fallthrough chain at 0x"
+            << utohexstr(Call.Continuation) << "\n";
+      return true;
+    }
+  }
+
   ArrayRef<DirectTextEntry>::iterator DirectEntry =
       std::lower_bound(DirectEntries.begin(), DirectEntries.end(), ChainBegin,
                        [](const DirectTextEntry &Indexed, uint64_t Offset) {
@@ -2223,6 +2267,7 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
                            uint64_t TextEnd, ArrayRef<uint64_t> DeclaredEntries,
                            ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
                            ArrayRef<KnownCallSite> Calls,
+                           ArrayRef<ExternalCallContinuation> ExternalCalls,
                            ArrayRef<uint64_t> ExternalEntries) {
   SmallVector<size_t, 2> ReturnIndices;
   for (size_t ReturnIndex = 0; ReturnIndex != Decoded.size(); ++ReturnIndex)
@@ -2316,9 +2361,9 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
         continue;
       }
 
-      if (hasUnprovenFallthroughEntry(Decoded, LS, FunctionBegin, Return.Offset,
-                                      SortedDeclaredEntries, Calls, CallEntries,
-                                      DirectEntries))
+      if (hasUnprovenFallthroughEntry(
+              Decoded, LS, FunctionBegin, Return.Offset, SortedDeclaredEntries,
+              Calls, ExternalCalls, CallEntries, DirectEntries))
         continue;
 
       // The link pair must retain the value written by the incoming call
@@ -2511,18 +2556,26 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls,
       DeclaredEntries, Text);
 
-  std::optional<SmallVector<KnownCallSite, 4>> Calls = collectKnownCallSites(
+  std::optional<KnownCallSites> Calls = collectKnownCallSites(
       Decoded, LS, TextAddr, *TextEnd, MaterializedCalls, ReusableCalls);
   if (!Calls)
     return std::nullopt;
   std::optional<SmallVector<BoundedSetPcReturn, 2>> BoundedReturns =
       collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,
-                                 DeclaredEntries, FunctionRanges, *Calls,
-                                 ExternalEntries);
+                                 DeclaredEntries, FunctionRanges, Calls->Local,
+                                 Calls->External, ExternalEntries);
   if (!BoundedReturns)
     return std::nullopt;
 
   DirectControlFlowInfo Info;
+  for (const BoundedSetPcReturn &Return : *BoundedReturns) {
+    for (uint64_t Target : Return.Targets)
+      Info.Targets.insert(Target);
+    Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
+  }
+  for (const ExternalCallContinuation &Call : Calls->External)
+    Info.Targets.insert(Call.Continuation);
+
   for (size_t InstIndex = 0; InstIndex != Decoded.size(); ++InstIndex) {
     const InternalDecodedInst &DI = Decoded[InstIndex];
     if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
@@ -2559,22 +2612,21 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
         Target = MaterializedCalls[InstIndex]->Target;
       }
       if (!ReusableCalls[InstIndex].empty()) {
-        if (llvm::any_of(ReusableCalls[InstIndex],
-                         [TextAddr, TextEnd](uint64_t ReusableTarget) {
-                           return ReusableTarget < TextAddr ||
-                                  ReusableTarget >= *TextEnd;
-                         })) {
-          log() << "hotswap: unresolved call target at 0x"
-                << utohexstr(DI.Offset) << " (reusable target outside .text)\n";
-          Info.HasUnresolvedTargets = true;
-          continue;
+        size_t LocalTargetCount = 0;
+        size_t ExternalTargetCount = 0;
+        for (uint64_t ReusableTarget : ReusableCalls[InstIndex]) {
+          if (ReusableTarget >= TextAddr && ReusableTarget < *TextEnd) {
+            Info.Targets.insert(ReusableTarget - TextAddr);
+            ++LocalTargetCount;
+          } else {
+            ++ExternalTargetCount;
+          }
         }
-        for (uint64_t ReusableTarget : ReusableCalls[InstIndex])
-          Info.Targets.insert(ReusableTarget - TextAddr);
         Info.BoundedIndirectTransfers.insert(DI.Offset);
         log() << "hotswap: resolved reusable PC-materialized call at 0x"
-              << utohexstr(DI.Offset) << " to "
-              << ReusableCalls[InstIndex].size() << " target(s)\n";
+              << utohexstr(DI.Offset) << " to " << LocalTargetCount
+              << " local and " << ExternalTargetCount
+              << " finite external target(s)\n";
         continue;
       }
       if (!Target) {
@@ -2587,12 +2639,17 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       if (*Target >= TextAddr && *Target < *TextEnd) {
         uint64_t RelativeTarget = *Target - TextAddr;
         Info.Targets.insert(RelativeTarget);
-        if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg())
+        if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg()) {
+          Info.BoundedIndirectTransfers.insert(DI.Offset);
           log() << "hotswap: resolved PC-materialized call at 0x"
                 << utohexstr(DI.Offset) << " to .text+0x"
                 << utohexstr(RelativeTarget) << "\n";
-        if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg())
-          Info.BoundedIndirectTransfers.insert(DI.Offset);
+        }
+      } else if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg()) {
+        Info.BoundedIndirectTransfers.insert(DI.Offset);
+        log() << "hotswap: resolved PC-materialized call at 0x"
+              << utohexstr(DI.Offset) << " to finite external target 0x"
+              << utohexstr(*Target) << "\n";
       }
       continue;
     }
@@ -2605,7 +2662,15 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
             << "; adjacent far trampolines will not be coalesced\n";
       return std::nullopt;
     }
-    Info.Targets.insert(*Target);
+    if (*Target < TextSize) {
+      Info.Targets.insert(*Target);
+    } else if (LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "finite external direct call continuation");
+      if (!Continuation)
+        return std::nullopt;
+      Info.Targets.insert(*Continuation);
+    }
   }
   for (const BoundedSetPcReturn &Return : *BoundedReturns)
     Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1773,15 +1773,15 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
 
   for (const ReachingCallGroup &Group : Groups) {
     ArrayRef<InternalDecodedInst>::const_iterator Begin =
-        std::lower_bound(Decoded.begin(), Decoded.end(), Group.Begin,
-                         [](const InternalDecodedInst &DI, uint64_t Offset) {
-                           return DI.Offset < Offset;
-                         });
-    ArrayRef<InternalDecodedInst>::const_iterator End =
-        std::lower_bound(Begin, Decoded.end(), Group.End,
-                         [](const InternalDecodedInst &DI, uint64_t Offset) {
-                           return DI.Offset < Offset;
-                         });
+        llvm::lower_bound(Decoded, Group.Begin,
+                          [](const InternalDecodedInst &DI, uint64_t Offset) {
+                            return DI.Offset < Offset;
+                          });
+    ArrayRef<InternalDecodedInst>::const_iterator End = llvm::lower_bound(
+        Begin, Decoded.end(), Group.End,
+        [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
     size_t BeginIndex = static_cast<size_t>(Begin - Decoded.begin());
     size_t EndIndex = static_cast<size_t>(End - Decoded.begin());
     if (BeginIndex == EndIndex)

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -243,6 +243,7 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
       }
       PendingWrites.push_back({DescOffset, std::move(NewBlob)});
     }
+
     if (Err) {
       log() << "hotswap: error: " << Context
             << ": failed to iterate AMDGPU notes: " << toString(std::move(Err))

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -409,7 +409,22 @@ NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
                          uint64_t Needed) {
   NopSled *Best = nullptr;
   uint64_t BestDist = std::numeric_limits<uint64_t>::max();
-  for (NopSled &Sled : Sleds) {
+  // buildNopSledMap emits non-overlapping sleds in text order, and advancing a
+  // sled's WritePos cannot move it past the following sled. Limit this hot
+  // lookup to the signed-s_branch corridor instead of rescanning every
+  // function's padding for every replacement in a large object.
+  uint64_t ReachBegin =
+      Offset >= MaxSledDistance ? Offset - MaxSledDistance + 1 : 0;
+  std::vector<NopSled>::iterator Begin = llvm::lower_bound(
+      Sleds, ReachBegin,
+      [](const NopSled &Sled, uint64_t Value) {
+        return Sled.WritePos < Value;
+      });
+  for (std::vector<NopSled>::iterator It = Begin; It != Sleds.end(); ++It) {
+    NopSled &Sled = *It;
+    if (Sled.WritePos >= Offset &&
+        Sled.WritePos - Offset >= MaxSledDistance)
+      break;
     if (Offset < Sled.FunctionStart || Offset >= Sled.FunctionEnd)
       continue;
     uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -479,6 +479,7 @@ ArrayRef<ElfView::FunctionTextRange> ElfView::cachedFunctionTextRanges() const {
   if (TextSizeValue > std::numeric_limits<uint64_t>::max() - TextBegin) {
     log() << "hotswap: error: function text range scan: .text virtual "
           << "address range overflows uint64_t.\n";
+    FunctionRangeCacheComplete = false;
     FunctionRangeCache.emplace();
     return *FunctionRangeCache;
   }
@@ -491,6 +492,7 @@ ArrayRef<ElfView::FunctionTextRange> ElfView::cachedFunctionTextRanges() const {
 
     Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
     if (!SymsOrErr) {
+      FunctionRangeCacheComplete = false;
       consumeError(SymsOrErr.takeError());
       continue;
     }
@@ -544,6 +546,11 @@ ArrayRef<ElfView::FunctionTextRange> ElfView::cachedFunctionTextRanges() const {
 std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
   ArrayRef<FunctionTextRange> Ranges = cachedFunctionTextRanges();
   return std::vector<FunctionTextRange>(Ranges.begin(), Ranges.end());
+}
+
+bool ElfView::functionTextRangesComplete() const {
+  (void)cachedFunctionTextRanges();
+  return FunctionRangeCacheComplete;
 }
 
 bool ElfView::isValidDataOnlyObject() const {

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -243,7 +243,6 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
       }
       PendingWrites.push_back({DescOffset, std::move(NewBlob)});
     }
-
     if (Err) {
       log() << "hotswap: error: " << Context
             << ": failed to iterate AMDGPU notes: " << toString(std::move(Err))
@@ -544,6 +543,163 @@ ArrayRef<ElfView::FunctionTextRange> ElfView::cachedFunctionTextRanges() const {
 std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
   ArrayRef<FunctionTextRange> Ranges = cachedFunctionTextRanges();
   return std::vector<FunctionTextRange>(Ranges.begin(), Ranges.end());
+}
+
+bool ElfView::isValidDataOnlyObject() const {
+  if (textSize() != 0) {
+    log() << "hotswap: error: data-only validation requires an empty .text "
+             "section.\n";
+    return false;
+  }
+
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if ((Shdr.sh_flags & ELF::SHF_EXECINSTR) != 0 && Shdr.sh_size != 0) {
+      Expected<StringRef> NameOrErr = File.getSectionName(Shdr);
+      if (!NameOrErr) {
+        log() << "hotswap: error: data-only validation found a non-empty "
+                 "executable section with an unreadable name: "
+              << toString(NameOrErr.takeError()) << "\n";
+        return false;
+      }
+      log() << "hotswap: error: data-only object has non-empty executable "
+               "section '"
+            << *NameOrErr << "'.\n";
+      return false;
+    }
+
+    if (Shdr.sh_type != ELF::SHT_SYMTAB && Shdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&Shdr);
+    if (!SymsOrErr) {
+      log() << "hotswap: error: data-only validation failed to read symbols: "
+            << toString(SymsOrErr.takeError()) << "\n";
+      return false;
+    }
+    Expected<StringRef> StrTabOrErr =
+        File.getStringTableForSymtab(Shdr, Sections);
+    if (!StrTabOrErr) {
+      log() << "hotswap: error: data-only validation failed to read the "
+               "symbol string table: "
+            << toString(StrTabOrErr.takeError()) << "\n";
+      return false;
+    }
+
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
+      if (!NameOrErr) {
+        log() << "hotswap: error: data-only validation found an unreadable "
+                 "symbol name: "
+              << toString(NameOrErr.takeError()) << "\n";
+        return false;
+      }
+      if ((Sym.getType() == ELF::STT_FUNC ||
+           Sym.getType() == ELF::STT_GNU_IFUNC) &&
+          Sym.st_shndx != ELF::SHN_UNDEF) {
+        if (Sym.st_shndx == TextSectionIndex)
+          log() << "hotswap: error: data-only object has a function/ifunc "
+                   "symbol in empty .text.\n";
+        else
+          log() << "hotswap: error: data-only object has defined "
+                   "function/ifunc symbol '"
+                << *NameOrErr << "'.\n";
+        return false;
+      }
+      if (NameOrErr->ends_with(".kd")) {
+        log() << "hotswap: error: data-only object has kernel descriptor "
+                 "symbol '"
+              << *NameOrErr << "'.\n";
+        return false;
+      }
+    }
+  }
+
+  bool SawMetadataNote = false;
+  auto validateMetadataNote = [&](ELFT::Note Note) {
+    if (Note.getName() != "AMDGPU" || Note.getType() != ELF::NT_AMDGPU_METADATA)
+      return true;
+    SawMetadataNote = true;
+
+    ArrayRef<uint8_t> Desc = Note.getDesc(4);
+    if (Desc.empty()) {
+      log() << "hotswap: error: data-only AMDGPU metadata note has an "
+               "empty descriptor.\n";
+      return false;
+    }
+    StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
+    msgpack::Document Doc;
+    if (!Doc.readFromBlob(Blob, false)) {
+      log() << "hotswap: error: failed to parse data-only AMDGPU metadata "
+               "note.\n";
+      return false;
+    }
+
+    msgpack::DocNode Root = Doc.getRoot();
+    if (!Root.isMap()) {
+      log() << "hotswap: error: data-only AMDGPU metadata root is not a map.\n";
+      return false;
+    }
+    msgpack::MapDocNode &RootMap = Root.getMap();
+    msgpack::DocNode::MapTy::iterator KernelsIt =
+        RootMap.find("amdhsa.kernels");
+    if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray()) {
+      log() << "hotswap: error: data-only AMDGPU metadata has no valid "
+               "amdhsa.kernels array.\n";
+      return false;
+    }
+    if (!KernelsIt->second.getArray().empty()) {
+      log() << "hotswap: error: data-only AMDGPU metadata claims "
+            << KernelsIt->second.getArray().size() << " kernel(s).\n";
+      return false;
+    }
+    return true;
+  };
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: data-only validation failed to read program "
+             "headers: "
+          << toString(PhdrsOrErr.takeError()) << "\n";
+    return false;
+  }
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_NOTE)
+      continue;
+
+    Error Err = Error::success();
+    for (ELFT::Note Note : File.notes(Phdr, Err))
+      if (!validateMetadataNote(Note))
+        return false;
+    if (Err) {
+      log() << "hotswap: error: data-only validation failed to iterate AMDGPU "
+               "notes: "
+            << toString(std::move(Err)) << "\n";
+      return false;
+    }
+  }
+
+  // Linked code objects normally expose metadata through PT_NOTE. Match
+  // COMGR's metadata lookup fallback for relocatable/unusual objects whose
+  // note exists only in the section table.
+  if (!SawMetadataNote) {
+    for (const ELFT::Shdr &Shdr : Sections) {
+      if (Shdr.sh_type != ELF::SHT_NOTE)
+        continue;
+
+      Error Err = Error::success();
+      for (ELFT::Note Note : File.notes(Shdr, Err))
+        if (!validateMetadataNote(Note))
+          return false;
+      if (Err) {
+        log()
+            << "hotswap: error: data-only validation failed to iterate AMDGPU "
+               "note sections: "
+            << toString(std::move(Err)) << "\n";
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 // -- ElfView::findKernelAtAddress ---------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -326,6 +326,14 @@ struct Trampoline {
   llvm::SmallVector<uint8_t> DirectSetPCForwardBytes;
   llvm::SmallVector<uint64_t, 4> ForwardBranchIslands;
   uint64_t ForwardBranchTargetOffset = 0;
+  // Dwords after the source's forward sequence are unreachable. A spare tail
+  // dword in an eight-byte or larger/coalesced source window can therefore
+  // serve as one safe, registerless relay for another far edge.
+  bool HasSourceTailBranchIsland = false;
+  uint64_t SourceTailBranchIslandOffset = 0;
+  uint64_t SourceTailBranchTargetOffset = 0;
+  llvm::SmallVector<uint64_t, 4> ReturnBranchIslands;
+  uint64_t ReturnBranchTargetOffset = 0;
   bool HasForwardGateway = false;
   uint64_t ForwardGatewayOffset = 0;
   llvm::SmallVector<uint8_t> ForwardGatewayBytes;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -365,6 +365,14 @@ struct Trampoline {
   bool UsesMirroredStubForward = false;
   uint32_t MirroredStubGroup = 0;
   uint64_t MirroredStubGatewayOffset = 0;
+  // Dense pair-only objects use one global affine gateway per scratch pair.
+  // A first sparse stub branches to a regional add/set-PC gateway, which maps
+  // the preserved stub PC into the existing bounded mirrored-stub prefix.
+  bool UsesHierarchicalMirroredStubForward = false;
+  uint32_t HierarchicalMirroredGroup = 0;
+  uint32_t HierarchicalGlobalPrefixBytes = 0;
+  uint32_t HierarchicalRegionPrefixBytes = 0;
+  uint32_t HierarchicalRegionGatewayDisplacement = 0;
   uint32_t PoolEntryPrefixBytes = 0;
   // A mirrored sparse prefix is initialized to NOPs except at its
   // source-selected branch stubs. One unused dword near its midpoint can

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1251,6 +1251,16 @@ struct SafeSgprUsageSummary {
   unsigned HighWatermark = 0;
 };
 
+/// Current-text, per-function SGPR liveness cached for one mutation
+/// generation. Bits [0, MaxSgprs) name numbered SGPRs; bit MaxSgprs names VCC.
+struct CurrentFunctionSgprLiveness {
+  uint64_t Generation = 0;
+  unsigned MaxSgprs = 0;
+  bool Valid = false;
+  llvm::DenseMap<uint64_t, size_t> InstructionIndices{0};
+  std::vector<llvm::BitVector> LiveBefore;
+};
+
 struct DirectControlFlowInfo {
   llvm::DenseSet<uint64_t> Targets;
   // Register-based transfers whose complete finite target set was proven.
@@ -1325,6 +1335,12 @@ struct PatchContext {
   llvm::StringMap<std::optional<KernelWorkgroupMetadata>>
       WorkgroupMetadataCache;
   llvm::StringMap<unsigned> KernelVgprGranuleCache;
+  // Immediate .text writes advance this generation. Scratch liveness is
+  // rebuilt from current bytes when a cached function belongs to an older
+  // generation, so earlier patches can never leave the proof stale.
+  uint64_t TextMutationGeneration = 0;
+  llvm::DenseMap<std::pair<uint64_t, uint64_t>, CurrentFunctionSgprLiveness>
+      CurrentFunctionSgprLivenessCache{0};
 };
 
 enum class VgprMsbOperand : unsigned {
@@ -1403,6 +1419,52 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
 bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                 const SafeSgprScratchBlock &Block,
                                 llvm::StringRef Context);
+
+/// Return whether \p DI consumes the incoming value of \p Register, including
+/// explicit read/modify/write destinations represented by MC tied-operand
+/// constraints. This conservative query underpins scratch-register liveness.
+[[nodiscard]] bool instructionReadsRegister(const InternalDecodedInst &DI,
+                                            const LLVMState &LS,
+                                            llvm::MCRegister Register);
+
+/// Return whether \p Replacement may consume the incoming value of \p Register
+/// before overwriting it. Undecodable or control-flow-bearing replacements are
+/// conservatively treated as reads.
+[[nodiscard]] bool
+replacementNeedsIncomingRegister(llvm::ArrayRef<uint8_t> Replacement,
+                                 const LLVMState &LS,
+                                 llvm::MCRegister Register);
+
+/// Return the numbered-SGPR/VCC values consumed by \p Replacement before an
+/// overwrite. Returns nullopt for undecodable or control-flow-bearing bytes.
+/// The result uses the bit numbering documented by
+/// CurrentFunctionSgprLiveness.
+[[nodiscard]] std::optional<llvm::BitVector>
+getReplacementIncomingSgprs(llvm::ArrayRef<uint8_t> Replacement,
+                            const LLVMState &LS, unsigned MaxSgprs);
+
+/// Return the complete numbered-SGPR/VCC live set immediately after
+/// [\p InstOffset, +\p InstSize). One current-function decode and bit-vector
+/// dataflow serves every candidate scratch register. Results are cached for
+/// PatchContext::TextMutationGeneration and fail closed with nullopt.
+[[nodiscard]] std::optional<llvm::BitVector>
+getLiveSgprsAtContinuation(PatchContext &Ctx, uint64_t InstOffset,
+                           uint32_t InstSize);
+
+/// Record an immediate write to PatchContext::Text. Production patch dispatch
+/// calls this after every successful per-instruction mutation; tests and any
+/// future direct writers must do the same.
+void noteCurrentTextMutation(PatchContext &Ctx);
+
+/// Prove that \p Register's incoming value is not read on any path from the
+/// instruction after [\p InstOffset, +\p InstSize) to the owning function's
+/// exits. The proof decodes the current text bytes rather than relying on the
+/// original PatchContext::Decoded snapshot. Prefer the batch SGPR query above
+/// when selecting among multiple candidates.
+[[nodiscard]] bool
+isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx, uint64_t InstOffset,
+                                       uint32_t InstSize,
+                                       llvm::MCRegister Register);
 
 // -- Trampoline emission helpers (defined in comgr-hotswap-b0a0.cpp) ----------
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1275,6 +1275,12 @@ struct DirectControlFlowInfo {
   // These do not make every instruction in their containing function a
   // potential indirect destination.
   llvm::DenseSet<uint64_t> BoundedIndirectTransfers;
+  // A reachable indirect transfer can enter bytes that are not represented
+  // by an original instruction or symbol, including synthetic source tails
+  // created while planning gateways. Keep this distinct from unresolved call
+  // targets, which conservatively disable all control-flow-sensitive
+  // mutations.
+  bool HasUnboundedIndirectEntries = false;
   bool HasUnresolvedTargets = false;
 };
 
@@ -1557,9 +1563,10 @@ resolveMaterializedPcTarget(llvm::ArrayRef<InternalDecodedInst> Decoded,
 /// contains text-relative function and kernel entry offsets; \p FunctionRanges
 /// supplies the symbol ranges used for the return proof; \p ExternalEntries
 /// identifies externally reachable symbol and kernel entries, including
-/// aliases at a local function's start. Other register-target control flow
-/// sets HasUnresolvedTargets so callers can disable transformations that
-/// consume possible destinations.
+/// aliases at a local function's start. Unresolved calls set
+/// HasUnresolvedTargets so callers can disable transformations that consume
+/// possible destinations. Other reachable register-target control flow sets
+/// HasUnboundedIndirectEntries so synthetic source tails are not created.
 std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextSize,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1360,6 +1360,11 @@ struct DirectControlFlowInfo {
   // These do not make every instruction in their containing function a
   // potential indirect destination.
   llvm::DenseSet<uint64_t> BoundedIndirectTransfers;
+  // Exact .text-relative decoded-boundary targets for each proven finite
+  // register transfer, keyed by that transfer's decoded offset. An empty
+  // target vector means the transfer is proven to leave local .text.
+  llvm::DenseMap<uint64_t, llvm::SmallVector<uint64_t, 2>>
+      BoundedIndirectTargets;
   // A reachable indirect transfer can enter bytes that are not represented
   // by an original instruction or symbol, including synthetic source tails
   // created while planning gateways. Keep this distinct from unresolved call

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -329,6 +329,17 @@ struct Trampoline {
   bool HasForwardGateway = false;
   uint64_t ForwardGatewayOffset = 0;
   llvm::SmallVector<uint8_t> ForwardGatewayBytes;
+  // Multiple 8-byte far sites can share one SCC-neutral gateway. Each source
+  // records its PC and branches to that gateway; a dispatcher prefixed to the
+  // first group trampoline maps the source PC to the corresponding body.
+  bool UsesSharedDispatcherForward = false;
+  uint32_t SharedDispatcherGroup = 0;
+  unsigned SharedDispatcherSgprBase = 0;
+  uint64_t SharedDispatcherGatewayOffset = 0;
+  uint64_t SharedDispatcherRelayOffset = 0;
+  uint64_t SharedDispatcherSecondaryGatewayOffset = 0;
+  llvm::SmallVector<uint8_t> SecondaryForwardGatewayBytes;
+  uint32_t PoolEntryPrefixBytes = 0;
   // A far-site run may only be coalesced within one known function. Unknown
   // ranges stay unmerged because adjacent symbols are independent entries.
   bool HasFunctionRange = false;
@@ -1242,6 +1253,10 @@ struct SafeSgprUsageSummary {
 
 struct DirectControlFlowInfo {
   llvm::DenseSet<uint64_t> Targets;
+  // Register-based transfers whose complete finite target set was proven.
+  // These do not make every instruction in their containing function a
+  // potential indirect destination.
+  llvm::DenseSet<uint64_t> BoundedIndirectTransfers;
   bool HasUnresolvedTargets = false;
 };
 
@@ -1478,7 +1493,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     uint64_t TextAddr, uint64_t TextSize,
     llvm::ArrayRef<uint64_t> DeclaredEntries,
     llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges = {},
-    llvm::ArrayRef<uint64_t> ExternalEntries = {});
+    llvm::ArrayRef<uint64_t> ExternalEntries = {},
+    llvm::ArrayRef<uint8_t> Text = {});
 
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -559,6 +559,12 @@ public:
   /// Zero-size symbols extend to the next function symbol or `.text` end.
   std::vector<FunctionTextRange> functionTextRanges() const;
 
+  /// Validate that an object with a present, empty `.text` section contains
+  /// data only: no executable section contents, no defined function/ifunc
+  /// symbols, no kernel descriptor symbols, and no AMDGPU metadata kernel
+  /// entries. Malformed symbol tables, notes, or metadata fail closed.
+  bool isValidDataOnlyObject() const;
+
   /// Find the kernel function symbol whose range includes \p TextAddress.
   /// Returns "" if no matching function symbol exists.
   std::string findKernelAtAddress(uint64_t TextAddress) const;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -951,6 +951,19 @@ struct LLVMState {
   unsigned SAddcU32Opcode = 0;
   unsigned SSetPcI64Opcode = 0;
 
+  /// Scalar MC identities used to recognize the two compiler-emitted
+  /// reusable-PC tensor tail-jump sequences. Resolved through the assembler
+  /// so the policy layer does not depend on disassembled mnemonic text.
+  unsigned SAddCoI32Opcode = 0;
+  unsigned SAddCoU32Opcode = 0;
+  unsigned SAddCoCiU32Opcode = 0;
+  unsigned SCmpGeI32Opcode = 0;
+  unsigned SCBranchScc1Opcode = 0;
+  unsigned SAbsI32Opcode = 0;
+  unsigned SSubCoU32Opcode = 0;
+  unsigned SSubCoCiU32Opcode = 0;
+  unsigned SMovB32Opcode = 0;
+
   /// MC identities used by far-trampoline relocation analysis. Each opcode is
   /// resolved once through the asm parser so policy code never compares
   /// disassembled mnemonic strings.

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1128,6 +1128,31 @@ struct VgprAllocator {
     return Base;
   }
 
+  /// Allocate \p N contiguous VGPRs above the kernel count without crossing a
+  /// \p BankSize-register boundary. Textual AMDGPU assembly only names
+  /// v0-v255; keeping a generated operand in one physical bank lets a caller
+  /// encode its low bits under one s_set_vgpr_msb mode.
+  std::optional<unsigned>
+  allocContiguousAboveKdInBank(unsigned N, unsigned Align = 2,
+                               unsigned BankSize = 256) {
+    if (N == 0 || N > BankSize)
+      return std::nullopt;
+    unsigned OldNext = NextAboveKd;
+    unsigned Base = NextAboveKd;
+    if (Align > 1 && (Base % Align) != 0)
+      Base += Align - (Base % Align);
+    if (Base / BankSize != (Base + N - 1) / BankSize)
+      Base = ((Base / BankSize) + 1) * BankSize;
+    if (Align > 1 && (Base % Align) != 0)
+      Base += Align - (Base % Align);
+    if (Base + N > MaxVgprs)
+      return std::nullopt;
+    ExtraAllocated += (Base + N) - OldNext;
+    LiveAtPoint.set(Base, Base + N);
+    NextAboveKd = Base + N;
+    return Base;
+  }
+
   unsigned extraVgprsNeeded() const { return ExtraAllocated; }
 };
 
@@ -1301,6 +1326,14 @@ void ensureVgprMsbModes(PatchContext &Ctx);
 /// CFG analysis.
 [[nodiscard]] std::optional<unsigned> getActiveVgprMsbMode(PatchContext &Ctx,
                                                            size_t Idx);
+
+/// Recover an exact mode by scanning backward through the local straight-line
+/// instruction sequence containing \p Idx. This is intentionally separate
+/// from CFG mode recovery: only a lowering whose original operands already
+/// depend on the local setter may use it when unrelated opaque control flow
+/// prevents object-wide analysis.
+[[nodiscard]] std::optional<unsigned>
+getLocallyEstablishedVgprMsbMode(PatchContext &Ctx, size_t Idx);
 
 unsigned getVgprMsbBank(unsigned Mode, VgprMsbOperand Operand);
 void setVgprMsbBank(unsigned &Mode, VgprMsbOperand Operand, unsigned Bank);

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -319,6 +319,13 @@ struct Trampoline {
   bool Long = false;
   bool UsesSetPCBack = false;
   unsigned LongBranchSgprBase = 0;
+  // When numbered SGPRs are exhausted, a far edge may use VCC after proving
+  // that the replacement does not consume its incoming value and that VCC is
+  // dead at the continuation.
+  bool LongBranchUsesVcc = false;
+  // A wave32 far edge may preserve live VCC_LO in one safe numbered SGPR.
+  // Its source tail is a restore-and-fallthrough landing pad.
+  bool LongBranchPreservesVcc = false;
   bool HasPoolBranchIsland = false;
   uint64_t PoolBranchIslandOffset = 0;
   bool UsesShortBranchForward = false;
@@ -332,6 +339,11 @@ struct Trampoline {
   bool HasSourceTailBranchIsland = false;
   uint64_t SourceTailBranchIslandOffset = 0;
   uint64_t SourceTailBranchTargetOffset = 0;
+  // A larger unreachable source tail may hold a pair-only affine gateway.
+  // fixupTrampolineBranches preserves this range instead of NOP-padding it.
+  bool HasSourceTailGateway = false;
+  uint64_t SourceTailGatewayOffset = 0;
+  uint32_t SourceTailGatewayBytes = 0;
   llvm::SmallVector<uint64_t, 4> ReturnBranchIslands;
   uint64_t ReturnBranchTargetOffset = 0;
   bool HasForwardGateway = false;
@@ -347,6 +359,13 @@ struct Trampoline {
   uint64_t SharedDispatcherRelayOffset = 0;
   uint64_t SharedDispatcherSecondaryGatewayOffset = 0;
   llvm::SmallVector<uint8_t> SecondaryForwardGatewayBytes;
+  // Sites that only have their reserved far-return pair use s_call_i64 to
+  // record source+4 and share a relocation-neutral add/set-PC gateway. The
+  // recorded PC selects a sparse mirrored branch stub in the pool without a
+  // register-hungry classifier.
+  bool UsesMirroredStubForward = false;
+  uint32_t MirroredStubGroup = 0;
+  uint64_t MirroredStubGatewayOffset = 0;
   uint32_t PoolEntryPrefixBytes = 0;
   // A far-site run may only be coalesced within one known function. Unknown
   // ranges stay unmerged because adjacent symbols are independent entries.
@@ -459,6 +478,9 @@ struct NopSled {
   uint64_t WritePos = 0;
   uint64_t FunctionStart = 0;
   uint64_t FunctionEnd = 0;
+  // Some unreachable source-tail ranges are reserved for one contiguous
+  // set-PC gateway. Branch-island allocators must not fragment these ranges.
+  bool GatewayOnly = false;
 };
 
 enum class MaskWorkaroundPolicy {
@@ -496,6 +518,13 @@ static constexpr uint32_t MinInstSize = 4;
 static constexpr uint32_t SetPcReturnReserveBytes = 20;
 
 static constexpr uint32_t SetPcForwardSequenceBytes = SetPcReturnReserveBytes;
+static constexpr uint32_t VccMoveBytes = MinInstSize;
+static constexpr uint32_t VccRestoreSequenceBytes = 2 * MinInstSize;
+static constexpr uint32_t VccPreservingReturnReserveBytes =
+    VccMoveBytes + SetPcReturnReserveBytes;
+static constexpr uint32_t VccLandingPadBytes = VccRestoreSequenceBytes;
+static constexpr uint32_t VccPreservingSourceBytes =
+    MinInstSize + VccLandingPadBytes;
 static constexpr uint32_t PoolBranchIslandBytes = MinInstSize;
 
 // s_branch encoding: 16-bit signed dword offset field bounds. Used by
@@ -1284,6 +1313,24 @@ struct DirectControlFlowInfo {
   bool HasUnresolvedTargets = false;
 };
 
+/// A synthetic source-tail interval is only safe when the complete replaced
+/// source belongs to exactly one distinct function range. Equal bounds from a
+/// global function's .symtab/.dynsym records are one logical range; differing
+/// nested or overlapping function bounds fail closed.
+bool sourceHasUniqueFunctionRange(
+    const Trampoline &T,
+    llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    uint64_t TextAddr);
+
+/// Return whether [Begin, End) is an entry-free interval strictly after the
+/// first source dword. The caller supplies the unique-function proof so dense
+/// objects can cache it per function instead of rescanning their symbol table
+/// for every patch site.
+bool isSafeSourceTailRange(const Trampoline &T,
+                           const DirectControlFlowInfo &ControlFlow,
+                           bool HasUniqueFunctionRange, uint64_t Begin,
+                           uint64_t End);
+
 // Per-instruction persistent gfx1250 VGPR-MSB mode (packed src0/src1/src2/dst,
 // two bits each, values 0-255) recovered by the WMMA split pass's
 // whole-function CFG fixed point. The sentinels distinguish "not analyzed",
@@ -1424,7 +1471,8 @@ struct SafeSgprScratchBlock {
 /// nullopt after logging when no block fits below RewriteConfig::MaxSgprs.
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
-                         unsigned Alignment, llvm::StringRef Context);
+                         unsigned Alignment, llvm::StringRef Context,
+                         bool ReportNoSpace = true);
 
 /// Charge a previously selected global block to the kernel owning \p
 /// TextOffset. If the site is in an ordinary device function, conservatively
@@ -1494,12 +1542,28 @@ isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx, uint64_t InstOffset,
 /// is emitted.
 std::optional<llvm::SmallVector<uint8_t>>
 encodeSetPCLongBranch(const LLVMState &LS, uint64_t FromOffset,
-                      uint64_t TargetOffset, unsigned SgprBase);
+                      uint64_t TargetOffset, unsigned SgprBase,
+                      bool UseVcc = false);
 
 struct EncodedSetPcGateway {
   NopSled *Sled = nullptr;
   llvm::SmallVector<uint8_t> Bytes;
 };
+
+struct EncodedSplitVccGateway {
+  size_t PrimaryIndex = 0;
+  size_t SecondaryIndex = 0;
+  llvm::SmallVector<uint8_t> PrimaryBytes;
+  llvm::SmallVector<uint8_t> SecondaryBytes;
+};
+
+/// Plan an eight-byte VCC-save/branch primary and a disjoint 16-byte
+/// VCC-backed set-PC secondary. The returned plan does not advance either
+/// sled or modify text.
+std::optional<EncodedSplitVccGateway>
+findSplitVccGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
+                    uint64_t FromOffset, uint64_t TargetOffset,
+                    unsigned SaveSgpr);
 
 /// Find the nearest short-branch-reachable gateway whose remaining space fits
 /// the set-PC sequence. Candidate widths are computed from the displacement;
@@ -1508,14 +1572,16 @@ struct EncodedSetPcGateway {
 llvm::Expected<std::optional<EncodedSetPcGateway>>
 findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                         uint64_t FromOffset, uint64_t TargetOffset,
-                        unsigned SgprBase);
+                        unsigned SgprBase, bool UseVcc = false,
+                        bool PreserveVcc = false);
 
 /// Count set-PC gateway slots reachable from \p FromOffset, up to \p MaxSlots.
 /// Candidate widths are computed without assembly. Zero means that no
 /// candidate fits; an Error means that a reachable candidate is invalid.
 llvm::Expected<uint64_t> countReachableSetPcGatewaySlots(
     llvm::ArrayRef<NopSled> Gateways, const LLVMState &LS, uint64_t FromOffset,
-    uint64_t TargetOffset, unsigned SgprBase, uint64_t MaxSlots);
+    uint64_t TargetOffset, unsigned SgprBase, uint64_t MaxSlots,
+    bool UseVcc = false, bool PreserveVcc = false);
 
 /// Return whether an s_branch at \p From can encode \p To, including the
 /// instruction-relative PC base, alignment, signed range, and overflow checks.

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1480,6 +1480,41 @@ struct PatchContext {
       CurrentFunctionSgprLivenessCache{0};
 };
 
+/// One node in the all-path proof that an incoming physical VGPR value is
+/// killed before it can be observed. Opaque nodes and unsafe exits observe
+/// every still-live value conservatively. A safe terminal (s_endpgm or the
+/// patched site on a later loop iteration) observes none.
+struct ForwardVgprProofNode {
+  llvm::BitVector Uses;
+  llvm::BitVector FullDefs;
+  llvm::SmallVector<size_t, 2> Successors;
+  bool Opaque = false;
+  bool HasUnsafeExit = false;
+  bool SafeTerminal = false;
+
+  explicit ForwardVgprProofNode(unsigned MaxVgprs = 0)
+      : Uses(MaxVgprs), FullDefs(MaxVgprs) {}
+};
+
+/// Return physical VGPR values whose incoming contents are killed on every
+/// path before a use, opaque instruction, unsafe exit, or non-killing cycle.
+/// Malformed graph inputs fail closed with std::nullopt.
+std::optional<llvm::BitVector>
+computeForwardDeadVgprs(llvm::ArrayRef<ForwardVgprProofNode> Nodes,
+                        size_t EntryNode, unsigned MaxVgprs);
+
+/// True when [Base, Base + Width) is non-empty, within MaxVgprs, and does not
+/// cross one of gfx1250's 256-register physical VGPR banks.
+bool physicalVgprRangeFitsOneBank(unsigned Base, unsigned Width,
+                                  unsigned MaxVgprs);
+
+/// Return true when \p Reg or one of its aliases belongs to a physical vector
+/// register file. Physical-VGPR proofs use this after encoded-range recovery
+/// fails: a true result must invalidate the proof rather than silently treating
+/// the operand as scalar.
+bool isVectorRegisterOrAlias(llvm::MCRegister Reg,
+                             const llvm::MCRegisterInfo &MRI);
+
 enum class VgprMsbOperand : unsigned {
   Src0 = 0,
   Src1 = 2,
@@ -1502,6 +1537,13 @@ void ensureVgprMsbModes(PatchContext &Ctx);
 /// prevents object-wide analysis.
 [[nodiscard]] std::optional<unsigned>
 getLocallyEstablishedVgprMsbMode(PatchContext &Ctx, size_t Idx);
+
+/// Apply one instruction's persistent VGPR-MSB transfer to an exact packed
+/// mode. Returns VgprMsbUnknown when the incoming state or the instruction's
+/// MODE effect is ambiguous; an exact setter can recover an exact mode.
+int16_t transferExactVgprMsbMode(int16_t Incoming,
+                                 const InternalDecodedInst &DI,
+                                 const LLVMState &LS);
 
 unsigned getVgprMsbBank(unsigned Mode, VgprMsbOperand Operand);
 void setVgprMsbBank(unsigned &Mode, VgprMsbOperand Operand, unsigned Bank);

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1287,6 +1287,24 @@ struct PatchContext {
   llvm::StringMap<unsigned> KernelVgprGranuleCache;
 };
 
+enum class VgprMsbOperand : unsigned {
+  Src0 = 0,
+  Src1 = 2,
+  Src2 = 4,
+  Dst = 6,
+};
+
+/// Populate PatchContext::VgprMsbModeBefore if it has not been computed yet.
+void ensureVgprMsbModes(PatchContext &Ctx);
+
+/// Return the exact VGPR-MSB mode before Decoded[Idx] proven by whole-function
+/// CFG analysis.
+[[nodiscard]] std::optional<unsigned> getActiveVgprMsbMode(PatchContext &Ctx,
+                                                           size_t Idx);
+
+unsigned getVgprMsbBank(unsigned Mode, VgprMsbOperand Operand);
+void setVgprMsbBank(unsigned &Mode, VgprMsbOperand Operand, unsigned Bank);
+
 /// Return occupancy limits for \p Processor from COMGR's ISA metadata table.
 std::optional<SubtargetOccupancyLimits>
 getSubtargetOccupancyLimits(llvm::StringRef Processor);

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1458,6 +1458,15 @@ struct PatchContext {
   std::optional<SafeSgprUsageSummary> WholeObjectSgprUsage;
   llvm::DenseMap<std::pair<uint64_t, uint64_t>, SafeSgprUsageSummary>
       FunctionSgprUsage{0};
+  // Kernel ownership and scratch-SGPR descriptor charging are immutable or
+  // monotone during one rewrite. Cache both so a promoted relay in a large
+  // non-kernel function does not repeat the same symbol lookup and full
+  // kernel-descriptor scan for every source instruction.
+  llvm::DenseMap<std::pair<uint64_t, uint64_t>, std::string>
+      FunctionKernelOwner{0};
+  unsigned AllKernelSgprRequirement = 0;
+  llvm::StringMap<unsigned> KernelSgprRequirements;
+  uint64_t SgprDescriptorChargePasses = 0;
   // Occupancy checks may run at several patch sites in one kernel. Cache the
   // immutable metadata so the AMDGPU note is parsed at most once per field.
   llvm::StringMap<std::optional<KernelWorkgroupMetadata>>

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1543,7 +1543,9 @@ resolveMaterializedPcTarget(llvm::ArrayRef<InternalDecodedInst> Decoded,
 /// bypass that definition. Canonical local-function returns are bounded to
 /// the continuations of calls that preserve the same link register, provided
 /// no interior call, overlapping external alias, or reachable fallthrough can
-/// enter the function without that link definition. \p DeclaredEntries
+/// enter the function without that link definition. A call with one proven
+/// finite target outside .text protects its local continuation without adding
+/// the external address to the local target set. \p DeclaredEntries
 /// contains text-relative function and kernel entry offsets; \p FunctionRanges
 /// supplies the symbol ranges used for the return proof; \p ExternalEntries
 /// identifies externally reachable symbol and kernel entries, including

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -333,12 +333,11 @@ struct Trampoline {
   llvm::SmallVector<uint8_t> DirectSetPCForwardBytes;
   llvm::SmallVector<uint64_t, 4> ForwardBranchIslands;
   uint64_t ForwardBranchTargetOffset = 0;
-  // Dwords after the source's forward sequence are unreachable. A spare tail
-  // dword in an eight-byte or larger/coalesced source window can therefore
-  // serve as one safe, registerless relay for another far edge.
-  bool HasSourceTailBranchIsland = false;
-  uint64_t SourceTailBranchIslandOffset = 0;
-  uint64_t SourceTailBranchTargetOffset = 0;
+  // Dwords after the source's forward sequence are unreachable. Safe tail
+  // dwords in a larger/coalesced source window can therefore serve as
+  // independent registerless relays for other far edges. Each pair is
+  // {source offset, branch target}.
+  llvm::SmallVector<std::pair<uint64_t, uint64_t>, 4> SourceTailBranchIslands;
   // A larger unreachable source tail may hold a pair-only affine gateway.
   // fixupTrampolineBranches preserves this range instead of NOP-padding it.
   bool HasSourceTailGateway = false;
@@ -367,6 +366,10 @@ struct Trampoline {
   uint32_t MirroredStubGroup = 0;
   uint64_t MirroredStubGatewayOffset = 0;
   uint32_t PoolEntryPrefixBytes = 0;
+  // A mirrored sparse prefix is initialized to NOPs except at its
+  // source-selected branch stubs. One unused dword near its midpoint can
+  // therefore be reserved as an unreachable object-wide branch relay without
+  // growing or shifting the pool layout.
   // A far-site run may only be coalesced within one known function. Unknown
   // ranges stay unmerged because adjacent symbols are independent entries.
   bool HasFunctionRange = false;
@@ -482,6 +485,47 @@ struct NopSled {
   // set-PC gateway. Branch-island allocators must not fragment these ranges.
   bool GatewayOnly = false;
 };
+
+struct BranchIslandAllocatorTestResult {
+  bool Success = false;
+  llvm::SmallVector<uint64_t, 4> Islands;
+  llvm::SmallVector<size_t, 4> HeldIslandCountsAtPromotion;
+  std::vector<NopSled> Gateways;
+  llvm::DenseSet<uint64_t> Occupied;
+};
+
+/// Exercise the late branch-island allocator without constructing an ELF.
+/// This is exposed for focused transactional/index invariant unit coverage.
+BranchIslandAllocatorTestResult
+runBranchIslandAllocatorForTest(std::vector<NopSled> Gateways,
+                                uint64_t OwnerOffset, uint64_t FromOffset,
+                                uint64_t TargetOffset, bool Backward,
+                                llvm::DenseSet<uint64_t> Occupied = {});
+
+/// As above, but append one supplied gateway window at each recoverable
+/// strand. Records the number of provisional occupied dwords held when every
+/// promotion succeeds.
+BranchIslandAllocatorTestResult runBranchIslandAllocatorWithPromotionsForTest(
+    std::vector<NopSled> Gateways, uint64_t OwnerOffset, uint64_t FromOffset,
+    uint64_t TargetOffset, bool Backward, llvm::ArrayRef<NopSled> Promotions);
+
+/// Return the decoded-source search band for one recoverable promotion. The
+/// band is clamped to starts whose set-PC tail can be one s_branch hop from
+/// CurrentOffset; exact reachability remains a per-candidate check.
+std::pair<uint64_t, uint64_t>
+branchPromotionSearchRangeForTest(uint64_t CurrentOffset,
+                                  uint64_t CorridorOffset, bool Forward);
+
+/// Return the decoded candidate indices visited by the promotion cursor after
+/// permanently rejected starts are removed. Forward corridors scan from high
+/// to low addresses; backward corridors scan from low to high addresses.
+llvm::SmallVector<size_t, 8> promotionCandidateOrderForTest(
+    size_t CandidateCount, llvm::ArrayRef<size_t> PermanentlyRejected,
+    size_t BeginIndex, size_t EndIndex, bool Forward);
+
+/// Split free gateway ranges at already committed branch dwords.
+std::vector<NopSled> subtractOccupiedBranchGatewaySlotsForTest(
+    std::vector<NopSled> Gateways, const llvm::DenseSet<uint64_t> &Occupied);
 
 enum class MaskWorkaroundPolicy {
   None,
@@ -606,6 +650,11 @@ public:
   /// Enumerate function symbol ranges in `.text` using virtual addresses.
   /// Zero-size symbols extend to the next function symbol or `.text` end.
   std::vector<FunctionTextRange> functionTextRanges() const;
+
+  /// Return whether every symbol table was parsed while building the function
+  /// range cache. Consumers that use the ranges as a closed-world target set
+  /// must reject an incomplete cache.
+  bool functionTextRangesComplete() const;
 
   /// Validate that an object with a present, empty `.text` section contains
   /// data only: no executable section contents, no defined function/ifunc
@@ -792,6 +841,7 @@ private:
   const ELFT::Shdr *TextSection;
   unsigned TextSectionIndex;
   mutable std::optional<std::vector<FunctionTextRange>> FunctionRangeCache;
+  mutable bool FunctionRangeCacheComplete = true;
   mutable std::optional<std::vector<KernelDescriptorInfo>>
       KernelDescriptorCache;
   mutable llvm::StringMap<uint64_t> KernelDescriptorFileOffsetCache;
@@ -1322,6 +1372,13 @@ bool sourceHasUniqueFunctionRange(
     llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
     uint64_t TextAddr);
 
+/// Indexed implementation of the same uniqueness predicate, exposed so unit
+/// tests can compare it against the simple linear oracle.
+bool sourceHasUniqueFunctionRangeIndexedForTest(
+    const Trampoline &T,
+    llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    uint64_t TextAddr);
+
 /// Return whether [Begin, End) is an entry-free interval strictly after the
 /// first source dword. The caller supplies the unique-function proof so dense
 /// objects can cache it per function instead of rescanning their symbol table
@@ -1330,6 +1387,16 @@ bool isSafeSourceTailRange(const Trampoline &T,
                            const DirectControlFlowInfo &ControlFlow,
                            bool HasUniqueFunctionRange, uint64_t Begin,
                            uint64_t End);
+
+/// Return whether the source's second dword must remain owner-only until its
+/// registerless far-return chain is allocated. Such a tail must not be offered
+/// to an earlier affine forward planner.
+bool mustReserveSourceTailForRegisterlessReturn(const Trampoline &T);
+
+/// Return the only source-local window a registerless source may offer to the
+/// early affine planner. The owner-reserved second dword is excluded.
+std::optional<std::pair<uint64_t, uint64_t>>
+registerlessSourceAffineGatewayRange(const Trampoline &T);
 
 // Per-instruction persistent gfx1250 VGPR-MSB mode (packed src0/src1/src2/dst,
 // two bits each, values 0-255) recovered by the WMMA split pass's
@@ -1563,7 +1630,8 @@ struct EncodedSplitVccGateway {
 std::optional<EncodedSplitVccGateway>
 findSplitVccGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                     uint64_t FromOffset, uint64_t TargetOffset,
-                    unsigned SaveSgpr);
+                    unsigned SaveSgpr,
+                    const llvm::DenseSet<uint64_t> *Occupied = nullptr);
 
 /// Find the nearest short-branch-reachable gateway whose remaining space fits
 /// the set-PC sequence. Candidate widths are computed from the displacement;
@@ -1573,7 +1641,8 @@ llvm::Expected<std::optional<EncodedSetPcGateway>>
 findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                         uint64_t FromOffset, uint64_t TargetOffset,
                         unsigned SgprBase, bool UseVcc = false,
-                        bool PreserveVcc = false);
+                        bool PreserveVcc = false,
+                        const llvm::DenseSet<uint64_t> *Occupied = nullptr);
 
 /// Count set-PC gateway slots reachable from \p FromOffset, up to \p MaxSlots.
 /// Candidate widths are computed without assembly. Zero means that no
@@ -1593,6 +1662,18 @@ bool isSBranchReachable(uint64_t From, uint64_t To);
 std::optional<uint64_t>
 evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
                                 const LLVMState &LS);
+
+/// Match the exact decoded operand layout of a canonical v_readlane_b32 or
+/// v_writelane_b32 frame transfer. Writelane additionally requires its tied
+/// incoming-VGPR operand to equal the destination.
+bool matchesCanonicalLaneTransfer(const InternalDecodedInst &DI,
+                                  llvm::StringRef Mnemonic,
+                                  llvm::MCRegister Dst, llvm::MCRegister Src,
+                                  int64_t Lane);
+
+/// Return whether an instruction truly changes the hardware PC. This excludes
+/// EXEC-mask operations that generic MC analysis may classify as branches.
+bool isTruePcTransfer(const InternalDecodedInst &DI, const LLVMState &LS);
 
 /// A canonical get-PC/add materialized address feeding a PC-materialized
 /// transfer (s_get_pc_i64 / s_add_nc_u64 / s_{swap,set}_pc_i64). \p Target is
@@ -1639,7 +1720,48 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     llvm::ArrayRef<uint64_t> DeclaredEntries,
     llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges = {},
     llvm::ArrayRef<uint64_t> ExternalEntries = {},
-    llvm::ArrayRef<uint8_t> Text = {});
+    llvm::ArrayRef<uint8_t> Text = {}, const ElfView *Elf = nullptr,
+    llvm::ArrayRef<uint64_t> NonCallEntries = {});
+
+/// Return whether \p DI fully defines \p Register. A definition of a strict
+/// subregister is not a kill of the incoming full-register value.
+[[nodiscard]] bool instructionFullyWritesRegister(const InternalDecodedInst &DI,
+                                                  const LLVMState &LS,
+                                                  llvm::MCRegister Register);
+
+/// Compute instruction offsets in one function range where the incoming value
+/// of \p Register may be observed before a full definition. Unknown control
+/// flow and exits are conservative.
+std::optional<llvm::DenseSet<uint64_t>>
+computeIncomingRegisterNeeds(llvm::ArrayRef<InternalDecodedInst> Decoded,
+                             const LLVMState &LS, uint64_t FunctionBegin,
+                             uint64_t FunctionEnd, llvm::MCRegister Register);
+
+/// Resolve s0 through s(MaxSgprs - 1) to their physical MC registers.
+std::optional<llvm::SmallVector<llvm::MCRegister, 128>>
+resolveNumberedSgprRegisters(const llvm::MCRegisterInfo &MRI,
+                             unsigned MaxSgprs);
+
+/// Collect numbered SGPR uses and definitions using MC register overlap, so
+/// tuple and subregister operands conservatively affect their numbered SGPRs.
+void getNumberedSgprUsesAndDefs(const InternalDecodedInst &DI,
+                                const LLVMState &LS,
+                                llvm::ArrayRef<llvm::MCRegister> NumberedSgprs,
+                                llvm::BitVector &Uses, llvm::BitVector &Defs);
+
+/// Return numbered SGPR incoming values observed by a replacement before a
+/// definition, conservatively retaining values at malformed or opaque control
+/// flow.
+llvm::BitVector unsafeIncomingNumberedSgprsInReplacement(
+    llvm::ArrayRef<uint8_t> Replacement, const LLVMState &LS,
+    llvm::ArrayRef<llvm::MCRegister> NumberedSgprs);
+
+/// Return numbered SGPR incoming values that may be read before a definition,
+/// or remain live at an opaque or invalid control-flow boundary.
+std::optional<llvm::BitVector> unsafeIncomingNumberedSgprsInRange(
+    llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t FunctionBegin, uint64_t FunctionEnd, uint64_t Continuation,
+    llvm::ArrayRef<llvm::MCRegister> NumberedSgprs);
 
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
@@ -1653,6 +1775,14 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
 [[nodiscard]] std::optional<std::vector<std::string>>
 expandDs2Addr(const llvm::MCInst &Inst, llvm::StringRef FromMnem,
               llvm::StringRef ToMnem, const LLVMState &LS);
+
+/// Rewrite a representable gfx1250 B0 DS2 offset pair to A0 byte offsets
+/// without changing the instruction's opcode, registers, or size. The narrow
+/// entry-local form is exposed so MC tests can verify its exact bytes.
+[[nodiscard]] bool
+rewriteDs2AddrOffsetsInPlace(llvm::MutableArrayRef<uint8_t> InstBytes,
+                             const llvm::MCInst &Inst, llvm::StringRef Mnemonic,
+                             const LLVMState &LS);
 
 // -- Patch dispatch vtable ----------------------------------------------------
 //

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1763,6 +1763,20 @@ std::optional<llvm::BitVector> unsafeIncomingNumberedSgprsInRange(
     uint64_t FunctionBegin, uint64_t FunctionEnd, uint64_t Continuation,
     llvm::ArrayRef<llvm::MCRegister> NumberedSgprs);
 
+struct BatchedSgprContinuationTestResult {
+  uint64_t Analyses = 0;
+  llvm::SmallVector<std::optional<llvm::BitVector>, 8> Queries;
+};
+
+/// Build one compact per-function numbered-SGPR continuation analysis and
+/// query it at every requested offset. Exposed for scalar-oracle and cache
+/// reuse unit coverage.
+BatchedSgprContinuationTestResult runBatchedSgprContinuationAnalysisForTest(
+    llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t FunctionBegin, uint64_t FunctionEnd,
+    llvm::ArrayRef<uint64_t> Continuations,
+    llvm::ArrayRef<llvm::MCRegister> NumberedSgprs);
+
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
                                        llvm::ArrayRef<uint8_t> Replacement);

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1502,6 +1502,25 @@ struct PatchContext {
   uint64_t TextMutationGeneration = 0;
   llvm::DenseMap<std::pair<uint64_t, uint64_t>, CurrentFunctionSgprLiveness>
       CurrentFunctionSgprLivenessCache{0};
+  // Per-dispatch mutation classification. A local DS2 split adds only
+  // register-neutral branches, DS operations, and a DS wait, so numbered-SGPR
+  // and VCC continuation liveness is unchanged and its cache remains valid.
+  bool LastReplacementUsedNopSled = false;
+  bool CurrentPatchPreservesSgprLiveness = false;
+  // Object-wide padding proven unreachable by the closed control-flow audit.
+  // Required rewrites may explicitly prefer these complete local body slots;
+  // ordinary near-pool placement keeps using the function-scoped NOP map.
+  std::vector<NopSled> PreferredLocalReplacementSleds;
+  // Disjoint external-padding partitions reserved for non-DS2 replacements
+  // whose appended pool would otherwise be outside short-branch reach.
+  std::vector<NopSled> PreferredFarReplacementSleds;
+  // Set-PC-sized external routing tails. A DS2 can keep its first DS1 in the
+  // original slot and place its compact second-half continuation here.
+  std::vector<NopSled> PreferredDs2ContinuationSleds;
+  // Tail dwords left unreachable behind local replacement branch-forwards.
+  // The closed control-flow audit proves these are safe globally distributed
+  // one-dword relay slots for the later branch-island planner.
+  std::vector<NopSled> LocalReplacementSourceTails;
 };
 
 /// One node in the all-path proof that an incoming physical VGPR value is
@@ -1677,7 +1696,8 @@ isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx, uint64_t InstOffset,
                                  llvm::ArrayRef<uint8_t> Replacement);
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    llvm::ArrayRef<uint8_t> Replacement);
+                                    llvm::ArrayRef<uint8_t> Replacement,
+                                    bool AllowRegisterless = true);
 
 /// Encode an SCC-neutral indirect long branch using the aligned SGPR pair at
 /// \p SgprBase. The displacement uses gfx12's s_add_nc_u64; no s_add_pc_i64
@@ -1854,7 +1874,15 @@ BatchedSgprContinuationTestResult runBatchedSgprContinuationAnalysisForTest(
 
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       llvm::ArrayRef<uint8_t> Replacement);
+                                       llvm::ArrayRef<uint8_t> Replacement,
+                                       bool PreferNopSled = false,
+                                       bool AllowTrampoline = true);
+
+[[nodiscard]] bool
+emitSplitDs2Continuation(PatchContext &Ctx, uint64_t InstOffset,
+                         llvm::ArrayRef<uint8_t> FirstInstruction,
+                         uint32_t OverwrittenSize,
+                         llvm::ArrayRef<uint8_t> Continuation);
 
 /// Expand one decoded gfx1250 DS two-address instruction into the ordered
 /// single-address instruction sequence used by the trampoline patch. Exposed
@@ -1864,14 +1892,6 @@ BatchedSgprContinuationTestResult runBatchedSgprContinuationAnalysisForTest(
 [[nodiscard]] std::optional<std::vector<std::string>>
 expandDs2Addr(const llvm::MCInst &Inst, llvm::StringRef FromMnem,
               llvm::StringRef ToMnem, const LLVMState &LS);
-
-/// Rewrite a representable gfx1250 B0 DS2 offset pair to A0 byte offsets
-/// without changing the instruction's opcode, registers, or size. The narrow
-/// entry-local form is exposed so MC tests can verify its exact bytes.
-[[nodiscard]] bool
-rewriteDs2AddrOffsetsInPlace(llvm::MutableArrayRef<uint8_t> InstBytes,
-                             const llvm::MCInst &Inst, llvm::StringRef Mnemonic,
-                             const LLVMState &LS);
 
 // -- Patch dispatch vtable ----------------------------------------------------
 //

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1035,6 +1035,12 @@ LLVMState initLLVM(const TargetIdentifier &TI);
 llvm::SmallVector<uint8_t> assembleSingleInst(llvm::StringRef AsmStr,
                                               const LLVMState &LS);
 
+/// Parse one non-empty assembly source line, returning the single MCInst
+/// captured from the target asm parser. Returns std::nullopt when parsing
+/// fails or the source expands to anything other than one MCInst.
+std::optional<llvm::MCInst> parseSingleMCInst(llvm::StringRef AsmStr,
+                                              const LLVMState &LS);
+
 /// Assemble a newline-separated instruction sequence, returning its encoded
 /// bytes.
 llvm::SmallVector<uint8_t> assembleInstructions(llvm::StringRef AsmStr,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -326,6 +326,12 @@ struct Trampoline {
   // A wave32 far edge may preserve live VCC_LO in one safe numbered SGPR.
   // Its source tail is a restore-and-fallthrough landing pad.
   bool LongBranchPreservesVcc = false;
+  // An isolated eight-byte source cannot hold that restore landing. In that
+  // case, append restore+branch bytes to its nearby forward gateway and return
+  // there from the pool instead.
+  bool UsesVccRestoreGateway = false;
+  uint64_t VccRestoreGatewayOffset = 0;
+  llvm::SmallVector<uint8_t> VccRestoreGatewayBytes;
   bool HasPoolBranchIsland = false;
   uint64_t PoolBranchIslandOffset = 0;
   bool UsesShortBranchForward = false;
@@ -343,6 +349,8 @@ struct Trampoline {
   bool HasSourceTailGateway = false;
   uint64_t SourceTailGatewayOffset = 0;
   uint32_t SourceTailGatewayBytes = 0;
+  llvm::SmallVector<std::pair<uint64_t, uint32_t>, 2>
+      AdditionalSourceTailGateways;
   llvm::SmallVector<uint64_t, 4> ReturnBranchIslands;
   uint64_t ReturnBranchTargetOffset = 0;
   bool HasForwardGateway = false;

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -344,6 +344,33 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_set_pc_i64 s[0:1]", "s_set_pc_i64", S,
                                      S.SSetPcI64Opcode))
     return S;
+  if (!resolveRequiredOpcodeViaParse("s_add_co_i32 s0, s0, s0", "s_add_co_i32",
+                                     S, S.SAddCoI32Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_add_co_u32 s0, s0, s0", "s_add_co_u32",
+                                     S, S.SAddCoU32Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_add_co_ci_u32 s0, s0, s0",
+                                     "s_add_co_ci_u32", S, S.SAddCoCiU32Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_cmp_ge_i32 s0, 0", "s_cmp_ge_i32", S,
+                                     S.SCmpGeI32Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_cbranch_scc1 0", "s_cbranch_scc1", S,
+                                     S.SCBranchScc1Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_abs_i32 s0, s0", "s_abs_i32", S,
+                                     S.SAbsI32Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_sub_co_u32 s0, s0, s0", "s_sub_co_u32",
+                                     S, S.SSubCoU32Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_sub_co_ci_u32 s0, s0, s0",
+                                     "s_sub_co_ci_u32", S, S.SSubCoCiU32Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_mov_b32 s0, 0", "s_mov_b32", S,
+                                     S.SMovB32Opcode))
+    return S;
   if (!resolveRequiredOpcodeViaParse("s_clause 0", "s_clause", S,
                                      S.SClauseOpcode))
     return S;

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -595,6 +595,30 @@ SmallVector<uint8_t> assembleSingleInst(StringRef AsmStr, const LLVMState &S) {
   return assembleInstructions(AsmStr, S);
 }
 
+std::optional<MCInst> parseSingleMCInst(StringRef AsmStr, const LLVMState &S) {
+  SmallVector<StringRef, 2> Lines;
+  AsmStr.split(Lines, '\n');
+  unsigned InstructionLines = 0;
+  for (StringRef Line : Lines)
+    if (!Line.trim().empty())
+      ++InstructionLines;
+  if (InstructionLines != 1) {
+    log() << "hotswap: error: parseSingleMCInst: expected one non-empty "
+             "assembly line, got "
+          << InstructionLines << " for asm:\n    " << AsmStr << "\n";
+    return std::nullopt;
+  }
+
+  SmallVector<MCInst, 2> Insts = parseAsmToMCInsts(AsmStr, S);
+  if (Insts.size() != 1) {
+    log() << "hotswap: error: parseSingleMCInst: expected one parsed MCInst, "
+             "got "
+          << Insts.size() << " for asm:\n    " << AsmStr << "\n";
+    return std::nullopt;
+  }
+  return Insts.front();
+}
+
 // -- buildTrampoline ----------------------------------------------------------
 
 std::string joinAsmLines(ArrayRef<std::string> AsmLines) {

--- a/amd/comgr/src/comgr-hotswap-occupancy.cpp
+++ b/amd/comgr/src/comgr-hotswap-occupancy.cpp
@@ -225,6 +225,19 @@ VgprBumpDecision checkKernelVgprBump(PatchContext &Ctx, StringRef KernelName,
   if (!Capacity)
     return failOrDeclineVgprBump(Ctx, Requirement);
 
+  // Some input kernels already reserve enough VGPRs that their declared
+  // maximum workgroup cannot meet the generic waves/EU target. Do not reject
+  // a bump merely because it cannot repair that pre-existing condition: the
+  // patch is occupancy-neutral when the proposed allocation admits at least
+  // as many waves as the input allocation.
+  std::optional<WorkgroupCapacity> CurrentCapacity = computeWorkgroupCapacity(
+      *CurrentVgprs, Cached->second->MaxFlatWorkgroupSize,
+      Cached->second->WavefrontSize, *Limits);
+  if (!CurrentCapacity)
+    return failOrDeclineVgprBump(Ctx, Requirement);
+  if (Capacity->AchievableWavesPerEU >= CurrentCapacity->AchievableWavesPerEU)
+    return VgprBumpDecision::Apply;
+
   VgprBumpDecision Decision = decideVgprBump(Requirement, *Capacity);
   if (Decision == VgprBumpDecision::Apply)
     return Decision;

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -37,6 +37,7 @@
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/TargetParser/AMDGPUMCOperand.h"
 
 #include <algorithm>
 #include <cstring>
@@ -117,6 +118,22 @@ SmallVector<MCRegister, 4> getDirectSubRegs(MCRegister Reg,
       Result.push_back(MCRegister(Sub));
   }
   return Result;
+}
+
+const MCOperand *getAMDGPUNamedOperand(const MCInst &Inst,
+                                       AMDGPU::NamedOperand Name) {
+  int16_t Index = AMDGPU::getNamedOperandIdx(Inst.getOpcode(), Name);
+  if (Index < 0 || static_cast<unsigned>(Index) >= Inst.getNumOperands())
+    return nullptr;
+  return &Inst.getOperand(static_cast<unsigned>(Index));
+}
+
+MCOperand *getMutableAMDGPUNamedOperand(MCInst &Inst,
+                                        AMDGPU::NamedOperand Name) {
+  int16_t Index = AMDGPU::getNamedOperandIdx(Inst.getOpcode(), Name);
+  if (Index < 0 || static_cast<unsigned>(Index) >= Inst.getNumOperands())
+    return nullptr;
+  return &Inst.getOperand(static_cast<unsigned>(Index));
 }
 
 // Format a VGPR pair as a range expression: (VGPR0, VGPR1) -> "v[0:1]".
@@ -418,9 +435,8 @@ bool rewriteDs2AddrOffsetsInPlaceImpl(MutableArrayRef<uint8_t> InstBytes,
   // and split-counter concerns do not apply: the opcode, register operands,
   // modifiers, instruction count, and entry behavior are unchanged.
   if (getDs2AddrReplacement(Mnemonic).empty() ||
-      Mnemonic.contains("_stride64_") ||
-      Ops.Off0 > Ds2AddrOffsetMax || Ops.Off1 > Ds2AddrOffsetMax ||
-      InstBytes.size() != 2 * MinInstSize)
+      Mnemonic.contains("_stride64_") || Ops.Off0 > Ds2AddrOffsetMax ||
+      Ops.Off1 > Ds2AddrOffsetMax || InstBytes.size() != 2 * MinInstSize)
     return false;
 
   // gfx1250 DS2 offset0/offset1 occupy instruction bits [7:0]/[15:8].
@@ -627,16 +643,17 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
 
 // -- getDescriptorBaseSgpr --------------------------------------------------
 //
-// Extract the base SGPR MCRegister from the second operand of a
-// tensor_load_to_lds instruction. The second operand is an 8-SGPR group
-// descriptor (SReg_256); we need its first sub-register for the
-// s_pack_hh_b32_b16 fix.
+// Extract the base SGPR MCRegister from tensor_load_to_lds's named vaddr1
+// operand. It is an 8-SGPR group descriptor (SReg_256); we need its first
+// sub-register for the s_pack_hh_b32_b16 fix.
 
 MCRegister getDescriptorBaseSgpr(const MCInst &Inst,
                                  const MCRegisterInfo &MRI) {
-  if (Inst.getNumOperands() < 2 || !Inst.getOperand(1).isReg())
+  const MCOperand *Descriptor =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::VAddr1);
+  if (!Descriptor || !Descriptor->isReg())
     return MCRegister();
-  MCRegister Tuple = MCRegister(Inst.getOperand(1).getReg());
+  MCRegister Tuple = MCRegister(Descriptor->getReg());
   SmallVector<MCRegister, 4> Subs = getDirectSubRegs(Tuple, MRI);
   return Subs.empty() ? MCRegister() : Subs[0];
 }
@@ -658,10 +675,12 @@ std::optional<unsigned> getSgprIndex(MCRegister Reg,
 SmallVector<unsigned, 8> getDescriptorSgprIndices(const MCInst &Inst,
                                                   const MCRegisterInfo &MRI) {
   SmallVector<unsigned, 8> Result;
-  if (Inst.getNumOperands() < 2 || !Inst.getOperand(1).isReg())
+  const MCOperand *Descriptor =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::VAddr1);
+  if (!Descriptor || !Descriptor->isReg())
     return Result;
 
-  MCRegister Tuple = MCRegister(Inst.getOperand(1).getReg());
+  MCRegister Tuple = MCRegister(Descriptor->getReg());
   for (MCRegister Sub : getDirectSubRegs(Tuple, MRI)) {
     if (std::optional<unsigned> Index = getSgprIndex(Sub, MRI))
       Result.push_back(*Index);
@@ -957,12 +976,18 @@ bool isLow16PreservingAndOnBase(const InternalDecodedInst &DI,
   if (DI.Inst.getOpcode() != LS.SAndB32Opcode)
     return false;
   const MCInst &Inst = DI.Inst;
-  if (!Inst.getOperand(2).isImm() ||
-      !LS.MRI->regsOverlap(MCRegister(Inst.getOperand(0).getReg()),
-                           BaseMCReg) ||
-      !LS.MRI->regsOverlap(MCRegister(Inst.getOperand(1).getReg()), BaseMCReg))
+  const MCOperand *Dst =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::SDst);
+  const MCOperand *Src0 =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::Src0);
+  const MCOperand *Src1 =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::Src1);
+  if (!Dst || !Dst->isReg() || !Dst->getReg() || !Src0 || !Src0->isReg() ||
+      !Src0->getReg() || !Src1 || !Src1->isImm() ||
+      !LS.MRI->regsOverlap(MCRegister(Dst->getReg()), BaseMCReg) ||
+      !LS.MRI->regsOverlap(MCRegister(Src0->getReg()), BaseMCReg))
     return false;
-  uint64_t Imm = static_cast<uint64_t>(Inst.getOperand(2).getImm());
+  uint64_t Imm = static_cast<uint64_t>(Src1->getImm());
   return (Imm & 0xffffu) == 0xffffu;
 }
 
@@ -973,12 +998,18 @@ bool isClearedMaskAndOnBase(const InternalDecodedInst &DI, MCRegister BaseMCReg,
   if (DI.Inst.getOpcode() != LS.SAndB32Opcode)
     return false;
   const MCInst &Inst = DI.Inst;
-  if (!Inst.getOperand(2).isImm() ||
-      !LS.MRI->regsOverlap(MCRegister(Inst.getOperand(0).getReg()),
-                           BaseMCReg) ||
-      !LS.MRI->regsOverlap(MCRegister(Inst.getOperand(1).getReg()), BaseMCReg))
+  const MCOperand *Dst =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::SDst);
+  const MCOperand *Src0 =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::Src0);
+  const MCOperand *Src1 =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::Src1);
+  if (!Dst || !Dst->isReg() || !Dst->getReg() || !Src0 || !Src0->isReg() ||
+      !Src0->getReg() || !Src1 || !Src1->isImm() ||
+      !LS.MRI->regsOverlap(MCRegister(Dst->getReg()), BaseMCReg) ||
+      !LS.MRI->regsOverlap(MCRegister(Src0->getReg()), BaseMCReg))
     return false;
-  return (static_cast<uint64_t>(Inst.getOperand(2).getImm()) & 0xffffu) == 0;
+  return (static_cast<uint64_t>(Src1->getImm()) & 0xffffu) == 0;
 }
 
 // True when \p DI writes \p BaseMCReg but provably leaves bits [15:0]
@@ -991,14 +1022,21 @@ bool writesBasePreservingZeroLow16(const InternalDecodedInst &DI,
   unsigned Opcode = Inst.getOpcode();
   if (Opcode != LS.SAndB32Opcode && Opcode != LS.SOrB32Opcode)
     return false;
-  if (!LS.MRI->regsOverlap(MCRegister(Inst.getOperand(0).getReg()),
-                           BaseMCReg) ||
-      !LS.MRI->regsOverlap(MCRegister(Inst.getOperand(1).getReg()), BaseMCReg))
+  const MCOperand *Dst =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::SDst);
+  const MCOperand *Src0 =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::Src0);
+  const MCOperand *Src1 =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::Src1);
+  if (!Dst || !Dst->isReg() || !Dst->getReg() || !Src0 || !Src0->isReg() ||
+      !Src0->getReg() || !Src1 ||
+      !LS.MRI->regsOverlap(MCRegister(Dst->getReg()), BaseMCReg) ||
+      !LS.MRI->regsOverlap(MCRegister(Src0->getReg()), BaseMCReg))
     return false;
   if (Opcode == LS.SAndB32Opcode)
     return true;
-  if (Inst.getOperand(2).isImm())
-    return (static_cast<uint64_t>(Inst.getOperand(2).getImm()) & 0xffffu) == 0;
+  if (Src1->isImm())
+    return (static_cast<uint64_t>(Src1->getImm()) & 0xffffu) == 0;
   return false;
 }
 
@@ -1047,8 +1085,10 @@ bool isTensorDescriptorUseOnly(const InternalDecodedInst &DI,
   // literal operand index: it is the group tuple that legitimately contains
   // BaseMCReg. Any other operand reading BaseMCReg is a foreign consumer.
   MCRegister DescriptorTuple;
-  if (DI.Inst.getOperand(1).isReg())
-    DescriptorTuple = MCRegister(DI.Inst.getOperand(1).getReg());
+  const MCOperand *Descriptor =
+      getAMDGPUNamedOperand(DI.Inst, AMDGPU::NamedOperand::VAddr1);
+  if (Descriptor && Descriptor->isReg())
+    DescriptorTuple = MCRegister(Descriptor->getReg());
 
   const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
   for (unsigned I = Desc.getNumDefs(), E = DI.Inst.getNumOperands(); I < E;
@@ -1087,11 +1127,16 @@ struct TensorLocalSetPcResolution {
   TensorLocalSetPcShape Shape = TensorLocalSetPcShape::Linear;
 };
 
-bool isExactTensorRegisterOperand(const MCInst &Inst, unsigned OperandIndex,
+bool isExactTensorRegisterOperand(const MCInst &Inst, AMDGPU::NamedOperand Name,
                                   MCRegister Reg) {
-  return OperandIndex < Inst.getNumOperands() &&
-         Inst.getOperand(OperandIndex).isReg() &&
-         Inst.getOperand(OperandIndex).getReg() == Reg;
+  const MCOperand *Operand = getAMDGPUNamedOperand(Inst, Name);
+  return Operand && Operand->isReg() && Operand->getReg() == Reg;
+}
+
+bool isImmediatelyBefore(const InternalDecodedInst &Before,
+                         const InternalDecodedInst &After) {
+  return Before.Offset <= std::numeric_limits<uint64_t>::max() - Before.Size &&
+         Before.Offset + Before.Size == After.Offset;
 }
 
 std::optional<uint32_t> evaluateTensorUint32Operand(const MCOperand &Operand) {
@@ -1133,67 +1178,68 @@ resolveTensorLinearSetPcTarget(const PatchContext &Ctx, size_t SetPcIndex,
       !AddLow.DecodeSucceeded || !AddHigh.DecodeSucceeded ||
       !SetPc.DecodeSucceeded ||
       GetPc.Inst.getOpcode() != Ctx.LS.SGetPcI64Opcode ||
-      MakeDelta.Mnemonic != "s_add_co_i32" ||
-      AddLow.Mnemonic != "s_add_co_u32" ||
-      AddHigh.Mnemonic != "s_add_co_ci_u32" ||
-      SetPc.Inst.getOpcode() != Ctx.LS.SSetPcI64Opcode ||
-      GetPc.Inst.getNumOperands() != 1 ||
-      MakeDelta.Inst.getNumOperands() != 3 ||
-      AddLow.Inst.getNumOperands() != 3 || AddHigh.Inst.getNumOperands() != 3 ||
-      SetPc.Inst.getNumOperands() != 1)
+      MakeDelta.Inst.getOpcode() != Ctx.LS.SAddCoI32Opcode ||
+      AddLow.Inst.getOpcode() != Ctx.LS.SAddCoU32Opcode ||
+      AddHigh.Inst.getOpcode() != Ctx.LS.SAddCoCiU32Opcode ||
+      SetPc.Inst.getOpcode() != Ctx.LS.SSetPcI64Opcode)
     return std::nullopt;
 
-  auto IsImmediatelyBefore = [](const InternalDecodedInst &Before,
-                                const InternalDecodedInst &After) {
-    return Before.Offset <=
-               std::numeric_limits<uint64_t>::max() - Before.Size &&
-           Before.Offset + Before.Size == After.Offset;
-  };
-  if (!IsImmediatelyBefore(GetPc, MakeDelta) ||
-      !IsImmediatelyBefore(MakeDelta, AddLow) ||
-      !IsImmediatelyBefore(AddLow, AddHigh) ||
-      !IsImmediatelyBefore(AddHigh, SetPc))
+  if (!isImmediatelyBefore(GetPc, MakeDelta) ||
+      !isImmediatelyBefore(MakeDelta, AddLow) ||
+      !isImmediatelyBefore(AddLow, AddHigh) ||
+      !isImmediatelyBefore(AddHigh, SetPc))
     return std::nullopt;
   if (GetPc.Offset < Range.Begin || SetPc.Offset >= Range.End ||
       SetPc.Size > Range.End - SetPc.Offset)
     return std::nullopt;
 
-  std::optional<uint32_t> FirstAddend =
-      evaluateTensorUint32Operand(MakeDelta.Inst.getOperand(1));
-  std::optional<uint32_t> SecondAddend =
-      evaluateTensorUint32Operand(MakeDelta.Inst.getOperand(2));
-
-  const MCOperand &GetPcPair = GetPc.Inst.getOperand(0);
-  const MCOperand &SetPcPair = SetPc.Inst.getOperand(0);
-  const MCOperand &DeltaDst = MakeDelta.Inst.getOperand(0);
-  if (!GetPcPair.isReg() || !GetPcPair.getReg() || !SetPcPair.isReg() ||
-      SetPcPair.getReg() != GetPcPair.getReg() || !DeltaDst.isReg() ||
-      !DeltaDst.getReg() || !FirstAddend || !SecondAddend)
+  const MCOperand *GetPcPair =
+      getAMDGPUNamedOperand(GetPc.Inst, AMDGPU::NamedOperand::SDst);
+  const MCOperand *SetPcPair =
+      getAMDGPUNamedOperand(SetPc.Inst, AMDGPU::NamedOperand::Src0);
+  const MCOperand *DeltaDst =
+      getAMDGPUNamedOperand(MakeDelta.Inst, AMDGPU::NamedOperand::SDst);
+  const MCOperand *FirstAddendOperand =
+      getAMDGPUNamedOperand(MakeDelta.Inst, AMDGPU::NamedOperand::Src0);
+  const MCOperand *SecondAddendOperand =
+      getAMDGPUNamedOperand(MakeDelta.Inst, AMDGPU::NamedOperand::Src1);
+  if (!GetPcPair || !GetPcPair->isReg() || !GetPcPair->getReg() || !SetPcPair ||
+      !SetPcPair->isReg() || SetPcPair->getReg() != GetPcPair->getReg() ||
+      !DeltaDst || !DeltaDst->isReg() || !DeltaDst->getReg() ||
+      !FirstAddendOperand || !SecondAddendOperand)
     return std::nullopt;
 
-  MCRegister Pair(GetPcPair.getReg());
-  MCRegister DeltaReg(DeltaDst.getReg());
+  std::optional<uint32_t> FirstAddend =
+      evaluateTensorUint32Operand(*FirstAddendOperand);
+  std::optional<uint32_t> SecondAddend =
+      evaluateTensorUint32Operand(*SecondAddendOperand);
+  if (!FirstAddend || !SecondAddend)
+    return std::nullopt;
+
+  MCRegister Pair(GetPcPair->getReg());
+  MCRegister DeltaReg(DeltaDst->getReg());
   if (Ctx.LS.MRI->regsOverlap(Pair, DeltaReg))
     return std::nullopt;
 
-  auto SameRegOperand = [](const MCInst &Inst, unsigned OperandIndex,
-                           MCRegister Reg) {
-    return Inst.getOperand(OperandIndex).isReg() &&
-           Inst.getOperand(OperandIndex).getReg() == Reg;
-  };
-
-  if (!AddLow.Inst.getOperand(0).isReg() ||
-      !AddLow.Inst.getOperand(0).getReg() ||
-      !AddHigh.Inst.getOperand(0).isReg() ||
-      !AddHigh.Inst.getOperand(0).getReg())
+  const MCOperand *AddLowDst =
+      getAMDGPUNamedOperand(AddLow.Inst, AMDGPU::NamedOperand::SDst);
+  const MCOperand *AddHighDst =
+      getAMDGPUNamedOperand(AddHigh.Inst, AMDGPU::NamedOperand::SDst);
+  const MCOperand *AddHighSrc1 =
+      getAMDGPUNamedOperand(AddHigh.Inst, AMDGPU::NamedOperand::Src1);
+  if (!AddLowDst || !AddLowDst->isReg() || !AddLowDst->getReg() ||
+      !AddHighDst || !AddHighDst->isReg() || !AddHighDst->getReg() ||
+      !AddHighSrc1 || !AddHighSrc1->isImm())
     return std::nullopt;
-  MCRegister Low(AddLow.Inst.getOperand(0).getReg());
-  MCRegister High(AddHigh.Inst.getOperand(0).getReg());
-  if (!SameRegOperand(AddLow.Inst, 1, Low) ||
-      !SameRegOperand(AddLow.Inst, 2, DeltaReg) ||
-      !SameRegOperand(AddHigh.Inst, 1, High) ||
-      !AddHigh.Inst.getOperand(2).isImm() ||
-      AddHigh.Inst.getOperand(2).getImm() != 0)
+  MCRegister Low(AddLowDst->getReg());
+  MCRegister High(AddHighDst->getReg());
+  if (!isExactTensorRegisterOperand(AddLow.Inst, AMDGPU::NamedOperand::Src0,
+                                    Low) ||
+      !isExactTensorRegisterOperand(AddLow.Inst, AMDGPU::NamedOperand::Src1,
+                                    DeltaReg) ||
+      !isExactTensorRegisterOperand(AddHigh.Inst, AMDGPU::NamedOperand::Src0,
+                                    High) ||
+      AddHighSrc1->getImm() != 0)
     return std::nullopt;
 
   std::optional<unsigned> LowIndex = getSgprIndex(Low, *Ctx.LS.MRI);
@@ -1214,6 +1260,43 @@ resolveTensorLinearSetPcTarget(const PatchContext &Ctx, size_t SetPcIndex,
     return std::nullopt;
   return TensorLocalSetPcResolution{*Target, SetPcIndex - 4, SetPcIndex,
                                     TensorLocalSetPcShape::Linear};
+}
+
+bool matchesTensorPairArithmetic(const PatchContext &Ctx,
+                                 const InternalDecodedInst &Low,
+                                 const InternalDecodedInst &High,
+                                 unsigned LowOpcode, unsigned HighOpcode,
+                                 MCRegister Pair, MCRegister DeltaReg) {
+  if (Low.Inst.getOpcode() != LowOpcode || High.Inst.getOpcode() != HighOpcode)
+    return false;
+
+  const MCOperand *LowDst =
+      getAMDGPUNamedOperand(Low.Inst, AMDGPU::NamedOperand::SDst);
+  const MCOperand *LowSrc0 =
+      getAMDGPUNamedOperand(Low.Inst, AMDGPU::NamedOperand::Src0);
+  const MCOperand *LowSrc1 =
+      getAMDGPUNamedOperand(Low.Inst, AMDGPU::NamedOperand::Src1);
+  const MCOperand *HighDst =
+      getAMDGPUNamedOperand(High.Inst, AMDGPU::NamedOperand::SDst);
+  const MCOperand *HighSrc0 =
+      getAMDGPUNamedOperand(High.Inst, AMDGPU::NamedOperand::Src0);
+  const MCOperand *HighSrc1 =
+      getAMDGPUNamedOperand(High.Inst, AMDGPU::NamedOperand::Src1);
+  if (!LowDst || !LowDst->isReg() || !LowDst->getReg() || !LowSrc0 ||
+      !LowSrc0->isReg() || LowSrc0->getReg() != LowDst->getReg() || !LowSrc1 ||
+      !LowSrc1->isReg() || LowSrc1->getReg() != DeltaReg || !HighDst ||
+      !HighDst->isReg() || !HighDst->getReg() || !HighSrc0 ||
+      !HighSrc0->isReg() || HighSrc0->getReg() != HighDst->getReg() ||
+      !HighSrc1 || !HighSrc1->isImm() || HighSrc1->getImm() != 0)
+    return false;
+
+  MCRegister LowReg(LowDst->getReg());
+  MCRegister HighReg(HighDst->getReg());
+  std::optional<unsigned> LowIndex = getSgprIndex(LowReg, *Ctx.LS.MRI);
+  std::optional<unsigned> HighIndex = getSgprIndex(HighReg, *Ctx.LS.MRI);
+  return LowIndex && HighIndex && *HighIndex == *LowIndex + 1 &&
+         Ctx.LS.MRI->regsOverlap(LowReg, Pair) &&
+         Ctx.LS.MRI->regsOverlap(HighReg, Pair);
 }
 
 // Resolve Tensile's signed-direction reusable-PC transfer. Both arms compute
@@ -1277,33 +1360,44 @@ resolveTensorSignedSetPcTarget(const PatchContext &Ctx, size_t SetPcIndex,
         PositiveSetPc.Offset >= Range.End ||
         PositiveSetPc.Size > Range.End - PositiveSetPc.Offset ||
         GetPc.Inst.getOpcode() != Ctx.LS.SGetPcI64Opcode ||
-        GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
-        !GetPc.Inst.getOperand(0).getReg() ||
-        MakeDelta.Mnemonic != "s_add_co_i32" ||
-        MakeDelta.Inst.getNumOperands() != 3 ||
-        !MakeDelta.Inst.getOperand(0).isReg() ||
-        !MakeDelta.Inst.getOperand(0).getReg() ||
-        !MakeDelta.Inst.getOperand(2).isImm())
+        MakeDelta.Inst.getOpcode() != Ctx.LS.SAddCoI32Opcode ||
+        Compare.Inst.getOpcode() != Ctx.LS.SCmpGeI32Opcode ||
+        Branch.Inst.getOpcode() != Ctx.LS.SCBranchScc1Opcode ||
+        Abs.Inst.getOpcode() != Ctx.LS.SAbsI32Opcode ||
+        NegativeSetPc.Inst.getOpcode() != Ctx.LS.SSetPcI64Opcode ||
+        PositiveSetPc.Inst.getOpcode() != Ctx.LS.SSetPcI64Opcode)
       continue;
 
-    MCRegister Pair(GetPc.Inst.getOperand(0).getReg());
-    MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
+    const MCOperand *GetPcPair =
+        getAMDGPUNamedOperand(GetPc.Inst, AMDGPU::NamedOperand::SDst);
+    const MCOperand *DeltaDst =
+        getAMDGPUNamedOperand(MakeDelta.Inst, AMDGPU::NamedOperand::SDst);
+    const MCOperand *FirstAddendOperand =
+        getAMDGPUNamedOperand(MakeDelta.Inst, AMDGPU::NamedOperand::Src0);
+    const MCOperand *SecondAddendOperand =
+        getAMDGPUNamedOperand(MakeDelta.Inst, AMDGPU::NamedOperand::Src1);
+    const MCOperand *CompareSrc1 =
+        getAMDGPUNamedOperand(Compare.Inst, AMDGPU::NamedOperand::Src1);
+    if (!GetPcPair || !GetPcPair->isReg() || !GetPcPair->getReg() ||
+        !DeltaDst || !DeltaDst->isReg() || !DeltaDst->getReg() ||
+        !FirstAddendOperand || !SecondAddendOperand ||
+        !SecondAddendOperand->isImm() || !CompareSrc1 ||
+        !CompareSrc1->isImm() || CompareSrc1->getImm() != 0)
+      continue;
+
+    MCRegister Pair(GetPcPair->getReg());
+    MCRegister DeltaReg(DeltaDst->getReg());
     if (Ctx.LS.MRI->regsOverlap(DeltaReg, Pair) ||
-        Compare.Mnemonic != "s_cmp_ge_i32" ||
-        Compare.Inst.getNumOperands() != 2 ||
-        !isExactTensorRegisterOperand(Compare.Inst, 0, DeltaReg) ||
-        !Compare.Inst.getOperand(1).isImm() ||
-        Compare.Inst.getOperand(1).getImm() != 0 ||
-        Branch.Mnemonic != "s_cbranch_scc1" || Abs.Mnemonic != "s_abs_i32" ||
-        Abs.Inst.getNumOperands() != 2 ||
-        !isExactTensorRegisterOperand(Abs.Inst, 0, DeltaReg) ||
-        !isExactTensorRegisterOperand(Abs.Inst, 1, DeltaReg) ||
-        NegativeSetPc.Inst.getOpcode() != Ctx.LS.SSetPcI64Opcode ||
-        NegativeSetPc.Inst.getNumOperands() != 1 ||
-        !isExactTensorRegisterOperand(NegativeSetPc.Inst, 0, Pair) ||
-        PositiveSetPc.Inst.getOpcode() != Ctx.LS.SSetPcI64Opcode ||
-        PositiveSetPc.Inst.getNumOperands() != 1 ||
-        !isExactTensorRegisterOperand(PositiveSetPc.Inst, 0, Pair))
+        !isExactTensorRegisterOperand(Compare.Inst, AMDGPU::NamedOperand::Src0,
+                                      DeltaReg) ||
+        !isExactTensorRegisterOperand(Abs.Inst, AMDGPU::NamedOperand::SDst,
+                                      DeltaReg) ||
+        !isExactTensorRegisterOperand(Abs.Inst, AMDGPU::NamedOperand::Src0,
+                                      DeltaReg) ||
+        !isExactTensorRegisterOperand(NegativeSetPc.Inst,
+                                      AMDGPU::NamedOperand::Src0, Pair) ||
+        !isExactTensorRegisterOperand(PositiveSetPc.Inst,
+                                      AMDGPU::NamedOperand::Src0, Pair))
       continue;
 
     uint64_t PositiveTarget = 0;
@@ -1312,44 +1406,20 @@ resolveTensorSignedSetPcTarget(const PatchContext &Ctx, size_t SetPcIndex,
         PositiveTarget != AddLow.Offset)
       continue;
 
-    auto MatchesPairArithmetic = [&](const InternalDecodedInst &Low,
-                                     const InternalDecodedInst &High,
-                                     StringRef LowMnemonic,
-                                     StringRef HighMnemonic) {
-      if (Low.Mnemonic != LowMnemonic || High.Mnemonic != HighMnemonic ||
-          Low.Inst.getNumOperands() != 3 || !Low.Inst.getOperand(0).isReg() ||
-          !Low.Inst.getOperand(1).isReg() || !Low.Inst.getOperand(0).getReg() ||
-          Low.Inst.getOperand(0).getReg() != Low.Inst.getOperand(1).getReg() ||
-          !isExactTensorRegisterOperand(Low.Inst, 2, DeltaReg) ||
-          High.Inst.getNumOperands() != 3 || !High.Inst.getOperand(0).isReg() ||
-          !High.Inst.getOperand(1).isReg() ||
-          !High.Inst.getOperand(0).getReg() ||
-          High.Inst.getOperand(0).getReg() !=
-              High.Inst.getOperand(1).getReg() ||
-          !High.Inst.getOperand(2).isImm() ||
-          High.Inst.getOperand(2).getImm() != 0)
-        return false;
-      MCRegister LowReg(Low.Inst.getOperand(0).getReg());
-      MCRegister HighReg(High.Inst.getOperand(0).getReg());
-      std::optional<unsigned> LowIndex = getSgprIndex(LowReg, *Ctx.LS.MRI);
-      std::optional<unsigned> HighIndex = getSgprIndex(HighReg, *Ctx.LS.MRI);
-      return LowIndex && HighIndex && *HighIndex == *LowIndex + 1 &&
-             Ctx.LS.MRI->regsOverlap(LowReg, Pair) &&
-             Ctx.LS.MRI->regsOverlap(HighReg, Pair);
-    };
-    if (!MatchesPairArithmetic(SubLow, SubHigh, "s_sub_co_u32",
-                               "s_sub_co_ci_u32") ||
-        !MatchesPairArithmetic(AddLow, AddHigh, "s_add_co_u32",
-                               "s_add_co_ci_u32"))
+    if (!matchesTensorPairArithmetic(
+            Ctx, SubLow, SubHigh, Ctx.LS.SSubCoU32Opcode,
+            Ctx.LS.SSubCoCiU32Opcode, Pair, DeltaReg) ||
+        !matchesTensorPairArithmetic(Ctx, AddLow, AddHigh,
+                                     Ctx.LS.SAddCoU32Opcode,
+                                     Ctx.LS.SAddCoCiU32Opcode, Pair, DeltaReg))
       continue;
 
     std::optional<uint32_t> FirstAddend =
-        evaluateTensorUint32Operand(MakeDelta.Inst.getOperand(1));
+        evaluateTensorUint32Operand(*FirstAddendOperand);
     if (!FirstAddend)
       continue;
     uint32_t DeltaBits =
-        *FirstAddend +
-        static_cast<uint32_t>(MakeDelta.Inst.getOperand(2).getImm());
+        *FirstAddend + static_cast<uint32_t>(SecondAddendOperand->getImm());
     int64_t SignedDelta = static_cast<int32_t>(DeltaBits);
     std::optional<uint64_t> PcValue = checkedAddUint64(
         GetPc.Offset, GetPc.Size, "tensor CFG signed reusable-PC value");
@@ -1360,6 +1430,35 @@ resolveTensorSignedSetPcTarget(const PatchContext &Ctx, size_t SetPcIndex,
                                       TensorLocalSetPcShape::SignedTwoArm};
   }
   return std::nullopt;
+}
+
+std::optional<bool>
+addAuditedBoundedTensorEdges(const PatchContext &Ctx, TensorFunctionCfg &Graph,
+                             const DenseMap<uint64_t, size_t> &IndexAtOffset,
+                             const ElfView::FunctionTextRange &Range,
+                             size_t LocalIndex, const InternalDecodedInst &DI) {
+  DenseMap<uint64_t, SmallVector<uint64_t, 2>>::const_iterator Bounded =
+      Ctx.DirectControlFlow.BoundedIndirectTargets.find(DI.Offset);
+  if (Bounded == Ctx.DirectControlFlow.BoundedIndirectTargets.end())
+    return std::nullopt;
+  for (uint64_t Target : Bounded->second) {
+    if (Target < Range.Begin || Target >= Range.End) {
+      log() << "hotswap: tensor CFG rejected bounded transfer at 0x"
+            << utohexstr(DI.Offset) << " with out-of-range target 0x"
+            << utohexstr(Target) << "\n";
+      return false;
+    }
+    DenseMap<uint64_t, size_t>::const_iterator TargetIt =
+        IndexAtOffset.find(Target);
+    if (TargetIt == IndexAtOffset.end()) {
+      log() << "hotswap: tensor CFG rejected bounded transfer at 0x"
+            << utohexstr(DI.Offset) << " with non-boundary target 0x"
+            << utohexstr(Target) << "\n";
+      return false;
+    }
+    Graph.addEdge(LocalIndex, TargetIt->second);
+  }
+  return true;
 }
 
 std::optional<TensorFunctionCfg>
@@ -1412,32 +1511,6 @@ buildTensorFunctionCfg(const PatchContext &Ctx,
   };
   SmallVector<PendingLocalSetPc, 2> PendingLocalSetPcs;
 
-  auto AddAuditedBoundedEdges =
-      [&](size_t LocalIndex,
-          const InternalDecodedInst &DI) -> std::optional<bool> {
-    auto Bounded = Ctx.DirectControlFlow.BoundedIndirectTargets.find(DI.Offset);
-    if (Bounded == Ctx.DirectControlFlow.BoundedIndirectTargets.end())
-      return std::nullopt;
-    for (uint64_t Target : Bounded->second) {
-      if (Target < Range.Begin || Target >= Range.End) {
-        log() << "hotswap: tensor CFG rejected bounded transfer at 0x"
-              << utohexstr(DI.Offset) << " with out-of-range target 0x"
-              << utohexstr(Target) << "\n";
-        return false;
-      }
-      DenseMap<uint64_t, size_t>::const_iterator TargetIt =
-          IndexAtOffset.find(Target);
-      if (TargetIt == IndexAtOffset.end()) {
-        log() << "hotswap: tensor CFG rejected bounded transfer at 0x"
-              << utohexstr(DI.Offset) << " with non-boundary target 0x"
-              << utohexstr(Target) << "\n";
-        return false;
-      }
-      Graph.addEdge(LocalIndex, TargetIt->second);
-    }
-    return true;
-  };
-
   for (size_t I = BeginIndex; I < EndIndex; ++I) {
     const InternalDecodedInst &DI = Ctx.Decoded[I];
     if (!DI.DecodeSucceeded) {
@@ -1469,7 +1542,8 @@ buildTensorFunctionCfg(const PatchContext &Ctx,
 
     if (Ctx.LS.MIA->isIndirectBranch(DI.Inst) ||
         Ctx.LS.MIA->isReturn(DI.Inst)) {
-      std::optional<bool> Added = AddAuditedBoundedEdges(LocalIndex, DI);
+      std::optional<bool> Added = addAuditedBoundedTensorEdges(
+          Ctx, Graph, IndexAtOffset, Range, LocalIndex, DI);
       if (Added) {
         if (!*Added)
           return std::nullopt;
@@ -1491,7 +1565,7 @@ buildTensorFunctionCfg(const PatchContext &Ctx,
                                                  Range);
         bool AuditedSetPc = false;
         if (SetPc) {
-          auto Audited =
+          DenseMap<uint64_t, SmallVector<uint64_t, 2>>::const_iterator Audited =
               Ctx.DirectControlFlow.BoundedIndirectTargets.find(DI.Offset);
           AuditedSetPc =
               Audited != Ctx.DirectControlFlow.BoundedIndirectTargets.end() &&
@@ -1506,7 +1580,8 @@ buildTensorFunctionCfg(const PatchContext &Ctx,
                                         LocalIndex, std::nullopt, SetPc->Shape,
                                         AuditedSetPc});
         } else {
-          std::optional<bool> Added = AddAuditedBoundedEdges(LocalIndex, DI);
+          std::optional<bool> Added = addAuditedBoundedTensorEdges(
+              Ctx, Graph, IndexAtOffset, Range, LocalIndex, DI);
           if (Added) {
             if (!*Added)
               return std::nullopt;
@@ -1612,20 +1687,27 @@ buildTensorFunctionCfg(const PatchContext &Ctx,
 bool writesBaseWithKnownZeroLow16(const InternalDecodedInst &DI,
                                   MCRegister BaseMCReg, const LLVMState &LS) {
   const MCInst &Inst = DI.Inst;
-  if (Inst.getNumOperands() < 2 || !Inst.getOperand(0).isReg() ||
-      !Inst.getOperand(0).getReg() ||
-      !LS.MRI->regsOverlap(MCRegister(Inst.getOperand(0).getReg()), BaseMCReg))
+  if (Inst.getOpcode() != LS.SMovB32Opcode &&
+      Inst.getOpcode() != LS.SAndB32Opcode)
+    return false;
+  const MCOperand *Dst =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::SDst);
+  const MCOperand *Src =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::Src0);
+  if (!Dst || !Dst->isReg() || !Dst->getReg() || !Src ||
+      !LS.MRI->regsOverlap(MCRegister(Dst->getReg()), BaseMCReg))
     return false;
 
-  if (DI.Mnemonic == "s_mov_b32")
-    return Inst.getOperand(1).isImm() &&
-           (static_cast<uint64_t>(Inst.getOperand(1).getImm()) & 0xffffu) == 0;
+  if (Inst.getOpcode() == LS.SMovB32Opcode)
+    return Src->isImm() &&
+           (static_cast<uint64_t>(Src->getImm()) & 0xffffu) == 0;
 
   // An immediate AND with zeros in bits [15:0] forces the result's low half
   // to zero regardless of the other input.
-  return Inst.getOpcode() == LS.SAndB32Opcode && Inst.getNumOperands() >= 3 &&
-         Inst.getOperand(2).isImm() &&
-         (static_cast<uint64_t>(Inst.getOperand(2).getImm()) & 0xffffu) == 0;
+  const MCOperand *Src1 =
+      getAMDGPUNamedOperand(Inst, AMDGPU::NamedOperand::Src1);
+  return Src1 && Src1->isImm() &&
+         (static_cast<uint64_t>(Src1->getImm()) & 0xffffu) == 0;
 }
 
 // Prove that the descriptor base already has a zero workgroup_mask at the
@@ -1896,9 +1978,16 @@ TensorMaskDef findTensorMaskSetDefinitions(const PatchContext &Ctx,
 bool clearWorkgroupMaskAtDefinition(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
-  MCRegister Dst = MCRegister(DI.Inst.getOperand(0).getReg());
+  MCOperand *DstOperand =
+      getMutableAMDGPUNamedOperand(DI.Inst, AMDGPU::NamedOperand::SDst);
+  MCOperand *MaskOperand =
+      getMutableAMDGPUNamedOperand(DI.Inst, AMDGPU::NamedOperand::Src1);
+  if (!DstOperand || !DstOperand->isReg() || !DstOperand->getReg() ||
+      !MaskOperand || !MaskOperand->isImm())
+    return false;
+  MCRegister Dst = MCRegister(DstOperand->getReg());
   std::string Reg = toAsmRegName(MRI, Dst);
-  uint64_t Imm = static_cast<uint64_t>(DI.Inst.getOperand(2).getImm());
+  uint64_t Imm = static_cast<uint64_t>(MaskOperand->getImm());
   uint32_t Cleared = static_cast<uint32_t>(Imm) & 0xffff0000u;
 
   std::string Asm =
@@ -1912,7 +2001,7 @@ bool clearWorkgroupMaskAtDefinition(PatchContext &Ctx, size_t Idx) {
     return false;
   }
   std::memcpy(Ctx.Text + DI.Offset, Bytes.data(), Bytes.size());
-  DI.Inst.getOperand(2).setImm(static_cast<int64_t>(Cleared));
+  MaskOperand->setImm(static_cast<int64_t>(Cleared));
 
   log() << "hotswap: tensor_load_to_lds: cleared workgroup_mask at descriptor "
            "definition 0x"
@@ -2617,8 +2706,7 @@ bool rewriteDs2AddrOffsetsInPlace(MutableArrayRef<uint8_t> InstBytes,
                                   const MCInst &Inst, StringRef Mnemonic,
                                   const LLVMState &LS) {
   std::optional<DsOperands> Ops = extractDsOperands(Inst, Mnemonic, LS);
-  return Ops &&
-         rewriteDs2AddrOffsetsInPlaceImpl(InstBytes, Mnemonic, *Ops);
+  return Ops && rewriteDs2AddrOffsetsInPlaceImpl(InstBytes, Mnemonic, *Ops);
 }
 
 // -- applyTrampolinePatches -------------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -415,7 +415,8 @@ bool hasUnencodableVgprName(StringRef Asm) {
   return false;
 }
 
-bool normalizeVgprOperand(StringRef Input, VgprMsbOperand Role, unsigned &Mode,
+bool normalizeVgprOperand(StringRef Input, VgprMsbOperand Role,
+                          unsigned OldMode, unsigned &NewMode,
                           std::string &Output) {
   StringRef Operand = Input.trim();
   StringRef Suffix;
@@ -440,15 +441,23 @@ bool normalizeVgprOperand(StringRef Input, VgprMsbOperand Role, unsigned &Mode,
   if (LoText.empty() || HiText.empty())
     return false;
 
-  unsigned Lo = 0;
-  unsigned Hi = 0;
-  if (LoText.getAsInteger(10, Lo) || HiText.getAsInteger(10, Hi) || Hi < Lo ||
-      Lo / 256 != Hi / 256)
+  unsigned EncodedLo = 0;
+  unsigned EncodedHi = 0;
+  if (LoText.getAsInteger(10, EncodedLo) ||
+      HiText.getAsInteger(10, EncodedHi) || EncodedHi < EncodedLo)
+    return false;
+  // MC register names contain the encoded low-byte index. A tuple expansion
+  // represents a low-byte wrap with values above 255, so rebase both ends
+  // relative to the incoming operand bank before selecting the new bank.
+  unsigned OriginalBank = getVgprMsbBank(OldMode, Role);
+  unsigned Lo = OriginalBank * 256 + EncodedLo;
+  unsigned Hi = OriginalBank * 256 + EncodedHi;
+  if (Lo / 256 != Hi / 256)
     return false;
   unsigned Bank = Lo / 256;
   if (Bank > 3)
     return false;
-  setVgprMsbBank(Mode, Role, Bank);
+  setVgprMsbBank(NewMode, Role, Bank);
   if (IsRange)
     Output =
         ("v[" + Twine(Lo & 255) + ":" + Twine(Hi & 255) + "]" + Suffix).str();
@@ -484,7 +493,7 @@ normalizeDsVgprBanks(StringRef Asm, StringRef FromMnem, unsigned OldMode) {
   std::string Normalized = Mnem.str();
   for (unsigned I = 0; I != Operands.size(); ++I) {
     std::string Operand;
-    if (!normalizeVgprOperand(Operands[I], Roles[I], NewMode, Operand))
+    if (!normalizeVgprOperand(Operands[I], Roles[I], OldMode, NewMode, Operand))
       return std::nullopt;
     Normalized += I == 0 ? " " : ", ";
     Normalized += Operand;

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -42,6 +42,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <vector>
 
 using namespace llvm;
@@ -402,6 +403,95 @@ std::optional<std::vector<std::string>> expandDs2AddrImpl(const MCInst &Inst,
   return std::nullopt;
 }
 
+bool hasUnencodableVgprName(StringRef Asm) {
+  for (size_t Pos = Asm.find('v'); Pos != StringRef::npos;
+       Pos = Asm.find('v', Pos + 1)) {
+    StringRef Tail = Asm.substr(Pos + 1);
+    Tail.consume_front("[");
+    unsigned Index = 0;
+    if (!Tail.consumeInteger(10, Index) && Index > 255)
+      return true;
+  }
+  return false;
+}
+
+bool normalizeVgprOperand(StringRef Input, VgprMsbOperand Role, unsigned &Mode,
+                          std::string &Output) {
+  StringRef Operand = Input.trim();
+  StringRef Suffix;
+  size_t Space = Operand.find(' ');
+  if (Space != StringRef::npos) {
+    Suffix = Operand.substr(Space);
+    Operand = Operand.take_front(Space);
+  }
+  if (!Operand.consume_front("v")) {
+    Output = Input.trim().str();
+    return true;
+  }
+
+  bool IsRange = Operand.consume_front("[");
+  if (IsRange && !Operand.consume_back("]"))
+    return false;
+  StringRef LoText;
+  StringRef HiText;
+  std::tie(LoText, HiText) = Operand.split(':');
+  if (!IsRange)
+    LoText = HiText = Operand;
+  if (LoText.empty() || HiText.empty())
+    return false;
+
+  unsigned Lo = 0;
+  unsigned Hi = 0;
+  if (LoText.getAsInteger(10, Lo) || HiText.getAsInteger(10, Hi) || Hi < Lo ||
+      Lo / 256 != Hi / 256)
+    return false;
+  unsigned Bank = Lo / 256;
+  if (Bank > 3)
+    return false;
+  setVgprMsbBank(Mode, Role, Bank);
+  if (IsRange)
+    Output =
+        ("v[" + Twine(Lo & 255) + ":" + Twine(Hi & 255) + "]" + Suffix).str();
+  else
+    Output = ("v" + Twine(Lo & 255) + Suffix).str();
+  return true;
+}
+
+std::optional<std::pair<std::string, unsigned>>
+normalizeDsVgprBanks(StringRef Asm, StringRef FromMnem, unsigned OldMode) {
+  size_t MnemEnd = Asm.find(' ');
+  if (MnemEnd == StringRef::npos)
+    return std::nullopt;
+  StringRef Mnem = Asm.take_front(MnemEnd);
+  SmallVector<StringRef, 3> Operands;
+  Asm.substr(MnemEnd + 1)
+      .split(Operands, ',', /*MaxSplit=*/-1,
+             /*KeepEmpty=*/false);
+
+  SmallVector<VgprMsbOperand, 3> Roles;
+  if (FromMnem.starts_with("ds_load_"))
+    Roles = {VgprMsbOperand::Dst, VgprMsbOperand::Src0};
+  else if (FromMnem.starts_with("ds_storexchg_"))
+    Roles = {VgprMsbOperand::Dst, VgprMsbOperand::Src0, VgprMsbOperand::Src1};
+  else if (FromMnem.starts_with("ds_store_"))
+    Roles = {VgprMsbOperand::Src0, VgprMsbOperand::Src1};
+  else
+    return std::nullopt;
+  if (Operands.size() != Roles.size())
+    return std::nullopt;
+
+  unsigned NewMode = OldMode;
+  std::string Normalized = Mnem.str();
+  for (unsigned I = 0; I != Operands.size(); ++I) {
+    std::string Operand;
+    if (!normalizeVgprOperand(Operands[I], Roles[I], NewMode, Operand))
+      return std::nullopt;
+    Normalized += I == 0 ? " " : ", ";
+    Normalized += Operand;
+  }
+  return std::pair<std::string, unsigned>{std::move(Normalized), NewMode};
+}
+
 // -- patchDs2Addr -----------------------------------------------------------
 //
 // Expand one ds_*_2addr_* instruction (stride64 or non-stride64) into two
@@ -421,9 +511,44 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   if (!Expanded)
     return failRequiredPatch(Ctx);
 
+  bool NeedsBankNormalization =
+      llvm::any_of(*Expanded, [](const std::string &Asm) {
+        return hasUnencodableVgprName(Asm);
+      });
+  std::optional<unsigned> ActiveMode;
+  if (NeedsBankNormalization) {
+    ActiveMode = getActiveVgprMsbMode(Ctx, Idx);
+    if (!ActiveMode) {
+      log() << "hotswap: error: ds_2addr at 0x" << utohexstr(DI.Offset)
+            << " crosses v255 but the active VGPR-MSB mode is unknown\n";
+      return failRequiredPatch(Ctx);
+    }
+  }
+
   std::string Combined;
-  for (const std::string &Line : *Expanded)
-    Combined += Line + "\n";
+  for (const std::string &Line : *Expanded) {
+    if (!NeedsBankNormalization) {
+      Combined += Line + "\n";
+      continue;
+    }
+    std::optional<std::pair<std::string, unsigned>> Normalized =
+        normalizeDsVgprBanks(Line, DI.Mnemonic, *ActiveMode);
+    if (!Normalized) {
+      log() << "hotswap: error: ds_2addr at 0x" << utohexstr(DI.Offset)
+            << " has a VGPR operand that crosses a 256-register bank\n";
+      return failRequiredPatch(Ctx);
+    }
+    unsigned NewMode = Normalized->second;
+    if (NewMode != *ActiveMode)
+      Combined +=
+          ("s_set_vgpr_msb " + Twine(NewMode | (*ActiveMode << 8)) + "\n")
+              .str();
+    Combined += Normalized->first + "\n";
+    if (NewMode != *ActiveMode)
+      Combined +=
+          ("s_set_vgpr_msb " + Twine(*ActiveMode | (NewMode << 8)) + "\n")
+              .str();
+  }
   // Drain the DS counter right after the split pair so both halves are
   // guaranteed complete before any downstream consumer. The original code
   // tracked completion of the single 2-addr instruction via a later

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -186,13 +186,6 @@ std::string fmtOffset(uint32_t Offset) {
 // this field directly, so any scaled byte offset that exceeds it cannot
 // be represented and the patch must be skipped.
 constexpr uint32_t Ds1AddrOffsetMax = 0xFFFF;
-// The gfx1250 DS two-address encoding has two eight-bit offset fields in the
-// low 16 bits of the instruction. B0 interprets non-stride64 fields as element
-// indices, while A0 requires byte offsets aligned to the payload size. When
-// both scaled byte offsets still fit in eight bits, rewriting the two fields
-// in place is an exact, entry-local fix and avoids a trampoline entirely.
-constexpr uint32_t Ds2AddrOffsetMax = 0xFF;
-
 struct DsOperands {
   SmallVector<MCRegister, 4> Regs;
   uint32_t Off0 = 0;
@@ -427,25 +420,6 @@ std::optional<std::vector<std::string>> expandDs2AddrImpl(const MCInst &Inst,
   return std::nullopt;
 }
 
-bool rewriteDs2AddrOffsetsInPlaceImpl(MutableArrayRef<uint8_t> InstBytes,
-                                      StringRef Mnemonic,
-                                      const DsOperands &Ops) {
-  // Every non-stride64 DS2 family uses the same two eight-bit fields. This
-  // rewrite changes only those fields, so load/exchange destination overlap
-  // and split-counter concerns do not apply: the opcode, register operands,
-  // modifiers, instruction count, and entry behavior are unchanged.
-  if (getDs2AddrReplacement(Mnemonic).empty() ||
-      Mnemonic.contains("_stride64_") || Ops.Off0 > Ds2AddrOffsetMax ||
-      Ops.Off1 > Ds2AddrOffsetMax || InstBytes.size() != 2 * MinInstSize)
-    return false;
-
-  // gfx1250 DS2 offset0/offset1 occupy instruction bits [7:0]/[15:8].
-  // Keep every opcode/register/modifier bit byte-for-byte identical.
-  InstBytes[0] = static_cast<uint8_t>(Ops.Off0);
-  InstBytes[1] = static_cast<uint8_t>(Ops.Off1);
-  return true;
-}
-
 bool hasUnencodableVgprName(StringRef Asm) {
   for (size_t Pos = Asm.find('v'); Pos != StringRef::npos;
        Pos = Asm.find('v', Pos + 1)) {
@@ -562,16 +536,9 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
       extractDsOperands(DI.Inst, DI.Mnemonic, Ctx.LS);
   if (!Ops)
     return failRequiredPatch(Ctx);
-  if (DI.Offset <= Ctx.TextSize && DI.Size <= Ctx.TextSize - DI.Offset &&
-      rewriteDs2AddrOffsetsInPlaceImpl(
-          MutableArrayRef<uint8_t>(Ctx.Text + DI.Offset, DI.Size), DI.Mnemonic,
-          *Ops)) {
-    log() << "hotswap: rewrote " << DI.Mnemonic << " at 0x"
-          << utohexstr(DI.Offset) << " in place with A0 byte offsets "
-          << Ops->Off0 << ", " << Ops->Off1 << "\n";
-    DI.Mnemonic = "<replaced>";
-    return true;
-  }
+  // Always lower DS2 operations through the split sequence. Re-encoding the
+  // B0 instruction with A0 byte offsets can disassemble as intended but does
+  // not preserve the operation's behavior on hardware.
   std::optional<std::vector<std::string>> Expanded =
       expandDs2AddrImpl(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
   if (!Expanded)
@@ -634,8 +601,88 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   }
 
   SmallVector<uint8_t> Replacement(Bytes.begin(), Bytes.end());
-  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
+  // A DS2 split is substantially larger than the original instruction and
+  // creates a registerless far-return chain when appended to the global pool.
+  // Prefer padding already proven unreachable by the closed control-flow
+  // audit: both edges remain ordinary s_branch instructions and relay demand
+  // no longer scales with the number of DS2 instructions in a large object.
+  bool Emitted = emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
+                                     /*PreferNopSled=*/true,
+                                     /*AllowTrampoline=*/false);
+
+  // A numbered pair or dead VCC gives the ordinary far trampoline a bounded,
+  // SCC-neutral return. Its source edge can then share the normal gateway
+  // backbone; reserve the dedicated compact-continuation tails for sites that
+  // would otherwise require both forward and return branch-island chains.
+  if (!Emitted)
+    Emitted = emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement,
+                               /*AllowRegisterless=*/false);
+
+  // If neither a complete local body nor a scratch-backed trampoline fits,
+  // keep the first DS1 in the original eight-byte slot and replace one
+  // adjacent instruction with a short branch. The continuation executes the
+  // second DS1, drains the perturbed DS counter, and (unless the overwritten
+  // instruction was already that wait) executes the displaced instruction
+  // before branching back. Only the narrow opcode set below is displaced:
+  // none requires another hotswap patch, transfers control, reads the PC, or
+  // establishes a hardware clause/state for its original address.
+  if (!Emitted && !NeedsBankNormalization && Expanded->size() >= 2 &&
+      Idx + 1 < Ctx.Decoded.size()) {
+    InternalDecodedInst &Next = Ctx.Decoded[Idx + 1];
+    bool IsAdjacentWait =
+        Next.Offset == DI.Offset + DI.Size && Next.Mnemonic == "s_wait_dscnt" &&
+        !Ctx.DirectControlFlow.Targets.contains(Next.Offset) &&
+        !llvm::is_contained(Ctx.DeclaredEntries, Next.Offset);
+    bool CanDisplaceFollower =
+        Next.Offset == DI.Offset + DI.Size && Next.DecodeSucceeded &&
+        Next.Offset <= Ctx.TextSize &&
+        Next.Size <= Ctx.TextSize - Next.Offset &&
+        !Ctx.DirectControlFlow.Targets.contains(Next.Offset) &&
+        !llvm::is_contained(Ctx.DeclaredEntries, Next.Offset) &&
+        StringSwitch<bool>(Next.Mnemonic)
+            .Cases({"s_bitcmp0_b64", "s_bitcmp1_b32", "s_cselect_b32"}, true)
+            .Cases({"s_mov_b32", "s_or_b32", "s_sub_co_i32"}, true)
+            .Cases({"v_add_nc_u32", "v_add_nc_u64"}, true)
+            .Cases({"v_ashrrev_i32", "v_cndmask_b32"}, true)
+            .Cases({"v_lshlrev_b32", "v_mov_b64"}, true)
+            .Case("v_sub_nc_u32", true)
+            .Cases({"ds_load_b32", "ds_load_b64"}, true)
+            .Cases({"ds_store_b32", "ds_store_b64"}, true)
+            .Cases({"v_add3_u32", "flat_load_b64"}, true)
+            .Cases({"v_dual_add_nc_u32", "v_dual_mov_b32"}, true)
+            .Default(false);
+    if (IsAdjacentWait || CanDisplaceFollower) {
+      SmallVector<uint8_t> First = assembleSingleInst((*Expanded)[0], Ctx.LS);
+      std::string ContinuationAsm;
+      for (size_t I = 1; I < Expanded->size(); ++I)
+        ContinuationAsm += (*Expanded)[I] + "\n";
+      ContinuationAsm += "s_wait_dscnt 0\n";
+      SmallVector<uint8_t> Continuation =
+          assembleInstructions(ContinuationAsm, Ctx.LS);
+      if (CanDisplaceFollower)
+        Continuation.append(Ctx.Text + Next.Offset,
+                            Ctx.Text + Next.Offset + Next.Size);
+      if (First.size() == DI.Size && !Continuation.empty() &&
+          emitSplitDs2Continuation(Ctx, DI.Offset, First, Next.Size,
+                                   Continuation)) {
+        log() << "hotswap: ds_2addr: used compact continuation at 0x"
+              << utohexstr(DI.Offset);
+        if (CanDisplaceFollower)
+          log() << " with displaced " << Next.Mnemonic;
+        log() << "\n";
+        Next.Mnemonic = "<replaced>";
+        Emitted = true;
+      }
+    }
+  }
+
+  if (!Emitted && !emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement,
+                                    /*AllowRegisterless=*/true))
     return failRequiredPatch(Ctx);
+  // A local split detours through only s_branch, DS operations, and
+  // s_wait_dscnt. It neither reads nor writes numbered SGPRs or VCC, and the
+  // single-entry/single-return detour preserves continuation liveness.
+  Ctx.CurrentPatchPreservesSgprLiveness = Ctx.LastReplacementUsedNopSled;
 
   DI.Mnemonic = "<replaced>";
   return true;
@@ -2700,13 +2747,6 @@ std::optional<std::vector<std::string>> expandDs2Addr(const MCInst &Inst,
                                                       StringRef ToMnem,
                                                       const LLVMState &LS) {
   return expandDs2AddrImpl(Inst, FromMnem, ToMnem, LS);
-}
-
-bool rewriteDs2AddrOffsetsInPlace(MutableArrayRef<uint8_t> InstBytes,
-                                  const MCInst &Inst, StringRef Mnemonic,
-                                  const LLVMState &LS) {
-  std::optional<DsOperands> Ops = extractDsOperands(Inst, Mnemonic, LS);
-  return Ops && rewriteDs2AddrOffsetsInPlaceImpl(InstBytes, Mnemonic, *Ops);
 }
 
 // -- applyTrampolinePatches -------------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -168,6 +168,12 @@ std::string fmtOffset(uint32_t Offset) {
 // this field directly, so any scaled byte offset that exceeds it cannot
 // be represented and the patch must be skipped.
 constexpr uint32_t Ds1AddrOffsetMax = 0xFFFF;
+// The gfx1250 DS two-address encoding has two eight-bit offset fields in the
+// low 16 bits of the instruction. B0 interprets non-stride64 fields as element
+// indices, while A0 requires byte offsets aligned to the payload size. When
+// both scaled byte offsets still fit in eight bits, rewriting the two fields
+// in place is an exact, entry-local fix and avoids a trampoline entirely.
+constexpr uint32_t Ds2AddrOffsetMax = 0xFF;
 
 struct DsOperands {
   SmallVector<MCRegister, 4> Regs;
@@ -403,6 +409,26 @@ std::optional<std::vector<std::string>> expandDs2AddrImpl(const MCInst &Inst,
   return std::nullopt;
 }
 
+bool rewriteDs2AddrOffsetsInPlaceImpl(MutableArrayRef<uint8_t> InstBytes,
+                                      StringRef Mnemonic,
+                                      const DsOperands &Ops) {
+  // Every non-stride64 DS2 family uses the same two eight-bit fields. This
+  // rewrite changes only those fields, so load/exchange destination overlap
+  // and split-counter concerns do not apply: the opcode, register operands,
+  // modifiers, instruction count, and entry behavior are unchanged.
+  if (getDs2AddrReplacement(Mnemonic).empty() ||
+      Mnemonic.contains("_stride64_") ||
+      Ops.Off0 > Ds2AddrOffsetMax || Ops.Off1 > Ds2AddrOffsetMax ||
+      InstBytes.size() != 2 * MinInstSize)
+    return false;
+
+  // gfx1250 DS2 offset0/offset1 occupy instruction bits [7:0]/[15:8].
+  // Keep every opcode/register/modifier bit byte-for-byte identical.
+  InstBytes[0] = static_cast<uint8_t>(Ops.Off0);
+  InstBytes[1] = static_cast<uint8_t>(Ops.Off1);
+  return true;
+}
+
 bool hasUnencodableVgprName(StringRef Asm) {
   for (size_t Pos = Asm.find('v'); Pos != StringRef::npos;
        Pos = Asm.find('v', Pos + 1)) {
@@ -515,6 +541,20 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   StringRef ToMnem = getDs2AddrReplacement(DI.Mnemonic);
   if (ToMnem.empty())
     return false;
+  std::optional<DsOperands> Ops =
+      extractDsOperands(DI.Inst, DI.Mnemonic, Ctx.LS);
+  if (!Ops)
+    return failRequiredPatch(Ctx);
+  if (DI.Offset <= Ctx.TextSize && DI.Size <= Ctx.TextSize - DI.Offset &&
+      rewriteDs2AddrOffsetsInPlaceImpl(
+          MutableArrayRef<uint8_t>(Ctx.Text + DI.Offset, DI.Size), DI.Mnemonic,
+          *Ops)) {
+    log() << "hotswap: rewrote " << DI.Mnemonic << " at 0x"
+          << utohexstr(DI.Offset) << " in place with A0 byte offsets "
+          << Ops->Off0 << ", " << Ops->Off1 << "\n";
+    DI.Mnemonic = "<replaced>";
+    return true;
+  }
   std::optional<std::vector<std::string>> Expanded =
       expandDs2AddrImpl(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
   if (!Expanded)
@@ -1980,6 +2020,14 @@ std::optional<std::vector<std::string>> expandDs2Addr(const MCInst &Inst,
                                                       StringRef ToMnem,
                                                       const LLVMState &LS) {
   return expandDs2AddrImpl(Inst, FromMnem, ToMnem, LS);
+}
+
+bool rewriteDs2AddrOffsetsInPlace(MutableArrayRef<uint8_t> InstBytes,
+                                  const MCInst &Inst, StringRef Mnemonic,
+                                  const LLVMState &LS) {
+  std::optional<DsOperands> Ops = extractDsOperands(Inst, Mnemonic, LS);
+  return Ops &&
+         rewriteDs2AddrOffsetsInPlaceImpl(InstBytes, Mnemonic, *Ops);
 }
 
 // -- applyTrampolinePatches -------------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -34,6 +34,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -1077,6 +1078,290 @@ struct TensorFunctionCfg {
   }
 };
 
+enum class TensorLocalSetPcShape { Linear, SignedTwoArm };
+
+struct TensorLocalSetPcResolution {
+  uint64_t Target = 0;
+  size_t SequenceBeginIndex = 0;
+  size_t SequenceEndIndex = 0;
+  TensorLocalSetPcShape Shape = TensorLocalSetPcShape::Linear;
+};
+
+bool isExactTensorRegisterOperand(const MCInst &Inst, unsigned OperandIndex,
+                                  MCRegister Reg) {
+  return OperandIndex < Inst.getNumOperands() &&
+         Inst.getOperand(OperandIndex).isReg() &&
+         Inst.getOperand(OperandIndex).getReg() == Reg;
+}
+
+std::optional<uint32_t> evaluateTensorUint32Operand(const MCOperand &Operand) {
+  if (Operand.isImm())
+    return static_cast<uint32_t>(Operand.getImm());
+  if (!Operand.isExpr())
+    return std::nullopt;
+  int64_t Value = 0;
+  if (!Operand.getExpr()->evaluateAsAbsolute(Value))
+    return std::nullopt;
+  return static_cast<uint32_t>(Value);
+}
+
+// Resolve the compiler-emitted reusable-PC tail jump used by large tensor
+// kernels:
+//
+//   s_get_pc_i64 Pair
+//   s_add_co_i32 Delta, Imm0, Imm1
+//   s_add_co_u32 Pair.lo, Pair.lo, Delta
+//   s_add_co_ci_u32 Pair.hi, Pair.hi, 0
+//   s_set_pc_i64 Pair
+//
+// Keep this recognizer deliberately narrow.  All five instructions must be
+// adjacent and use the exact register relationships above; any variation
+// remains unresolved and makes the tensor definition proof fail closed.
+std::optional<TensorLocalSetPcResolution>
+resolveTensorLinearSetPcTarget(const PatchContext &Ctx, size_t SetPcIndex,
+                               size_t BeginIndex,
+                               const ElfView::FunctionTextRange &Range) {
+  if (SetPcIndex < BeginIndex || SetPcIndex - BeginIndex < 4)
+    return std::nullopt;
+
+  const InternalDecodedInst &GetPc = Ctx.Decoded[SetPcIndex - 4];
+  const InternalDecodedInst &MakeDelta = Ctx.Decoded[SetPcIndex - 3];
+  const InternalDecodedInst &AddLow = Ctx.Decoded[SetPcIndex - 2];
+  const InternalDecodedInst &AddHigh = Ctx.Decoded[SetPcIndex - 1];
+  const InternalDecodedInst &SetPc = Ctx.Decoded[SetPcIndex];
+  if (!GetPc.DecodeSucceeded || !MakeDelta.DecodeSucceeded ||
+      !AddLow.DecodeSucceeded || !AddHigh.DecodeSucceeded ||
+      !SetPc.DecodeSucceeded ||
+      GetPc.Inst.getOpcode() != Ctx.LS.SGetPcI64Opcode ||
+      MakeDelta.Mnemonic != "s_add_co_i32" ||
+      AddLow.Mnemonic != "s_add_co_u32" ||
+      AddHigh.Mnemonic != "s_add_co_ci_u32" ||
+      SetPc.Inst.getOpcode() != Ctx.LS.SSetPcI64Opcode ||
+      GetPc.Inst.getNumOperands() != 1 ||
+      MakeDelta.Inst.getNumOperands() != 3 ||
+      AddLow.Inst.getNumOperands() != 3 || AddHigh.Inst.getNumOperands() != 3 ||
+      SetPc.Inst.getNumOperands() != 1)
+    return std::nullopt;
+
+  auto IsImmediatelyBefore = [](const InternalDecodedInst &Before,
+                                const InternalDecodedInst &After) {
+    return Before.Offset <=
+               std::numeric_limits<uint64_t>::max() - Before.Size &&
+           Before.Offset + Before.Size == After.Offset;
+  };
+  if (!IsImmediatelyBefore(GetPc, MakeDelta) ||
+      !IsImmediatelyBefore(MakeDelta, AddLow) ||
+      !IsImmediatelyBefore(AddLow, AddHigh) ||
+      !IsImmediatelyBefore(AddHigh, SetPc))
+    return std::nullopt;
+  if (GetPc.Offset < Range.Begin || SetPc.Offset >= Range.End ||
+      SetPc.Size > Range.End - SetPc.Offset)
+    return std::nullopt;
+
+  std::optional<uint32_t> FirstAddend =
+      evaluateTensorUint32Operand(MakeDelta.Inst.getOperand(1));
+  std::optional<uint32_t> SecondAddend =
+      evaluateTensorUint32Operand(MakeDelta.Inst.getOperand(2));
+
+  const MCOperand &GetPcPair = GetPc.Inst.getOperand(0);
+  const MCOperand &SetPcPair = SetPc.Inst.getOperand(0);
+  const MCOperand &DeltaDst = MakeDelta.Inst.getOperand(0);
+  if (!GetPcPair.isReg() || !GetPcPair.getReg() || !SetPcPair.isReg() ||
+      SetPcPair.getReg() != GetPcPair.getReg() || !DeltaDst.isReg() ||
+      !DeltaDst.getReg() || !FirstAddend || !SecondAddend)
+    return std::nullopt;
+
+  MCRegister Pair(GetPcPair.getReg());
+  MCRegister DeltaReg(DeltaDst.getReg());
+  if (Ctx.LS.MRI->regsOverlap(Pair, DeltaReg))
+    return std::nullopt;
+
+  auto SameRegOperand = [](const MCInst &Inst, unsigned OperandIndex,
+                           MCRegister Reg) {
+    return Inst.getOperand(OperandIndex).isReg() &&
+           Inst.getOperand(OperandIndex).getReg() == Reg;
+  };
+
+  if (!AddLow.Inst.getOperand(0).isReg() ||
+      !AddLow.Inst.getOperand(0).getReg() ||
+      !AddHigh.Inst.getOperand(0).isReg() ||
+      !AddHigh.Inst.getOperand(0).getReg())
+    return std::nullopt;
+  MCRegister Low(AddLow.Inst.getOperand(0).getReg());
+  MCRegister High(AddHigh.Inst.getOperand(0).getReg());
+  if (!SameRegOperand(AddLow.Inst, 1, Low) ||
+      !SameRegOperand(AddLow.Inst, 2, DeltaReg) ||
+      !SameRegOperand(AddHigh.Inst, 1, High) ||
+      !AddHigh.Inst.getOperand(2).isImm() ||
+      AddHigh.Inst.getOperand(2).getImm() != 0)
+    return std::nullopt;
+
+  std::optional<unsigned> LowIndex = getSgprIndex(Low, *Ctx.LS.MRI);
+  std::optional<unsigned> HighIndex = getSgprIndex(High, *Ctx.LS.MRI);
+  if (!LowIndex || !HighIndex || *HighIndex != *LowIndex + 1 ||
+      !Ctx.LS.MRI->regsOverlap(Low, Pair) ||
+      !Ctx.LS.MRI->regsOverlap(High, Pair))
+    return std::nullopt;
+
+  uint32_t Delta = *FirstAddend + *SecondAddend;
+  std::optional<uint64_t> PcValue = checkedAddUint64(
+      GetPc.Offset, GetPc.Size, "tensor CFG reusable-PC instruction");
+  if (!PcValue)
+    return std::nullopt;
+  std::optional<uint64_t> Target =
+      checkedAddUint64(*PcValue, Delta, "tensor CFG reusable-PC target");
+  if (!Target)
+    return std::nullopt;
+  return TensorLocalSetPcResolution{*Target, SetPcIndex - 4, SetPcIndex,
+                                    TensorLocalSetPcShape::Linear};
+}
+
+// Resolve Tensile's signed-direction reusable-PC transfer. Both arms compute
+// the same modulo-2^64 target:
+//
+//   s_get_pc_i64 Pair
+//   s_add_co_i32 Delta, Imm0, Imm1
+//   s_cmp_ge_i32 Delta, 0
+//   s_cbranch_scc1 Positive
+//   s_abs_i32 Delta, Delta
+//   s_sub_co_u32 Pair.lo, Pair.lo, Delta
+//   s_sub_co_ci_u32 Pair.hi, Pair.hi, 0
+//   s_set_pc_i64 Pair
+// Positive:
+//   s_add_co_u32 Pair.lo, Pair.lo, Delta
+//   s_add_co_ci_u32 Pair.hi, Pair.hi, 0
+//   s_set_pc_i64 Pair
+//
+// The caller separately verifies that no control-flow edge enters either arm
+// or the materialization interior.
+std::optional<TensorLocalSetPcResolution>
+resolveTensorSignedSetPcTarget(const PatchContext &Ctx, size_t SetPcIndex,
+                               size_t BeginIndex, size_t EndIndex,
+                               const ElfView::FunctionTextRange &Range) {
+  for (size_t SetPcPosition : {size_t{7}, size_t{10}}) {
+    if (SetPcIndex < BeginIndex || SetPcIndex - BeginIndex < SetPcPosition)
+      continue;
+    size_t FirstIndex = SetPcIndex - SetPcPosition;
+    if (FirstIndex > EndIndex || EndIndex - FirstIndex <= 10)
+      continue;
+
+    const InternalDecodedInst &GetPc = Ctx.Decoded[FirstIndex];
+    const InternalDecodedInst &MakeDelta = Ctx.Decoded[FirstIndex + 1];
+    const InternalDecodedInst &Compare = Ctx.Decoded[FirstIndex + 2];
+    const InternalDecodedInst &Branch = Ctx.Decoded[FirstIndex + 3];
+    const InternalDecodedInst &Abs = Ctx.Decoded[FirstIndex + 4];
+    const InternalDecodedInst &SubLow = Ctx.Decoded[FirstIndex + 5];
+    const InternalDecodedInst &SubHigh = Ctx.Decoded[FirstIndex + 6];
+    const InternalDecodedInst &NegativeSetPc = Ctx.Decoded[FirstIndex + 7];
+    const InternalDecodedInst &AddLow = Ctx.Decoded[FirstIndex + 8];
+    const InternalDecodedInst &AddHigh = Ctx.Decoded[FirstIndex + 9];
+    const InternalDecodedInst &PositiveSetPc = Ctx.Decoded[FirstIndex + 10];
+
+    bool AllDecodedAndAdjacent = true;
+    for (size_t I = FirstIndex; I <= FirstIndex + 10; ++I) {
+      if (!Ctx.Decoded[I].DecodeSucceeded) {
+        AllDecodedAndAdjacent = false;
+        break;
+      }
+      if (I == FirstIndex + 10)
+        continue;
+      const InternalDecodedInst &Current = Ctx.Decoded[I];
+      if (Current.Offset >
+              std::numeric_limits<uint64_t>::max() - Current.Size ||
+          Current.Offset + Current.Size != Ctx.Decoded[I + 1].Offset) {
+        AllDecodedAndAdjacent = false;
+        break;
+      }
+    }
+    if (!AllDecodedAndAdjacent || GetPc.Offset < Range.Begin ||
+        PositiveSetPc.Offset >= Range.End ||
+        PositiveSetPc.Size > Range.End - PositiveSetPc.Offset ||
+        GetPc.Inst.getOpcode() != Ctx.LS.SGetPcI64Opcode ||
+        GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+        !GetPc.Inst.getOperand(0).getReg() ||
+        MakeDelta.Mnemonic != "s_add_co_i32" ||
+        MakeDelta.Inst.getNumOperands() != 3 ||
+        !MakeDelta.Inst.getOperand(0).isReg() ||
+        !MakeDelta.Inst.getOperand(0).getReg() ||
+        !MakeDelta.Inst.getOperand(2).isImm())
+      continue;
+
+    MCRegister Pair(GetPc.Inst.getOperand(0).getReg());
+    MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
+    if (Ctx.LS.MRI->regsOverlap(DeltaReg, Pair) ||
+        Compare.Mnemonic != "s_cmp_ge_i32" ||
+        Compare.Inst.getNumOperands() != 2 ||
+        !isExactTensorRegisterOperand(Compare.Inst, 0, DeltaReg) ||
+        !Compare.Inst.getOperand(1).isImm() ||
+        Compare.Inst.getOperand(1).getImm() != 0 ||
+        Branch.Mnemonic != "s_cbranch_scc1" || Abs.Mnemonic != "s_abs_i32" ||
+        Abs.Inst.getNumOperands() != 2 ||
+        !isExactTensorRegisterOperand(Abs.Inst, 0, DeltaReg) ||
+        !isExactTensorRegisterOperand(Abs.Inst, 1, DeltaReg) ||
+        NegativeSetPc.Inst.getOpcode() != Ctx.LS.SSetPcI64Opcode ||
+        NegativeSetPc.Inst.getNumOperands() != 1 ||
+        !isExactTensorRegisterOperand(NegativeSetPc.Inst, 0, Pair) ||
+        PositiveSetPc.Inst.getOpcode() != Ctx.LS.SSetPcI64Opcode ||
+        PositiveSetPc.Inst.getNumOperands() != 1 ||
+        !isExactTensorRegisterOperand(PositiveSetPc.Inst, 0, Pair))
+      continue;
+
+    uint64_t PositiveTarget = 0;
+    if (!Ctx.LS.MIA->evaluateBranch(Branch.Inst, Branch.Offset, Branch.Size,
+                                    PositiveTarget) ||
+        PositiveTarget != AddLow.Offset)
+      continue;
+
+    auto MatchesPairArithmetic = [&](const InternalDecodedInst &Low,
+                                     const InternalDecodedInst &High,
+                                     StringRef LowMnemonic,
+                                     StringRef HighMnemonic) {
+      if (Low.Mnemonic != LowMnemonic || High.Mnemonic != HighMnemonic ||
+          Low.Inst.getNumOperands() != 3 || !Low.Inst.getOperand(0).isReg() ||
+          !Low.Inst.getOperand(1).isReg() || !Low.Inst.getOperand(0).getReg() ||
+          Low.Inst.getOperand(0).getReg() != Low.Inst.getOperand(1).getReg() ||
+          !isExactTensorRegisterOperand(Low.Inst, 2, DeltaReg) ||
+          High.Inst.getNumOperands() != 3 || !High.Inst.getOperand(0).isReg() ||
+          !High.Inst.getOperand(1).isReg() ||
+          !High.Inst.getOperand(0).getReg() ||
+          High.Inst.getOperand(0).getReg() !=
+              High.Inst.getOperand(1).getReg() ||
+          !High.Inst.getOperand(2).isImm() ||
+          High.Inst.getOperand(2).getImm() != 0)
+        return false;
+      MCRegister LowReg(Low.Inst.getOperand(0).getReg());
+      MCRegister HighReg(High.Inst.getOperand(0).getReg());
+      std::optional<unsigned> LowIndex = getSgprIndex(LowReg, *Ctx.LS.MRI);
+      std::optional<unsigned> HighIndex = getSgprIndex(HighReg, *Ctx.LS.MRI);
+      return LowIndex && HighIndex && *HighIndex == *LowIndex + 1 &&
+             Ctx.LS.MRI->regsOverlap(LowReg, Pair) &&
+             Ctx.LS.MRI->regsOverlap(HighReg, Pair);
+    };
+    if (!MatchesPairArithmetic(SubLow, SubHigh, "s_sub_co_u32",
+                               "s_sub_co_ci_u32") ||
+        !MatchesPairArithmetic(AddLow, AddHigh, "s_add_co_u32",
+                               "s_add_co_ci_u32"))
+      continue;
+
+    std::optional<uint32_t> FirstAddend =
+        evaluateTensorUint32Operand(MakeDelta.Inst.getOperand(1));
+    if (!FirstAddend)
+      continue;
+    uint32_t DeltaBits =
+        *FirstAddend +
+        static_cast<uint32_t>(MakeDelta.Inst.getOperand(2).getImm());
+    int64_t SignedDelta = static_cast<int32_t>(DeltaBits);
+    std::optional<uint64_t> PcValue = checkedAddUint64(
+        GetPc.Offset, GetPc.Size, "tensor CFG signed reusable-PC value");
+    if (!PcValue)
+      continue;
+    uint64_t Target = *PcValue + static_cast<uint64_t>(SignedDelta);
+    return TensorLocalSetPcResolution{Target, FirstIndex, FirstIndex + 10,
+                                      TensorLocalSetPcShape::SignedTwoArm};
+  }
+  return std::nullopt;
+}
+
 std::optional<TensorFunctionCfg>
 buildTensorFunctionCfg(const PatchContext &Ctx,
                        const ElfView::FunctionTextRange &Range) {
@@ -1091,8 +1376,21 @@ buildTensorFunctionCfg(const PatchContext &Ctx,
   while (EndIndex < Ctx.Decoded.size() &&
          Ctx.Decoded[EndIndex].Offset < Range.End)
     ++EndIndex;
-  if (BeginIndex == EndIndex || Ctx.Decoded[BeginIndex].Offset != Range.Begin)
+  if (BeginIndex == EndIndex || Ctx.Decoded[BeginIndex].Offset != Range.Begin) {
+    log() << "hotswap: tensor CFG rejected range [0x" << utohexstr(Range.Begin)
+          << ", 0x" << utohexstr(Range.End)
+          << "): range does not begin at a decoded instruction\n";
     return std::nullopt;
+  }
+  for (uint64_t Entry : Ctx.DeclaredEntries) {
+    if (Entry <= Range.Begin || Entry >= Range.End)
+      continue;
+    log() << "hotswap: tensor CFG rejected range [0x" << utohexstr(Range.Begin)
+          << ", 0x" << utohexstr(Range.End)
+          << "): declared entry at interior offset 0x" << utohexstr(Entry)
+          << "\n";
+    return std::nullopt;
+  }
 
   TensorFunctionCfg Graph;
   Graph.BeginIndex = BeginIndex;
@@ -1104,10 +1402,50 @@ buildTensorFunctionCfg(const PatchContext &Ctx,
   for (size_t I = BeginIndex; I < EndIndex; ++I)
     IndexAtOffset[Ctx.Decoded[I].Offset] = I - BeginIndex;
 
+  struct PendingLocalSetPc {
+    size_t FirstLocalIndex;
+    size_t LastLocalIndex;
+    size_t SetPcLocalIndex;
+    std::optional<size_t> TargetLocalIndex;
+    TensorLocalSetPcShape Shape;
+    bool Audited;
+  };
+  SmallVector<PendingLocalSetPc, 2> PendingLocalSetPcs;
+
+  auto AddAuditedBoundedEdges =
+      [&](size_t LocalIndex,
+          const InternalDecodedInst &DI) -> std::optional<bool> {
+    auto Bounded = Ctx.DirectControlFlow.BoundedIndirectTargets.find(DI.Offset);
+    if (Bounded == Ctx.DirectControlFlow.BoundedIndirectTargets.end())
+      return std::nullopt;
+    for (uint64_t Target : Bounded->second) {
+      if (Target < Range.Begin || Target >= Range.End) {
+        log() << "hotswap: tensor CFG rejected bounded transfer at 0x"
+              << utohexstr(DI.Offset) << " with out-of-range target 0x"
+              << utohexstr(Target) << "\n";
+        return false;
+      }
+      DenseMap<uint64_t, size_t>::const_iterator TargetIt =
+          IndexAtOffset.find(Target);
+      if (TargetIt == IndexAtOffset.end()) {
+        log() << "hotswap: tensor CFG rejected bounded transfer at 0x"
+              << utohexstr(DI.Offset) << " with non-boundary target 0x"
+              << utohexstr(Target) << "\n";
+        return false;
+      }
+      Graph.addEdge(LocalIndex, TargetIt->second);
+    }
+    return true;
+  };
+
   for (size_t I = BeginIndex; I < EndIndex; ++I) {
     const InternalDecodedInst &DI = Ctx.Decoded[I];
-    if (!DI.DecodeSucceeded)
+    if (!DI.DecodeSucceeded) {
+      log() << "hotswap: tensor CFG rejected range [0x"
+            << utohexstr(Range.Begin) << ", 0x" << utohexstr(Range.End)
+            << "): undecoded instruction at 0x" << utohexstr(DI.Offset) << "\n";
       return std::nullopt;
+    }
 
     size_t LocalIndex = I - BeginIndex;
     bool HasFallthrough = I + 1 < EndIndex;
@@ -1115,40 +1453,251 @@ buildTensorFunctionCfg(const PatchContext &Ctx,
         DI.Inst.getOpcode() == Ctx.LS.SEndPgmSavedOpcode)
       continue;
 
-    if (Ctx.LS.MIA->isCall(DI.Inst) || Ctx.LS.MIA->isIndirectBranch(DI.Inst) ||
-        Ctx.LS.MIA->isReturn(DI.Inst))
+    // Calls return to the next instruction, so retain their local fallthrough
+    // edge.  The reaching-definition checks below reject a call only while a
+    // changed descriptor or SCC value is live; a call elsewhere in a broad
+    // symbol-less function range must not make an otherwise local proof fail.
+    if (Ctx.LS.MIA->isCall(DI.Inst)) {
+      if (!HasFallthrough) {
+        log() << "hotswap: tensor CFG rejected call without fallthrough at 0x"
+              << utohexstr(DI.Offset) << "\n";
+        return std::nullopt;
+      }
+      Graph.addEdge(LocalIndex, LocalIndex + 1);
+      continue;
+    }
+
+    if (Ctx.LS.MIA->isIndirectBranch(DI.Inst) ||
+        Ctx.LS.MIA->isReturn(DI.Inst)) {
+      std::optional<bool> Added = AddAuditedBoundedEdges(LocalIndex, DI);
+      if (Added) {
+        if (!*Added)
+          return std::nullopt;
+        continue;
+      }
+      log() << "hotswap: tensor CFG rejected unresolved control flow at 0x"
+            << utohexstr(DI.Offset) << " (" << DI.Mnemonic << ")\n";
       return std::nullopt;
+    }
 
     if (Ctx.LS.MIA->isBranch(DI.Inst)) {
       uint64_t Target = 0;
-      if (!Ctx.LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target))
-        return std::nullopt;
+      bool ResolvedSetPc = false;
+      if (!Ctx.LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target)) {
+        std::optional<TensorLocalSetPcResolution> SetPc =
+            resolveTensorLinearSetPcTarget(Ctx, I, BeginIndex, Range);
+        if (!SetPc)
+          SetPc = resolveTensorSignedSetPcTarget(Ctx, I, BeginIndex, EndIndex,
+                                                 Range);
+        bool AuditedSetPc = false;
+        if (SetPc) {
+          auto Audited =
+              Ctx.DirectControlFlow.BoundedIndirectTargets.find(DI.Offset);
+          AuditedSetPc =
+              Audited != Ctx.DirectControlFlow.BoundedIndirectTargets.end() &&
+              Audited->second.size() == 1 &&
+              Audited->second.front() == SetPc->Target;
+        }
+        if (SetPc) {
+          Target = SetPc->Target;
+          ResolvedSetPc = true;
+          PendingLocalSetPcs.push_back({SetPc->SequenceBeginIndex - BeginIndex,
+                                        SetPc->SequenceEndIndex - BeginIndex,
+                                        LocalIndex, std::nullopt, SetPc->Shape,
+                                        AuditedSetPc});
+        } else {
+          std::optional<bool> Added = AddAuditedBoundedEdges(LocalIndex, DI);
+          if (Added) {
+            if (!*Added)
+              return std::nullopt;
+            continue;
+          }
+          log() << "hotswap: tensor CFG rejected unresolved branch at 0x"
+                << utohexstr(DI.Offset) << " (" << DI.Mnemonic << ")\n";
+          return std::nullopt;
+        }
+      }
+
+      std::optional<size_t> TargetLocalIndex;
       if (Target != Range.End) {
         DenseMap<uint64_t, size_t>::const_iterator TargetIt =
             IndexAtOffset.find(Target);
-        if (TargetIt == IndexAtOffset.end())
+        if (TargetIt == IndexAtOffset.end()) {
+          log() << "hotswap: tensor CFG rejected non-local branch target 0x"
+                << utohexstr(Target) << " from 0x" << utohexstr(DI.Offset)
+                << "\n";
           return std::nullopt;
-        Graph.addEdge(LocalIndex, TargetIt->second);
+        }
+        TargetLocalIndex = TargetIt->second;
       }
 
+      if (ResolvedSetPc) {
+        PendingLocalSetPcs.back().TargetLocalIndex = TargetLocalIndex;
+        continue;
+      }
+      if (TargetLocalIndex)
+        Graph.addEdge(LocalIndex, *TargetLocalIndex);
+
       if (Ctx.LS.MIA->isConditionalBranch(DI.Inst)) {
-        if (!HasFallthrough)
+        if (!HasFallthrough) {
+          log() << "hotswap: tensor CFG rejected conditional branch without "
+                   "fallthrough at 0x"
+                << utohexstr(DI.Offset) << "\n";
           return std::nullopt;
+        }
         Graph.addEdge(LocalIndex, LocalIndex + 1);
       } else if (!Ctx.LS.MIA->isUnconditionalBranch(DI.Inst)) {
+        log() << "hotswap: tensor CFG rejected unclassified branch at 0x"
+              << utohexstr(DI.Offset) << "\n";
         return std::nullopt;
       }
       continue;
     }
 
     const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
-    if (Desc.mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
+    if (Desc.mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI)) {
+      log() << "hotswap: tensor CFG rejected control-flow instruction at 0x"
+            << utohexstr(DI.Offset) << " (" << DI.Mnemonic << ")\n";
       return std::nullopt;
+    }
     if (HasFallthrough)
       Graph.addEdge(LocalIndex, LocalIndex + 1);
   }
 
+  // Add every resolved transfer before validating sequence interiors so a
+  // second reusable-PC jump targeting another sequence's interior is visible
+  // as an alternate predecessor too.
+  for (const PendingLocalSetPc &Pending : PendingLocalSetPcs)
+    if (Pending.TargetLocalIndex)
+      Graph.addEdge(Pending.SetPcLocalIndex, *Pending.TargetLocalIndex);
+
+  // Entering after s_get_pc_i64 can reuse stale pair/delta state, invalidating
+  // the computed target. Require every sequence-interior instruction to have
+  // only its exact arm predecessor as an entry. The signed form's positive
+  // add arm is entered by its conditional branch; every other instruction is
+  // entered by its immediate predecessor. This rejects direct targets, call
+  // continuations, function entry, and targets from another recognized
+  // reusable-PC transfer.
+  for (const PendingLocalSetPc &Pending : PendingLocalSetPcs) {
+    for (size_t LocalIndex = Pending.FirstLocalIndex + 1;
+         LocalIndex <= Pending.LastLocalIndex; ++LocalIndex) {
+      size_t ExpectedPredecessor = LocalIndex - 1;
+      if (Pending.Shape == TensorLocalSetPcShape::SignedTwoArm &&
+          LocalIndex == Pending.FirstLocalIndex + 8)
+        ExpectedPredecessor = Pending.FirstLocalIndex + 3;
+      ArrayRef<size_t> Predecessors = Graph.Predecessors[LocalIndex];
+      if (Predecessors.size() == 1 &&
+          Predecessors.front() == ExpectedPredecessor)
+        continue;
+      const InternalDecodedInst &Interior =
+          Ctx.Decoded[BeginIndex + LocalIndex];
+      log() << "hotswap: tensor CFG rejected alternate entry into reusable-PC "
+               "sequence at 0x"
+            << utohexstr(Interior.Offset) << "\n";
+      return std::nullopt;
+    }
+    if (!Pending.Audited) {
+      const InternalDecodedInst &SetPc =
+          Ctx.Decoded[BeginIndex + Pending.SetPcLocalIndex];
+      log() << "hotswap: tensor CFG rejected unaudited reusable-PC transfer at "
+               "0x"
+            << utohexstr(SetPc.Offset) << "\n";
+      return std::nullopt;
+    }
+  }
+
   return Graph;
+}
+
+bool writesBaseWithKnownZeroLow16(const InternalDecodedInst &DI,
+                                  MCRegister BaseMCReg, const LLVMState &LS) {
+  const MCInst &Inst = DI.Inst;
+  if (Inst.getNumOperands() < 2 || !Inst.getOperand(0).isReg() ||
+      !Inst.getOperand(0).getReg() ||
+      !LS.MRI->regsOverlap(MCRegister(Inst.getOperand(0).getReg()), BaseMCReg))
+    return false;
+
+  if (DI.Mnemonic == "s_mov_b32")
+    return Inst.getOperand(1).isImm() &&
+           (static_cast<uint64_t>(Inst.getOperand(1).getImm()) & 0xffffu) == 0;
+
+  // An immediate AND with zeros in bits [15:0] forces the result's low half
+  // to zero regardless of the other input.
+  return Inst.getOpcode() == LS.SAndB32Opcode && Inst.getNumOperands() >= 3 &&
+         Inst.getOperand(2).isImm() &&
+         (static_cast<uint64_t>(Inst.getOperand(2).getImm()) & 0xffffu) == 0;
+}
+
+// Prove that the descriptor base already has a zero workgroup_mask at the
+// tensor. Walk every reachable predecessor path backward. A path is complete
+// only at an immediate zero definition (or zero-forcing AND); otherwise it may
+// cross exact self-writes that cannot introduce a low bit. Calls, unresolved
+// control flow, non-preserving definitions, and entry without a proven
+// definition all reject. Reads are harmless because this proof changes no
+// value.
+bool isTensorMaskAlreadyZero(const PatchContext &Ctx, size_t TensorIdx,
+                             MCRegister BaseMCReg) {
+  const InternalDecodedInst &Tensor = Ctx.Decoded[TensorIdx];
+  std::optional<ElfView::FunctionTextRange> Range =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Tensor.Offset);
+  if (!Range)
+    return false;
+
+  std::optional<TensorFunctionCfg> Graph = buildTensorFunctionCfg(Ctx, *Range);
+  if (!Graph || TensorIdx < Graph->BeginIndex || TensorIdx >= Graph->EndIndex)
+    return false;
+
+  size_t TensorLocal = TensorIdx - Graph->BeginIndex;
+  SmallVector<uint8_t, 32> Reachable(Graph->Successors.size(), 0);
+  SmallVector<size_t, 16> Worklist;
+  Worklist.push_back(0);
+  while (!Worklist.empty()) {
+    size_t LocalIndex = Worklist.pop_back_val();
+    if (Reachable[LocalIndex] != 0)
+      continue;
+    Reachable[LocalIndex] = 1;
+    for (size_t Successor : Graph->Successors[LocalIndex])
+      Worklist.push_back(Successor);
+  }
+  if (Reachable[TensorLocal] == 0)
+    return false;
+
+  SmallVector<uint8_t, 32> Visited(Graph->Successors.size(), 0);
+  for (size_t Predecessor : Graph->Predecessors[TensorLocal])
+    if (Reachable[Predecessor] != 0)
+      Worklist.push_back(Predecessor);
+  if (Worklist.empty())
+    return false;
+
+  while (!Worklist.empty()) {
+    size_t LocalIndex = Worklist.pop_back_val();
+    if (Visited[LocalIndex] != 0)
+      continue;
+    Visited[LocalIndex] = 1;
+
+    const InternalDecodedInst &DI = Ctx.Decoded[Graph->BeginIndex + LocalIndex];
+    if (Ctx.LS.MIA->isCall(DI.Inst))
+      return false;
+
+    if (instructionDefinesBase(DI, BaseMCReg, Ctx.LS)) {
+      if (writesBaseWithKnownZeroLow16(DI, BaseMCReg, Ctx.LS))
+        continue;
+      if (!writesBasePreservingZeroLow16(DI, BaseMCReg, Ctx.LS))
+        return false;
+    }
+
+    bool HasReachablePredecessor = false;
+    for (size_t Predecessor : Graph->Predecessors[LocalIndex]) {
+      if (Reachable[Predecessor] == 0)
+        continue;
+      HasReachablePredecessor = true;
+      Worklist.push_back(Predecessor);
+    }
+    if (!HasReachablePredecessor)
+      return false;
+  }
+
+  return true;
 }
 
 bool isMaskDefinitionSafe(const PatchContext &Ctx,
@@ -1179,14 +1728,27 @@ bool isMaskDefinitionSafe(const PatchContext &Ctx,
     const InternalDecodedInst &DI = Ctx.Decoded[Graph.BeginIndex + LocalIndex];
     const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
 
+    if (Ctx.LS.MIA->isCall(DI.Inst)) {
+      log() << "hotswap: tensor mask definition 0x"
+            << utohexstr(Ctx.Decoded[MaskIndex].Offset)
+            << " rejected: call while descriptor state is live at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return false;
+    }
+
     bool PreservesBaseValue =
         (State & BaseValueLive) != 0 &&
         writesBasePreservingZeroLow16(DI, BaseMCReg, Ctx.LS);
     if ((State & BaseValueLive) != 0) {
       if (!PreservesBaseValue) {
         if (instructionReadsRegister(DI, BaseMCReg, Ctx.LS) &&
-            !isTensorDescriptorUseOnly(DI, BaseMCReg, Ctx.LS))
+            !isTensorDescriptorUseOnly(DI, BaseMCReg, Ctx.LS)) {
+          log() << "hotswap: tensor mask definition 0x"
+                << utohexstr(Ctx.Decoded[MaskIndex].Offset)
+                << " rejected: descriptor base read at 0x"
+                << utohexstr(DI.Offset) << " by " << DI.Mnemonic << "\n";
           return false;
+        }
         if (instructionDefinesBase(DI, BaseMCReg, Ctx.LS))
           State &= ~BaseValueLive;
       }
@@ -1195,8 +1757,13 @@ bool isMaskDefinitionSafe(const PatchContext &Ctx,
     // A preserving writer propagates the changed base and may derive a changed
     // SCC value from it, so its SCC definition does not end the safety check.
     if ((State & SccValueLive) != 0) {
-      if (instReadsScc(DI.Inst, Desc, *Ctx.LS.MRI))
+      if (instReadsScc(DI.Inst, Desc, *Ctx.LS.MRI)) {
+        log() << "hotswap: tensor mask definition 0x"
+              << utohexstr(Ctx.Decoded[MaskIndex].Offset)
+              << " rejected: changed SCC read at 0x" << utohexstr(DI.Offset)
+              << " by " << DI.Mnemonic << "\n";
         return false;
+      }
       if (instWritesScc(DI.Inst, Desc, *Ctx.LS.MRI) && !PreservesBaseValue)
         State &= ~SccValueLive;
     } else if (PreservesBaseValue &&
@@ -1266,6 +1833,13 @@ TensorMaskDef findTensorMaskSetDefinitions(const PatchContext &Ctx,
 
     size_t InstIndex = Graph->BeginIndex + LocalIndex;
     const InternalDecodedInst &DI = Ctx.Decoded[InstIndex];
+    if (Ctx.LS.MIA->isCall(DI.Inst)) {
+      log() << "hotswap: tensor mask definition search for tensor 0x"
+            << utohexstr(Tensor.Offset) << " rejected: call at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      return TensorMaskDef::NotApplicable;
+    }
+
     bool PreservesBaseValue =
         writesBasePreservingZeroLow16(DI, BaseMCReg, Ctx.LS);
     if (instructionDefinesBase(DI, BaseMCReg, Ctx.LS)) {
@@ -1277,13 +1851,23 @@ TensorMaskDef findTensorMaskSetDefinitions(const PatchContext &Ctx,
       if (isClearedMaskAndOnBase(DI, BaseMCReg, Ctx.LS))
         continue;
       if (!PreservesBaseValue)
+        log() << "hotswap: tensor mask definition search for tensor 0x"
+              << utohexstr(Tensor.Offset)
+              << " rejected: non-preserving base definition at 0x"
+              << utohexstr(DI.Offset) << " by " << DI.Mnemonic << "\n";
+      if (!PreservesBaseValue)
         return TensorMaskDef::NotApplicable;
     }
 
     if (!PreservesBaseValue &&
         instructionReadsRegister(DI, BaseMCReg, Ctx.LS) &&
-        !isTensorDescriptorUseOnly(DI, BaseMCReg, Ctx.LS))
+        !isTensorDescriptorUseOnly(DI, BaseMCReg, Ctx.LS)) {
+      log() << "hotswap: tensor mask definition search for tensor 0x"
+            << utohexstr(Tensor.Offset)
+            << " rejected: descriptor base read at 0x" << utohexstr(DI.Offset)
+            << " by " << DI.Mnemonic << "\n";
       return TensorMaskDef::NotApplicable;
+    }
 
     bool HasReachablePredecessor = false;
     for (size_t Predecessor : Graph->Predecessors[LocalIndex]) {
@@ -1432,6 +2016,13 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
 
   if (isAlreadyTensorMaskPatched(Ctx, Idx, BaseMCReg))
     return false;
+
+  if (isTensorMaskAlreadyZero(Ctx, Idx, BaseMCReg)) {
+    log() << "hotswap: tensor_load_to_lds: descriptor workgroup_mask is "
+             "already zero on every path\n";
+    DI.Mnemonic = "<replaced>";
+    return false;
+  }
 
   SmallVector<size_t> MaskSets;
   TensorMaskDef Result =

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -34,9 +34,12 @@
 /// Each pass's block-32 scale is a byte-gather of the block-16 scale bytes:
 /// even bytes feed the low subblocks, odd bytes the high ones.
 ///
-/// The masked A copy lands in a contiguous VGPR block allocated above the
-/// kernel's VGPR count and below MaxVgprs (256 on GFX1250), so it stays in VGPR
-/// bank 0 and needs no s_set_vgpr_msb switch.
+/// The replacement is assembled from textual register names, for which the
+/// AMDGPU parser accepts v0-v255. Scratch may nevertheless live above v255:
+/// the generated assembly encodes each scratch VGPR's low byte and brackets
+/// mixed-bank instructions with role-specific s_set_vgpr_msb transitions.
+/// Matrix B is copied into the scratch bank so the lowered WMMA can use one
+/// src1 bank for both its gathered scale and matrix-B operands.
 ///
 /// Fail-closed fallback: when the scratch budget (A-width VGPRs plus a few
 /// scale/temp VGPRs and one scratch SGPR) is unavailable, the pass marks the
@@ -56,6 +59,8 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <initializer_list>
+
 using namespace llvm;
 
 namespace COMGR {
@@ -68,8 +73,13 @@ static constexpr unsigned VOP3PXSize = 16;
 
 // AMDGPU SRC operand encoding: VGPRs are 256 + N.
 static constexpr unsigned VgprEncBase = 256;
+static constexpr unsigned VgprBankSize = 256;
 
 static std::string vgprName(unsigned N) { return ("v" + Twine(N)).str(); }
+
+static std::string encodedVgprName(unsigned Physical) {
+  return vgprName(Physical % VgprBankSize);
+}
 
 static bool isVgprEncoding(unsigned Enc) { return Enc >= VgprEncBase; }
 
@@ -105,6 +115,7 @@ static void writeScaleSrc1(uint8_t *Raw, unsigned Enc) {
 // -- Base WMMA uop field accessors (bytes 8-15) ------------------------------
 //   VDST: byte[8] (8-bit raw VGPR number, no +256)
 //   SRC0: byte[12] + byte[13] bit[0] (9-bit; matrix A)
+//   SRC1: byte[13] bits[7:1] + byte[14] bits[1:0] (9-bit; matrix B)
 //   SRC2: byte[14] bits[7:2] + byte[15] bits[2:0] (9-bit; accumulator C)
 
 static unsigned extractVdst(const uint8_t *Raw) { return Raw[8]; }
@@ -112,6 +123,11 @@ static unsigned extractVdst(const uint8_t *Raw) { return Raw[8]; }
 static void writeSrc0(uint8_t *Raw, unsigned Enc) {
   Raw[12] = Enc & 0xFF;
   Raw[13] = (Raw[13] & 0xFE) | ((Enc >> 8) & 0x01);
+}
+
+static void writeSrc1(uint8_t *Raw, unsigned Enc) {
+  Raw[13] = (Raw[13] & 0x01) | ((Enc & 0x7F) << 1);
+  Raw[14] = (Raw[14] & 0xFC) | ((Enc >> 7) & 0x03);
 }
 
 static void writeSrc2(uint8_t *Raw, unsigned Enc) {
@@ -162,28 +178,105 @@ static SmallVector<uint8_t> rewriteScale16ToScale(const uint8_t *OrigRaw,
 // (odd byte 2j+1) for pass-high, packed into one VGPR as
 // [byte0..3] = k-block 0..3.
 
-static void emitGatherEven(raw_string_ostream &OS, StringRef Lo, StringRef Hi,
-                           StringRef Dst, StringRef T) {
-  // Dst = { Lo[7:0], Lo[23:16], Hi[7:0], Hi[23:16] } (bytes 0,2,4,6)
-  OS << "v_and_b32 " << Dst << ", 0xff, " << Lo << "\n";
-  OS << "v_bfe_u32 " << T << ", " << Lo << ", 16, 8\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 8, " << Dst << "\n";
-  OS << "v_and_b32 " << T << ", 0xff, " << Hi << "\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 16, " << Dst << "\n";
-  OS << "v_bfe_u32 " << T << ", " << Hi << ", 16, 8\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 24, " << Dst << "\n";
+using VgprBankRequirement = std::pair<VgprMsbOperand, unsigned>;
+
+static void
+emitModeForOperands(raw_string_ostream &OS, unsigned &CurrentMode,
+                    std::initializer_list<VgprBankRequirement> Requirements) {
+  unsigned NewMode = CurrentMode;
+  for (const VgprBankRequirement &Requirement : Requirements)
+    setVgprMsbBank(NewMode, Requirement.first, Requirement.second);
+  if (NewMode == CurrentMode)
+    return;
+  OS << "s_set_vgpr_msb " << (NewMode | (CurrentMode << 8)) << "\n";
+  CurrentMode = NewMode;
 }
 
-static void emitGatherOdd(raw_string_ostream &OS, StringRef Lo, StringRef Hi,
-                          StringRef Dst, StringRef T) {
+static void emitGatherEven(raw_string_ostream &OS, unsigned Lo, unsigned Hi,
+                           unsigned Dst, unsigned T, unsigned ScratchBank,
+                           unsigned &CurrentMode) {
+  std::string LoName = encodedVgprName(Lo);
+  std::string HiName = encodedVgprName(Hi);
+  std::string DstName = encodedVgprName(Dst);
+  std::string TName = encodedVgprName(T);
+
+  // Dst = { Lo[7:0], Lo[23:16], Hi[7:0], Hi[23:16] } (bytes 0,2,4,6)
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src1, Lo / VgprBankSize}});
+  OS << "v_and_b32 " << DstName << ", 0xff, " << LoName << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, Lo / VgprBankSize}});
+  OS << "v_bfe_u32 " << TName << ", " << LoName << ", 16, 8\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 8, " << DstName
+     << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src1, Hi / VgprBankSize}});
+  OS << "v_and_b32 " << TName << ", 0xff, " << HiName << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 16, " << DstName
+     << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, Hi / VgprBankSize}});
+  OS << "v_bfe_u32 " << TName << ", " << HiName << ", 16, 8\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 24, " << DstName
+     << "\n";
+}
+
+static void emitGatherOdd(raw_string_ostream &OS, unsigned Lo, unsigned Hi,
+                          unsigned Dst, unsigned T, unsigned ScratchBank,
+                          unsigned &CurrentMode) {
+  std::string LoName = encodedVgprName(Lo);
+  std::string HiName = encodedVgprName(Hi);
+  std::string DstName = encodedVgprName(Dst);
+  std::string TName = encodedVgprName(T);
+
   // Dst = { Lo[15:8], Lo[31:24], Hi[15:8], Hi[31:24] } (bytes 1,3,5,7)
-  OS << "v_bfe_u32 " << Dst << ", " << Lo << ", 8, 8\n";
-  OS << "v_bfe_u32 " << T << ", " << Lo << ", 24, 8\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 8, " << Dst << "\n";
-  OS << "v_bfe_u32 " << T << ", " << Hi << ", 8, 8\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 16, " << Dst << "\n";
-  OS << "v_lshrrev_b32 " << T << ", 24, " << Hi << "\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 24, " << Dst << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, Lo / VgprBankSize}});
+  OS << "v_bfe_u32 " << DstName << ", " << LoName << ", 8, 8\n";
+  OS << "v_bfe_u32 " << TName << ", " << LoName << ", 24, 8\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 8, " << DstName
+     << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, Hi / VgprBankSize}});
+  OS << "v_bfe_u32 " << TName << ", " << HiName << ", 8, 8\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 16, " << DstName
+     << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src1, Hi / VgprBankSize}});
+  OS << "v_lshrrev_b32 " << TName << ", 24, " << HiName << "\n";
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, ScratchBank},
+                       {VgprMsbOperand::Src0, ScratchBank},
+                       {VgprMsbOperand::Src2, ScratchBank}});
+  OS << "v_lshl_or_b32 " << DstName << ", " << TName << ", 24, " << DstName
+     << "\n";
 }
 
 // A' = mask ? A : 0, per lane, for W consecutive VGPRs from ABase into SBase.
@@ -193,11 +286,16 @@ static void emitGatherOdd(raw_string_ostream &OS, StringRef Lo, StringRef Hi,
 // high-16 in lanes 16-31, so a lane mask isolates a subblock.
 static void emitLaneMaskCopy(raw_string_ostream &OS, StringRef MaskSgpr,
                              uint32_t MaskImm, unsigned SBase, unsigned ABase,
-                             unsigned W) {
+                             unsigned W, unsigned ScratchBank,
+                             unsigned &CurrentMode) {
   OS << "s_mov_b32 " << MaskSgpr << ", 0x" << utohexstr(MaskImm) << "\n";
-  for (unsigned I = 0; I < W; ++I)
-    OS << "v_cndmask_b32_e64 " << vgprName(SBase + I) << ", 0, "
-       << vgprName(ABase + I) << ", " << MaskSgpr << "\n";
+  for (unsigned I = 0; I < W; ++I) {
+    emitModeForOperands(OS, CurrentMode,
+                        {{VgprMsbOperand::Dst, ScratchBank},
+                         {VgprMsbOperand::Src1, (ABase + I) / VgprBankSize}});
+    OS << "v_cndmask_b32_e64 " << encodedVgprName(SBase + I) << ", 0, "
+       << encodedVgprName(ABase + I) << ", " << MaskSgpr << "\n";
+  }
 }
 
 // A' keeps the VGPRs of the low (KeepLow=true) or high 16-K subblocks and zeros
@@ -210,25 +308,45 @@ static void emitLaneMaskCopy(raw_string_ostream &OS, StringRef MaskSgpr,
 // subblock's VGPRs instead.
 static void emitVgprSelectCopy(raw_string_ostream &OS, bool KeepLow,
                                unsigned SBase, unsigned ABase, unsigned W,
-                               unsigned SubW) {
+                               unsigned SubW, unsigned ScratchBank,
+                               unsigned &CurrentMode) {
   for (unsigned I = 0; I < W; ++I) {
     bool IsLow = ((I / SubW) % 2) == 0;
-    if (IsLow == KeepLow)
-      OS << "v_mov_b32 " << vgprName(SBase + I) << ", " << vgprName(ABase + I)
-         << "\n";
-    else
-      OS << "v_mov_b32 " << vgprName(SBase + I) << ", 0\n";
+    if (IsLow == KeepLow) {
+      emitModeForOperands(OS, CurrentMode,
+                          {{VgprMsbOperand::Dst, ScratchBank},
+                           {VgprMsbOperand::Src0, (ABase + I) / VgprBankSize}});
+      OS << "v_mov_b32 " << encodedVgprName(SBase + I) << ", "
+         << encodedVgprName(ABase + I) << "\n";
+    } else {
+      emitModeForOperands(OS, CurrentMode,
+                          {{VgprMsbOperand::Dst, ScratchBank}});
+      OS << "v_mov_b32 " << encodedVgprName(SBase + I) << ", 0\n";
+    }
   }
 }
 
-// Parse the matrix-A (src0) VGPR range from the printer's canonical form.
+static void emitVgprCopy(raw_string_ostream &OS, unsigned DstBase,
+                         unsigned SrcBase, unsigned W, unsigned ScratchBank,
+                         unsigned &CurrentMode) {
+  for (unsigned I = 0; I < W; ++I) {
+    emitModeForOperands(OS, CurrentMode,
+                        {{VgprMsbOperand::Dst, ScratchBank},
+                         {VgprMsbOperand::Src0, (SrcBase + I) / VgprBankSize}});
+    OS << "v_mov_b32 " << encodedVgprName(DstBase + I) << ", "
+       << encodedVgprName(SrcBase + I) << "\n";
+  }
+}
+
+// Parse a matrix VGPR range from the printer's canonical form.
 struct VgprRange {
   unsigned Base;
   unsigned Width;
 };
 
 static std::optional<VgprRange>
-matrixAOperandRange(PatchContext &Ctx, const InternalDecodedInst &DI) {
+matrixOperandRange(PatchContext &Ctx, const InternalDecodedInst &DI,
+                   unsigned OperandIndex) {
   SmallString<256> Buf;
   raw_svector_ostream OS(Buf);
   Ctx.LS.MCIP->printInst(&DI.Inst, /*Address=*/0, /*Annot=*/"", *Ctx.LS.STI,
@@ -238,17 +356,18 @@ matrixAOperandRange(PatchContext &Ctx, const InternalDecodedInst &DI) {
   if (MnemEnd == StringRef::npos)
     return std::nullopt;
   StringRef Rest = S.substr(MnemEnd).ltrim();
-  // Operand 0 = vdst, operand 1 = src0 (matrix A).
-  size_t Comma0 = Rest.find(',');
-  if (Comma0 == StringRef::npos)
+  for (unsigned I = 0; I < OperandIndex; ++I) {
+    size_t Comma = Rest.find(',');
+    if (Comma == StringRef::npos)
+      return std::nullopt;
+    Rest = Rest.substr(Comma + 1).ltrim();
+  }
+  size_t End = Rest.find(',');
+  StringRef Operand = (End == StringRef::npos) ? Rest : Rest.substr(0, End);
+  Operand = Operand.trim();
+  if (!Operand.starts_with("v[") || !Operand.ends_with("]"))
     return std::nullopt;
-  Rest = Rest.substr(Comma0 + 1).ltrim();
-  size_t Comma1 = Rest.find(',');
-  StringRef A = (Comma1 == StringRef::npos) ? Rest : Rest.substr(0, Comma1);
-  A = A.trim();
-  if (!A.starts_with("v[") || !A.ends_with("]"))
-    return std::nullopt;
-  StringRef Inside = A.drop_front(2).drop_back(1);
+  StringRef Inside = Operand.drop_front(2).drop_back(1);
   StringRef LoS, HiS;
   std::tie(LoS, HiS) = Inside.split(':');
   unsigned Lo = 0, Hi = 0;
@@ -329,14 +448,40 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   if (!ScaleABase || !ScaleBBase)
     return failClosed(Ctx, DI, "non-VGPR block-16 scale operand");
 
-  unsigned ScaleALo = *ScaleABase, ScaleAHi = ScaleALo + 1;
-  unsigned ScaleBLo = *ScaleBBase, ScaleBHi = ScaleBLo + 1;
+  std::optional<unsigned> ActiveMode = getActiveVgprMsbMode(Ctx, Idx);
+  // A compiler-emitted scale16 whose immediately preceding instruction sets
+  // the mode already depends on that setter for the original fused operands.
+  // Preserve that local contract when unrelated opaque control flow prevents
+  // object-wide mode recovery.
+  if (!ActiveMode)
+    ActiveMode = getLocallyEstablishedVgprMsbMode(Ctx, Idx);
+  if (!ActiveMode)
+    return failClosed(Ctx, DI, "cannot determine active VGPR-MSB mode");
 
-  std::optional<VgprRange> ARange = matrixAOperandRange(Ctx, DI);
-  if (!ARange)
-    return failClosed(Ctx, DI, "could not determine matrix-A VGPR range");
-  unsigned ABase = ARange->Base;
+  unsigned OrigSrc0Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0);
+  unsigned OrigSrc1Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1);
+  unsigned OrigDstBank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst);
+
+  unsigned ScaleALo = *ScaleABase + OrigSrc0Bank * VgprBankSize;
+  unsigned ScaleAHi = ScaleALo + 1;
+  unsigned ScaleBLo = *ScaleBBase + OrigSrc1Bank * VgprBankSize;
+  unsigned ScaleBHi = ScaleBLo + 1;
+  if (ScaleAHi >= Ctx.Config.MaxVgprs || ScaleBHi >= Ctx.Config.MaxVgprs)
+    return failClosed(Ctx, DI, "block-16 scale tuple exceeds VGPR capacity");
+
+  std::optional<VgprRange> ARange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/1);
+  std::optional<VgprRange> BRange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/2);
+  if (!ARange || !BRange)
+    return failClosed(Ctx, DI, "could not determine matrix-A/B VGPR ranges");
+  unsigned ABase = ARange->Base + OrigSrc0Bank * VgprBankSize;
   unsigned AWidth = ARange->Width;
+  unsigned BBase = BRange->Base + OrigSrc1Bank * VgprBankSize;
+  unsigned BWidth = BRange->Width;
+  if (ABase + AWidth > Ctx.Config.MaxVgprs ||
+      BBase + BWidth > Ctx.Config.MaxVgprs)
+    return failClosed(Ctx, DI, "matrix operand exceeds VGPR capacity");
 
   // The masking scheme depends on the matrix-A data format.
   std::optional<AMaskPlan> Plan = matrixAMaskPlan(Ctx, DI);
@@ -362,18 +507,28 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   VgprAllocator Alloc(Ctx.Liveness.liveBefore(Idx), KdCount,
                       Ctx.Config.MaxVgprs);
 
-  // Four block-32 scale VGPRs (A/B x low/high) plus one byte-extraction temp,
-  // then a contiguous, even-aligned block for the masked A copy.
-  std::optional<unsigned> ScaleAloReg = Alloc.alloc();
-  std::optional<unsigned> ScaleBloReg = Alloc.alloc();
-  std::optional<unsigned> ScaleAhiReg = Alloc.alloc();
-  std::optional<unsigned> ScaleBhiReg = Alloc.alloc();
-  std::optional<unsigned> TmpReg = Alloc.alloc();
-  std::optional<unsigned> SBase =
-      Alloc.allocContiguousAboveKd(AWidth, /*Align=*/2);
-  if (!ScaleAloReg || !ScaleBloReg || !ScaleAhiReg || !ScaleBhiReg || !TmpReg ||
-      !SBase)
-    return failClosed(Ctx, DI, "insufficient scratch VGPRs for exact K-split");
+  // Keep every generated operand in one physical VGPR bank. Five scalar
+  // temporaries precede an even-aligned masked-A block and a matrix-B copy.
+  // Copying B is necessary because both scale-B and matrix-B use the WMMA
+  // src1 VGPR-MSB field.
+  constexpr unsigned ScalarScratchCount = 5;
+  unsigned AOffset = (ScalarScratchCount + 1) & ~1u;
+  unsigned BOffset = AOffset + AWidth;
+  unsigned ScratchCount = BOffset + BWidth;
+  std::optional<unsigned> ScratchBase = Alloc.allocContiguousAboveKdInBank(
+      ScratchCount, /*Align=*/2, VgprBankSize);
+  if (!ScratchBase)
+    return failClosed(Ctx, DI,
+                      "no single-bank above-KD VGPR block for exact K-split");
+
+  unsigned ScaleAloReg = *ScratchBase;
+  unsigned ScaleBloReg = *ScratchBase + 1;
+  unsigned ScaleAhiReg = *ScratchBase + 2;
+  unsigned ScaleBhiReg = *ScratchBase + 3;
+  unsigned TmpReg = *ScratchBase + 4;
+  unsigned SBase = *ScratchBase + AOffset;
+  unsigned BCopyBase = *ScratchBase + BOffset;
+  unsigned ScratchBank = *ScratchBase / VgprBankSize;
 
   // The lane-mask scheme (FP8/BF8) needs one scratch SGPR for the wave-lane
   // bitmask; the VGPR-select scheme (FP4/FP6) uses plain v_mov and needs none.
@@ -389,52 +544,96 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   }
 
   // Preamble + pass-low masked copy (assembled together), then pass-high copy.
-  std::string PreAsm, HiAsm;
-  raw_string_ostream PreOS(PreAsm), HiOS(HiAsm);
+  std::string PreAsm, HiAsm, PostAsm;
+  raw_string_ostream PreOS(PreAsm), HiOS(HiAsm), PostOS(PostAsm);
+  unsigned PreMode = *ActiveMode;
 
-  emitGatherEven(PreOS, vgprName(ScaleALo), vgprName(ScaleAHi),
-                 vgprName(*ScaleAloReg), vgprName(*TmpReg));
-  emitGatherEven(PreOS, vgprName(ScaleBLo), vgprName(ScaleBHi),
-                 vgprName(*ScaleBloReg), vgprName(*TmpReg));
-  emitGatherOdd(PreOS, vgprName(ScaleALo), vgprName(ScaleAHi),
-                vgprName(*ScaleAhiReg), vgprName(*TmpReg));
-  emitGatherOdd(PreOS, vgprName(ScaleBLo), vgprName(ScaleBHi),
-                vgprName(*ScaleBhiReg), vgprName(*TmpReg));
+  emitGatherEven(PreOS, ScaleALo, ScaleAHi, ScaleAloReg, TmpReg, ScratchBank,
+                 PreMode);
+  emitGatherEven(PreOS, ScaleBLo, ScaleBHi, ScaleBloReg, TmpReg, ScratchBank,
+                 PreMode);
+  emitGatherOdd(PreOS, ScaleALo, ScaleAHi, ScaleAhiReg, TmpReg, ScratchBank,
+                PreMode);
+  emitGatherOdd(PreOS, ScaleBLo, ScaleBHi, ScaleBhiReg, TmpReg, ScratchBank,
+                PreMode);
+  emitVgprCopy(PreOS, BCopyBase, BBase, BWidth, ScratchBank, PreMode);
   if (Plan->Scheme == AMaskScheme::Lane) {
     // pass-low keeps lanes 0-15 (low-16 subblocks); pass-high lanes 16-31.
-    emitLaneMaskCopy(PreOS, MaskS, 0x0000FFFFu, *SBase, ABase, AWidth);
-    emitLaneMaskCopy(HiOS, MaskS, 0xFFFF0000u, *SBase, ABase, AWidth);
+    emitLaneMaskCopy(PreOS, MaskS, 0x0000FFFFu, SBase, ABase, AWidth,
+                     ScratchBank, PreMode);
   } else {
     // pass-low keeps the low-16 subblock VGPRs; pass-high the high-16 ones.
-    emitVgprSelectCopy(PreOS, /*KeepLow=*/true, *SBase, ABase, AWidth,
-                       Plan->SubW);
-    emitVgprSelectCopy(HiOS, /*KeepLow=*/false, *SBase, ABase, AWidth,
-                       Plan->SubW);
+    emitVgprSelectCopy(PreOS, /*KeepLow=*/true, SBase, ABase, AWidth,
+                       Plan->SubW, ScratchBank, PreMode);
   }
 
-  SmallVector<uint8_t> PreBytes = assembleInstructions(PreAsm, Ctx.LS);
-  SmallVector<uint8_t> HiBytes = assembleInstructions(HiAsm, Ctx.LS);
-  if (PreBytes.empty() || HiBytes.empty())
-    return failClosed(Ctx, DI, "preamble assembly failed");
+  unsigned WmmaLoMode = *ActiveMode;
+  setVgprMsbBank(WmmaLoMode, VgprMsbOperand::Src0, ScratchBank);
+  setVgprMsbBank(WmmaLoMode, VgprMsbOperand::Src1, ScratchBank);
+  emitModeForOperands(
+      PreOS, PreMode,
+      {{VgprMsbOperand::Src0, ScratchBank},
+       {VgprMsbOperand::Src1, ScratchBank},
+       {VgprMsbOperand::Src2, getVgprMsbBank(WmmaLoMode, VgprMsbOperand::Src2)},
+       {VgprMsbOperand::Dst, getVgprMsbBank(WmmaLoMode, VgprMsbOperand::Dst)}});
 
   // pass-low WMMA: matrix A = masked copy, scales = even-byte gathers, src2 =
   // original C (preserved by the byte copy).
-  SmallVector<uint8_t> WmmaLo =
-      rewriteScale16ToScale(Raw, DI.Size, VgprEncBase + *ScaleAloReg,
-                            VgprEncBase + *ScaleBloReg, Ctx.LS);
+  SmallVector<uint8_t> WmmaLo = rewriteScale16ToScale(
+      Raw, DI.Size, VgprEncBase + (ScaleAloReg % VgprBankSize),
+      VgprEncBase + (ScaleBloReg % VgprBankSize), Ctx.LS);
   if (WmmaLo.empty())
     return failClosed(Ctx, DI, "pass-low WMMA rewrite failed");
-  writeSrc0(WmmaLo.data(), VgprEncBase + *SBase);
+  writeSrc0(WmmaLo.data(), VgprEncBase + (SBase % VgprBankSize));
+  writeSrc1(WmmaLo.data(), VgprEncBase + (BCopyBase % VgprBankSize));
 
   // pass-high WMMA: odd-byte gathers, and src2 = D so it accumulates onto the
   // pass-low result.
-  SmallVector<uint8_t> WmmaHi =
-      rewriteScale16ToScale(Raw, DI.Size, VgprEncBase + *ScaleAhiReg,
-                            VgprEncBase + *ScaleBhiReg, Ctx.LS);
+  SmallVector<uint8_t> WmmaHi = rewriteScale16ToScale(
+      Raw, DI.Size, VgprEncBase + (ScaleAhiReg % VgprBankSize),
+      VgprEncBase + (ScaleBhiReg % VgprBankSize), Ctx.LS);
   if (WmmaHi.empty())
     return failClosed(Ctx, DI, "pass-high WMMA rewrite failed");
-  writeSrc0(WmmaHi.data(), VgprEncBase + *SBase);
+  writeSrc0(WmmaHi.data(), VgprEncBase + (SBase % VgprBankSize));
+  writeSrc1(WmmaHi.data(), VgprEncBase + (BCopyBase % VgprBankSize));
   writeSrc2(WmmaHi.data(), VgprEncBase + extractVdst(Raw));
+
+  unsigned HiMode = WmmaLoMode;
+  if (Plan->Scheme == AMaskScheme::Lane) {
+    emitLaneMaskCopy(HiOS, MaskS, 0xFFFF0000u, SBase, ABase, AWidth,
+                     ScratchBank, HiMode);
+  } else {
+    emitVgprSelectCopy(HiOS, /*KeepLow=*/false, SBase, ABase, AWidth,
+                       Plan->SubW, ScratchBank, HiMode);
+  }
+  unsigned WmmaHiMode = WmmaLoMode;
+  setVgprMsbBank(WmmaHiMode, VgprMsbOperand::Src2, OrigDstBank);
+  emitModeForOperands(
+      HiOS, HiMode,
+      {{VgprMsbOperand::Src0, ScratchBank},
+       {VgprMsbOperand::Src1, ScratchBank},
+       {VgprMsbOperand::Src2, OrigDstBank},
+       {VgprMsbOperand::Dst, getVgprMsbBank(WmmaHiMode, VgprMsbOperand::Dst)}});
+
+  unsigned PostMode = WmmaHiMode;
+  unsigned ActiveSrc0 = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0);
+  unsigned ActiveSrc1 = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1);
+  unsigned ActiveSrc2 = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src2);
+  unsigned ActiveDst = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst);
+  emitModeForOperands(PostOS, PostMode,
+                      {{VgprMsbOperand::Src0, ActiveSrc0},
+                       {VgprMsbOperand::Src1, ActiveSrc1},
+                       {VgprMsbOperand::Src2, ActiveSrc2},
+                       {VgprMsbOperand::Dst, ActiveDst}});
+
+  SmallVector<uint8_t> PreBytes = assembleInstructions(PreAsm, Ctx.LS);
+  SmallVector<uint8_t> HiBytes = assembleInstructions(HiAsm, Ctx.LS);
+  SmallVector<uint8_t> PostBytes;
+  if (!PostAsm.empty())
+    PostBytes = assembleInstructions(PostAsm, Ctx.LS);
+  if (PreBytes.empty() || HiBytes.empty() ||
+      (!PostAsm.empty() && PostBytes.empty()))
+    return failClosed(Ctx, DI, "mode-aware preamble assembly failed");
 
   // gfx1250 WMMA co-exec hazard: the pass-high copy (VALU) overwrites the
   // masked-A block the pass-low WMMA still reads, so it must not co-execute
@@ -454,6 +653,7 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
     Replacement.append(VNop.begin(), VNop.end());
   Replacement.append(HiBytes.begin(), HiBytes.end());
   Replacement.append(WmmaHi.begin(), WmmaHi.end());
+  Replacement.append(PostBytes.begin(), PostBytes.end());
 
   unsigned Extra = Alloc.extraVgprsNeeded();
   if (checkKernelVgprBump(Ctx, KernelName, Extra, PatchRequirement::Required) !=
@@ -481,8 +681,9 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
         << utohexstr(DI.Offset) << " ("
         << (Plan->Scheme == AMaskScheme::Lane ? "lane-mask" : "vgpr-select")
         << ", A=v" << ABase << ":" << (ABase + AWidth - 1) << " -> masked v"
-        << *SBase << ", +" << Extra << " vgpr, " << A0Nops << " hazard v_nop, "
-        << Replacement.size() << " bytes)\n";
+        << SBase << ", B copy=v" << BCopyBase << ":" << (BCopyBase + BWidth - 1)
+        << ", scratch bank " << ScratchBank << ", +" << Extra << " vgpr, "
+        << A0Nops << " hazard v_nop, " << Replacement.size() << " bytes)\n";
   return 1;
 }
 

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -60,7 +60,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
-#include "llvm/Support/FormatVariadic.h"
+#include "llvm/MC/MCFixup.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <array>
@@ -191,9 +191,8 @@ static SmallVector<uint8_t> rewriteScale16ToScale(const uint8_t *OrigRaw,
 
 using VgprBankRequirement = std::pair<VgprMsbOperand, unsigned>;
 
-static void
-emitModeForOperands(raw_string_ostream &OS, unsigned &CurrentMode,
-                    ArrayRef<VgprBankRequirement> Requirements) {
+static void emitModeForOperands(raw_string_ostream &OS, unsigned &CurrentMode,
+                                ArrayRef<VgprBankRequirement> Requirements) {
   unsigned NewMode = CurrentMode;
   for (const VgprBankRequirement &Requirement : Requirements)
     setVgprMsbBank(NewMode, Requirement.first, Requirement.second);
@@ -433,143 +432,6 @@ matrixOperandRange(PatchContext &Ctx, const InternalDecodedInst &DI,
   return VgprRange{Lo, Hi - Lo + 1};
 }
 
-struct Scale32PrintedAsm {
-  std::string Operands[6]; // dst, matrix A/B, src2, scale A/B
-  std::string ModifierSuffix;
-};
-
-// Parse the six positional operands of the M=32 scaled WMMA while preserving
-// the printer's exact inline-immediate spelling and modifier ordering.
-static std::optional<Scale32PrintedAsm>
-parseScale32PrintedAsm(PatchContext &Ctx, const InternalDecodedInst &DI) {
-  SmallString<256> Buf;
-  raw_svector_ostream OS(Buf);
-  Ctx.LS.MCIP->printInst(&DI.Inst, /*Address=*/0, /*Annot=*/"", *Ctx.LS.STI,
-                         OS);
-  StringRef S = StringRef(Buf).trim();
-  size_t MnemEnd = S.find_first_of(" \t");
-  if (MnemEnd == StringRef::npos)
-    return std::nullopt;
-
-  Scale32PrintedAsm Result;
-  StringRef Rest = S.substr(MnemEnd).ltrim();
-  for (unsigned I = 0; I != 5; ++I) {
-    size_t Comma = Rest.find(',');
-    if (Comma == StringRef::npos)
-      return std::nullopt;
-    Result.Operands[I] = Rest.substr(0, Comma).trim().str();
-    Rest = Rest.substr(Comma + 1).ltrim();
-  }
-  size_t ModBegin = Rest.find_first_of(" \t");
-  if (ModBegin == StringRef::npos) {
-    Result.Operands[5] = Rest.str();
-  } else {
-    Result.Operands[5] = Rest.substr(0, ModBegin).str();
-    Result.ModifierSuffix = Rest.substr(ModBegin).str();
-  }
-  return Result;
-}
-
-static SmallVector<StringRef, 8> tokenizeScaleModifiers(StringRef Suffix) {
-  SmallVector<StringRef, 8> Result;
-  StringRef Rest = Suffix.ltrim();
-  while (!Rest.empty()) {
-    size_t Space = Rest.find_first_of(" \t");
-    if (Space == StringRef::npos) {
-      Result.push_back(Rest);
-      break;
-    }
-    Result.push_back(Rest.substr(0, Space));
-    Rest = Rest.substr(Space + 1).ltrim();
-  }
-  return Result;
-}
-
-static bool parsePackedScaleModifier(StringRef Token, StringRef Name,
-                                     std::array<StringRef, 3> &Bits) {
-  if (!Token.starts_with(Name) || !Token.ends_with("]"))
-    return false;
-  Token = Token.drop_front(Name.size());
-  if (!Token.starts_with(":["))
-    return false;
-  SmallVector<StringRef, 3> Parts;
-  Token.drop_front(2).drop_back(1).split(Parts, ",");
-  if (Parts.size() != 3)
-    return false;
-  for (unsigned I = 0; I != 3; ++I) {
-    Bits[I] = Parts[I].trim();
-    if (Bits[I] != "0" && Bits[I] != "1")
-      return false;
-  }
-  return true;
-}
-
-static bool isKnownScale32Modifier(StringRef Token) {
-  if (Token == "matrix_a_reuse" || Token == "matrix_b_reuse" ||
-      Token == "matrix_a_scale:MATRIX_SCALE_ROW1" ||
-      Token == "matrix_b_scale:MATRIX_SCALE_ROW1" ||
-      Token == "matrix_a_scale_fmt:MATRIX_SCALE_FMT_E8" ||
-      Token == "matrix_a_scale_fmt:MATRIX_SCALE_FMT_E5M3" ||
-      Token == "matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3" ||
-      Token == "matrix_b_scale_fmt:MATRIX_SCALE_FMT_E8" ||
-      Token == "matrix_b_scale_fmt:MATRIX_SCALE_FMT_E5M3" ||
-      Token == "matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3")
-    return true;
-  std::array<StringRef, 3> Bits;
-  return parsePackedScaleModifier(Token, "neg_lo", Bits) ||
-         parsePackedScaleModifier(Token, "neg_hi", Bits);
-}
-
-// The split changes both matrix register layout and the K-pass accumulator.
-// Reuse promises therefore no longer describe the generated sequence and are
-// removed. On each high-K pass src2 is the low-pass result, not the original
-// C, so clear the src2 neg/abs bit instead of applying C's modifier twice.
-static std::optional<std::string>
-transformScale32ModifierSuffix(StringRef Suffix, bool HighKPass) {
-  std::string Result;
-  for (StringRef Token : tokenizeScaleModifiers(Suffix)) {
-    if (!isKnownScale32Modifier(Token)) {
-      log() << "hotswap: error: wmma_scale16: unsupported M=32 modifier token "
-               "\""
-            << Token << "\"\n";
-      return std::nullopt;
-    }
-    if (Token == "matrix_a_reuse" || Token == "matrix_b_reuse")
-      continue;
-
-    std::array<StringRef, 3> Bits;
-    if (HighKPass && (parsePackedScaleModifier(Token, "neg_lo", Bits) ||
-                      parsePackedScaleModifier(Token, "neg_hi", Bits))) {
-      if (Bits[0] == "0" && Bits[1] == "0")
-        continue;
-      StringRef Name = Token.take_front(Token.find(':'));
-      Result += (" " + Name + ":[" + Bits[0] + "," + Bits[1] + ",0]").str();
-      continue;
-    }
-    Result += ' ';
-    Result += Token.str();
-  }
-  return Result;
-}
-
-static std::string encodedVgprRange(unsigned PhysicalBase, unsigned Width) {
-  assert(Width > 0);
-  unsigned EncodedBase = PhysicalBase % VgprBankSize;
-  return formatv("v[{0}:{1}]", EncodedBase, EncodedBase + Width - 1).str();
-}
-
-static void emitScale32Half(raw_string_ostream &OS, unsigned DstBase,
-                            unsigned MatrixABase, unsigned MatrixBBase,
-                            StringRef Src2, unsigned ScaleAReg,
-                            unsigned ScaleBReg, StringRef ModifierSuffix) {
-  OS << "v_wmma_scale_f32_16x16x128_f8f6f4 " << encodedVgprRange(DstBase, 8)
-     << ", " << encodedVgprRange(MatrixABase, 8) << ", "
-     << encodedVgprRange(MatrixBBase, 8) << ", " << Src2 << ", "
-     << encodedVgprName(ScaleAReg) << ", " << encodedVgprName(ScaleBReg)
-     << " matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4"
-     << ModifierSuffix << "\n";
-}
-
 // Prefer one exact-liveness-proven dead block inside the kernel's declared
 // allocation. Fully allocated production kernels often have no above-KD
 // headroom even though a particular WMMA site has a large dead interval.
@@ -689,6 +551,376 @@ getEncodedVgprRange(MCRegister Reg, const MCRegisterInfo &MRI) {
                           static_cast<unsigned>(Scalars.size()), true};
 }
 
+static bool sameMCOperand(const MCOperand &LHS, const MCOperand &RHS) {
+  if (LHS.isReg() && RHS.isReg())
+    return LHS.getReg() == RHS.getReg();
+  if (LHS.isImm() && RHS.isImm())
+    return LHS.getImm() == RHS.getImm();
+  return false;
+}
+
+static std::optional<SmallVector<unsigned, 2>>
+changedMCOperands(const MCInst &Baseline, const Twine &VariantAsm,
+                  const LLVMState &LS) {
+  std::string Asm = VariantAsm.str();
+  std::optional<MCInst> Variant = parseSingleMCInst(Asm, LS);
+  if (!Variant || Variant->getOpcode() != Baseline.getOpcode() ||
+      Variant->getNumOperands() != Baseline.getNumOperands())
+    return std::nullopt;
+
+  SmallVector<unsigned, 2> Changed;
+  for (unsigned I = 0, E = Baseline.getNumOperands(); I != E; ++I)
+    if (!sameMCOperand(Baseline.getOperand(I), Variant->getOperand(I)))
+      Changed.push_back(I);
+  return Changed;
+}
+
+static std::optional<unsigned> singleChangedMCOperand(const MCInst &Baseline,
+                                                      const Twine &VariantAsm,
+                                                      const LLVMState &LS) {
+  std::optional<SmallVector<unsigned, 2>> Changed =
+      changedMCOperands(Baseline, VariantAsm, LS);
+  if (!Changed || Changed->size() != 1)
+    return std::nullopt;
+  return Changed->front();
+}
+
+struct Scale32MCLayout {
+  unsigned SourceOpcode = 0;
+  unsigned SourceVDst = 0;
+  unsigned SourceSrc0 = 0;
+  unsigned SourceSrc1 = 0;
+  unsigned SourceSrc2Modifiers = 0;
+  unsigned SourceSrc2 = 0;
+  unsigned SourceScaleSrc0 = 0;
+  unsigned SourceScaleSrc1 = 0;
+  unsigned SourceMatrixAScale = 0;
+  unsigned SourceMatrixBScale = 0;
+  unsigned SourceMatrixAScaleFmt = 0;
+  unsigned SourceMatrixBScaleFmt = 0;
+  unsigned SourceMatrixAReuse = 0;
+  unsigned SourceMatrixBReuse = 0;
+  unsigned SourceNegLo = 0;
+  unsigned SourceNegHi = 0;
+
+  unsigned DestOpcode = 0;
+  MCInst DestTemplate;
+  unsigned DestVDst = 0;
+  unsigned DestSrc0 = 0;
+  unsigned DestSrc1 = 0;
+  unsigned DestSrc2Modifiers = 0;
+  unsigned DestSrc2 = 0;
+  unsigned DestScaleSrc0 = 0;
+  unsigned DestScaleSrc1 = 0;
+  unsigned DestMatrixAScale = 0;
+  unsigned DestMatrixBScale = 0;
+  unsigned DestMatrixAScaleFmt = 0;
+  unsigned DestMatrixBScaleFmt = 0;
+  unsigned DestMatrixAReuse = 0;
+  unsigned DestMatrixBReuse = 0;
+  unsigned DestNegLo = 0;
+  unsigned DestNegHi = 0;
+};
+
+static bool allUniqueAndCover(ArrayRef<unsigned> Indices,
+                              unsigned OperandCount) {
+  if (Indices.size() != OperandCount)
+    return false;
+  SmallVector<unsigned, 16> Sorted(Indices);
+  llvm::sort(Sorted);
+  for (unsigned I = 0; I != OperandCount; ++I)
+    if (Sorted[I] != I)
+      return false;
+  return true;
+}
+
+static bool discoverNegOperandRoles(const MCInst &Baseline,
+                                    const Twine &NegLoAsm,
+                                    const Twine &NegHiAsm, const LLVMState &LS,
+                                    unsigned &NegLo, unsigned &NegHi) {
+  std::optional<SmallVector<unsigned, 2>> LoChanged =
+      changedMCOperands(Baseline, NegLoAsm, LS);
+  std::optional<SmallVector<unsigned, 2>> HiChanged =
+      changedMCOperands(Baseline, NegHiAsm, LS);
+  if (!LoChanged || !HiChanged || LoChanged->empty() || HiChanged->empty() ||
+      LoChanged->size() > 2 || HiChanged->size() > 2)
+    return false;
+
+  if (LoChanged->size() == 1 && HiChanged->size() == 1) {
+    NegLo = LoChanged->front();
+    NegHi = HiChanged->front();
+    return NegLo != NegHi;
+  }
+  if (LoChanged->size() != 2 || HiChanged->size() != 2)
+    return false;
+
+  SmallVector<unsigned, 1> Common;
+  for (unsigned LoIndex : *LoChanged)
+    if (llvm::is_contained(*HiChanged, LoIndex))
+      Common.push_back(LoIndex);
+  if (Common.size() != 1)
+    return false;
+
+  unsigned CommonIndex = Common.front();
+  NegLo = LoChanged->front() == CommonIndex ? LoChanged->back()
+                                            : LoChanged->front();
+  NegHi = HiChanged->front() == CommonIndex ? HiChanged->back()
+                                            : HiChanged->front();
+  return NegLo != NegHi;
+}
+
+static std::optional<Scale32MCLayout>
+discoverScale32MCLayout(const LLVMState &LS) {
+  static constexpr StringLiteral SourceBaseline =
+      "v_wmma_scale16_f32_32x16x128_f4 "
+      "v[0:15], v[16:31], v[32:39], v[48:63], v[64:65], v[66:67]";
+  static constexpr StringLiteral DestBaseline =
+      "v_wmma_scale_f32_16x16x128_f8f6f4 "
+      "v[0:7], v[16:23], v[32:39], v[48:55], v64, v66 "
+      "matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4";
+  static constexpr StringLiteral DestAScaleFmtBaseline =
+      "v_wmma_scale_f32_16x16x128_f8f6f4 "
+      "v[0:7], v[8:15], v[24:39], v[40:47], v1, v2 "
+      "matrix_a_fmt:MATRIX_FMT_FP4";
+  static constexpr StringLiteral DestBScaleFmtBaseline =
+      "v_wmma_scale_f32_16x16x128_f8f6f4 "
+      "v[0:7], v[8:23], v[24:31], v[40:47], v1, v2 "
+      "matrix_b_fmt:MATRIX_FMT_FP4";
+
+  std::optional<MCInst> Source = parseSingleMCInst(SourceBaseline, LS);
+  std::optional<MCInst> Dest = parseSingleMCInst(DestBaseline, LS);
+  std::optional<MCInst> DestAScaleFmt =
+      parseSingleMCInst(DestAScaleFmtBaseline, LS);
+  std::optional<MCInst> DestBScaleFmt =
+      parseSingleMCInst(DestBScaleFmtBaseline, LS);
+  if (!Source || !Dest || !DestAScaleFmt || !DestBScaleFmt) {
+    log() << "hotswap: error: wmma_scale16: could not parse the semantic MC "
+             "layout probes\n";
+    return std::nullopt;
+  }
+
+  Scale32MCLayout Layout;
+  Layout.SourceOpcode = Source->getOpcode();
+  Layout.DestOpcode = Dest->getOpcode();
+  Layout.DestTemplate = *Dest;
+
+#define DISCOVER_SOURCE_ROLE(Field, Asm)                                       \
+  do {                                                                         \
+    std::optional<unsigned> Index = singleChangedMCOperand(*Source, Asm, LS);  \
+    if (!Index) {                                                              \
+      log() << "hotswap: error: wmma_scale16: could not discover source "      \
+            << #Field << " MC operand\n";                                      \
+      return std::nullopt;                                                     \
+    }                                                                          \
+    Layout.Field = *Index;                                                     \
+  } while (false)
+
+  DISCOVER_SOURCE_ROLE(
+      SourceVDst, "v_wmma_scale16_f32_32x16x128_f4 "
+                  "v[80:95], v[16:31], v[32:39], v[48:63], v[64:65], v[66:67]");
+  DISCOVER_SOURCE_ROLE(
+      SourceSrc0, "v_wmma_scale16_f32_32x16x128_f4 "
+                  "v[0:15], v[80:95], v[32:39], v[48:63], v[64:65], v[66:67]");
+  DISCOVER_SOURCE_ROLE(
+      SourceSrc1, "v_wmma_scale16_f32_32x16x128_f4 "
+                  "v[0:15], v[16:31], v[80:87], v[48:63], v[64:65], v[66:67]");
+  DISCOVER_SOURCE_ROLE(
+      SourceSrc2, "v_wmma_scale16_f32_32x16x128_f4 "
+                  "v[0:15], v[16:31], v[32:39], v[80:95], v[64:65], v[66:67]");
+  DISCOVER_SOURCE_ROLE(
+      SourceScaleSrc0,
+      "v_wmma_scale16_f32_32x16x128_f4 "
+      "v[0:15], v[16:31], v[32:39], v[48:63], v[80:81], v[66:67]");
+  DISCOVER_SOURCE_ROLE(
+      SourceScaleSrc1,
+      "v_wmma_scale16_f32_32x16x128_f4 "
+      "v[0:15], v[16:31], v[32:39], v[48:63], v[64:65], v[80:81]");
+  DISCOVER_SOURCE_ROLE(SourceMatrixAScale,
+                       SourceBaseline + " matrix_a_scale:MATRIX_SCALE_ROW1");
+  DISCOVER_SOURCE_ROLE(SourceMatrixBScale,
+                       SourceBaseline + " matrix_b_scale:MATRIX_SCALE_ROW1");
+  DISCOVER_SOURCE_ROLE(SourceMatrixAScaleFmt,
+                       SourceBaseline +
+                           " matrix_a_scale_fmt:MATRIX_SCALE_FMT_E5M3");
+  DISCOVER_SOURCE_ROLE(SourceMatrixBScaleFmt,
+                       SourceBaseline +
+                           " matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3");
+  DISCOVER_SOURCE_ROLE(SourceMatrixAReuse, SourceBaseline + " matrix_a_reuse");
+  DISCOVER_SOURCE_ROLE(SourceMatrixBReuse, SourceBaseline + " matrix_b_reuse");
+#undef DISCOVER_SOURCE_ROLE
+
+  if (!discoverNegOperandRoles(*Source, SourceBaseline + " neg_lo:[0,0,1]",
+                               SourceBaseline + " neg_hi:[0,0,1]", LS,
+                               Layout.SourceNegLo, Layout.SourceNegHi)) {
+    log() << "hotswap: error: wmma_scale16: could not discover source "
+             "negative-modifier MC operands\n";
+    return std::nullopt;
+  }
+
+  std::array<unsigned, 14> KnownSourceIndices = {Layout.SourceVDst,
+                                                 Layout.SourceSrc0,
+                                                 Layout.SourceSrc1,
+                                                 Layout.SourceSrc2,
+                                                 Layout.SourceScaleSrc0,
+                                                 Layout.SourceScaleSrc1,
+                                                 Layout.SourceMatrixAScale,
+                                                 Layout.SourceMatrixBScale,
+                                                 Layout.SourceMatrixAScaleFmt,
+                                                 Layout.SourceMatrixBScaleFmt,
+                                                 Layout.SourceMatrixAReuse,
+                                                 Layout.SourceMatrixBReuse,
+                                                 Layout.SourceNegLo,
+                                                 Layout.SourceNegHi};
+  SmallVector<unsigned, 15> SourceIndices(KnownSourceIndices.begin(),
+                                          KnownSourceIndices.end());
+  for (unsigned I = 0, E = Source->getNumOperands(); I != E; ++I) {
+    if (llvm::is_contained(SourceIndices, I))
+      continue;
+    const MCOperand &Op = Source->getOperand(I);
+    if (Layout.SourceSrc2Modifiers != 0 || !Op.isImm())
+      return std::nullopt;
+    Layout.SourceSrc2Modifiers = I;
+    SourceIndices.push_back(I);
+  }
+  if (!allUniqueAndCover(SourceIndices, Source->getNumOperands())) {
+    log() << "hotswap: error: wmma_scale16: source MC operand roles do not "
+             "cover the instruction\n";
+    return std::nullopt;
+  }
+
+#define DISCOVER_DEST_ROLE(Field, Asm)                                         \
+  do {                                                                         \
+    std::optional<unsigned> Index = singleChangedMCOperand(*Dest, Asm, LS);    \
+    if (!Index) {                                                              \
+      log() << "hotswap: error: wmma_scale16: could not discover destination " \
+            << #Field << " MC operand\n";                                      \
+      return std::nullopt;                                                     \
+    }                                                                          \
+    Layout.Field = *Index;                                                     \
+  } while (false)
+
+  DISCOVER_DEST_ROLE(DestVDst,
+                     "v_wmma_scale_f32_16x16x128_f8f6f4 "
+                     "v[80:87], v[16:23], v[32:39], v[48:55], v64, v66 "
+                     "matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4");
+  DISCOVER_DEST_ROLE(DestSrc0,
+                     "v_wmma_scale_f32_16x16x128_f8f6f4 "
+                     "v[0:7], v[80:87], v[32:39], v[48:55], v64, v66 "
+                     "matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4");
+  DISCOVER_DEST_ROLE(DestSrc1,
+                     "v_wmma_scale_f32_16x16x128_f8f6f4 "
+                     "v[0:7], v[16:23], v[80:87], v[48:55], v64, v66 "
+                     "matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4");
+  DISCOVER_DEST_ROLE(DestSrc2,
+                     "v_wmma_scale_f32_16x16x128_f8f6f4 "
+                     "v[0:7], v[16:23], v[32:39], v[80:87], v64, v66 "
+                     "matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4");
+  DISCOVER_DEST_ROLE(DestScaleSrc0,
+                     "v_wmma_scale_f32_16x16x128_f8f6f4 "
+                     "v[0:7], v[16:23], v[32:39], v[48:55], v80, v66 "
+                     "matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4");
+  DISCOVER_DEST_ROLE(DestScaleSrc1,
+                     "v_wmma_scale_f32_16x16x128_f8f6f4 "
+                     "v[0:7], v[16:23], v[32:39], v[48:55], v64, v80 "
+                     "matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4");
+  DISCOVER_DEST_ROLE(DestMatrixAScale,
+                     DestBaseline + " matrix_a_scale:MATRIX_SCALE_ROW1");
+  DISCOVER_DEST_ROLE(DestMatrixBScale,
+                     DestBaseline + " matrix_b_scale:MATRIX_SCALE_ROW1");
+  std::optional<unsigned> DestMatrixAScaleFmt = singleChangedMCOperand(
+      *DestAScaleFmt,
+      DestAScaleFmtBaseline + " matrix_a_scale_fmt:MATRIX_SCALE_FMT_E5M3", LS);
+  std::optional<unsigned> DestMatrixBScaleFmt = singleChangedMCOperand(
+      *DestBScaleFmt,
+      DestBScaleFmtBaseline + " matrix_b_scale_fmt:MATRIX_SCALE_FMT_E5M3", LS);
+  if (!DestMatrixAScaleFmt || !DestMatrixBScaleFmt) {
+    log() << "hotswap: error: wmma_scale16: could not discover destination "
+             "matrix scale-format MC operands\n";
+    return std::nullopt;
+  }
+  Layout.DestMatrixAScaleFmt = *DestMatrixAScaleFmt;
+  Layout.DestMatrixBScaleFmt = *DestMatrixBScaleFmt;
+  DISCOVER_DEST_ROLE(DestMatrixAReuse, DestBaseline + " matrix_a_reuse");
+  DISCOVER_DEST_ROLE(DestMatrixBReuse, DestBaseline + " matrix_b_reuse");
+#undef DISCOVER_DEST_ROLE
+
+  if (!discoverNegOperandRoles(*Dest, DestBaseline + " neg_lo:[0,0,1]",
+                               DestBaseline + " neg_hi:[0,0,1]", LS,
+                               Layout.DestNegLo, Layout.DestNegHi)) {
+    log() << "hotswap: error: wmma_scale16: could not discover destination "
+             "negative-modifier MC operands\n";
+    return std::nullopt;
+  }
+
+  std::array<unsigned, 14> KnownDestIndices = {Layout.DestVDst,
+                                               Layout.DestSrc0,
+                                               Layout.DestSrc1,
+                                               Layout.DestSrc2,
+                                               Layout.DestScaleSrc0,
+                                               Layout.DestScaleSrc1,
+                                               Layout.DestMatrixAScale,
+                                               Layout.DestMatrixBScale,
+                                               Layout.DestMatrixAScaleFmt,
+                                               Layout.DestMatrixBScaleFmt,
+                                               Layout.DestMatrixAReuse,
+                                               Layout.DestMatrixBReuse,
+                                               Layout.DestNegLo,
+                                               Layout.DestNegHi};
+  SmallVector<unsigned, 17> DestCoverage(KnownDestIndices.begin(),
+                                         KnownDestIndices.end());
+  for (unsigned I = 0, E = Dest->getNumOperands(); I != E; ++I) {
+    if (llvm::is_contained(DestCoverage, I))
+      continue;
+    const MCOperand &Op = Dest->getOperand(I);
+    if (!Op.isImm()) {
+      log() << "hotswap: error: wmma_scale16: unexpected undiscovered "
+               "destination MC operand "
+            << I << "\n";
+      return std::nullopt;
+    }
+    if (Op.getImm() == 0 && Layout.DestSrc2Modifiers == 0) {
+      Layout.DestSrc2Modifiers = I;
+      DestCoverage.push_back(I);
+      continue;
+    }
+    if (Op.getImm() != 4) {
+      log() << "hotswap: error: wmma_scale16: unexpected undiscovered "
+               "destination MC immediate at operand "
+            << I << "\n";
+      return std::nullopt;
+    }
+    DestCoverage.push_back(I);
+  }
+  if (!allUniqueAndCover(DestCoverage, Dest->getNumOperands())) {
+    log() << "hotswap: error: wmma_scale16: destination MC operand roles do "
+             "not cover the instruction\n";
+    return std::nullopt;
+  }
+
+  return Layout;
+}
+
+static const Scale32MCLayout *getScale32MCLayout(const LLVMState &LS) {
+  thread_local const MCSubtargetInfo *CachedSTI = nullptr;
+  thread_local std::optional<Scale32MCLayout> CachedLayout;
+  if (CachedSTI != LS.STI.get()) {
+    CachedSTI = LS.STI.get();
+    CachedLayout = discoverScale32MCLayout(LS);
+  }
+  return CachedLayout ? &*CachedLayout : nullptr;
+}
+
+static std::optional<EncodedVgprRange>
+getOperandVgprRange(const MCInst &Inst, unsigned OperandIndex,
+                    const MCRegisterInfo &MRI) {
+  if (OperandIndex >= Inst.getNumOperands())
+    return std::nullopt;
+  const MCOperand &Op = Inst.getOperand(OperandIndex);
+  if (!Op.isReg() || !Op.getReg())
+    return std::nullopt;
+  return getEncodedVgprRange(MCRegister(Op.getReg()), MRI);
+}
+
 bool isVectorRegisterOrAlias(MCRegister Reg, const MCRegisterInfo &MRI) {
   if (!Reg)
     return false;
@@ -729,20 +961,20 @@ struct PhysicalVgprAccess {
 // their role is structurally unambiguous.
 static std::optional<VgprMsbOperand>
 getExactSourceRole(const InternalDecodedInst &DI, unsigned OperandIndex,
-                   unsigned NumDefs) {
+                   unsigned NumDefs, const LLVMState &LS) {
   if (DI.Mnemonic == "v_wmma_scale16_f32_32x16x128_f4") {
-    switch (OperandIndex) {
-    case 1:
-    case 5:
-      return VgprMsbOperand::Src0;
-    case 2:
-    case 6:
-      return VgprMsbOperand::Src1;
-    case 4:
-      return VgprMsbOperand::Src2;
-    default:
+    const Scale32MCLayout *Layout = getScale32MCLayout(LS);
+    if (!Layout || DI.Inst.getOpcode() != Layout->SourceOpcode)
       return std::nullopt;
-    }
+    if (OperandIndex == Layout->SourceSrc0 ||
+        OperandIndex == Layout->SourceScaleSrc0)
+      return VgprMsbOperand::Src0;
+    if (OperandIndex == Layout->SourceSrc1 ||
+        OperandIndex == Layout->SourceScaleSrc1)
+      return VgprMsbOperand::Src1;
+    if (OperandIndex == Layout->SourceSrc2)
+      return VgprMsbOperand::Src2;
+    return std::nullopt;
   }
   if (StringRef(DI.Mnemonic).starts_with("ds_") && OperandIndex == NumDefs)
     return VgprMsbOperand::Src0;
@@ -793,7 +1025,7 @@ static PhysicalVgprAccess getPhysicalVgprAccess(const InternalDecodedInst &DI,
     bool IsDef = I < NumDefs;
     if (!IsDef) {
       if (std::optional<VgprMsbOperand> Role =
-              getExactSourceRole(DI, I, NumDefs)) {
+              getExactSourceRole(DI, I, NumDefs, LS)) {
         unsigned Bank = getVgprMsbBank(Mode, *Role);
         if (!setPhysicalVgprRange(Result.Uses, *Range, Bank, MaxVgprs))
           Result.Valid = false;
@@ -977,24 +1209,24 @@ struct ScaleForwardGraph {
 // no kill, and skip the split continuation dword. This is enough to traverse
 // the instruction without relying on whether opcode 0x31 has a vector or
 // scalar destination on B0.
-static bool recognizeUndecodedB0Vop3ScalarSources(
-    PatchContext &Ctx, size_t Global, unsigned MaxVgprs,
-    BitVector &ConservativeUses) {
+static bool recognizeUndecodedB0Vop3ScalarSources(PatchContext &Ctx,
+                                                  size_t Global,
+                                                  unsigned MaxVgprs,
+                                                  BitVector &ConservativeUses) {
   if (Global + 1 >= Ctx.Decoded.size())
     return false;
   const InternalDecodedInst &Head = Ctx.Decoded[Global];
   const InternalDecodedInst &Tail = Ctx.Decoded[Global + 1];
   if (Head.DecodeSucceeded || Head.Size != MinInstSize ||
-      Tail.Offset != Head.Offset + MinInstSize ||
-      Head.Offset > Ctx.TextSize || 2 * MinInstSize > Ctx.TextSize - Head.Offset)
+      Tail.Offset != Head.Offset + MinInstSize || Head.Offset > Ctx.TextSize ||
+      2 * MinInstSize > Ctx.TextSize - Head.Offset)
     return false;
 
   const uint8_t *Raw = Ctx.Text + Head.Offset;
   uint32_t Word0 = support::endian::read32le(Raw);
   uint32_t Word1 = support::endian::read32le(Raw + MinInstSize);
   constexpr uint32_t Bit14 = 1u << 14;
-  if ((Word0 & ~Bit14) != 0xd0310000u ||
-      (Word1 != 0 && Word1 != 0x00100000u))
+  if ((Word0 & ~Bit14) != 0xd0310000u || (Word1 != 0 && Word1 != 0x00100000u))
     return false;
 
   // A direct/declared entry into the decoder-created continuation slot would
@@ -1003,8 +1235,7 @@ static bool recognizeUndecodedB0Vop3ScalarSources(
       llvm::is_contained(Ctx.DeclaredEntries, Tail.Offset))
     return false;
 
-  for (unsigned Physical = 0; Physical < MaxVgprs;
-       Physical += VgprBankSize)
+  for (unsigned Physical = 0; Physical < MaxVgprs; Physical += VgprBankSize)
     ConservativeUses.set(Physical);
   return true;
 }
@@ -1065,9 +1296,8 @@ buildScaleForwardGraph(PatchContext &Ctx, size_t SiteIdx, unsigned EntryMode,
       Node.SafeTerminal = true;
       continue;
     }
-    if (!DI.DecodeSucceeded &&
-        recognizeUndecodedB0Vop3ScalarSources(Ctx, Global, MaxVgprs,
-                                              Node.Uses)) {
+    if (!DI.DecodeSucceeded && recognizeUndecodedB0Vop3ScalarSources(
+                                   Ctx, Global, MaxVgprs, Node.Uses)) {
       if (Local + 2 >= Count)
         Node.HasUnsafeExit = true;
       else
@@ -1124,12 +1354,11 @@ buildScaleForwardGraph(PatchContext &Ctx, size_t SiteIdx, unsigned EntryMode,
     const ForwardVgprProofNode &Node = Graph.Nodes[Local];
     if (Node.Opaque || Node.SafeTerminal)
       continue;
-    int16_t Out =
-        Graph.UndecodedVop3Heads.test(Local)
-            ? Graph.ModeBefore[Local]
-            : transferExactVgprMsbMode(
-                  Graph.ModeBefore[Local],
-                  Ctx.Decoded[Graph.GlobalIndices[Local]], Ctx.LS);
+    int16_t Out = Graph.UndecodedVop3Heads.test(Local)
+                      ? Graph.ModeBefore[Local]
+                      : transferExactVgprMsbMode(
+                            Graph.ModeBefore[Local],
+                            Ctx.Decoded[Graph.GlobalIndices[Local]], Ctx.LS);
     for (size_t Successor : Node.Successors) {
       int16_t Old = Graph.ModeBefore[Successor];
       int16_t Merged = Old == VgprMsbUnreachable ? Out
@@ -1500,6 +1729,180 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
 // v_wmma_scale16_f32_32x16x128_f4 -> exact M+K split
 // ---------------------------------------------------------------------------
 
+static std::optional<MCRegister>
+findEncodedVgprRegister(unsigned EncodedBase, unsigned Width, unsigned Opcode,
+                        unsigned OperandIndex, const LLVMState &LS) {
+  const MCInstrDesc &Desc = LS.MCII->get(Opcode);
+  if (OperandIndex >= Desc.getNumOperands())
+    return std::nullopt;
+
+  const MCOperandInfo &OperandInfo = Desc.operands()[OperandIndex];
+  int16_t RegClassID =
+      LS.MCII->getOpRegClassID(OperandInfo, LS.STI->getHwMode());
+  if (RegClassID < 0 ||
+      static_cast<unsigned>(RegClassID) >= LS.MRI->getNumRegClasses())
+    return std::nullopt;
+  const MCRegisterClass &RegClass = LS.MRI->getRegClass(RegClassID);
+
+  std::optional<MCRegister> Match;
+  for (unsigned I = 1, E = LS.MRI->getNumRegs(); I != E; ++I) {
+    MCRegister Reg(I);
+    if (!RegClass.contains(Reg))
+      continue;
+    std::optional<EncodedVgprRange> Range = getEncodedVgprRange(Reg, *LS.MRI);
+    if (!Range || !Range->FullDwords || Range->Base != EncodedBase ||
+        Range->Width != Width)
+      continue;
+    if (Match)
+      return std::nullopt;
+    Match = Reg;
+  }
+  return Match;
+}
+
+static bool setEncodedVgprOperand(MCInst &Inst, unsigned OperandIndex,
+                                  unsigned EncodedBase, unsigned Width,
+                                  StringRef Role, const LLVMState &LS) {
+  if (OperandIndex >= Inst.getNumOperands()) {
+    log() << "hotswap: error: wmma_scale16: destination " << Role
+          << " MC operand index " << OperandIndex << " exceeds operand count "
+          << Inst.getNumOperands() << "\n";
+    return false;
+  }
+  std::optional<MCRegister> Reg = findEncodedVgprRegister(
+      EncodedBase, Width, Inst.getOpcode(), OperandIndex, LS);
+  if (!Reg) {
+    log() << "hotswap: error: wmma_scale16: destination " << Role
+          << " has no unique MC register for encoded v" << EncodedBase
+          << ", width " << Width << ", operand " << OperandIndex << "\n";
+    return false;
+  }
+  Inst.getOperand(OperandIndex) = MCOperand::createReg(*Reg);
+  return true;
+}
+
+static bool copyImmediateOperand(MCInst &Dest, unsigned DestIndex,
+                                 const MCInst &Source, unsigned SourceIndex) {
+  if (DestIndex >= Dest.getNumOperands() ||
+      SourceIndex >= Source.getNumOperands())
+    return false;
+  const MCOperand &SourceOperand = Source.getOperand(SourceIndex);
+  if (!SourceOperand.isImm())
+    return false;
+  Dest.getOperand(DestIndex) = SourceOperand;
+  return true;
+}
+
+static std::optional<SmallVector<uint8_t>>
+encodeScale32Half(const InternalDecodedInst &DI, const Scale32MCLayout &Layout,
+                  unsigned DstBase, unsigned MatrixABase, unsigned MatrixBBase,
+                  std::optional<unsigned> OriginalSrc2Base, unsigned ScaleAReg,
+                  unsigned ScaleBReg, bool HighK, const LLVMState &LS) {
+  if (DI.Inst.getOpcode() != Layout.SourceOpcode)
+    return std::nullopt;
+
+  MCInst Inst = Layout.DestTemplate;
+  if (Inst.getOpcode() != Layout.DestOpcode)
+    return std::nullopt;
+  if (!setEncodedVgprOperand(Inst, Layout.DestVDst, DstBase % VgprBankSize,
+                             /*Width=*/8, "vdst", LS) ||
+      !setEncodedVgprOperand(Inst, Layout.DestSrc0, MatrixABase % VgprBankSize,
+                             /*Width=*/8, "src0", LS) ||
+      !setEncodedVgprOperand(Inst, Layout.DestSrc1, MatrixBBase % VgprBankSize,
+                             /*Width=*/8, "src1", LS) ||
+      !setEncodedVgprOperand(Inst, Layout.DestScaleSrc0,
+                             ScaleAReg % VgprBankSize, /*Width=*/1,
+                             "scale_src0", LS) ||
+      !setEncodedVgprOperand(Inst, Layout.DestScaleSrc1,
+                             ScaleBReg % VgprBankSize, /*Width=*/1,
+                             "scale_src1", LS))
+    return std::nullopt;
+
+  if (HighK) {
+    if (!setEncodedVgprOperand(Inst, Layout.DestSrc2, DstBase % VgprBankSize,
+                               /*Width=*/8, "src2", LS))
+      return std::nullopt;
+  } else if (OriginalSrc2Base) {
+    if (!setEncodedVgprOperand(Inst, Layout.DestSrc2,
+                               *OriginalSrc2Base % VgprBankSize,
+                               /*Width=*/8, "src2", LS))
+      return std::nullopt;
+  } else {
+    if (Layout.SourceSrc2 >= DI.Inst.getNumOperands() ||
+        !DI.Inst.getOperand(Layout.SourceSrc2).isImm()) {
+      log() << "hotswap: error: wmma_scale16: immediate source src2 operand "
+               "is unavailable at index "
+            << Layout.SourceSrc2 << " of " << DI.Inst.getNumOperands() << "\n";
+      return std::nullopt;
+    }
+    Inst.getOperand(Layout.DestSrc2) = DI.Inst.getOperand(Layout.SourceSrc2);
+  }
+
+  std::array<std::pair<unsigned, unsigned>, 4> ImmediateCopies = {
+      std::pair<unsigned, unsigned>{Layout.DestMatrixAScale,
+                                    Layout.SourceMatrixAScale},
+      std::pair<unsigned, unsigned>{Layout.DestMatrixBScale,
+                                    Layout.SourceMatrixBScale},
+      std::pair<unsigned, unsigned>{Layout.DestMatrixAScaleFmt,
+                                    Layout.SourceMatrixAScaleFmt},
+      std::pair<unsigned, unsigned>{Layout.DestMatrixBScaleFmt,
+                                    Layout.SourceMatrixBScaleFmt}};
+  for (const std::pair<unsigned, unsigned> &Copy : ImmediateCopies) {
+    if (!copyImmediateOperand(Inst, Copy.first, DI.Inst, Copy.second)) {
+      log() << "hotswap: error: wmma_scale16: could not copy source MC "
+               "immediate operand "
+            << Copy.second << " to destination operand " << Copy.first << "\n";
+      return std::nullopt;
+    }
+  }
+
+  if (Layout.SourceSrc2Modifiers >= DI.Inst.getNumOperands() ||
+      !DI.Inst.getOperand(Layout.SourceSrc2Modifiers).isImm()) {
+    log() << "hotswap: error: wmma_scale16: decoded source has no packed "
+             "src2-modifier immediate at operand "
+          << Layout.SourceSrc2Modifiers << "\n";
+    return std::nullopt;
+  }
+  int64_t Src2Modifiers =
+      DI.Inst.getOperand(Layout.SourceSrc2Modifiers).getImm();
+  if (Src2Modifiers < 0 || Src2Modifiers > 3) {
+    log() << "hotswap: error: wmma_scale16: source packed src2 modifiers "
+          << Src2Modifiers << " are outside [0, 3]\n";
+    return std::nullopt;
+  }
+  if (HighK)
+    Src2Modifiers = 0;
+  Inst.getOperand(Layout.DestSrc2Modifiers) =
+      MCOperand::createImm(Src2Modifiers);
+  Inst.getOperand(Layout.DestNegLo) =
+      MCOperand::createImm((Src2Modifiers & 1) != 0 ? 4 : 0);
+  Inst.getOperand(Layout.DestNegHi) =
+      MCOperand::createImm((Src2Modifiers & 2) != 0 ? 4 : 0);
+  Inst.getOperand(Layout.DestMatrixAReuse) = MCOperand::createImm(0);
+  Inst.getOperand(Layout.DestMatrixBReuse) = MCOperand::createImm(0);
+
+  SmallVector<char, 16> Code;
+  SmallVector<MCFixup, 4> Fixups;
+  LS.MCE->encodeInstruction(Inst, Code, Fixups, *LS.STI);
+  if (!Fixups.empty() || Code.size() != VOP3PXSize) {
+    log() << "hotswap: error: wmma_scale16: destination MC encoding produced "
+          << Code.size() << " bytes and " << Fixups.size() << " fixups\n";
+    return std::nullopt;
+  }
+  return SmallVector<uint8_t>(Code.begin(), Code.end());
+}
+
+static bool appendAssembledInstructions(SmallVectorImpl<uint8_t> &Out,
+                                        StringRef Asm, const LLVMState &LS) {
+  if (Asm.empty())
+    return true;
+  SmallVector<uint8_t> Bytes = assembleInstructions(Asm, LS);
+  if (Bytes.empty())
+    return false;
+  Out.append(Bytes.begin(), Bytes.end());
+  return true;
+}
+
 static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   const InternalDecodedInst &DI = Ctx.Decoded[Idx];
 
@@ -1509,13 +1912,41 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
     if (T.OriginalOffset == DI.Offset)
       return 0;
 
-  const uint8_t *Raw = Ctx.Text + DI.Offset;
-  std::optional<unsigned> ScaleABase =
-      decodeVgprEncoding(extractScaleSrc0(Raw));
-  std::optional<unsigned> ScaleBBase =
-      decodeVgprEncoding(extractScaleSrc1(Raw));
-  if (!ScaleABase || !ScaleBBase)
-    return failClosed(Ctx, DI, "non-VGPR block-16 scale operand");
+  const Scale32MCLayout *Layout = getScale32MCLayout(Ctx.LS);
+  if (!Layout || DI.Inst.getOpcode() != Layout->SourceOpcode)
+    return failClosed(Ctx, DI,
+                      "could not discover the semantic MC operand layout");
+
+  std::optional<EncodedVgprRange> DRange =
+      getOperandVgprRange(DI.Inst, Layout->SourceVDst, *Ctx.LS.MRI);
+  std::optional<EncodedVgprRange> ARange =
+      getOperandVgprRange(DI.Inst, Layout->SourceSrc0, *Ctx.LS.MRI);
+  std::optional<EncodedVgprRange> BRange =
+      getOperandVgprRange(DI.Inst, Layout->SourceSrc1, *Ctx.LS.MRI);
+  std::optional<EncodedVgprRange> ScaleARange =
+      getOperandVgprRange(DI.Inst, Layout->SourceScaleSrc0, *Ctx.LS.MRI);
+  std::optional<EncodedVgprRange> ScaleBRange =
+      getOperandVgprRange(DI.Inst, Layout->SourceScaleSrc1, *Ctx.LS.MRI);
+  if (!DRange || !ARange || !BRange || !ScaleARange || !ScaleBRange ||
+      !DRange->FullDwords || !ARange->FullDwords || !BRange->FullDwords ||
+      !ScaleARange->FullDwords || !ScaleBRange->FullDwords ||
+      DRange->Width != 16 || ARange->Width != 16 || BRange->Width != 8 ||
+      ScaleARange->Width != 2 || ScaleBRange->Width != 2)
+    return failClosed(Ctx, DI, "unexpected M=32 matrix/scale MC operand shape");
+
+  if (Layout->SourceSrc2 >= DI.Inst.getNumOperands())
+    return failClosed(Ctx, DI, "missing semantic src2 MC operand");
+  const MCOperand &Src2Op = DI.Inst.getOperand(Layout->SourceSrc2);
+  bool Src2IsImm = Src2Op.isImm();
+  std::optional<EncodedVgprRange> CRange;
+  if (Src2Op.isReg())
+    CRange = getOperandVgprRange(DI.Inst, Layout->SourceSrc2, *Ctx.LS.MRI);
+  else if (!Src2IsImm)
+    return failClosed(Ctx, DI, "unsupported non-VGPR/non-immediate src2");
+  if (CRange && (!CRange->FullDwords || CRange->Width != DRange->Width))
+    return failClosed(Ctx, DI, "src2 and destination widths differ");
+  if (!Src2IsImm && !CRange)
+    return failClosed(Ctx, DI, "could not determine src2 VGPR range");
 
   std::optional<unsigned> ActiveMode = getActiveVgprMsbMode(Ctx, Idx);
   if (!ActiveMode)
@@ -1529,45 +1960,6 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
     return failClosed(Ctx, DI, Detail);
   }
 
-  std::optional<Scale32PrintedAsm> Printed = parseScale32PrintedAsm(Ctx, DI);
-  if (!Printed)
-    return failClosed(Ctx, DI, "could not parse canonical instruction");
-  std::optional<std::string> LowSuffix =
-      transformScale32ModifierSuffix(Printed->ModifierSuffix,
-                                     /*HighKPass=*/false);
-  std::optional<std::string> HighSuffix =
-      transformScale32ModifierSuffix(Printed->ModifierSuffix,
-                                     /*HighKPass=*/true);
-  if (!LowSuffix || !HighSuffix)
-    return failClosed(Ctx, DI, "unsupported modifier combination");
-
-  std::optional<VgprRange> DRange =
-      matrixOperandRange(Ctx, DI, /*OperandIndex=*/0);
-  std::optional<VgprRange> ARange =
-      matrixOperandRange(Ctx, DI, /*OperandIndex=*/1);
-  std::optional<VgprRange> BRange =
-      matrixOperandRange(Ctx, DI, /*OperandIndex=*/2);
-  if (!DRange || !ARange || !BRange || DRange->Width != 16 ||
-      ARange->Width != 16 || BRange->Width != 8)
-    return failClosed(Ctx, DI, "unexpected M=32 matrix operand widths/layout");
-
-  // The M=32 profile mirrors the common VOP3P layout in its first five MC
-  // operands: vdst, src0, src1, src2 modifiers, src2. Validate that mirror at
-  // runtime so a TableGen layout change fails closed.
-  if (DI.Inst.getNumOperands() < 5)
-    return failClosed(Ctx, DI, "truncated M=32 MC operand layout");
-  const MCOperand &Src2Op = DI.Inst.getOperand(4);
-  bool Src2IsImm = Src2Op.isImm();
-  std::optional<VgprRange> CRange;
-  if (Src2Op.isReg())
-    CRange = matrixOperandRange(Ctx, DI, /*OperandIndex=*/3);
-  else if (!Src2IsImm)
-    return failClosed(Ctx, DI, "unsupported non-VGPR/non-immediate src2");
-  if (CRange && CRange->Width != 16)
-    return failClosed(Ctx, DI, "src2 and destination widths differ");
-  if (!Src2IsImm && !CRange)
-    return failClosed(Ctx, DI, "could not determine src2 VGPR range");
-
   unsigned Src0Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0);
   unsigned Src1Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1);
   unsigned Src2Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src2);
@@ -1577,9 +1969,9 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   unsigned ABase = ARange->Base + Src0Bank * VgprBankSize;
   unsigned BBase = BRange->Base + Src1Bank * VgprBankSize;
   unsigned CBase = CRange ? CRange->Base + Src2Bank * VgprBankSize : 0;
-  unsigned ScaleALo = *ScaleABase + Src0Bank * VgprBankSize;
+  unsigned ScaleALo = ScaleARange->Base + Src0Bank * VgprBankSize;
   unsigned ScaleAHi = ScaleALo + 1;
-  unsigned ScaleBLo = *ScaleBBase + Src1Bank * VgprBankSize;
+  unsigned ScaleBLo = ScaleBRange->Base + Src1Bank * VgprBankSize;
   unsigned ScaleBHi = ScaleBLo + 1;
 
   if (!physicalVgprRangeFitsOneBank(DBase, 16, Ctx.Config.MaxVgprs) ||
@@ -1703,8 +2095,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   std::array<unsigned, SavedARegCount> SavedARegs;
   for (unsigned &Reg : SavedARegs) {
     std::optional<unsigned> Allocated = allocContiguousDeadOrAboveInBank(
-        Alloc, /*Count=*/1, /*Align=*/1, VgprBankSize,
-        ForwardDead.has_value());
+        Alloc, /*Count=*/1, /*Align=*/1, VgprBankSize, ForwardDead.has_value());
     if (!Allocated)
       return failClosed(Ctx, DI,
                         "fewer than four dead/above-KD VGPRs for exact M+K "
@@ -1713,17 +2104,21 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   }
   unsigned TmpReg = SavedARegs.front();
 
-  std::string ReplacementAsm;
-  raw_string_ostream OS(ReplacementAsm);
+  SmallVector<uint8_t> Replacement;
   unsigned CurrentMode = *ActiveMode;
-  emitScalePairSplitInPlace(OS, ScaleALo, ScaleAHi, TmpReg, CurrentMode);
-  emitScalePairSplitInPlace(OS, ScaleBLo, ScaleBHi, TmpReg, CurrentMode);
+  {
+    std::string SplitAsm;
+    raw_string_ostream SplitOS(SplitAsm);
+    emitScalePairSplitInPlace(SplitOS, ScaleALo, ScaleAHi, TmpReg, CurrentMode);
+    emitScalePairSplitInPlace(SplitOS, ScaleBLo, ScaleBHi, TmpReg, CurrentMode);
+    if (!appendAssembledInstructions(Replacement, SplitAsm, Ctx.LS))
+      return failClosed(Ctx, DI, "scale-pair split assembly failed");
+  }
 
   int HazardNops = classifyWmmaNops("v_wmma_scale_f32_16x16x128_f8f6f4").A0Nops;
-  auto EmitHazardNops = [&] {
-    for (int I = 0; I != HazardNops; ++I)
-      OS << "v_nop\n";
-  };
+  SmallVector<uint8_t> VNop = assembleSingleInst("v_nop", Ctx.LS);
+  if (VNop.empty())
+    return failClosed(Ctx, DI, "v_nop assembly failed");
 
   for (bool HighK : {false, true}) {
     for (unsigned MHalf = 0; MHalf != 2; ++MHalf) {
@@ -1732,69 +2127,84 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
       unsigned ABank = OriginalAHalf / VgprBankSize;
       unsigned BBank = BBase / VgprBankSize;
 
+      std::string PreAsm;
+      raw_string_ostream PreOS(PreAsm);
       unsigned SavedIndex = 0;
       for (unsigned I = 0; I != MatrixHalfWidth; ++I) {
         bool IsLow = ((I / 2) % 2) == 0;
         if (IsLow == !HighK)
           continue;
         unsigned Saved = SavedARegs[SavedIndex++];
-        emitVgprCopy(OS, Saved, OriginalAHalf + I, /*W=*/1,
+        emitVgprCopy(PreOS, Saved, OriginalAHalf + I, /*W=*/1,
                      Saved / VgprBankSize, CurrentMode);
       }
       assert(SavedIndex == SavedARegCount);
-      emitMaskVgprsInPlace(OS, /*KeepLow=*/!HighK, OriginalAHalf,
+      emitMaskVgprsInPlace(PreOS, /*KeepLow=*/!HighK, OriginalAHalf,
                            MatrixHalfWidth, /*SubW=*/2, CurrentMode);
 
       SmallVector<VgprBankRequirement, 4> WmmaMode = {
           {VgprMsbOperand::Dst, DstHalf / VgprBankSize},
           {VgprMsbOperand::Src0, ABank},
           {VgprMsbOperand::Src1, BBank}};
-      std::string Src2;
+      std::optional<unsigned> OriginalSrc2Half;
       if (HighK) {
         WmmaMode.push_back({VgprMsbOperand::Src2, DstHalf / VgprBankSize});
-        Src2 = encodedVgprRange(DstHalf, MatrixHalfWidth);
       } else if (CRange) {
         unsigned CHalf = CBase + MHalf * MatrixHalfWidth;
         WmmaMode.push_back({VgprMsbOperand::Src2, CHalf / VgprBankSize});
-        Src2 = encodedVgprRange(CHalf, MatrixHalfWidth);
-      } else {
-        Src2 = Printed->Operands[3];
+        OriginalSrc2Half = CHalf;
       }
-      emitModeForOperands(OS, CurrentMode, WmmaMode);
-      emitScale32Half(OS, DstHalf, OriginalAHalf, BBase, Src2,
-                      HighK ? ScaleAHi : ScaleALo, HighK ? ScaleBHi : ScaleBLo,
-                      HighK ? *HighSuffix : *LowSuffix);
+      emitModeForOperands(PreOS, CurrentMode, WmmaMode);
+      if (!appendAssembledInstructions(Replacement, PreAsm, Ctx.LS))
+        return failClosed(Ctx, DI, "M+K split preamble assembly failed");
 
-      EmitHazardNops();
+      std::optional<SmallVector<uint8_t>> Wmma =
+          encodeScale32Half(DI, *Layout, DstHalf, OriginalAHalf, BBase,
+                            OriginalSrc2Half, HighK ? ScaleAHi : ScaleALo,
+                            HighK ? ScaleBHi : ScaleBLo, HighK, Ctx.LS);
+      if (!Wmma)
+        return failClosed(Ctx, DI,
+                          "semantic M=16 WMMA construction/encoding failed");
+      Replacement.append(Wmma->begin(), Wmma->end());
+      for (int I = 0; I != HazardNops; ++I)
+        Replacement.append(VNop.begin(), VNop.end());
+
+      std::string RestoreAsm;
+      raw_string_ostream RestoreOS(RestoreAsm);
       SavedIndex = 0;
       for (unsigned I = 0; I != MatrixHalfWidth; ++I) {
         bool IsLow = ((I / 2) % 2) == 0;
         if (IsLow == !HighK)
           continue;
         unsigned Saved = SavedARegs[SavedIndex++];
-        emitVgprCopy(OS, OriginalAHalf + I, Saved, /*W=*/1, ABank,
+        emitVgprCopy(RestoreOS, OriginalAHalf + I, Saved, /*W=*/1, ABank,
                      CurrentMode);
       }
       assert(SavedIndex == SavedARegCount);
+      if (!appendAssembledInstructions(Replacement, RestoreAsm, Ctx.LS))
+        return failClosed(Ctx, DI, "saved matrix-A restore assembly failed");
     }
   }
 
-  emitScalePairRestoreInPlace(OS, ScaleALo, ScaleAHi, TmpReg, CurrentMode);
-  emitScalePairRestoreInPlace(OS, ScaleBLo, ScaleBHi, TmpReg, CurrentMode);
-  emitModeForOperands(OS, CurrentMode,
-                      {{VgprMsbOperand::Src0,
-                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0)},
-                       {VgprMsbOperand::Src1,
-                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1)},
-                       {VgprMsbOperand::Src2,
-                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src2)},
-                       {VgprMsbOperand::Dst,
-                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst)}});
-
-  SmallVector<uint8_t> Replacement =
-      assembleInstructions(ReplacementAsm, Ctx.LS);
-  if (Replacement.empty())
-    return failClosed(Ctx, DI, "M+K split assembly failed");
+  {
+    std::string RestoreAsm;
+    raw_string_ostream RestoreOS(RestoreAsm);
+    emitScalePairRestoreInPlace(RestoreOS, ScaleALo, ScaleAHi, TmpReg,
+                                CurrentMode);
+    emitScalePairRestoreInPlace(RestoreOS, ScaleBLo, ScaleBHi, TmpReg,
+                                CurrentMode);
+    emitModeForOperands(RestoreOS, CurrentMode,
+                        {{VgprMsbOperand::Src0,
+                          getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0)},
+                         {VgprMsbOperand::Src1,
+                          getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1)},
+                         {VgprMsbOperand::Src2,
+                          getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src2)},
+                         {VgprMsbOperand::Dst,
+                          getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst)}});
+    if (!appendAssembledInstructions(Replacement, RestoreAsm, Ctx.LS))
+      return failClosed(Ctx, DI, "scale-pair/mode restore assembly failed");
+  }
 
   unsigned Extra = Alloc.extraVgprsNeeded();
   if (checkKernelVgprBump(Ctx, KernelName, Extra, PatchRequirement::Required) !=
@@ -1819,8 +2229,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
         << utohexstr(DI.Offset) << " (D=v" << DBase << ":" << (DBase + 15)
         << ", A=v" << ABase << ":" << (ABase + 15) << ", B=v" << BBase << ":"
         << (BBase + 7) << ", four saved-A VGPRs, tmp=v" << TmpReg << ", +"
-        << Extra << " vgpr, 4 WMMAs, "
-        << Replacement.size() << " bytes)\n";
+        << Extra << " vgpr, 4 WMMAs, " << Replacement.size() << " bytes)\n";
   return 1;
 }
 

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -46,8 +46,11 @@
 /// patch failed so the rewrite returns an error instead of a miscompile. A loud
 /// failure beats silent wrong results.
 ///
-/// The 32x16x128_f4 (M=32) variant also needs an M-split; it is not lowered
-/// exactly yet and fails closed.
+/// The 32x16x128_f4 (M=32) variant is split into two M=16 halves, and each
+/// resulting half is K-split as above, for four exact block-32 WMMAs total.
+/// Scratch reuse inside a fully allocated kernel is allowed only when exact
+/// all-path physical-register liveness proves each of its four scratch values
+/// dead.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -57,8 +60,10 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <array>
 #include <initializer_list>
 
 using namespace llvm;
@@ -74,6 +79,12 @@ static constexpr unsigned VOP3PXSize = 16;
 // AMDGPU SRC operand encoding: VGPRs are 256 + N.
 static constexpr unsigned VgprEncBase = 256;
 static constexpr unsigned VgprBankSize = 256;
+
+bool physicalVgprRangeFitsOneBank(unsigned Base, unsigned Width,
+                                  unsigned MaxVgprs) {
+  return Width != 0 && Base < MaxVgprs && Width <= MaxVgprs - Base &&
+         Base / VgprBankSize == (Base + Width - 1) / VgprBankSize;
+}
 
 static std::string vgprName(unsigned N) { return ("v" + Twine(N)).str(); }
 
@@ -182,7 +193,7 @@ using VgprBankRequirement = std::pair<VgprMsbOperand, unsigned>;
 
 static void
 emitModeForOperands(raw_string_ostream &OS, unsigned &CurrentMode,
-                    std::initializer_list<VgprBankRequirement> Requirements) {
+                    ArrayRef<VgprBankRequirement> Requirements) {
   unsigned NewMode = CurrentMode;
   for (const VgprBankRequirement &Requirement : Requirements)
     setVgprMsbBank(NewMode, Requirement.first, Requirement.second);
@@ -338,6 +349,52 @@ static void emitVgprCopy(raw_string_ostream &OS, unsigned DstBase,
   }
 }
 
+static void emitScalePairSplitInPlace(raw_string_ostream &OS, unsigned Lo,
+                                      unsigned Hi, unsigned Tmp,
+                                      unsigned &CurrentMode) {
+  unsigned PairBank = Lo / VgprBankSize;
+  unsigned TmpBank = Tmp / VgprBankSize;
+  emitVgprCopy(OS, Tmp, Lo, /*W=*/1, TmpBank, CurrentMode);
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, PairBank},
+                       {VgprMsbOperand::Src0, TmpBank},
+                       {VgprMsbOperand::Src1, PairBank}});
+  OS << "v_perm_b32 " << encodedVgprName(Lo) << ", " << encodedVgprName(Tmp)
+     << ", " << encodedVgprName(Hi) << ", 0x06040200\n";
+  OS << "v_perm_b32 " << encodedVgprName(Hi) << ", " << encodedVgprName(Tmp)
+     << ", " << encodedVgprName(Hi) << ", 0x07050301\n";
+}
+
+static void emitScalePairRestoreInPlace(raw_string_ostream &OS, unsigned Lo,
+                                        unsigned Hi, unsigned Tmp,
+                                        unsigned &CurrentMode) {
+  unsigned PairBank = Lo / VgprBankSize;
+  unsigned TmpBank = Tmp / VgprBankSize;
+  emitVgprCopy(OS, Tmp, Lo, /*W=*/1, TmpBank, CurrentMode);
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, PairBank},
+                       {VgprMsbOperand::Src0, TmpBank},
+                       {VgprMsbOperand::Src1, PairBank}});
+  OS << "v_perm_b32 " << encodedVgprName(Lo) << ", " << encodedVgprName(Tmp)
+     << ", " << encodedVgprName(Hi) << ", 0x05010400\n";
+  OS << "v_perm_b32 " << encodedVgprName(Hi) << ", " << encodedVgprName(Tmp)
+     << ", " << encodedVgprName(Hi) << ", 0x07030602\n";
+}
+
+static void emitMaskVgprsInPlace(raw_string_ostream &OS, bool KeepLow,
+                                 unsigned Base, unsigned W, unsigned SubW,
+                                 unsigned &CurrentMode) {
+  for (unsigned I = 0; I != W; ++I) {
+    bool IsLow = ((I / SubW) % 2) == 0;
+    if (IsLow == KeepLow)
+      continue;
+    unsigned Physical = Base + I;
+    emitModeForOperands(OS, CurrentMode,
+                        {{VgprMsbOperand::Dst, Physical / VgprBankSize}});
+    OS << "v_mov_b32 " << encodedVgprName(Physical) << ", 0\n";
+  }
+}
+
 // Parse a matrix VGPR range from the printer's canonical form.
 struct VgprRange {
   unsigned Base;
@@ -374,6 +431,757 @@ matrixOperandRange(PatchContext &Ctx, const InternalDecodedInst &DI,
   if (LoS.getAsInteger(10, Lo) || HiS.getAsInteger(10, Hi) || Hi < Lo)
     return std::nullopt;
   return VgprRange{Lo, Hi - Lo + 1};
+}
+
+struct Scale32PrintedAsm {
+  std::string Operands[6]; // dst, matrix A/B, src2, scale A/B
+  std::string ModifierSuffix;
+};
+
+// Parse the six positional operands of the M=32 scaled WMMA while preserving
+// the printer's exact inline-immediate spelling and modifier ordering.
+static std::optional<Scale32PrintedAsm>
+parseScale32PrintedAsm(PatchContext &Ctx, const InternalDecodedInst &DI) {
+  SmallString<256> Buf;
+  raw_svector_ostream OS(Buf);
+  Ctx.LS.MCIP->printInst(&DI.Inst, /*Address=*/0, /*Annot=*/"", *Ctx.LS.STI,
+                         OS);
+  StringRef S = StringRef(Buf).trim();
+  size_t MnemEnd = S.find_first_of(" \t");
+  if (MnemEnd == StringRef::npos)
+    return std::nullopt;
+
+  Scale32PrintedAsm Result;
+  StringRef Rest = S.substr(MnemEnd).ltrim();
+  for (unsigned I = 0; I != 5; ++I) {
+    size_t Comma = Rest.find(',');
+    if (Comma == StringRef::npos)
+      return std::nullopt;
+    Result.Operands[I] = Rest.substr(0, Comma).trim().str();
+    Rest = Rest.substr(Comma + 1).ltrim();
+  }
+  size_t ModBegin = Rest.find_first_of(" \t");
+  if (ModBegin == StringRef::npos) {
+    Result.Operands[5] = Rest.str();
+  } else {
+    Result.Operands[5] = Rest.substr(0, ModBegin).str();
+    Result.ModifierSuffix = Rest.substr(ModBegin).str();
+  }
+  return Result;
+}
+
+static SmallVector<StringRef, 8> tokenizeScaleModifiers(StringRef Suffix) {
+  SmallVector<StringRef, 8> Result;
+  StringRef Rest = Suffix.ltrim();
+  while (!Rest.empty()) {
+    size_t Space = Rest.find_first_of(" \t");
+    if (Space == StringRef::npos) {
+      Result.push_back(Rest);
+      break;
+    }
+    Result.push_back(Rest.substr(0, Space));
+    Rest = Rest.substr(Space + 1).ltrim();
+  }
+  return Result;
+}
+
+static bool parsePackedScaleModifier(StringRef Token, StringRef Name,
+                                     std::array<StringRef, 3> &Bits) {
+  if (!Token.starts_with(Name) || !Token.ends_with("]"))
+    return false;
+  Token = Token.drop_front(Name.size());
+  if (!Token.starts_with(":["))
+    return false;
+  SmallVector<StringRef, 3> Parts;
+  Token.drop_front(2).drop_back(1).split(Parts, ",");
+  if (Parts.size() != 3)
+    return false;
+  for (unsigned I = 0; I != 3; ++I) {
+    Bits[I] = Parts[I].trim();
+    if (Bits[I] != "0" && Bits[I] != "1")
+      return false;
+  }
+  return true;
+}
+
+static bool isKnownScale32Modifier(StringRef Token) {
+  if (Token == "matrix_a_reuse" || Token == "matrix_b_reuse" ||
+      Token == "matrix_a_scale:MATRIX_SCALE_ROW1" ||
+      Token == "matrix_b_scale:MATRIX_SCALE_ROW1" ||
+      Token == "matrix_a_scale_fmt:MATRIX_SCALE_FMT_E8" ||
+      Token == "matrix_a_scale_fmt:MATRIX_SCALE_FMT_E5M3" ||
+      Token == "matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3" ||
+      Token == "matrix_b_scale_fmt:MATRIX_SCALE_FMT_E8" ||
+      Token == "matrix_b_scale_fmt:MATRIX_SCALE_FMT_E5M3" ||
+      Token == "matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3")
+    return true;
+  std::array<StringRef, 3> Bits;
+  return parsePackedScaleModifier(Token, "neg_lo", Bits) ||
+         parsePackedScaleModifier(Token, "neg_hi", Bits);
+}
+
+// The split changes both matrix register layout and the K-pass accumulator.
+// Reuse promises therefore no longer describe the generated sequence and are
+// removed. On each high-K pass src2 is the low-pass result, not the original
+// C, so clear the src2 neg/abs bit instead of applying C's modifier twice.
+static std::optional<std::string>
+transformScale32ModifierSuffix(StringRef Suffix, bool HighKPass) {
+  std::string Result;
+  for (StringRef Token : tokenizeScaleModifiers(Suffix)) {
+    if (!isKnownScale32Modifier(Token)) {
+      log() << "hotswap: error: wmma_scale16: unsupported M=32 modifier token "
+               "\""
+            << Token << "\"\n";
+      return std::nullopt;
+    }
+    if (Token == "matrix_a_reuse" || Token == "matrix_b_reuse")
+      continue;
+
+    std::array<StringRef, 3> Bits;
+    if (HighKPass && (parsePackedScaleModifier(Token, "neg_lo", Bits) ||
+                      parsePackedScaleModifier(Token, "neg_hi", Bits))) {
+      if (Bits[0] == "0" && Bits[1] == "0")
+        continue;
+      StringRef Name = Token.take_front(Token.find(':'));
+      Result += (" " + Name + ":[" + Bits[0] + "," + Bits[1] + ",0]").str();
+      continue;
+    }
+    Result += ' ';
+    Result += Token.str();
+  }
+  return Result;
+}
+
+static std::string encodedVgprRange(unsigned PhysicalBase, unsigned Width) {
+  assert(Width > 0);
+  unsigned EncodedBase = PhysicalBase % VgprBankSize;
+  return formatv("v[{0}:{1}]", EncodedBase, EncodedBase + Width - 1).str();
+}
+
+static void emitScale32Half(raw_string_ostream &OS, unsigned DstBase,
+                            unsigned MatrixABase, unsigned MatrixBBase,
+                            StringRef Src2, unsigned ScaleAReg,
+                            unsigned ScaleBReg, StringRef ModifierSuffix) {
+  OS << "v_wmma_scale_f32_16x16x128_f8f6f4 " << encodedVgprRange(DstBase, 8)
+     << ", " << encodedVgprRange(MatrixABase, 8) << ", "
+     << encodedVgprRange(MatrixBBase, 8) << ", " << Src2 << ", "
+     << encodedVgprName(ScaleAReg) << ", " << encodedVgprName(ScaleBReg)
+     << " matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4"
+     << ModifierSuffix << "\n";
+}
+
+// Prefer one exact-liveness-proven dead block inside the kernel's declared
+// allocation. Fully allocated production kernels often have no above-KD
+// headroom even though a particular WMMA site has a large dead interval.
+// Search high-to-low within each physical bank so every generated range keeps
+// one VGPR-MSB setting. Fall back to the allocator's normal above-KD growth.
+static std::optional<unsigned>
+allocContiguousDeadOrAboveInBank(VgprAllocator &Alloc, unsigned Count,
+                                 unsigned Align, unsigned BankSize,
+                                 bool AllowDeadReuse) {
+  if (Count == 0 || Count > BankSize || Align == 0)
+    return std::nullopt;
+
+  if (AllowDeadReuse) {
+    unsigned BankCount = (Alloc.KdAllocatedVgprs + BankSize - 1) / BankSize;
+    for (unsigned ReverseBank = BankCount; ReverseBank != 0; --ReverseBank) {
+      unsigned Bank = ReverseBank - 1;
+      unsigned BankBegin = Bank * BankSize;
+      unsigned BankEnd = std::min(Alloc.KdAllocatedVgprs, BankBegin + BankSize);
+      if (BankEnd < BankBegin + Count)
+        continue;
+
+      unsigned Base = BankEnd - Count;
+      Base -= Base % Align;
+      while (Base >= BankBegin) {
+        bool AllDead = true;
+        for (unsigned V = Base; V != Base + Count; ++V) {
+          if (V >= static_cast<unsigned>(Alloc.LiveAtPoint.size()) ||
+              Alloc.LiveAtPoint.test(V)) {
+            AllDead = false;
+            break;
+          }
+        }
+        if (AllDead) {
+          Alloc.LiveAtPoint.set(Base, Base + Count);
+          return Base;
+        }
+        if (Base < BankBegin + Align)
+          break;
+        Base -= Align;
+      }
+    }
+  }
+  return Alloc.allocContiguousAboveKdInBank(Count, Align, BankSize);
+}
+
+static bool rangesOverlap(unsigned ABase, unsigned AWidth, unsigned BBase,
+                          unsigned BWidth) {
+  return ABase < BBase + BWidth && BBase < ABase + AWidth;
+}
+
+static bool sameRange(unsigned ABase, unsigned AWidth, unsigned BBase,
+                      unsigned BWidth) {
+  return ABase == BBase && AWidth == BWidth;
+}
+
+static void reserveVgprRange(VgprAllocator &Alloc, unsigned Base,
+                             unsigned Width) {
+  assert(Width > 0 && Base <= Alloc.LiveAtPoint.size() &&
+         Width <= Alloc.LiveAtPoint.size() - Base);
+  Alloc.LiveAtPoint.set(Base, Base + Width);
+}
+
+struct EncodedVgprRange {
+  unsigned Base = 0;
+  unsigned Width = 0;
+  bool FullDwords = false;
+};
+
+static std::optional<unsigned> parseScalarVgprName(StringRef Name,
+                                                   bool &IsPartial) {
+  IsPartial = false;
+  if (!Name.consume_front("VGPR"))
+    return std::nullopt;
+  size_t Digits = Name.find_first_not_of("0123456789");
+  StringRef Number = Digits == StringRef::npos ? Name : Name.take_front(Digits);
+  unsigned Index = 0;
+  if (Number.empty() || Number.getAsInteger(10, Index))
+    return std::nullopt;
+  if (Digits == StringRef::npos)
+    return Index;
+  StringRef Suffix = Name.drop_front(Digits);
+  if (Suffix == "_LO16" || Suffix == "_HI16") {
+    IsPartial = true;
+    return Index;
+  }
+  return std::nullopt;
+}
+
+// Convert an explicit MC VGPR or VGPR tuple to its encoded v0..v255 interval.
+// True16 operands are identified but never accepted as a full-value kill.
+static std::optional<EncodedVgprRange>
+getEncodedVgprRange(MCRegister Reg, const MCRegisterInfo &MRI) {
+  if (!Reg)
+    return std::nullopt;
+
+  bool IsPartial = false;
+  if (std::optional<unsigned> Scalar =
+          parseScalarVgprName(MRI.getName(Reg), IsPartial))
+    return EncodedVgprRange{*Scalar, 1, !IsPartial};
+
+  SmallVector<unsigned, 16> Scalars;
+  for (MCPhysReg Sub : MRI.subregs(Reg)) {
+    bool SubPartial = false;
+    std::optional<unsigned> Index =
+        parseScalarVgprName(MRI.getName(Sub), SubPartial);
+    if (Index && !SubPartial)
+      Scalars.push_back(*Index);
+  }
+  if (Scalars.empty())
+    return std::nullopt;
+  llvm::sort(Scalars);
+  Scalars.erase(std::unique(Scalars.begin(), Scalars.end()), Scalars.end());
+  for (unsigned I = 1; I != Scalars.size(); ++I)
+    if (Scalars[I] != Scalars.front() + I)
+      return std::nullopt;
+  return EncodedVgprRange{Scalars.front(),
+                          static_cast<unsigned>(Scalars.size()), true};
+}
+
+bool isVectorRegisterOrAlias(MCRegister Reg, const MCRegisterInfo &MRI) {
+  if (!Reg)
+    return false;
+  for (MCRegAliasIterator Alias(Reg, &MRI, /*IncludeSelf=*/true);
+       Alias.isValid(); ++Alias) {
+    StringRef Name = MRI.getName(*Alias);
+    if (Name.contains("VGPR") || Name.contains("AGPR"))
+      return true;
+  }
+  return false;
+}
+
+static bool setPhysicalVgprRange(BitVector &Out, const EncodedVgprRange &Range,
+                                 unsigned Bank, unsigned MaxVgprs) {
+  if (Range.Width == 0 || Range.Base >= VgprBankSize ||
+      Range.Width > VgprBankSize - Range.Base)
+    return false;
+  unsigned Base = Range.Base + Bank * VgprBankSize;
+  if (Base >= MaxVgprs || Range.Width > MaxVgprs - Base)
+    return false;
+  Out.set(Base, Base + Range.Width);
+  return true;
+}
+
+struct PhysicalVgprAccess {
+  BitVector Uses;
+  BitVector FullDefs;
+  bool Valid = true;
+
+  explicit PhysicalVgprAccess(unsigned MaxVgprs)
+      : Uses(MaxVgprs), FullDefs(MaxVgprs) {}
+};
+
+// The M=32 Scale16 MC layout is mirrored and runtime-validated by the
+// lowering below. Its two scale operands reuse the matrix source banks:
+// matrix-A/scale-A use src0, matrix-B/scale-B use src1, and the accumulator
+// uses src2. Other instruction layouts remain conservative-all-banks unless
+// their role is structurally unambiguous.
+static std::optional<VgprMsbOperand>
+getExactSourceRole(const InternalDecodedInst &DI, unsigned OperandIndex,
+                   unsigned NumDefs) {
+  if (DI.Mnemonic == "v_wmma_scale16_f32_32x16x128_f4") {
+    switch (OperandIndex) {
+    case 1:
+    case 5:
+      return VgprMsbOperand::Src0;
+    case 2:
+    case 6:
+      return VgprMsbOperand::Src1;
+    case 4:
+      return VgprMsbOperand::Src2;
+    default:
+      return std::nullopt;
+    }
+  }
+  if (StringRef(DI.Mnemonic).starts_with("ds_") && OperandIndex == NumDefs)
+    return VgprMsbOperand::Src0;
+  return std::nullopt;
+}
+
+// Resolve every explicit access through the exact persistent VGPR-MSB mode.
+// Sources with a validated architectural role use that role's bank. Every
+// other source maps through the union of src0/src1/src2 banks, which can only
+// add uses, never hide one. Explicit full-width definitions use the
+// architectural dst bank. Tied definitions are reads of their incoming
+// destination. Implicit/partial VGPR operands cannot prove a kill and
+// conservatively block the encoded range in every bank.
+static PhysicalVgprAccess getPhysicalVgprAccess(const InternalDecodedInst &DI,
+                                                const LLVMState &LS,
+                                                unsigned Mode,
+                                                unsigned MaxVgprs) {
+  PhysicalVgprAccess Result(MaxVgprs);
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  const MCRegisterInfo &MRI = *LS.MRI;
+  unsigned DstBank = getVgprMsbBank(Mode, VgprMsbOperand::Dst);
+  SmallVector<unsigned, 3> SrcBanks = {
+      getVgprMsbBank(Mode, VgprMsbOperand::Src0),
+      getVgprMsbBank(Mode, VgprMsbOperand::Src1),
+      getVgprMsbBank(Mode, VgprMsbOperand::Src2)};
+  llvm::sort(SrcBanks);
+  SrcBanks.erase(std::unique(SrcBanks.begin(), SrcBanks.end()), SrcBanks.end());
+
+  auto AddEveryBankUse = [&](const EncodedVgprRange &Range) {
+    for (unsigned Bank = 0; Bank * VgprBankSize < MaxVgprs; ++Bank)
+      if (!setPhysicalVgprRange(Result.Uses, Range, Bank, MaxVgprs))
+        Result.Valid = false;
+  };
+
+  unsigned NumDefs = Desc.getNumDefs();
+  for (unsigned I = 0, E = DI.Inst.getNumOperands(); I != E; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (!Op.isReg() || !Op.getReg())
+      continue;
+    std::optional<EncodedVgprRange> Range =
+        getEncodedVgprRange(MCRegister(Op.getReg()), MRI);
+    if (!Range) {
+      if (isVectorRegisterOrAlias(MCRegister(Op.getReg()), MRI))
+        Result.Valid = false;
+      continue;
+    }
+
+    bool IsDef = I < NumDefs;
+    if (!IsDef) {
+      if (std::optional<VgprMsbOperand> Role =
+              getExactSourceRole(DI, I, NumDefs)) {
+        unsigned Bank = getVgprMsbBank(Mode, *Role);
+        if (!setPhysicalVgprRange(Result.Uses, *Range, Bank, MaxVgprs))
+          Result.Valid = false;
+      } else {
+        for (unsigned Bank : SrcBanks)
+          if (!setPhysicalVgprRange(Result.Uses, *Range, Bank, MaxVgprs))
+            Result.Valid = false;
+      }
+      continue;
+    }
+
+    int TiedTo = Desc.getOperandConstraint(I, MCOI::TIED_TO);
+    if (TiedTo >= 0) {
+      if (!setPhysicalVgprRange(Result.Uses, *Range, DstBank, MaxVgprs))
+        Result.Valid = false;
+    }
+    if (!Range->FullDwords) {
+      AddEveryBankUse(*Range);
+      continue;
+    }
+    if (!setPhysicalVgprRange(Result.FullDefs, *Range, DstBank, MaxVgprs))
+      Result.Valid = false;
+  }
+
+  for (MCPhysReg Implicit : Desc.implicit_uses()) {
+    std::optional<EncodedVgprRange> Range =
+        getEncodedVgprRange(MCRegister(Implicit), MRI);
+    if (Range)
+      AddEveryBankUse(*Range);
+    else if (isVectorRegisterOrAlias(MCRegister(Implicit), MRI))
+      Result.Valid = false;
+  }
+  for (MCPhysReg Implicit : Desc.implicit_defs()) {
+    std::optional<EncodedVgprRange> Range =
+        getEncodedVgprRange(MCRegister(Implicit), MRI);
+    if (Range)
+      AddEveryBankUse(*Range);
+    else if (isVectorRegisterOrAlias(MCRegister(Implicit), MRI))
+      Result.Valid = false;
+  }
+  return Result;
+}
+
+static bool hasDynamicVgprAddressing(ArrayRef<InternalDecodedInst> Decoded,
+                                     size_t Begin, size_t End) {
+  for (size_t I = Begin; I != End; ++I) {
+    StringRef Mnemonic = Decoded[I].Mnemonic;
+    if (Mnemonic.contains("movrel") || Mnemonic.contains("gpr_idx") ||
+        Mnemonic.starts_with("s_setreg"))
+      return true;
+  }
+  return false;
+}
+
+std::optional<BitVector>
+computeForwardDeadVgprs(ArrayRef<ForwardVgprProofNode> Nodes, size_t EntryNode,
+                        unsigned MaxVgprs) {
+  if (Nodes.empty() || EntryNode >= Nodes.size() || MaxVgprs == 0)
+    return std::nullopt;
+  for (const ForwardVgprProofNode &Node : Nodes) {
+    if (Node.Uses.size() != MaxVgprs || Node.FullDefs.size() != MaxVgprs)
+      return std::nullopt;
+    for (size_t Successor : Node.Successors)
+      if (Successor >= Nodes.size())
+        return std::nullopt;
+  }
+
+  std::vector<BitVector> AliveAt(Nodes.size(), BitVector(MaxVgprs));
+  AliveAt[EntryNode].set();
+  BitVector Unsafe(MaxVgprs);
+  SmallVector<size_t, 64> Worklist;
+  Worklist.push_back(EntryNode);
+
+  while (!Worklist.empty()) {
+    size_t Index = Worklist.pop_back_val();
+    BitVector Alive = AliveAt[Index];
+    if (Alive.none())
+      continue;
+
+    const ForwardVgprProofNode &Node = Nodes[Index];
+    if (Node.Opaque) {
+      Unsafe |= Alive;
+      continue;
+    }
+
+    BitVector UsedAlive = Alive;
+    UsedAlive &= Node.Uses;
+    Unsafe |= UsedAlive;
+    Alive.reset(Node.Uses);
+    Alive.reset(Node.FullDefs);
+
+    if (Node.HasUnsafeExit)
+      Unsafe |= Alive;
+    if (Node.Successors.empty()) {
+      if (!Node.SafeTerminal)
+        Unsafe |= Alive;
+      continue;
+    }
+
+    for (size_t Successor : Node.Successors) {
+      BitVector NewBits = Alive;
+      NewBits.reset(AliveAt[Successor]);
+      if (NewBits.none())
+        continue;
+      AliveAt[Successor] |= Alive;
+      Worklist.push_back(Successor);
+    }
+  }
+
+  // A value that can circulate around a cycle without a use or full kill is
+  // not accepted as scratch. Detect such cycles in the per-value subgraph:
+  // Kahn removal leaves exactly the nodes belonging to, or fed only by, a
+  // surviving cycle. This is intentionally conservative for non-terminating
+  // paths and makes loop handling independent of worklist visitation order.
+  SmallVector<unsigned, 64> InDegree(Nodes.size());
+  SmallVector<size_t, 64> Queue;
+  BitVector Included(Nodes.size());
+  for (unsigned V = 0; V != MaxVgprs; ++V) {
+    if (Unsafe.test(V))
+      continue;
+    Included.reset();
+    unsigned IncludedCount = 0;
+    for (size_t I = 0; I != Nodes.size(); ++I) {
+      const ForwardVgprProofNode &Node = Nodes[I];
+      if (AliveAt[I].test(V) && !Node.Opaque && !Node.Uses.test(V) &&
+          !Node.FullDefs.test(V)) {
+        Included.set(I);
+        ++IncludedCount;
+      }
+    }
+    if (IncludedCount == 0)
+      continue;
+
+    llvm::fill(InDegree, 0);
+    for (int I = Included.find_first(); I >= 0; I = Included.find_next(I))
+      for (size_t Successor : Nodes[static_cast<size_t>(I)].Successors)
+        if (Included.test(Successor))
+          ++InDegree[Successor];
+    Queue.clear();
+    for (int I = Included.find_first(); I >= 0; I = Included.find_next(I))
+      if (InDegree[static_cast<size_t>(I)] == 0)
+        Queue.push_back(static_cast<size_t>(I));
+
+    unsigned Removed = 0;
+    while (!Queue.empty()) {
+      size_t I = Queue.pop_back_val();
+      ++Removed;
+      for (size_t Successor : Nodes[I].Successors)
+        if (Included.test(Successor) && --InDegree[Successor] == 0)
+          Queue.push_back(Successor);
+    }
+    if (Removed != IncludedCount)
+      Unsafe.set(V);
+  }
+
+  BitVector Safe(MaxVgprs);
+  Safe.set();
+  Safe.reset(Unsafe);
+  return Safe;
+}
+
+struct ScaleForwardGraph {
+  std::vector<ForwardVgprProofNode> Nodes;
+  std::vector<size_t> GlobalIndices;
+  std::vector<int16_t> ModeBefore;
+  BitVector UndecodedVop3Heads;
+  size_t EntryNode = 0;
+};
+
+// The B0 f4gemm object contains a legacy VOP3 opcode that the A0 gfx1250 MC
+// decoder intentionally does not recognize. The failed decode advances only
+// one dword, so its second dword appears as a separate unknown instruction.
+//
+// Recognize only the exact observed encoding:
+//   * legacy VOP3 major 0x34 and opcode 0x31;
+//   * vdst encoding zero, with only the observed bit-14 modifier variation;
+//   * scalar source encodings, in either observed second-dword spelling.
+//
+// We do not assign the unknown opcode semantics. Instead, conservatively model
+// encoded v0 as a use in every physical bank (so it cannot be scratch), model
+// no kill, and skip the split continuation dword. This is enough to traverse
+// the instruction without relying on whether opcode 0x31 has a vector or
+// scalar destination on B0.
+static bool recognizeUndecodedB0Vop3ScalarSources(
+    PatchContext &Ctx, size_t Global, unsigned MaxVgprs,
+    BitVector &ConservativeUses) {
+  if (Global + 1 >= Ctx.Decoded.size())
+    return false;
+  const InternalDecodedInst &Head = Ctx.Decoded[Global];
+  const InternalDecodedInst &Tail = Ctx.Decoded[Global + 1];
+  if (Head.DecodeSucceeded || Head.Size != MinInstSize ||
+      Tail.Offset != Head.Offset + MinInstSize ||
+      Head.Offset > Ctx.TextSize || 2 * MinInstSize > Ctx.TextSize - Head.Offset)
+    return false;
+
+  const uint8_t *Raw = Ctx.Text + Head.Offset;
+  uint32_t Word0 = support::endian::read32le(Raw);
+  uint32_t Word1 = support::endian::read32le(Raw + MinInstSize);
+  constexpr uint32_t Bit14 = 1u << 14;
+  if ((Word0 & ~Bit14) != 0xd0310000u ||
+      (Word1 != 0 && Word1 != 0x00100000u))
+    return false;
+
+  // A direct/declared entry into the decoder-created continuation slot would
+  // make treating the pair as one instruction unsound.
+  if (Ctx.DirectControlFlow.Targets.contains(Tail.Offset) ||
+      llvm::is_contained(Ctx.DeclaredEntries, Tail.Offset))
+    return false;
+
+  for (unsigned Physical = 0; Physical < MaxVgprs;
+       Physical += VgprBankSize)
+    ConservativeUses.set(Physical);
+  return true;
+}
+
+static std::optional<ScaleForwardGraph>
+buildScaleForwardGraph(PatchContext &Ctx, size_t SiteIdx, unsigned EntryMode,
+                       unsigned MaxVgprs) {
+  if (!Ctx.LS.MIA || !Ctx.LS.MCII || !Ctx.LS.MRI ||
+      SiteIdx >= Ctx.Decoded.size())
+    return std::nullopt;
+
+  std::optional<ElfView::FunctionTextRange> Owner =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Ctx.Decoded[SiteIdx].Offset);
+  if (!Owner || SiteIdx + 1 >= Ctx.Decoded.size())
+    return std::nullopt;
+
+  size_t BeginIndex = SiteIdx;
+  while (BeginIndex > 0 && Ctx.Decoded[BeginIndex - 1].Offset >= Owner->Begin)
+    --BeginIndex;
+  size_t EndIndex = SiteIdx + 1;
+  while (EndIndex < Ctx.Decoded.size() &&
+         Ctx.Decoded[EndIndex].Offset < Owner->End)
+    ++EndIndex;
+  if (BeginIndex == EndIndex || SiteIdx + 1 >= EndIndex)
+    return std::nullopt;
+
+  ScaleForwardGraph Graph;
+  size_t Count = EndIndex - BeginIndex;
+  Graph.Nodes.reserve(Count);
+  Graph.GlobalIndices.reserve(Count);
+  for (size_t I = BeginIndex; I != EndIndex; ++I) {
+    Graph.Nodes.emplace_back(MaxVgprs);
+    Graph.GlobalIndices.push_back(I);
+  }
+  Graph.UndecodedVop3Heads.resize(Count);
+  Graph.EntryNode = SiteIdx + 1 - BeginIndex;
+
+  DenseMap<uint64_t, size_t> IndexAtOffset;
+  for (size_t Local = 0; Local != Count; ++Local)
+    IndexAtOffset[Ctx.Decoded[Graph.GlobalIndices[Local]].Offset] = Local;
+
+  auto AddFallthrough = [&](size_t Local) {
+    if (Local + 1 < Count)
+      Graph.Nodes[Local].Successors.push_back(Local + 1);
+    else
+      Graph.Nodes[Local].HasUnsafeExit = true;
+  };
+
+  for (size_t Local = 0; Local != Count; ++Local) {
+    size_t Global = Graph.GlobalIndices[Local];
+    const InternalDecodedInst &DI = Ctx.Decoded[Global];
+    ForwardVgprProofNode &Node = Graph.Nodes[Local];
+
+    // A later loop iteration reaches the replacement itself. Scratch excludes
+    // every original operand, and the replacement defines its scratch before
+    // reading it, so no incoming scratch value can be observed there.
+    if (Global == SiteIdx) {
+      Node.SafeTerminal = true;
+      continue;
+    }
+    if (!DI.DecodeSucceeded &&
+        recognizeUndecodedB0Vop3ScalarSources(Ctx, Global, MaxVgprs,
+                                              Node.Uses)) {
+      if (Local + 2 >= Count)
+        Node.HasUnsafeExit = true;
+      else
+        Node.Successors.push_back(Local + 2);
+      Graph.UndecodedVop3Heads.set(Local);
+      continue;
+    }
+    if (!DI.DecodeSucceeded ||
+        hasDynamicVgprAddressing(Ctx.Decoded, Global, Global + 1)) {
+      Node.Opaque = true;
+      continue;
+    }
+    if (DI.Inst.getOpcode() == Ctx.LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == Ctx.LS.SEndPgmSavedOpcode) {
+      Node.SafeTerminal = true;
+      continue;
+    }
+    if (Ctx.LS.MIA->isCall(DI.Inst) || Ctx.LS.MIA->isIndirectBranch(DI.Inst) ||
+        Ctx.LS.MIA->isReturn(DI.Inst)) {
+      Node.Opaque = true;
+      continue;
+    }
+    if (Ctx.LS.MIA->isBranch(DI.Inst)) {
+      uint64_t Target = 0;
+      if (!Ctx.LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target)) {
+        Node.Opaque = true;
+        continue;
+      }
+      DenseMap<uint64_t, size_t>::const_iterator TargetIt =
+          IndexAtOffset.find(Target);
+      if (TargetIt == IndexAtOffset.end())
+        Node.HasUnsafeExit = true;
+      else
+        Node.Successors.push_back(TargetIt->second);
+      if (Ctx.LS.MIA->isConditionalBranch(DI.Inst))
+        AddFallthrough(Local);
+      else if (!Ctx.LS.MIA->isUnconditionalBranch(DI.Inst))
+        Node.Opaque = true;
+      continue;
+    }
+    if (Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI)) {
+      Node.Opaque = true;
+      continue;
+    }
+    AddFallthrough(Local);
+  }
+
+  Graph.ModeBefore.assign(Count, VgprMsbUnreachable);
+  Graph.ModeBefore[Graph.EntryNode] = static_cast<int16_t>(EntryMode & 0xff);
+  SmallVector<size_t, 64> Worklist;
+  Worklist.push_back(Graph.EntryNode);
+  for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+    size_t Local = Worklist[Next];
+    const ForwardVgprProofNode &Node = Graph.Nodes[Local];
+    if (Node.Opaque || Node.SafeTerminal)
+      continue;
+    int16_t Out =
+        Graph.UndecodedVop3Heads.test(Local)
+            ? Graph.ModeBefore[Local]
+            : transferExactVgprMsbMode(
+                  Graph.ModeBefore[Local],
+                  Ctx.Decoded[Graph.GlobalIndices[Local]], Ctx.LS);
+    for (size_t Successor : Node.Successors) {
+      int16_t Old = Graph.ModeBefore[Successor];
+      int16_t Merged = Old == VgprMsbUnreachable ? Out
+                       : Old == Out              ? Old
+                                                 : VgprMsbUnknown;
+      if (Merged != Old) {
+        Graph.ModeBefore[Successor] = Merged;
+        Worklist.push_back(Successor);
+      }
+    }
+  }
+  return Graph;
+}
+
+// Return physical VGPR values whose incoming contents cannot be observed on
+// any continuation path after SiteIdx. This deliberately does not consume the
+// generic LivenessInfo: its weak in-tree implementation is encoded-v0..v255
+// conservative liveness, not a proof over gfx1250's four physical banks.
+static std::optional<BitVector>
+computeForwardDeadPhysicalVgprs(PatchContext &Ctx, size_t SiteIdx,
+                                unsigned EntryMode, unsigned MaxVgprs) {
+  if (Ctx.DirectControlFlow.HasUnresolvedTargets ||
+      Ctx.DirectControlFlow.HasUnboundedIndirectEntries || !Ctx.LS.MIA ||
+      !Ctx.LS.MCII || !Ctx.LS.MRI || SiteIdx >= Ctx.Decoded.size())
+    return std::nullopt;
+
+  std::optional<ScaleForwardGraph> Graph =
+      buildScaleForwardGraph(Ctx, SiteIdx, EntryMode, MaxVgprs);
+  if (!Graph)
+    return std::nullopt;
+
+  for (size_t Local = 0; Local != Graph->Nodes.size(); ++Local) {
+    ForwardVgprProofNode &Node = Graph->Nodes[Local];
+    if (Node.Opaque || Node.SafeTerminal)
+      continue;
+    if (Graph->UndecodedVop3Heads.test(Local))
+      continue;
+
+    int16_t Mode = Graph->ModeBefore[Local];
+    if (Mode == VgprMsbUnreachable)
+      continue;
+    unsigned AccessMode = Mode >= 0 ? static_cast<unsigned>(Mode) : 0;
+    PhysicalVgprAccess Access = getPhysicalVgprAccess(
+        Ctx.Decoded[Graph->GlobalIndices[Local]], Ctx.LS, AccessMode, MaxVgprs);
+    if (!Access.Valid)
+      return std::nullopt;
+    if (Mode < 0 && (Access.Uses.any() || Access.FullDefs.any()))
+      return std::nullopt;
+    Node.Uses = std::move(Access.Uses);
+    Node.FullDefs = std::move(Access.FullDefs);
+  }
+  return computeForwardDeadVgprs(Graph->Nodes, Graph->EntryNode, MaxVgprs);
 }
 
 // Matrix-A K-subblock masking scheme, chosen by the matrix-A data format.
@@ -674,7 +1482,8 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
 
   ScratchPatchInfo Info;
   Info.Offset = DI.Offset;
-  Info.ScratchRegs = Alloc.LiveAtPoint;
+  Info.ScratchRegs.resize(Ctx.Config.MaxVgprs);
+  Info.ScratchRegs.set(*ScratchBase, *ScratchBase + ScratchCount);
   Ctx.OutScratchPatches.push_back(std::move(Info));
 
   log() << "hotswap: wmma_scale16: exact K-split at offset 0x"
@@ -688,6 +1497,334 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
 }
 
 // ---------------------------------------------------------------------------
+// v_wmma_scale16_f32_32x16x128_f4 -> exact M+K split
+// ---------------------------------------------------------------------------
+
+static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
+  const InternalDecodedInst &DI = Ctx.Decoded[Idx];
+
+  if (DI.Size != VOP3PXSize)
+    return failClosed(Ctx, DI, "unexpected instruction size " + Twine(DI.Size));
+  for (const Trampoline &T : Ctx.OutTrampolines)
+    if (T.OriginalOffset == DI.Offset)
+      return 0;
+
+  const uint8_t *Raw = Ctx.Text + DI.Offset;
+  std::optional<unsigned> ScaleABase =
+      decodeVgprEncoding(extractScaleSrc0(Raw));
+  std::optional<unsigned> ScaleBBase =
+      decodeVgprEncoding(extractScaleSrc1(Raw));
+  if (!ScaleABase || !ScaleBBase)
+    return failClosed(Ctx, DI, "non-VGPR block-16 scale operand");
+
+  std::optional<unsigned> ActiveMode = getActiveVgprMsbMode(Ctx, Idx);
+  if (!ActiveMode)
+    ActiveMode = getLocallyEstablishedVgprMsbMode(Ctx, Idx);
+  if (!ActiveMode) {
+    std::string Detail = "cannot determine active VGPR-MSB mode";
+    if (Ctx.DirectControlFlow.HasUnresolvedTargets)
+      Detail += " (unresolved control-flow target)";
+    if (Ctx.DirectControlFlow.HasUnboundedIndirectEntries)
+      Detail += " (unbounded indirect entry)";
+    return failClosed(Ctx, DI, Detail);
+  }
+
+  std::optional<Scale32PrintedAsm> Printed = parseScale32PrintedAsm(Ctx, DI);
+  if (!Printed)
+    return failClosed(Ctx, DI, "could not parse canonical instruction");
+  std::optional<std::string> LowSuffix =
+      transformScale32ModifierSuffix(Printed->ModifierSuffix,
+                                     /*HighKPass=*/false);
+  std::optional<std::string> HighSuffix =
+      transformScale32ModifierSuffix(Printed->ModifierSuffix,
+                                     /*HighKPass=*/true);
+  if (!LowSuffix || !HighSuffix)
+    return failClosed(Ctx, DI, "unsupported modifier combination");
+
+  std::optional<VgprRange> DRange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/0);
+  std::optional<VgprRange> ARange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/1);
+  std::optional<VgprRange> BRange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/2);
+  if (!DRange || !ARange || !BRange || DRange->Width != 16 ||
+      ARange->Width != 16 || BRange->Width != 8)
+    return failClosed(Ctx, DI, "unexpected M=32 matrix operand widths/layout");
+
+  // The M=32 profile mirrors the common VOP3P layout in its first five MC
+  // operands: vdst, src0, src1, src2 modifiers, src2. Validate that mirror at
+  // runtime so a TableGen layout change fails closed.
+  if (DI.Inst.getNumOperands() < 5)
+    return failClosed(Ctx, DI, "truncated M=32 MC operand layout");
+  const MCOperand &Src2Op = DI.Inst.getOperand(4);
+  bool Src2IsImm = Src2Op.isImm();
+  std::optional<VgprRange> CRange;
+  if (Src2Op.isReg())
+    CRange = matrixOperandRange(Ctx, DI, /*OperandIndex=*/3);
+  else if (!Src2IsImm)
+    return failClosed(Ctx, DI, "unsupported non-VGPR/non-immediate src2");
+  if (CRange && CRange->Width != 16)
+    return failClosed(Ctx, DI, "src2 and destination widths differ");
+  if (!Src2IsImm && !CRange)
+    return failClosed(Ctx, DI, "could not determine src2 VGPR range");
+
+  unsigned Src0Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0);
+  unsigned Src1Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1);
+  unsigned Src2Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src2);
+  unsigned DstBank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst);
+
+  unsigned DBase = DRange->Base + DstBank * VgprBankSize;
+  unsigned ABase = ARange->Base + Src0Bank * VgprBankSize;
+  unsigned BBase = BRange->Base + Src1Bank * VgprBankSize;
+  unsigned CBase = CRange ? CRange->Base + Src2Bank * VgprBankSize : 0;
+  unsigned ScaleALo = *ScaleABase + Src0Bank * VgprBankSize;
+  unsigned ScaleAHi = ScaleALo + 1;
+  unsigned ScaleBLo = *ScaleBBase + Src1Bank * VgprBankSize;
+  unsigned ScaleBHi = ScaleBLo + 1;
+
+  if (!physicalVgprRangeFitsOneBank(DBase, 16, Ctx.Config.MaxVgprs) ||
+      !physicalVgprRangeFitsOneBank(ABase, 16, Ctx.Config.MaxVgprs) ||
+      !physicalVgprRangeFitsOneBank(BBase, 8, Ctx.Config.MaxVgprs) ||
+      (CRange &&
+       !physicalVgprRangeFitsOneBank(CBase, 16, Ctx.Config.MaxVgprs)) ||
+      !physicalVgprRangeFitsOneBank(ScaleALo, 2, Ctx.Config.MaxVgprs) ||
+      !physicalVgprRangeFitsOneBank(ScaleBLo, 2, Ctx.Config.MaxVgprs))
+    return failClosed(Ctx, DI,
+                      "M=32 operand exceeds or crosses a physical VGPR bank");
+
+  // The split reads A in stages after its first D-half write. The fused source
+  // instruction reads all of A before writing D, so any D/A overlap would
+  // otherwise let the replacement destroy a later A read.
+  if (rangesOverlap(DBase, 16, ABase, 16))
+    return failClosed(Ctx, DI,
+                      "destination overlaps matrix A across staged reads");
+  if (rangesOverlap(DBase, 16, BBase, 8))
+    return failClosed(Ctx, DI,
+                      "destination overlaps matrix B across staged reads");
+  if (rangesOverlap(ABase, 16, BBase, 8))
+    return failClosed(Ctx, DI,
+                      "matrix A overlaps matrix B during in-place masking");
+
+  // Exact D==C is the ordinary in-place accumulator form. A disjoint C is
+  // likewise safe. Reject partial/cross-half overlap: writing DLo could
+  // otherwise destroy CHi before the second low-K pass consumes it.
+  if (CRange && rangesOverlap(DBase, 16, CBase, 16) &&
+      !sameRange(DBase, 16, CBase, 16))
+    return failClosed(Ctx, DI,
+                      "partial destination/src2 overlap across staged reads");
+
+  auto ScaleOverlaps = [&](unsigned Base, unsigned Width) {
+    return rangesOverlap(ScaleALo, 2, Base, Width) ||
+           rangesOverlap(ScaleBLo, 2, Base, Width);
+  };
+  if (ScaleOverlaps(DBase, 16) || ScaleOverlaps(ABase, 16) ||
+      ScaleOverlaps(BBase, 8) || (CRange && ScaleOverlaps(CBase, 16)) ||
+      rangesOverlap(ScaleALo, 2, ScaleBLo, 2))
+    return failClosed(
+        Ctx, DI,
+        "scale pair overlaps a staged matrix operand or the other scale");
+  if (CRange && rangesOverlap(ABase, 16, CBase, 16))
+    return failClosed(Ctx, DI,
+                      "matrix A overlaps src2 during in-place masking");
+
+  std::string KernelName =
+      Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
+  std::optional<unsigned> KdVgprs = Ctx.Elf.getKernelVgprCount(
+      KernelName, getKernelVgprGranuleSize(Ctx, KernelName));
+  unsigned KdCount = KdVgprs.value_or(Ctx.Config.MaxVgprs);
+  VgprAllocator Alloc(Ctx.Liveness.liveBefore(Idx), KdCount,
+                      Ctx.Config.MaxVgprs);
+
+  // Replace generic encoded-register liveness with a physical-bank all-path
+  // proof when available. An unset bit is the only state the in-KD allocator
+  // accepts; failure leaves the allocator conservative-all-live and therefore
+  // permits only ordinary above-KD growth.
+  std::optional<BitVector> ForwardDead = computeForwardDeadPhysicalVgprs(
+      Ctx, Idx, *ActiveMode, Ctx.Config.MaxVgprs);
+  if (ForwardDead) {
+    for (int V = ForwardDead->find_first(); V >= 0;
+         V = ForwardDead->find_next(V))
+      Alloc.LiveAtPoint.reset(static_cast<unsigned>(V));
+    unsigned BestBase = 0;
+    unsigned BestWidth = 0;
+    for (unsigned BankBase = 0; BankBase < Ctx.Config.MaxVgprs;
+         BankBase += VgprBankSize) {
+      unsigned BankEnd = std::min(Ctx.Config.MaxVgprs, BankBase + VgprBankSize);
+      for (unsigned V = BankBase; V != BankEnd;) {
+        if (!ForwardDead->test(V)) {
+          ++V;
+          continue;
+        }
+        unsigned Begin = V;
+        while (V != BankEnd && ForwardDead->test(V))
+          ++V;
+        if (V - Begin > BestWidth) {
+          BestBase = Begin;
+          BestWidth = V - Begin;
+        }
+      }
+    }
+    log() << "hotswap: wmma_scale16: physical forward-dead proof at offset 0x"
+          << utohexstr(DI.Offset) << " found " << ForwardDead->count()
+          << " VGPRs; longest single-bank run ";
+    if (BestWidth)
+      log() << "v" << BestBase << ":" << (BestBase + BestWidth - 1) << " ("
+            << BestWidth << ")\n";
+    else
+      log() << "<none>\n";
+  } else {
+    log() << "hotswap: wmma_scale16: physical forward-dead proof unavailable "
+             "at offset 0x"
+          << utohexstr(DI.Offset) << "\n";
+  }
+
+  // Liveness describes values entering the original instruction. Its
+  // destination can therefore appear dead even though every replacement
+  // writes it, and tied/overlapping inputs need the same protection. Reserve
+  // every physical VGPR range decoded from the original instruction before
+  // considering an in-KD scratch block.
+  reserveVgprRange(Alloc, DBase, 16);
+  reserveVgprRange(Alloc, ABase, 16);
+  reserveVgprRange(Alloc, BBase, 8);
+  if (CRange)
+    reserveVgprRange(Alloc, CBase, 16);
+  reserveVgprRange(Alloc, ScaleALo, 2);
+  reserveVgprRange(Alloc, ScaleBLo, 2);
+
+  // Masking one eight-register FP4 A half overwrites exactly four registers.
+  // Preserve only those four values, not the four already-retained values.
+  // The first save slot doubles as the reversible scale-pair permutation
+  // temporary before the first A save and after the final A restore. Low-K
+  // runs for both M halves before high-K, so the same four slots serve all four
+  // WMMAs. Matrix B stays in place.
+  constexpr unsigned MatrixHalfWidth = 8;
+  constexpr unsigned SavedARegCount = MatrixHalfWidth / 2;
+  constexpr unsigned ScratchCount = SavedARegCount;
+  std::array<unsigned, SavedARegCount> SavedARegs;
+  for (unsigned &Reg : SavedARegs) {
+    std::optional<unsigned> Allocated = allocContiguousDeadOrAboveInBank(
+        Alloc, /*Count=*/1, /*Align=*/1, VgprBankSize,
+        ForwardDead.has_value());
+    if (!Allocated)
+      return failClosed(Ctx, DI,
+                        "fewer than four dead/above-KD VGPRs for exact M+K "
+                        "split");
+    Reg = *Allocated;
+  }
+  unsigned TmpReg = SavedARegs.front();
+
+  std::string ReplacementAsm;
+  raw_string_ostream OS(ReplacementAsm);
+  unsigned CurrentMode = *ActiveMode;
+  emitScalePairSplitInPlace(OS, ScaleALo, ScaleAHi, TmpReg, CurrentMode);
+  emitScalePairSplitInPlace(OS, ScaleBLo, ScaleBHi, TmpReg, CurrentMode);
+
+  int HazardNops = classifyWmmaNops("v_wmma_scale_f32_16x16x128_f8f6f4").A0Nops;
+  auto EmitHazardNops = [&] {
+    for (int I = 0; I != HazardNops; ++I)
+      OS << "v_nop\n";
+  };
+
+  for (bool HighK : {false, true}) {
+    for (unsigned MHalf = 0; MHalf != 2; ++MHalf) {
+      unsigned OriginalAHalf = ABase + MHalf * MatrixHalfWidth;
+      unsigned DstHalf = DBase + MHalf * MatrixHalfWidth;
+      unsigned ABank = OriginalAHalf / VgprBankSize;
+      unsigned BBank = BBase / VgprBankSize;
+
+      unsigned SavedIndex = 0;
+      for (unsigned I = 0; I != MatrixHalfWidth; ++I) {
+        bool IsLow = ((I / 2) % 2) == 0;
+        if (IsLow == !HighK)
+          continue;
+        unsigned Saved = SavedARegs[SavedIndex++];
+        emitVgprCopy(OS, Saved, OriginalAHalf + I, /*W=*/1,
+                     Saved / VgprBankSize, CurrentMode);
+      }
+      assert(SavedIndex == SavedARegCount);
+      emitMaskVgprsInPlace(OS, /*KeepLow=*/!HighK, OriginalAHalf,
+                           MatrixHalfWidth, /*SubW=*/2, CurrentMode);
+
+      SmallVector<VgprBankRequirement, 4> WmmaMode = {
+          {VgprMsbOperand::Dst, DstHalf / VgprBankSize},
+          {VgprMsbOperand::Src0, ABank},
+          {VgprMsbOperand::Src1, BBank}};
+      std::string Src2;
+      if (HighK) {
+        WmmaMode.push_back({VgprMsbOperand::Src2, DstHalf / VgprBankSize});
+        Src2 = encodedVgprRange(DstHalf, MatrixHalfWidth);
+      } else if (CRange) {
+        unsigned CHalf = CBase + MHalf * MatrixHalfWidth;
+        WmmaMode.push_back({VgprMsbOperand::Src2, CHalf / VgprBankSize});
+        Src2 = encodedVgprRange(CHalf, MatrixHalfWidth);
+      } else {
+        Src2 = Printed->Operands[3];
+      }
+      emitModeForOperands(OS, CurrentMode, WmmaMode);
+      emitScale32Half(OS, DstHalf, OriginalAHalf, BBase, Src2,
+                      HighK ? ScaleAHi : ScaleALo, HighK ? ScaleBHi : ScaleBLo,
+                      HighK ? *HighSuffix : *LowSuffix);
+
+      EmitHazardNops();
+      SavedIndex = 0;
+      for (unsigned I = 0; I != MatrixHalfWidth; ++I) {
+        bool IsLow = ((I / 2) % 2) == 0;
+        if (IsLow == !HighK)
+          continue;
+        unsigned Saved = SavedARegs[SavedIndex++];
+        emitVgprCopy(OS, OriginalAHalf + I, Saved, /*W=*/1, ABank,
+                     CurrentMode);
+      }
+      assert(SavedIndex == SavedARegCount);
+    }
+  }
+
+  emitScalePairRestoreInPlace(OS, ScaleALo, ScaleAHi, TmpReg, CurrentMode);
+  emitScalePairRestoreInPlace(OS, ScaleBLo, ScaleBHi, TmpReg, CurrentMode);
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Src0,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0)},
+                       {VgprMsbOperand::Src1,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1)},
+                       {VgprMsbOperand::Src2,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src2)},
+                       {VgprMsbOperand::Dst,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst)}});
+
+  SmallVector<uint8_t> Replacement =
+      assembleInstructions(ReplacementAsm, Ctx.LS);
+  if (Replacement.empty())
+    return failClosed(Ctx, DI, "M+K split assembly failed");
+
+  unsigned Extra = Alloc.extraVgprsNeeded();
+  if (checkKernelVgprBump(Ctx, KernelName, Extra, PatchRequirement::Required) !=
+      VgprBumpDecision::Apply)
+    return 0;
+  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement))
+    return failClosed(Ctx, DI, "M+K split trampoline emission failed");
+
+  KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
+  Stats.ExtraVgprs = std::max(Stats.ExtraVgprs, Extra);
+  if (Extra == 0)
+    Stats.ScratchReused += ScratchCount;
+  Stats.ScratchAboveKd += Extra;
+  ScratchPatchInfo Info;
+  Info.Offset = DI.Offset;
+  Info.ScratchRegs.resize(Ctx.Config.MaxVgprs);
+  for (unsigned Reg : SavedARegs)
+    Info.ScratchRegs.set(Reg);
+  Ctx.OutScratchPatches.push_back(std::move(Info));
+
+  log() << "hotswap: wmma_scale16: exact M+K split at offset 0x"
+        << utohexstr(DI.Offset) << " (D=v" << DBase << ":" << (DBase + 15)
+        << ", A=v" << ABase << ":" << (ABase + 15) << ", B=v" << BBase << ":"
+        << (BBase + 7) << ", four saved-A VGPRs, tmp=v" << TmpReg << ", +"
+        << Extra << " vgpr, 4 WMMAs, "
+        << Replacement.size() << " bytes)\n";
+  return 1;
+}
+
+// ---------------------------------------------------------------------------
 // patchWmmaScale16 -- dispatch
 // ---------------------------------------------------------------------------
 
@@ -696,9 +1833,9 @@ static uint32_t applyWmmaScale16PatchesImpl(PatchContext &Ctx, size_t Idx) {
 
   if (Mnem == "v_wmma_scale16_f32_16x16x128_f8f6f4")
     return patchWmmaScale16_16x16(Ctx, Idx);
+  if (Mnem == "v_wmma_scale16_f32_32x16x128_f4")
+    return patchWmmaScale16_32x16(Ctx, Idx);
 
-  // The M=32 FP4 form needs an M-split in addition to the K-split; not yet
-  // lowered exactly, so fail closed rather than miscompile.
   if (Mnem.starts_with("v_wmma_scale16_f32_"))
     return failClosed(Ctx, Ctx.Decoded[Idx],
                       "block-16 scaled variant has no exact lowering yet");

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -1134,6 +1134,35 @@ std::optional<unsigned> getActiveVgprMsbMode(PatchContext &Ctx, size_t Idx) {
   return findActiveVgprMsbMode(Ctx, Idx);
 }
 
+std::optional<unsigned> getLocallyEstablishedVgprMsbMode(PatchContext &Ctx,
+                                                         size_t Idx) {
+  while (Idx > 0) {
+    const InternalDecodedInst &Prev = Ctx.Decoded[Idx - 1];
+    const InternalDecodedInst &Current = Ctx.Decoded[Idx];
+    if (Prev.Offset + Prev.Size != Current.Offset)
+      return std::nullopt;
+
+    if (Ctx.DirectControlFlow.Targets.contains(Current.Offset))
+      return std::nullopt;
+    for (uint64_t Entry : Ctx.DeclaredEntries)
+      if (Entry == Current.Offset)
+        return std::nullopt;
+
+    if (std::optional<unsigned> Mode = getExactVgprMsbModeWritten(Prev, Ctx.LS))
+      return Mode;
+
+    if (Prev.Mnemonic == "<unknown>" ||
+        Prev.Inst.getOpcode() == Ctx.LS.SSetVgprMsbOpcode ||
+        instructionDefinesNamedRegister(Prev, "MODE", Ctx.LS) ||
+        (Ctx.LS.MIA &&
+         (Ctx.LS.MIA->isBranch(Prev.Inst) || Ctx.LS.MIA->isCall(Prev.Inst) ||
+          Ctx.LS.MIA->isReturn(Prev.Inst))))
+      return std::nullopt;
+    --Idx;
+  }
+  return std::nullopt;
+}
+
 unsigned getVgprMsbBank(unsigned Mode, VgprMsbOperand Operand) {
   return getVgprMsbs(Mode, Operand);
 }

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -72,6 +72,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Endian.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -652,6 +653,34 @@ VgprMsbState mergeVgprMsbState(VgprMsbState Old, VgprMsbState Incoming) {
           mergeVgprMsbValue(Old.Src2, Incoming.Src2)};
 }
 
+// The B0 f4gemm corpus uses one legacy VOP3 encoding that the A0 gfx1250
+// decoder splits into two unknown dwords. It cannot write MODE: recognize only
+// the exact observed opcode/operand spellings, and only when no known entry
+// reaches the decoder-created continuation dword.
+bool isUndecodedB0Vop3Pair(const PatchContext &Ctx, size_t HeadIndex) {
+  if (HeadIndex + 1 >= Ctx.Decoded.size())
+    return false;
+  const InternalDecodedInst &Head = Ctx.Decoded[HeadIndex];
+  const InternalDecodedInst &Tail = Ctx.Decoded[HeadIndex + 1];
+  if (Head.DecodeSucceeded || Head.Size != MinInstSize ||
+      Tail.Offset != Head.Offset + MinInstSize ||
+      Head.Offset > Ctx.TextSize ||
+      2 * MinInstSize > Ctx.TextSize - Head.Offset)
+    return false;
+
+  uint32_t Word0 = support::endian::read32le(Ctx.Text + Head.Offset);
+  uint32_t Word1 =
+      support::endian::read32le(Ctx.Text + Head.Offset + MinInstSize);
+  constexpr uint32_t Bit14 = 1u << 14;
+  if ((Word0 & ~Bit14) != 0xd0310000u ||
+      (Word1 != 0 && Word1 != 0x00100000u))
+    return false;
+  if (Ctx.DirectControlFlow.Targets.contains(Tail.Offset) ||
+      llvm::is_contained(Ctx.DeclaredEntries, Tail.Offset))
+    return false;
+  return true;
+}
+
 // Populate Ctx.VgprMsbModeBefore with a per-instruction packed VGPR-MSB mode
 // via a forward CFG fixed point over each analyzable function. Fail-closed:
 // only exact, consistent modes are recorded; any conflict, unknown MODE write,
@@ -680,7 +709,8 @@ void computeVgprMsbModes(PatchContext &Ctx) {
   // function's s_set_vgpr_msb prefix. The incoming mode is then unprovable
   // object-wide, so decline the whole analysis and let each required split fail
   // closed rather than risk seeding a wrong mode.
-  if (Ctx.DirectControlFlow.HasUnresolvedTargets)
+  if (Ctx.DirectControlFlow.HasUnresolvedTargets ||
+      Ctx.DirectControlFlow.HasUnboundedIndirectEntries)
     return;
 
   // Functions entered at a non-start offset by a cross-function branch or call
@@ -792,11 +822,21 @@ void computeVgprMsbModes(PatchContext &Ctx) {
     const size_t Count = static_cast<size_t>(After - First);
     DenseMap<uint64_t, unsigned> OffsetToLocalIndex;
     OffsetToLocalIndex.reserve(Count);
+    BitVector UndecodedVop3Heads(Count);
+    BitVector UndecodedVop3Tails(Count);
     bool Valid = true;
     for (unsigned I = 0; I != Count; ++I) {
       OffsetToLocalIndex.try_emplace(First[I].Offset, I);
-      if (First[I].Mnemonic == "<unknown>")
+      if (First[I].Mnemonic != "<unknown>")
+        continue;
+      if (isUndecodedB0Vop3Pair(Ctx, GlobalFirst + I) && I + 1 < Count) {
+        UndecodedVop3Heads.set(I);
+        UndecodedVop3Tails.set(I + 1);
+        OffsetToLocalIndex.erase(First[I + 1].Offset);
+        ++I;
+      } else {
         Valid = false;
+      }
     }
     if (!Valid)
       continue;
@@ -821,6 +861,13 @@ void computeVgprMsbModes(PatchContext &Ctx) {
     for (unsigned I = 0; I != Count && Valid; ++I) {
       const InternalDecodedInst &DI = First[I];
       SmallVectorImpl<unsigned> &Out = Successors[I];
+      if (UndecodedVop3Tails.test(I))
+        continue;
+      if (UndecodedVop3Heads.test(I)) {
+        if (I + 2 < Count)
+          Out.push_back(I + 2);
+        continue;
+      }
       if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
           DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
           LS.MIA->isReturn(DI.Inst) || isStandardLinkReturn(DI, LS))
@@ -936,7 +983,9 @@ void computeVgprMsbModes(PatchContext &Ctx) {
     for (size_t Next = 0; Next != Worklist.size(); ++Next) {
       unsigned I = Worklist[Next];
       ModeBefore[GlobalFirst + I] = exactVgprMsbMode(In[I]);
-      VgprMsbState Out = transferVgprMsbState(In[I], First[I], LS);
+      VgprMsbState Out = UndecodedVop3Heads.test(I)
+                             ? In[I]
+                             : transferVgprMsbState(In[I], First[I], LS);
       for (unsigned Succ : Successors[I]) {
         VgprMsbState Merged = mergeVgprMsbState(In[Succ], Out);
         if (Merged.Dst != In[Succ].Dst || Merged.Src0 != In[Succ].Src0 ||
@@ -1136,6 +1185,12 @@ std::optional<unsigned> getActiveVgprMsbMode(PatchContext &Ctx, size_t Idx) {
 
 std::optional<unsigned> getLocallyEstablishedVgprMsbMode(PatchContext &Ctx,
                                                          size_t Idx) {
+  // An unresolved transfer can enter at any instruction in the object, so an
+  // apparently adjacent setter is not a dominance proof in that case.
+  if (Ctx.DirectControlFlow.HasUnresolvedTargets ||
+      Ctx.DirectControlFlow.HasUnboundedIndirectEntries)
+    return std::nullopt;
+
   while (Idx > 0) {
     const InternalDecodedInst &Prev = Ctx.Decoded[Idx - 1];
     const InternalDecodedInst &Current = Ctx.Decoded[Idx];
@@ -1148,6 +1203,15 @@ std::optional<unsigned> getLocallyEstablishedVgprMsbMode(PatchContext &Ctx,
       if (Entry == Current.Offset)
         return std::nullopt;
 
+    // The A0 decoder represents the exact B0 legacy-VOP3 pair as two unknown
+    // dwords. It cannot change MODE, so a straight-line local dominance scan
+    // may step over the complete pair. isUndecodedB0Vop3Pair also rejects a
+    // known entry into its continuation dword.
+    if (Idx >= 2 && isUndecodedB0Vop3Pair(Ctx, Idx - 2)) {
+      Idx -= 2;
+      continue;
+    }
+
     if (std::optional<unsigned> Mode = getExactVgprMsbModeWritten(Prev, Ctx.LS))
       return Mode;
 
@@ -1155,12 +1219,20 @@ std::optional<unsigned> getLocallyEstablishedVgprMsbMode(PatchContext &Ctx,
         Prev.Inst.getOpcode() == Ctx.LS.SSetVgprMsbOpcode ||
         instructionDefinesNamedRegister(Prev, "MODE", Ctx.LS) ||
         (Ctx.LS.MIA &&
-         (Ctx.LS.MIA->isBranch(Prev.Inst) || Ctx.LS.MIA->isCall(Prev.Inst) ||
-          Ctx.LS.MIA->isReturn(Prev.Inst))))
+         Ctx.LS.MIA->mayAffectControlFlow(Prev.Inst, *Ctx.LS.MRI)))
       return std::nullopt;
     --Idx;
   }
   return std::nullopt;
+}
+
+int16_t transferExactVgprMsbMode(int16_t Incoming,
+                                 const InternalDecodedInst &DI,
+                                 const LLVMState &LS) {
+  VgprMsbState State =
+      Incoming >= 0 ? vgprMsbStateFromMode(static_cast<unsigned>(Incoming))
+                    : unknownVgprMsbState();
+  return exactVgprMsbMode(transferVgprMsbState(State, DI, LS));
 }
 
 unsigned getVgprMsbBank(unsigned Mode, VgprMsbOperand Operand) {

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -966,13 +966,6 @@ findActiveVgprMsbMode(const PatchContext &Ctx, size_t Idx) {
   return static_cast<unsigned>(Ctx.VgprMsbModeBefore[Idx]);
 }
 
-enum class VgprMsbOperand : unsigned {
-  Src0 = 0,
-  Src1 = 2,
-  Src2 = 4,
-  Dst = 6,
-};
-
 unsigned getVgprMsbs(unsigned Mode, VgprMsbOperand Operand) {
   return (Mode >> static_cast<unsigned>(Operand)) & 0x3;
 }
@@ -1131,6 +1124,24 @@ buildSplit32x16Asm(StringRef Replacement, const PrintedAsm &P, const WmmaOps &R,
 
 } // anonymous namespace
 
+void ensureVgprMsbModes(PatchContext &Ctx) {
+  if (Ctx.VgprMsbModeBefore.empty())
+    computeVgprMsbModes(Ctx);
+}
+
+std::optional<unsigned> getActiveVgprMsbMode(PatchContext &Ctx, size_t Idx) {
+  ensureVgprMsbModes(Ctx);
+  return findActiveVgprMsbMode(Ctx, Idx);
+}
+
+unsigned getVgprMsbBank(unsigned Mode, VgprMsbOperand Operand) {
+  return getVgprMsbs(Mode, Operand);
+}
+
+void setVgprMsbBank(unsigned &Mode, VgprMsbOperand Operand, unsigned Bank) {
+  setVgprMsbs(Mode, Operand, Bank);
+}
+
 // Return-value semantics (current shared dispatcher API in b0a0.cpp):
 //   0  = either "this patch did not match the instruction" OR "matched
 //        but failed to apply" -- the dispatcher cannot distinguish the
@@ -1221,8 +1232,7 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   // the transition and restore it. K-splits always consult the mode (the
   // upper half reuses dst as src2). M-splits consult it only when a half
   // actually crosses v255.
-  if (Ctx.VgprMsbModeBefore.empty())
-    computeVgprMsbModes(Ctx);
+  ensureVgprMsbModes(Ctx);
 
   bool UsesVgprMsbTransition = false;
   bool NeedsKnownVgprMsbMode = Match->Kind == SplitKind::Split128to64FP8BF8;
@@ -1235,7 +1245,7 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
 
   unsigned ActiveVgprMsbMode = 0;
   if (NeedsKnownVgprMsbMode) {
-    std::optional<unsigned> Mode = findActiveVgprMsbMode(Ctx, Idx);
+    std::optional<unsigned> Mode = getActiveVgprMsbMode(Ctx, Idx);
     if (!Mode) {
       log() << "hotswap: error: WMMA split: cannot determine VGPR-MSB mode "
                "for "

--- a/amd/comgr/test-lit/hotswap-absolute-call.s
+++ b/amd/comgr/test-lit/hotswap-absolute-call.s
@@ -34,9 +34,20 @@ test_absolute_call:
 .Ltest_absolute_call_end:
 .size test_absolute_call, .Ltest_absolute_call_end-test_absolute_call
 
-// Two separate long sites need two 20-byte SCC-neutral gateways. This
-// padding follows s_endpgm and lies outside the function, so it is safe.
-.fill 64, 1, 0
+// Two separate long sites need two 20-byte SCC-neutral gateways. Keep these
+// NOP runs function-owned: the global planner may use them, while replacement
+// bodies in test_absolute_call cannot borrow another function's padding.
+.type gateway_0,@function
+gateway_0:
+  s_endpgm
+  .fill 20, 1, 0
+.size gateway_0, .-gateway_0
+
+.type gateway_1,@function
+gateway_1:
+  s_endpgm
+  .fill 20, 1, 0
+.size gateway_1, .-gateway_1
 
 // Push the appended trampoline pool beyond s_branch's signed 16-bit dword
 // range and force direct-target-aware far-site handling.

--- a/amd/comgr/test-lit/hotswap-absolute-call.s
+++ b/amd/comgr/test-lit/hotswap-absolute-call.s
@@ -15,9 +15,9 @@
 
 // DISASM-LABEL: <test_absolute_call>:
 // DISASM-NEXT: s_swap_pc_i64 s[0:1], 0x1010
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-control-flow-index-scale.s
+++ b/amd/comgr/test-lit/hotswap-control-flow-index-scale.s
@@ -1,0 +1,59 @@
+// COM: Exercise the public rewrite path with thousands of unrelated local
+// COM: set-PC functions. Control-flow proof must remain fail-closed without
+// COM: forming the Cartesian product of every set-PC and function range.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+// RUN: %llvm-readelf --file-header --section-headers --program-headers \
+// RUN:   %t.out.elf > /dev/null
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.macro local_set_pc_function
+.type local_set_pc_\@,@function
+local_set_pc_\@:
+  s_set_pc_i64 s[0:1]
+.Llocal_set_pc_end_\@:
+.size local_set_pc_\@, .Llocal_set_pc_end_\@-local_set_pc_\@
+.endm
+
+.rept 4096
+  local_set_pc_function
+.endr
+
+.globl control_flow_index_kernel
+.protected control_flow_index_kernel
+.type control_flow_index_kernel,@function
+control_flow_index_kernel:
+  s_endpgm
+.Lcontrol_flow_index_kernel_end:
+.size control_flow_index_kernel, .Lcontrol_flow_index_kernel_end-control_flow_index_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel control_flow_index_kernel
+  .amdhsa_next_free_vgpr 0
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: control_flow_index_kernel
+      .symbol: control_flow_index_kernel.kd
+      .sgpr_count: 0
+      .vgpr_count: 0
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-data-only-empty-text.s
+++ b/amd/comgr/test-lit/hotswap-data-only-empty-text.s
@@ -1,0 +1,191 @@
+// COM: Data-only HIP device objects can carry global constants and variables
+// COM: but no kernels or device functions. Such an object has a present,
+// COM: zero-size .text section and an empty amdhsa.kernels array. There are no
+// COM: instructions or kernel revision tags to transform, so return a
+// COM: byte-identical successful output after validating that shape.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %llvm-readobj --sections --symbols --notes %t.elf \
+// RUN:   | %FileCheck --check-prefix=SHAPE --implicit-check-not=.kd %s
+// SHAPE: Name: .text
+// SHAPE: Size: 0
+// SHAPE: Name: data_only_constant
+// SHAPE: Type: Object
+// SHAPE: AMDGPU Metadata: ---
+// SHAPE-NEXT: amdhsa.kernels:  []
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=ACCEPT %s
+// ACCEPT: hotswap: accepted data-only code object with empty .text;
+// ACCEPT-SAME: returning a byte-identical copy.
+// ACCEPT: RESULT: SUCCESS
+// RUN: cmp %t.elf %t.out.elf
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// RUN: sed 's/^\.set claimed_function, 0$/.set claimed_function, 1/' \
+// RUN:   %s > %t.function.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.function.s -o %t.function.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.function.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=FUNCTION,REJECT %s
+// FUNCTION: hotswap: error: data-only object has a function/ifunc symbol
+// FUNCTION-SAME: in empty .text.
+
+// RUN: sed 's/^\.set claimed_other_function, 0$/.set claimed_other_function, 1/' \
+// RUN:   %s > %t.other-function.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.other-function.s -o %t.other-function.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   hotswap-rewrite %t.other-function.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=OTHER-FUNCTION,REJECT %s
+// OTHER-FUNCTION: hotswap: error: data-only object has defined function/ifunc
+// OTHER-FUNCTION-SAME: symbol 'claimed_other_function'.
+
+// RUN: sed 's/^\.set executable_section, 0$/.set executable_section, 1/' \
+// RUN:   %s > %t.executable.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.executable.s -o %t.executable.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.executable.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=EXECUTABLE,REJECT %s
+// EXECUTABLE: hotswap: error: data-only object has non-empty executable
+// EXECUTABLE-SAME: section '.other_text'.
+
+// RUN: sed 's/^\.set claimed_descriptor, 0$/.set claimed_descriptor, 1/' \
+// RUN:   %s > %t.descriptor.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.descriptor.s -o %t.descriptor.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.descriptor.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=DESCRIPTOR,REJECT %s
+// DESCRIPTOR: hotswap: error: data-only object has kernel descriptor symbol
+// DESCRIPTOR-SAME: 'claimed_kernel.kd'.
+
+// RUN: sed 's/^\.set claimed_kernel, 0$/.set claimed_kernel, 1/' \
+// RUN:   %s > %t.kernel.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.kernel.s -o %t.kernel.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.kernel.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=KERNEL,REJECT %s
+// KERNEL: hotswap: error: data-only AMDGPU metadata claims 1 kernel(s).
+
+// RUN: sed 's/^\.set malformed_metadata, 0$/.set malformed_metadata, 1/' \
+// RUN:   %s > %t.malformed.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.malformed.s -o %t.malformed.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.malformed.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=MALFORMED,REJECT %s
+// MALFORMED: hotswap: error: failed to parse data-only AMDGPU metadata note.
+
+// RUN: %llvm-objcopy --remove-section=.text %t.elf %t.missing-text.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.missing-text.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT 2>&1 \
+// RUN:   | %FileCheck --check-prefix=MISSING %s
+// MISSING: no .text section found
+// MISSING: RESULT: INVALID_ARGUMENT
+
+// REJECT: hotswap: error: retargetCodeObject:
+// REJECT-SAME: does not describe a valid data-only code object.
+// REJECT: RESULT: INVALID_ARGUMENT
+
+.set claimed_function, 0
+.set claimed_other_function, 0
+.set executable_section, 0
+.set claimed_descriptor, 0
+.set claimed_kernel, 0
+.set malformed_metadata, 0
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.if claimed_function
+.globl claimed_function
+.type claimed_function,@function
+claimed_function:
+.size claimed_function, .-claimed_function
+.endif
+
+.rodata
+.globl data_only_constant
+.type data_only_constant,@object
+.p2align 2
+data_only_constant:
+  .long 1
+.size data_only_constant, .-data_only_constant
+
+.if claimed_other_function
+.globl claimed_other_function
+.type claimed_other_function,@function
+claimed_other_function:
+.size claimed_other_function, .-claimed_other_function
+.endif
+
+.if executable_section
+.section .other_text,"ax",@progbits
+  v_nop
+.endif
+
+.if claimed_descriptor
+.globl claimed_kernel.kd
+.type claimed_kernel.kd,@object
+.p2align 6
+claimed_kernel.kd:
+  .zero 64
+.size claimed_kernel.kd, .-claimed_kernel.kd
+.endif
+
+.if malformed_metadata
+.section .note,"a",@note
+.p2align 2
+  .long 7
+  .long 4
+  .long 32
+  .asciz "AMDGPU"
+.p2align 2
+  .byte 0xc1, 0xc1, 0xc1, 0xc1
+.p2align 2
+.else
+.section .note,"a",@note
+.p2align 2
+  .long 7
+  .long .Lmetadata_desc_end-.Lmetadata_desc_begin
+  .long 32
+  .asciz "AMDGPU"
+.p2align 2
+.Lmetadata_desc_begin:
+.if claimed_kernel
+  // {"amdhsa.kernels": [{}]}
+  .byte 0x81, 0xae
+  .ascii "amdhsa.kernels"
+  .byte 0x91, 0x80
+.else
+  // Match the corpus note:
+  // {"amdhsa.kernels": [], "amdhsa.target": "...gfx1250",
+  //  "amdhsa.version": [1, 2]}
+  .byte 0x83, 0xae
+  .ascii "amdhsa.kernels"
+  .byte 0x90, 0xad
+  .ascii "amdhsa.target"
+  .byte 0xba
+  .ascii "amdgcn-amd-amdhsa--gfx1250"
+  .byte 0xae
+  .ascii "amdhsa.version"
+  .byte 0x92, 0x01, 0x02
+.endif
+.Lmetadata_desc_end:
+.p2align 2
+.endif

--- a/amd/comgr/test-lit/hotswap-data-only-empty-text.s
+++ b/amd/comgr/test-lit/hotswap-data-only-empty-text.s
@@ -25,6 +25,18 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES
+// RUN: env AMD_COMGR_TIME_STATISTICS=1 \
+// RUN:   AMD_COMGR_TIME_STATISTICS_GRANULARITY=ns \
+// RUN:   AMD_COMGR_REDIRECT_LOGS=%t.profile.log \
+// RUN:   hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.profile.elf
+// RUN: %FileCheck --check-prefix=PROFILE-PARSE \
+// RUN:   --input-file=%t.profile.log %s
+// RUN: %FileCheck --check-prefix=PROFILE-COPY \
+// RUN:   --input-file=%t.profile.log %s
+// PROFILE-PARSE: phase:elf_parse{{ +}}1 calls
+// PROFILE-COPY: phase:output_copy{{ +}}1 calls
 
 // RUN: sed 's/^\.set claimed_function, 0$/.set claimed_function, 1/' \
 // RUN:   %s > %t.function.s

--- a/amd/comgr/test-lit/hotswap-ds2-compact-registerless.s
+++ b/amd/comgr/test-lit/hotswap-ds2-compact-registerless.s
@@ -1,0 +1,151 @@
+// COM: Compact DS2 continuations are a scarce fallback for far sites without
+// COM: any safe SGPR pair or dead VCC. Scratch-backed sites should keep using
+// COM: the ordinary trampoline path so they do not consume set-PC-sized local
+// COM: padding needed by object-wide gateway planning.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: safe far return: no register pair at 0x
+// LOG: hotswap: ds_2addr: used compact continuation at 0x{{.*}}with displaced v_ashrrev_i32
+// LOG: hotswap: safe far return: no register pair at 0x
+// LOG: hotswap: ds_2addr: used compact continuation at 0x{{.*}}with displaced flat_load_b64
+// LOG-NOT: hotswap: ds_2addr: used compact continuation at 0x
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_ds2_safe_far>:
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <test_ds2_registerless_far>:
+// DISASM: ds_load_b32 v0, v2 offset:4
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: ds_load_b32 v6, v8 offset:4
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM: ds_load_b32 v1, v2 offset:12
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: v_ashrrev_i32_e32 v4, 31, v5
+// DISASM-NEXT: s_branch
+// DISASM: ds_load_b32 v7, v8 offset:12
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: flat_load_b64 v[10:11], v12, s[8:9] scale_offset
+// DISASM-NEXT: s_branch
+// DISASM-NOT: ds_load_2addr
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl test_ds2_safe_far
+.p2align 8
+.type test_ds2_safe_far,@function
+test_ds2_safe_far:
+  ds_load_2addr_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+.size test_ds2_safe_far, .-test_ds2_safe_far
+
+.globl test_ds2_registerless_far
+.type test_ds2_registerless_far,@function
+test_ds2_registerless_far:
+  s_mov_b64 vcc, -1
+  ds_load_2addr_b32 v[0:1], v2 offset0:1 offset1:3
+  v_ashrrev_i32_e32 v4, 31, v5
+  ds_load_2addr_b32 v[6:7], v8 offset0:1 offset1:3
+  flat_load_b64 v[10:11], v12, s[8:9] scale_offset
+  s_wait_dscnt 0x0
+.irp live_reg, s0, s2, s4, s6, s8, s10, s12, s14, s16, s18, s20, s22, s24, s26, s28, s30, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104
+  s_mov_b32 s1, \live_reg
+.endr
+  s_cbranch_vccz .Lregisterless_done
+.Lregisterless_done:
+  s_endpgm
+.size test_ds2_registerless_far, .-test_ds2_registerless_far
+
+// Three exact 20-byte external padding tails occupy the same reach bucket.
+// The first remains the global-routing backbone; the safe DS2 must leave the
+// surplus tails untouched so the registerless DS2 can claim one.
+.type tail_guard_0,@function
+tail_guard_0:
+  s_endpgm
+.size tail_guard_0, .-tail_guard_0
+.fill 20, 1, 0
+s_mov_b32 s0, s0
+
+.type tail_guard_1,@function
+tail_guard_1:
+  s_endpgm
+.size tail_guard_1, .-tail_guard_1
+.fill 20, 1, 0
+s_mov_b32 s0, s0
+
+.type tail_guard_2,@function
+tail_guard_2:
+  s_endpgm
+.size tail_guard_2, .-tail_guard_2
+.fill 20, 1, 0
+s_mov_b32 s0, s0
+
+// This run contributes one 44-byte far-body partition and one 20-byte tail.
+// The displaced 12-byte flat load makes a 28-byte continuation, proving that
+// the larger compact form uses the far-body partition without a trampoline.
+.type tail_guard_3,@function
+tail_guard_3:
+  s_endpgm
+.size tail_guard_3, .-tail_guard_3
+.fill 64, 1, 0
+s_mov_b32 s0, s0
+
+// Keep the appended trampoline pool outside signed s_branch reach.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds2_safe_far
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 4
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds2_registerless_far
+  .amdhsa_next_free_vgpr 13
+  .amdhsa_next_free_sgpr 105
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_ds2_safe_far
+      .symbol: test_ds2_safe_far.kd
+      .sgpr_count: 4
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2_registerless_far
+      .symbol: test_ds2_registerless_far.kd
+      .sgpr_count: 105
+      .vgpr_count: 13
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-entry-local-offset.s
+++ b/amd/comgr/test-lit/hotswap-ds2-entry-local-offset.s
@@ -1,43 +1,26 @@
 // COM: Reduced from corpus object
 // COM: 8737ad6b480494d2a19aa82de8dfdd53e6c4b788975bd57e3c3437bc368ea780.
 // COM: The original B0 ds_store_2addr_b64 uses element offsets (0, 1), which
-// COM: A0 must interpret as byte offsets (0, 8). Both corrected values fit the
-// COM: original DS2 fields, so patch the two immediate bytes in place.
+// COM: must be lowered to two A0 operations with byte offsets (0, 8). Rewriting
+// COM: only the immediate bytes disassembles plausibly but is not equivalent on
+// COM: hardware, so this operation must use the split trampoline path.
 // COM:
 // COM: The unresolved register call deliberately keeps indirect entry points
 // COM: unbounded, and the filler makes any appended pool unreachable by
-// COM: s_branch. Success therefore proves that this rewrite is entry-local:
-// COM: it neither consumes neighboring instructions nor weakens the unknown
-// COM: control-flow guards.
+// COM: s_branch. There is no safe route to the required trampoline, so the
+// COM: rewrite must fail closed.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
-// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=LOG,API %s
 // LOG: hotswap: unresolved call target
 // LOG: hotswap: unresolved control-flow target disables NOP-sled emission,
 // LOG-SAME: trampoline coalescing, source relocation, and .text gateways
-// LOG: hotswap: rewrote ds_store_2addr_b64 at 0x{{[0-9A-F]+}} in place with A0 byte offsets 0, 8
-// API: RESULT: SUCCESS
-
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
-// DISASM-LABEL: <test_ds2_entry_local>:
-// DISASM-NEXT: s_swap_pc_i64 s[30:31], s[0:1]
-// DISASM-NEXT: ds_store_2addr_b64 v19, v[14:15], v[20:21] offset1:8
-// DISASM-NEXT: s_wait_loadcnt_dscnt 0x1
-// DISASM-NEXT: s_endpgm
-
-// COM: Relabel the first pass's output as A0 source. This disables the B0-to-A0
-// COM: family and must produce a byte-identical second object; legacy ISA names
-// COM: intentionally default the source to B0 on every independent invocation.
-// RUN: hotswap-rewrite %t.out.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
-// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
-// RUN:   --output %t.out2.elf | %FileCheck --check-prefix=API2 %s
-// API2: RESULT: SUCCESS
-// RUN: cmp %t.out.elf %t.out2.elf
+// LOG: hotswap: error: no safe short-branch gateway for far site
+// API: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-ds2-entry-local-offset.s
+++ b/amd/comgr/test-lit/hotswap-ds2-entry-local-offset.s
@@ -1,0 +1,81 @@
+// COM: Reduced from corpus object
+// COM: 8737ad6b480494d2a19aa82de8dfdd53e6c4b788975bd57e3c3437bc368ea780.
+// COM: The original B0 ds_store_2addr_b64 uses element offsets (0, 1), which
+// COM: A0 must interpret as byte offsets (0, 8). Both corrected values fit the
+// COM: original DS2 fields, so patch the two immediate bytes in place.
+// COM:
+// COM: The unresolved register call deliberately keeps indirect entry points
+// COM: unbounded, and the filler makes any appended pool unreachable by
+// COM: s_branch. Success therefore proves that this rewrite is entry-local:
+// COM: it neither consumes neighboring instructions nor weakens the unknown
+// COM: control-flow guards.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: unresolved call target
+// LOG: hotswap: unresolved control-flow target disables NOP-sled emission,
+// LOG-SAME: trampoline coalescing, source relocation, and .text gateways
+// LOG: hotswap: rewrote ds_store_2addr_b64 at 0x{{[0-9A-F]+}} in place with A0 byte offsets 0, 8
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_ds2_entry_local>:
+// DISASM-NEXT: s_swap_pc_i64 s[30:31], s[0:1]
+// DISASM-NEXT: ds_store_2addr_b64 v19, v[14:15], v[20:21] offset1:8
+// DISASM-NEXT: s_wait_loadcnt_dscnt 0x1
+// DISASM-NEXT: s_endpgm
+
+// COM: Relabel the first pass's output as A0 source. This disables the B0-to-A0
+// COM: family and must produce a byte-identical second object; legacy ISA names
+// COM: intentionally default the source to B0 on every independent invocation.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out2.elf | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds2_entry_local
+.p2align 8
+.type test_ds2_entry_local,@function
+test_ds2_entry_local:
+  s_swap_pc_i64 s[30:31], s[0:1]
+  ds_store_2addr_b64 v19, v[14:15], v[20:21] offset1:1
+  s_wait_loadcnt_dscnt 0x1
+  s_endpgm
+.size test_ds2_entry_local, .-test_ds2_entry_local
+
+// Keep a hypothetical appended trampoline pool outside signed s_branch reach.
+.rept 40000
+  s_mov_b32 s2, s3
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds2_entry_local
+  .amdhsa_next_free_vgpr 22
+  .amdhsa_next_free_sgpr 32
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_ds2_entry_local
+      .symbol: test_ds2_entry_local.kd
+      .sgpr_count: 32
+      .vgpr_count: 22
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-far-local-nop.s
+++ b/amd/comgr/test-lit/hotswap-ds2-far-local-nop.s
@@ -1,0 +1,180 @@
+// COM: A required DS2 split should use proven padding in its own function even
+// COM: when a large unrelated text tail places the appended pool outside
+// COM: s_branch reach. Keeping the replacement local avoids a registerless
+// COM: pool return and its object-size-dependent relay chain.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: trampoline: ds_load_addtid_b32 -> ds_load_b32
+// LOG-NOT: hotswap: ds_2addr: used compact continuation
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_ds2_far_local_nop>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: ds_load_b32 v0, v2 offset:4
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:12
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <test_ds2_far_compact_continuation>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_endpgm
+// DISASM-NOT: ds_load_2addr
+// DISASM-LABEL: <test_ds2_far_external_padding>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: ds_load_b32 v0, v2 offset:4
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:12
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_branch
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds2_far_local_nop
+.p2align 8
+.type test_ds2_far_local_nop,@function
+test_ds2_far_local_nop:
+  ds_load_2addr_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_endpgm
+.size test_ds2_far_local_nop, .-test_ds2_far_local_nop
+s_mov_b32 s0, s0
+
+// A DS2 followed by a wait should prefer a safe scratch-register trampoline
+// over consuming an exact 20-byte compact-continuation tail.
+.globl test_ds2_far_compact_continuation
+.p2align 8
+.type test_ds2_far_compact_continuation,@function
+test_ds2_far_compact_continuation:
+  ds_load_2addr_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+.size test_ds2_far_compact_continuation, .-test_ds2_far_compact_continuation
+.fill 20, 1, 0
+s_mov_b32 s0, s0
+.type compact_tail_barrier,@function
+compact_tail_barrier:
+  s_endpgm
+.size compact_tail_barrier, .-compact_tail_barrier
+.fill 20, 1, 0
+s_mov_b32 s0, s0
+.rept 40000
+  s_mov_b32 s0, s0
+.endr
+
+.globl test_ds2_far_external_padding
+.p2align 8
+.type test_ds2_far_external_padding,@function
+test_ds2_far_external_padding:
+  ds_load_2addr_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+.size test_ds2_far_external_padding, .-test_ds2_far_external_padding
+
+// Ordinary far-pool replacements use the same audited external-local policy,
+// so their source and return edges do not create object-spanning relay chains.
+.globl test_ds2_source_tail_planner
+.p2align 8
+.type test_ds2_source_tail_planner,@function
+test_ds2_source_tail_planner:
+  ds_load_addtid_b32 v3 offset:128
+  s_wait_dscnt 0x0
+  s_endpgm
+.size test_ds2_source_tail_planner, .-test_ds2_source_tail_planner
+
+// Proven unreachable code-end alignment padding outside the sized function
+// can host local replacements; any residual dwords remain available to global
+// routing. Production linked objects use this pattern extensively.
+.rept 32
+  s_code_end
+.endr
+
+// Keep a hypothetical appended trampoline pool outside signed s_branch reach.
+.rept 40000
+  s_mov_b32 s2, s3
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds2_far_local_nop
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 4
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds2_far_external_padding
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 4
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds2_source_tail_planner
+  .amdhsa_next_free_vgpr 4
+  .amdhsa_next_free_sgpr 4
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds2_far_compact_continuation
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 4
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_ds2_far_local_nop
+      .symbol: test_ds2_far_local_nop.kd
+      .sgpr_count: 4
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2_far_external_padding
+      .symbol: test_ds2_far_external_padding.kd
+      .sgpr_count: 4
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2_source_tail_planner
+      .symbol: test_ds2_source_tail_planner.kd
+      .sgpr_count: 4
+      .vgpr_count: 4
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2_far_compact_continuation
+      .symbol: test_ds2_far_compact_continuation.kd
+      .sgpr_count: 4
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-finite-external-call.s
+++ b/amd/comgr/test-lit/hotswap-finite-external-call.s
@@ -1,0 +1,70 @@
+// COM: A canonical PC-materialized call with one target outside .text has no
+// COM: local destination, but its continuation is a local entry. Proving both
+// COM: facts permits a far required rewrite to use the code-end gateway while
+// COM: preserving the external call's return point.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: resolved PC-materialized call
+// LOG-SAME: to finite external target
+// LOG-NOT: hotswap: unresolved call target
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <finite_external_call>:
+// DISASM: s_swap_pc_i64
+// DISASM-NEXT: s_branch
+// DISASM: ds_load_b32 v0, v2 offset:256
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:768
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl finite_external_call
+.p2align 8
+.type finite_external_call,@function
+finite_external_call:
+.Lgetpc:
+  s_get_pc_i64 s[2:3]
+  s_add_nc_u64 s[2:3], s[2:3], 0x100000000
+  s_swap_pc_i64 s[6:7], s[2:3]
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+.size finite_external_call, .-finite_external_call
+
+.fill 20, 1, 0
+.rept 40000
+  s_mov_b32 s10, s11
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel finite_external_call
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: finite_external_call
+      .symbol: finite_external_call.kd
+      .sgpr_count: 12
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-finite-materialized-call-closure.s
+++ b/amd/comgr/test-lit/hotswap-finite-materialized-call-closure.s
@@ -1,0 +1,65 @@
+// COM: An exact PC-materialized singleton call enters a defined local helper.
+// COM: The helper uses s[30:31] as scratch only after saving the incoming link
+// COM: in callee-saved VGPR lanes, then restores it before returning. Prove the
+// COM: call, canonical return, and call continuation together without falling
+// COM: back to an object-wide unknown indirect-entry assumption.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: accepted exact materialized-call/canonical-return closure for 1 register call(s)
+// LOG-NOT: hotswap: unresolved call target
+// LOG-NOT: hotswap: unresolved control-flow target disables
+// LOG: RESULT: SUCCESS
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl exact_closure_kernel
+.type exact_closure_kernel,@function
+exact_closure_kernel:
+  s_get_pc_i64 s[0:1]
+  // PC after get-PC is 4; exact_closure_helper begins at 16.
+  s_add_nc_u64 s[0:1], s[0:1], 12
+  s_swap_pc_i64 s[30:31], s[0:1]
+  s_endpgm
+.size exact_closure_kernel, .-exact_closure_kernel
+
+.local exact_closure_helper
+.type exact_closure_helper,@function
+exact_closure_helper:
+  v_writelane_b32 v40, s30, 0
+  v_writelane_b32 v41, s31, 1
+  s_mov_b32 s30, 0
+  s_mov_b32 s31, 0
+  v_readlane_b32 s30, v40, 0
+  v_readlane_b32 s31, v41, 1
+  s_set_pc_i64 s[30:31]
+  s_endpgm
+.size exact_closure_helper, .-exact_closure_helper
+
+.rodata
+.p2align 8
+.amdhsa_kernel exact_closure_kernel
+  .amdhsa_next_free_vgpr 42
+  .amdhsa_next_free_sgpr 42
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: exact_closure_kernel
+      .symbol: exact_closure_kernel.kd
+      .sgpr_count: 42
+      .vgpr_count: 42
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-materialized-call-joint-gateway.s
+++ b/amd/comgr/test-lit/hotswap-materialized-call-joint-gateway.s
@@ -11,7 +11,7 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=LOG,API %s
-// LOG: hotswap: resolved {{(reusable )?}}PC-materialized call
+// LOG: hotswap: accepted exact materialized-call/canonical-return closure
 // LOG-NOT: hotswap: unresolved call target
 // LOG-NOT: hotswap: unresolved control-flow target disables
 // API: RESULT: SUCCESS
@@ -32,14 +32,24 @@
 .local joint_helper
 .type joint_helper,@function
 joint_helper:
-  // This exact local set-PC jump is needed to reach the canonical return.
+  // Match the production helper: preserve its incoming link in callee-saved
+  // VGPR lanes, use s30:s31 as scratch, then restore it before returning.
+  v_writelane_b32 v40, s30, 0
+  v_writelane_b32 v41, s31, 1
+  s_mov_b32 s30, 0
+  s_mov_b32 s31, 0
+
+  // This exact local set-PC jump is needed to reach the restore/return path.
   s_get_pc_i64 s[4:5]
 .Lhelper_pc:
-  s_add_nc_u64 s[4:5], s[4:5], .Lhelper_return-.Lhelper_pc
+  s_add_nc_u64 s[4:5], s[4:5], .Lhelper_restore-.Lhelper_pc
   s_set_pc_i64 s[4:5]
-  s_nop 0
-.Lhelper_return:
+  s_endpgm
+.Lhelper_restore:
+  v_readlane_b32 s30, v40, 0
+  v_readlane_b32 s31, v41, 1
   s_set_pc_i64 s[30:31]
+  s_endpgm
 .size joint_helper, .-joint_helper
 
 .globl test_materialized_call_joint_gateway
@@ -69,8 +79,8 @@ test_materialized_call_joint_gateway:
 .rodata
 .p2align 8
 .amdhsa_kernel test_materialized_call_joint_gateway
-  .amdhsa_next_free_vgpr 5
-  .amdhsa_next_free_sgpr 32
+  .amdhsa_next_free_vgpr 42
+  .amdhsa_next_free_sgpr 42
 .end_amdhsa_kernel
 
 .amdgpu_metadata
@@ -80,8 +90,8 @@ test_materialized_call_joint_gateway:
   amdhsa.kernels:
     - .name: test_materialized_call_joint_gateway
       .symbol: test_materialized_call_joint_gateway.kd
-      .sgpr_count: 32
-      .vgpr_count: 5
+      .sgpr_count: 42
+      .vgpr_count: 42
       .kernarg_segment_size: 0
       .group_segment_fixed_size: 0
       .private_segment_fixed_size: 0

--- a/amd/comgr/test-lit/hotswap-materialized-call-joint-gateway.s
+++ b/amd/comgr/test-lit/hotswap-materialized-call-joint-gateway.s
@@ -1,0 +1,91 @@
+// COM: The production corpus contains compiler PC-materialized s30 calls into
+// COM: a helper with exact materialized set-PC jumps and an s30 return. Those
+// COM: three edge families form one finite component. MC also classifies the
+// COM: swap-call as an indirect branch; that generic classification must not
+// COM: create an unbounded self-edge after the same call has been proven
+// COM: finite. Closing the component keeps external zero padding available as
+// COM: a gateway for an otherwise-stranded far eight-byte DS2 patch.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: resolved {{(reusable )?}}PC-materialized call
+// LOG-NOT: hotswap: unresolved call target
+// LOG-NOT: hotswap: unresolved control-flow target disables
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-NOT: ds_load_2addr
+// DISASM: ds_load_b64
+// DISASM-NEXT: ds_load_b64
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local joint_helper
+.type joint_helper,@function
+joint_helper:
+  // This exact local set-PC jump is needed to reach the canonical return.
+  s_get_pc_i64 s[4:5]
+.Lhelper_pc:
+  s_add_nc_u64 s[4:5], s[4:5], .Lhelper_return-.Lhelper_pc
+  s_set_pc_i64 s[4:5]
+  s_nop 0
+.Lhelper_return:
+  s_set_pc_i64 s[30:31]
+.size joint_helper, .-joint_helper
+
+.globl test_materialized_call_joint_gateway
+.p2align 8
+.type test_materialized_call_joint_gateway,@function
+test_materialized_call_joint_gateway:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+
+  // The call target is the exact local helper entry. Its continuation is the
+  // following s_endpgm instruction.
+  s_get_pc_i64 s[0:1]
+.Lcaller_pc:
+  s_add_nc_u64 s[0:1], s[0:1], joint_helper-.Lcaller_pc
+  s_swap_pc_i64 s[30:31], s[0:1]
+  s_endpgm
+.size test_materialized_call_joint_gateway, .-test_materialized_call_joint_gateway
+
+// Safe external gateway space. A falsely-unbounded call clears this map and
+// makes the far eight-byte patch fail closed.
+.fill 64, 1, 0
+
+// Keep the appended trampoline pool beyond one signed s_branch span.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_materialized_call_joint_gateway
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 32
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_materialized_call_joint_gateway
+      .symbol: test_materialized_call_joint_gateway.kd
+      .sgpr_count: 32
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
+++ b/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
@@ -50,6 +50,9 @@ first_kernel:
   s_endpgm
 .Lfirst_kernel_end:
 .size first_kernel, .Lfirst_kernel_end-first_kernel
+// Prevent the following alignment hole from becoming external padding. This
+// test specifically proves that function-owned NOPs are not borrowed.
+s_mov_b32 s0, s0
 
 .globl second_kernel
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call.s
@@ -52,6 +52,9 @@ local_return_helper:
   s_branch .Llocal_return_epilogue
 .Llocal_return_helper_end:
 .size local_return_helper, .Llocal_return_helper_end-local_return_helper
+// Keep the following kernel-alignment hole out of the external sled map; the
+// exact gateway-sized windows below are the routing resources under test.
+s_mov_b32 s0, s0
 
 .globl test_pc_materialized_call
 .p2align 8
@@ -74,9 +77,20 @@ test_pc_materialized_call:
 .Ltest_pc_materialized_call_end:
 .size test_pc_materialized_call, .Ltest_pc_materialized_call_end-test_pc_materialized_call
 
-// Each far site needs its own 20-byte SCC-neutral gateway. This padding
-// follows s_endpgm and lies outside the function, so it is safe.
-.fill 64, 1, 0
+// Each far site needs its own 20-byte SCC-neutral gateway. Keep these NOP runs
+// function-owned: the global planner may use them, while replacement bodies
+// in test_pc_materialized_call cannot borrow another function's padding.
+.type gateway_0,@function
+gateway_0:
+  s_endpgm
+  .fill 20, 1, 0
+.size gateway_0, .-gateway_0
+
+.type gateway_1,@function
+gateway_1:
+  s_endpgm
+  .fill 20, 1, 0
+.size gateway_1, .-gateway_1
 
 // Push the appended trampoline pool beyond s_branch's signed 16-bit dword
 // range and force direct-target-aware far-site handling.

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call.s
@@ -24,9 +24,9 @@
 // DISASM-NEXT: s_get_pc_i64 s[2:3]
 // DISASM-NEXT: s_add_nc_u64 s[2:3], s[2:3], 16
 // DISASM-NEXT: s_swap_pc_i64 s[0:1], s[2:3]
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[6:7],
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[6:7],
 
 // COM: A second rewrite must preserve the resolved call and patched object.
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -24,10 +24,63 @@
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=BYPASS,FAIL %s
 // BYPASS: hotswap: unresolved call target
+// OVERLAP: hotswap: unresolved call target
+// CLOBBER: hotswap: resolved reusable PC-materialized call
+// CLOBBER: hotswap: unresolved call target
+// TAIL: hotswap: resolved reusable PC-materialized call
+// TAIL: hotswap: unresolved call target
+// INDIRECT: hotswap: resolved reusable PC-materialized call
+// INDIRECT: hotswap: unresolved call target
+// EXTERNAL: hotswap: unresolved call target
 // FAIL: hotswap: unresolved control-flow target disables NOP-sled emission,
 // FAIL-SAME: trampoline coalescing, source relocation, and .text gateways
 // FAIL: hotswap: error: no safe short-branch gateway for far site
 // FAIL: RESULT: ERROR
+
+// RUN: sed 's/^\.set overlap_delta, 0$/.set overlap_delta, 1/' \
+// RUN:   %s > %t.overlap.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.overlap.s -o %t.overlap.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.overlap.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=OVERLAP,FAIL %s
+
+// RUN: sed 's/^\.set clobber_target, 0$/.set clobber_target, 1/' \
+// RUN:   %s > %t.clobber.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.clobber.s -o %t.clobber.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.clobber.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=CLOBBER,FAIL %s
+
+// RUN: sed 's/^\.set tail_escape, 0$/.set tail_escape, 1/' \
+// RUN:   %s > %t.tail.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.tail.s -o %t.tail.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.tail.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=TAIL,FAIL %s
+
+// RUN: sed 's/^\.set indirect_escape, 0$/.set indirect_escape, 1/' \
+// RUN:   %s > %t.indirect.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.indirect.s -o %t.indirect.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.indirect.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=INDIRECT,FAIL %s
+
+// RUN: sed 's/^\.set external_entry, 0$/.set external_entry, 1/' \
+// RUN:   %s > %t.external.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.external.s -o %t.external.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.external.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=EXTERNAL,FAIL %s
 
 // RUN: sed 's/^\.set outside_selector, 0$/.set outside_selector, 1/' \
 // RUN:   %s > %t.outside.s
@@ -67,9 +120,23 @@
 
 .set unsafe_selector, 0
 .set outside_selector, 0
+.set overlap_delta, 0
+.set clobber_target, 0
+.set tail_escape, 0
+.set indirect_escape, 0
+.set external_entry, 0
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
+.if external_entry
+.type external_materialization_entry,@function
+external_materialization_entry:
+  // This independent function enters after get-PC and delta creation.
+  s_branch .Lfirst_add_low
+  s_endpgm
+.size external_materialization_entry, .-external_materialization_entry
+.endif
+
 .globl reusable_pc_targets
 .p2align 8
 .type reusable_pc_targets,@function
@@ -87,14 +154,27 @@ reusable_pc_targets:
   s_cbranch_scc1 .Lselect_second
 .Lselect_first:
   s_get_pc_i64 s[2:3]
+.if overlap_delta
+  // The temporary aliases the PC pair and destroys its low half.
+  s_add_co_i32 s2, callee_first-(.Lselect_first+4)-4, 4
+.Lfirst_add_low:
+  s_add_co_u32 s2, s2, s2
+.else
   s_add_co_i32 s4, callee_first-(.Lselect_first+4)-4, 4
+.Lfirst_add_low:
   s_add_co_u32 s2, s2, s4
+.endif
   s_add_co_ci_u32 s3, s3, 0
   s_branch .Lselected
 .Lselect_second:
   s_get_pc_i64 s[2:3]
+.if overlap_delta
+  s_add_co_i32 s2, callee_second-(.Lselect_second+4)-4, 4
+  s_add_co_u32 s2, s2, s2
+.else
   s_add_co_i32 s4, callee_second-(.Lselect_second+4)-4, 4
   s_add_co_u32 s2, s2, s4
+.endif
   s_add_co_ci_u32 s3, s3, 0
 .if outside_selector
   s_branch .Lselected
@@ -105,6 +185,8 @@ reusable_pc_targets:
   s_add_co_ci_u32 s3, s3, 0
 .endif
 .Lselected:
+  s_swap_pc_i64 s[6:7], s[2:3]
+  // Production kernels reuse this selected pair for multiple calls.
   s_swap_pc_i64 s[6:7], s[2:3]
   s_branch .Lpatch0
 .Lpatch0:
@@ -139,6 +221,15 @@ reusable_pc_targets:
 .type callee_first,@function
 callee_first:
   s_mov_b32 s8, 1
+.if clobber_target
+  s_mov_b32 s2, 0
+.endif
+.if tail_escape
+  s_branch clobber_helper
+.endif
+.if indirect_escape
+  s_set_pc_i64 s[10:11]
+.endif
   s_set_pc_i64 s[6:7]
 .size callee_first, .-callee_first
 
@@ -146,8 +237,26 @@ callee_first:
 .type callee_second,@function
 callee_second:
   s_mov_b32 s8, 2
+.if clobber_target
+  s_mov_b32 s2, 0
+.endif
+.if tail_escape
+  s_branch clobber_helper
+.endif
+.if indirect_escape
+  s_set_pc_i64 s[10:11]
+.endif
   s_set_pc_i64 s[6:7]
 .size callee_second, .-callee_second
+
+.if tail_escape
+.local clobber_helper
+.type clobber_helper,@function
+clobber_helper:
+  s_mov_b32 s2, 0
+  s_set_pc_i64 s[6:7]
+.size clobber_helper, .-clobber_helper
+.endif
 
 .type gateway_barrier,@function
 gateway_barrier:

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -30,8 +30,6 @@
 // OVERLAP: hotswap: unresolved call target
 // CLOBBER: hotswap: resolved reusable PC-materialized call
 // CLOBBER: hotswap: unresolved call target
-// BOOTSTRAP-CLOBBER: hotswap: resolved PC-materialized call
-// BOOTSTRAP-CLOBBER: hotswap: unresolved call target
 // TAIL: hotswap: resolved reusable PC-materialized call
 // TAIL: hotswap: unresolved call target
 // INDIRECT: hotswap: resolved reusable PC-materialized call
@@ -59,15 +57,6 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=CLOBBER,FAIL %s
-
-// RUN: sed 's/^\.set clobber_bootstrap, 0$/.set clobber_bootstrap, 1/' \
-// RUN:   %s > %t.bootstrap-clobber.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
-// RUN:   %t.bootstrap-clobber.s -o %t.bootstrap-clobber.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
-// RUN:   %t.bootstrap-clobber.elf amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 --expect-status ERROR 2>&1 \
-// RUN:   | %FileCheck --check-prefixes=BOOTSTRAP-CLOBBER,FAIL %s
 
 // RUN: sed 's/^\.set tail_escape, 0$/.set tail_escape, 1/' \
 // RUN:   %s > %t.tail.s
@@ -139,7 +128,6 @@
 .set outside_selector, 0
 .set overlap_delta, 0
 .set clobber_target, 0
-.set clobber_bootstrap, 0
 .set tail_escape, 0
 .set indirect_escape, 0
 .set external_entry, 0
@@ -154,16 +142,6 @@ external_materialization_entry:
   s_endpgm
 .size external_materialization_entry, .-external_materialization_entry
 .endif
-
-.local callee_bootstrap
-.type callee_bootstrap,@function
-callee_bootstrap:
-  s_mov_b32 s8, 3
-.if clobber_bootstrap
-  s_mov_b32 s10, 0
-.endif
-  s_set_pc_i64 s[12:13]
-.size callee_bootstrap, .-callee_bootstrap
 
 .globl reusable_pc_targets
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -30,8 +30,9 @@
 // OVERLAP: hotswap: unresolved call target
 // CLOBBER: hotswap: resolved reusable PC-materialized call
 // CLOBBER: hotswap: unresolved call target
-// BOOTSTRAP-CLOBBER: hotswap: resolved PC-materialized call
+// BOOTSTRAP-CLOBBER-NOT: hotswap: resolved PC-materialized call
 // BOOTSTRAP-CLOBBER: hotswap: unresolved call target
+// BOOTSTRAP-CLOBBER-NOT: hotswap: resolved PC-materialized call
 // TAIL: hotswap: resolved reusable PC-materialized call
 // TAIL: hotswap: unresolved call target
 // INDIRECT: hotswap: resolved reusable PC-materialized call
@@ -102,14 +103,17 @@
 // RUN:   %t.outside.s -o %t.outside.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.outside.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   --output %t.outside.out.elf 2>&1 \
 // RUN:   | %FileCheck --check-prefix=OUTSIDE %s
-// OUTSIDE: hotswap: unresolved call target
-// OUTSIDE-SAME: (reusable target outside .text)
-// OUTSIDE: hotswap: unresolved control-flow target disables NOP-sled emission,
-// OUTSIDE-SAME: trampoline coalescing, source relocation, and .text gateways
-// OUTSIDE: hotswap: error: no safe short-branch gateway for far site
-// OUTSIDE: RESULT: ERROR
+// OUTSIDE: hotswap: resolved reusable PC-materialized call{{.*}}to 3 target(s)
+// OUTSIDE-NOT: hotswap: unresolved call target
+// OUTSIDE: hotswap: planned 1 shared far-dispatch gateway group(s) for 8 source site(s)
+// OUTSIDE: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.outside.out.elf \
+// RUN:   | %FileCheck --check-prefix=OUTSIDE-DISASM %s
+// OUTSIDE-DISASM-LABEL: <reusable_pc_targets>:
+// OUTSIDE-DISASM: s_swap_pc_i64
+// OUTSIDE-DISASM-NEXT: s_swap_pc_i64
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
 // RUN:   --implicit-check-not=s_add_pc_i64 %s
@@ -160,6 +164,8 @@ external_materialization_entry:
 callee_bootstrap:
   s_mov_b32 s8, 3
 .if clobber_bootstrap
+  // The later unresolved bootstrap reuse makes the object-wide indirect-flow
+  // audit non-closed, so even the preceding one-shot proof is retracted.
   s_mov_b32 s10, 0
 .endif
   s_set_pc_i64 s[12:13]

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -30,6 +30,8 @@
 // OVERLAP: hotswap: unresolved call target
 // CLOBBER: hotswap: resolved reusable PC-materialized call
 // CLOBBER: hotswap: unresolved call target
+// BOOTSTRAP-CLOBBER: hotswap: resolved PC-materialized call
+// BOOTSTRAP-CLOBBER: hotswap: unresolved call target
 // TAIL: hotswap: resolved reusable PC-materialized call
 // TAIL: hotswap: unresolved call target
 // INDIRECT: hotswap: resolved reusable PC-materialized call
@@ -57,6 +59,15 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=CLOBBER,FAIL %s
+
+// RUN: sed 's/^\.set clobber_bootstrap, 0$/.set clobber_bootstrap, 1/' \
+// RUN:   %s > %t.bootstrap-clobber.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.bootstrap-clobber.s -o %t.bootstrap-clobber.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.bootstrap-clobber.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=BOOTSTRAP-CLOBBER,FAIL %s
 
 // RUN: sed 's/^\.set tail_escape, 0$/.set tail_escape, 1/' \
 // RUN:   %s > %t.tail.s
@@ -128,6 +139,7 @@
 .set outside_selector, 0
 .set overlap_delta, 0
 .set clobber_target, 0
+.set clobber_bootstrap, 0
 .set tail_escape, 0
 .set indirect_escape, 0
 .set external_entry, 0
@@ -142,6 +154,16 @@ external_materialization_entry:
   s_endpgm
 .size external_materialization_entry, .-external_materialization_entry
 .endif
+
+.local callee_bootstrap
+.type callee_bootstrap,@function
+callee_bootstrap:
+  s_mov_b32 s8, 3
+.if clobber_bootstrap
+  s_mov_b32 s10, 0
+.endif
+  s_set_pc_i64 s[12:13]
+.size callee_bootstrap, .-callee_bootstrap
 
 .globl reusable_pc_targets
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -1,0 +1,185 @@
+// COM: Production activation kernels select one of several local callees with
+// COM: get-PC/carry materialization, merge the selected address, and reuse it
+// COM: across many register calls. Resolve the finite reaching-target set so
+// COM: an unrelated required far rewrite may safely use external gateway
+// COM: padding. A selector bypass would leave the target unknown and must
+// COM: continue to fail closed.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: resolved reusable PC-materialized call
+// LOG-SAME: to 2 target(s)
+// LOG-NOT: hotswap: unresolved call target
+// LOG: hotswap: planned 1 shared far-dispatch gateway group(s) for 8 source site(s)
+// LOG: RESULT: SUCCESS
+
+// RUN: sed 's/^\.set unsafe_selector, 0$/.set unsafe_selector, 1/' \
+// RUN:   %s > %t.bypass.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.bypass.s -o %t.bypass.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.bypass.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=BYPASS,FAIL %s
+// BYPASS: hotswap: unresolved call target
+// FAIL: hotswap: unresolved control-flow target disables NOP-sled emission,
+// FAIL-SAME: trampoline coalescing, source relocation, and .text gateways
+// FAIL: hotswap: error: no safe short-branch gateway for far site
+// FAIL: RESULT: ERROR
+
+// RUN: sed 's/^\.set outside_selector, 0$/.set outside_selector, 1/' \
+// RUN:   %s > %t.outside.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.outside.s -o %t.outside.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.outside.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=OUTSIDE %s
+// OUTSIDE: hotswap: unresolved call target
+// OUTSIDE-SAME: (reusable target outside .text)
+// OUTSIDE: hotswap: unresolved control-flow target disables NOP-sled emission,
+// OUTSIDE-SAME: trampoline coalescing, source relocation, and .text gateways
+// OUTSIDE: hotswap: error: no safe short-branch gateway for far site
+// OUTSIDE: RESULT: ERROR
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// DISASM-LABEL: <reusable_pc_targets>:
+// DISASM: s_swap_pc_i64
+// DISASM: s_get_pc_i64
+// DISASM: s_branch
+// DISASM: s_get_pc_i64
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <gateway_barrier>:
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+// DISASM: ds_load_b32 v0, v2 offset:256
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:768
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.set unsafe_selector, 0
+.set outside_selector, 0
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl reusable_pc_targets
+.p2align 8
+.type reusable_pc_targets,@function
+reusable_pc_targets:
+.if unsafe_selector
+  // This edge reaches the call without executing either get-PC sequence.
+  s_cmp_eq_u32 s0, 2
+  s_cbranch_scc1 .Lselected
+.endif
+.if outside_selector
+  s_cmp_eq_u32 s0, 3
+  s_cbranch_scc1 .Lselect_outside
+.endif
+  s_cmp_eq_u32 s0, 0
+  s_cbranch_scc1 .Lselect_second
+.Lselect_first:
+  s_get_pc_i64 s[2:3]
+  s_add_co_i32 s4, callee_first-(.Lselect_first+4)-4, 4
+  s_add_co_u32 s2, s2, s4
+  s_add_co_ci_u32 s3, s3, 0
+  s_branch .Lselected
+.Lselect_second:
+  s_get_pc_i64 s[2:3]
+  s_add_co_i32 s4, callee_second-(.Lselect_second+4)-4, 4
+  s_add_co_u32 s2, s2, s4
+  s_add_co_ci_u32 s3, s3, 0
+.if outside_selector
+  s_branch .Lselected
+.Lselect_outside:
+  s_get_pc_i64 s[2:3]
+  s_add_co_i32 s4, outside_text_end-(.Lselect_outside+4)-4, 4
+  s_add_co_u32 s2, s2, s4
+  s_add_co_ci_u32 s3, s3, 0
+.endif
+.Lselected:
+  s_swap_pc_i64 s[6:7], s[2:3]
+  s_branch .Lpatch0
+.Lpatch0:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch1
+.Lpatch1:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch2
+.Lpatch2:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch3
+.Lpatch3:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch4
+.Lpatch4:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch5
+.Lpatch5:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch6
+.Lpatch6:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch7
+.Lpatch7:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+.Lpatch_done:
+  s_wait_dscnt 0x0
+  s_endpgm
+.size reusable_pc_targets, .-reusable_pc_targets
+
+.local callee_first
+.type callee_first,@function
+callee_first:
+  s_mov_b32 s8, 1
+  s_set_pc_i64 s[6:7]
+.size callee_first, .-callee_first
+
+.local callee_second
+.type callee_second,@function
+callee_second:
+  s_mov_b32 s8, 2
+  s_set_pc_i64 s[6:7]
+.size callee_second, .-callee_second
+
+.type gateway_barrier,@function
+gateway_barrier:
+  s_endpgm
+.size gateway_barrier, .-gateway_barrier
+.fill 20, 1, 0
+
+.rept 40000
+  s_mov_b32 s10, s11
+.endr
+
+outside_text_end:
+.rodata
+.p2align 8
+.amdhsa_kernel reusable_pc_targets
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: reusable_pc_targets
+      .symbol: reusable_pc_targets.kd
+      .sgpr_count: 12
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -118,14 +118,10 @@
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
 // RUN:   --implicit-check-not=s_add_pc_i64 %s
 // DISASM-LABEL: <reusable_pc_targets>:
-// DISASM: s_swap_pc_i64 s[6:7]
-// DISASM-NEXT: s_swap_pc_i64 s[6:7]
-// DISASM-NEXT: s_branch
-// DISASM-NEXT: s_get_pc_i64
-// DISASM-NEXT: s_branch
-// DISASM-NEXT: s_branch
-// DISASM-NEXT: s_get_pc_i64
-// DISASM-NEXT: s_branch
+// DISASM: s_swap_pc_i64 s[12:13], s[10:11]
+// DISASM-NEXT: s_swap_pc_i64 s[12:13], s[10:11]
+// DISASM: s_call_i64 s[14:15]
+// DISASM-NEXT: s_nop 0
 // DISASM-LABEL: <gateway_barrier>:
 // DISASM-NEXT: s_endpgm
 // DISASM-NEXT: s_get_pc_i64

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -166,6 +166,9 @@ callee_bootstrap:
 .endif
   s_set_pc_i64 s[12:13]
 .size callee_bootstrap, .-callee_bootstrap
+// Keep the following kernel-alignment hole out of the external sled map; the
+// exact gateway-sized window below is the routing resource under test.
+s_mov_b32 s0, s0
 
 .globl reusable_pc_targets
 .p2align 8
@@ -298,8 +301,8 @@ clobber_helper:
 .type gateway_barrier,@function
 gateway_barrier:
   s_endpgm
+  .fill 20, 1, 0
 .size gateway_barrier, .-gateway_barrier
-.fill 20, 1, 0
 
 .rept 40000
   s_mov_b32 s10, s11

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -9,6 +9,9 @@
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: resolved PC-materialized call
+// LOG: hotswap: resolved reusable PC-materialized call
+// LOG-SAME: to 1 target(s)
 // LOG: hotswap: resolved reusable PC-materialized call
 // LOG-SAME: to 2 target(s)
 // LOG-NOT: hotswap: unresolved call target
@@ -27,6 +30,8 @@
 // OVERLAP: hotswap: unresolved call target
 // CLOBBER: hotswap: resolved reusable PC-materialized call
 // CLOBBER: hotswap: unresolved call target
+// BOOTSTRAP-CLOBBER: hotswap: resolved PC-materialized call
+// BOOTSTRAP-CLOBBER: hotswap: unresolved call target
 // TAIL: hotswap: resolved reusable PC-materialized call
 // TAIL: hotswap: unresolved call target
 // INDIRECT: hotswap: resolved reusable PC-materialized call
@@ -54,6 +59,15 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=CLOBBER,FAIL %s
+
+// RUN: sed 's/^\.set clobber_bootstrap, 0$/.set clobber_bootstrap, 1/' \
+// RUN:   %s > %t.bootstrap-clobber.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.bootstrap-clobber.s -o %t.bootstrap-clobber.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.bootstrap-clobber.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=BOOTSTRAP-CLOBBER,FAIL %s
 
 // RUN: sed 's/^\.set tail_escape, 0$/.set tail_escape, 1/' \
 // RUN:   %s > %t.tail.s
@@ -100,10 +114,13 @@
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
 // RUN:   --implicit-check-not=s_add_pc_i64 %s
 // DISASM-LABEL: <reusable_pc_targets>:
-// DISASM: s_swap_pc_i64
-// DISASM: s_get_pc_i64
-// DISASM: s_branch
-// DISASM: s_get_pc_i64
+// DISASM: s_swap_pc_i64 s[6:7]
+// DISASM-NEXT: s_swap_pc_i64 s[6:7]
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_get_pc_i64
 // DISASM-NEXT: s_branch
 // DISASM-LABEL: <gateway_barrier>:
 // DISASM-NEXT: s_endpgm
@@ -122,6 +139,7 @@
 .set outside_selector, 0
 .set overlap_delta, 0
 .set clobber_target, 0
+.set clobber_bootstrap, 0
 .set tail_escape, 0
 .set indirect_escape, 0
 .set external_entry, 0
@@ -137,10 +155,27 @@ external_materialization_entry:
 .size external_materialization_entry, .-external_materialization_entry
 .endif
 
+.local callee_bootstrap
+.type callee_bootstrap,@function
+callee_bootstrap:
+  s_mov_b32 s8, 3
+.if clobber_bootstrap
+  s_mov_b32 s10, 0
+.endif
+  s_set_pc_i64 s[12:13]
+.size callee_bootstrap, .-callee_bootstrap
+
 .globl reusable_pc_targets
 .p2align 8
 .type reusable_pc_targets,@function
 reusable_pc_targets:
+  // A straight-line first call is resolved by the one-shot matcher. Its
+  // proven target remains reusable after the audited callee returns.
+.Lbootstrap_getpc:
+  s_get_pc_i64 s[10:11]
+  s_add_nc_u64 s[10:11], s[10:11], callee_bootstrap-(.Lbootstrap_getpc+4)
+  s_swap_pc_i64 s[12:13], s[10:11]
+  s_swap_pc_i64 s[12:13], s[10:11]
 .if unsafe_selector
   // This edge reaches the call without executing either get-PC sequence.
   s_cmp_eq_u32 s0, 2
@@ -273,7 +308,7 @@ outside_text_end:
 .p2align 8
 .amdhsa_kernel reusable_pc_targets
   .amdhsa_next_free_vgpr 3
-  .amdhsa_next_free_sgpr 12
+  .amdhsa_next_free_sgpr 14
 .end_amdhsa_kernel
 
 .amdgpu_metadata
@@ -283,7 +318,7 @@ outside_text_end:
   amdhsa.kernels:
     - .name: reusable_pc_targets
       .symbol: reusable_pc_targets.kd
-      .sgpr_count: 12
+      .sgpr_count: 14
       .vgpr_count: 3
       .kernarg_segment_size: 0
       .group_segment_fixed_size: 0

--- a/amd/comgr/test-lit/hotswap-rewrite.c
+++ b/amd/comgr/test-lit/hotswap-rewrite.c
@@ -1,4 +1,5 @@
 // COM: Test HotSwap rewrite API
+// clang-format off
 
 // COM: Create a minimal test ELF file (ELF64 header only, no sections).
 // RUN: printf '\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00' > %t.elf
@@ -40,3 +41,4 @@
 
 // COM: End-to-end coverage on real gfx1250 code objects is covered by
 // COM: hotswap-rewrite-e2e.hip and hotswap-kernel-entry-trampoline.s.
+// clang-format on

--- a/amd/comgr/test-lit/hotswap-rewrite.c
+++ b/amd/comgr/test-lit/hotswap-rewrite.c
@@ -31,10 +31,9 @@
 // RUN:   | %FileCheck --check-prefix=ZEROSIZE %s
 // ZEROSIZE: RESULT: INVALID_ARGUMENT
 
-// COM: Supported GFX1250 pair on a malformed ELF (no .text section).
-// COM: retargetCodeObject rejects inputs that fail ELF64 parsing or have
-// COM: an empty .text section with INVALID_ARGUMENT -- returning SUCCESS with
-// COM: an unchanged copy there would silently hide caller-side bugs.
+// COM: Supported GFX1250 pair on a malformed ELF (no section table and no
+// COM: .text section). retargetCodeObject rejects inputs that fail ELF64
+// COM: parsing instead of silently returning an unchanged successful copy.
 // RUN: hotswap-rewrite %t.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   | %FileCheck --check-prefix=MALFORMED %s
 // MALFORMED: RESULT: INVALID_ARGUMENT

--- a/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
@@ -66,8 +66,10 @@ kernel_b:
 .size kernel_b, .Lkernel_b_end-kernel_b
 
 // Safe external gateway space: it follows a no-fallthrough instruction and is
-// outside every function range, so it cannot be executed by fallthrough.
-.rept 8
+// outside every function range, so it cannot be executed by fallthrough. Its
+// exact 20-byte size can carry a set-PC gateway but not the replacement body,
+// preserving this fixture's intended long-branch path.
+.rept 5
   s_nop 0
 .endr
 

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
@@ -101,6 +101,12 @@ test_ds2addr_far_load:
   s_endpgm
 .Ltest_ds2addr_far_load_end:
 .size test_ds2addr_far_load, .Ltest_ds2addr_far_load_end-test_ds2addr_far_load
+.type gateway_load,@function
+gateway_load:
+  s_endpgm
+  .fill 20, 1, 0
+.size gateway_load, .-gateway_load
+s_mov_b32 s0, s0
 
 .globl test_ds2addr_far_adjacent
 .p2align 8
@@ -114,6 +120,12 @@ test_ds2addr_far_adjacent:
   s_endpgm
 .Ltest_ds2addr_far_adjacent_end:
 .size test_ds2addr_far_adjacent, .Ltest_ds2addr_far_adjacent_end-test_ds2addr_far_adjacent
+.type gateway_adjacent,@function
+gateway_adjacent:
+  s_endpgm
+  .fill 20, 1, 0
+.size gateway_adjacent, .-gateway_adjacent
+s_mov_b32 s0, s0
 
 .globl test_ds2addr_far_branch_target
 .p2align 8
@@ -127,6 +139,12 @@ test_ds2addr_far_branch_target:
   s_endpgm
 .Ltest_ds2addr_far_branch_target_end:
 .size test_ds2addr_far_branch_target, .Ltest_ds2addr_far_branch_target_end-test_ds2addr_far_branch_target
+.type gateway_branch_target,@function
+gateway_branch_target:
+  s_endpgm
+  .fill 20, 1, 0
+.size gateway_branch_target, .-gateway_branch_target
+s_mov_b32 s0, s0
 
 .globl test_ds2addr_far_call_target
 .p2align 8
@@ -140,6 +158,12 @@ test_ds2addr_far_call_target:
   s_endpgm
 .Ltest_ds2addr_far_call_target_end:
 .size test_ds2addr_far_call_target, .Ltest_ds2addr_far_call_target_end-test_ds2addr_far_call_target
+.type gateway_call_target,@function
+gateway_call_target:
+  s_endpgm
+  .fill 20, 1, 0
+.size gateway_call_target, .-gateway_call_target
+s_mov_b32 s0, s0
 
 .globl test_ds2addr_far_store
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
@@ -27,7 +27,7 @@
 // COM: Case 1 (2-address load, RCCL's pattern).
 // DISASM-NOT: s_add_pc_i64
 // DISASM-LABEL: <test_ds2addr_far_load>:
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // COM: Case 2 (adjacent sites coalesced into a set-PC forward gateway).
 // DISASM-LABEL: <test_ds2addr_far_adjacent>:
@@ -38,20 +38,20 @@
 // COM: Case 3 (an interior direct-branch target must prevent coalescing).
 // DISASM-LABEL: <test_ds2addr_far_branch_target>:
 // DISASM-NEXT: s_cbranch_scc1
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // COM: Case 4 (a direct-call target is also an interior entry point).
 // DISASM-LABEL: <test_ds2addr_far_call_target>:
 // DISASM-NEXT: s_call_i64
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // COM: Case 5 (2-address store).
 // DISASM-LABEL: <test_ds2addr_far_store>:
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // DISASM-NOT: ds_load_2addr
 // DISASM-NOT: ds_store_2addr

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
@@ -29,26 +29,26 @@
 // COM: expansion sleds. The single shared s_wait_dscnt stays at 0x0
 // COM: (drain preservation under stacking in the non-stride64 path).
 // COM: The two sleds together expand to 4 single-address ds_load_b32
-// COM: instructions; offsets (raw 1/2 and 3/4) scale by ElemBytes=4 to
-// COM: byte offsets 4/8 and 12/16 across the two sites.
+// COM: instructions. Raw offsets start at 64 so the scaled byte offsets no
+// COM: longer fit the in-place DS2 fields; they become 256/260 and 264/268.
 // DISASM-LABEL: <test_multi_ds_nostride64>:
 // DISASM-NOT: ds_load_2addr_b32
 // DISASM: s_branch
 // DISASM: s_branch
 // DISASM: s_wait_dscnt 0x0
 // COM: Sled 1 (first DS2 site, vdst pair v[0:1]).
-// DISASM: ds_load_b32 v0, v4 offset:4
-// DISASM-NEXT: ds_load_b32 v1, v4 offset:8
+// DISASM: ds_load_b32 v0, v4 offset:256
+// DISASM-NEXT: ds_load_b32 v1, v4 offset:260
 // COM: Sled 2 (second DS2 site, vdst pair v[2:3]).
-// DISASM: ds_load_b32 v2, v4 offset:12
-// DISASM-NEXT: ds_load_b32 v3, v4 offset:16
+// DISASM: ds_load_b32 v2, v4 offset:264
+// DISASM-NEXT: ds_load_b32 v3, v4 offset:268
 
 .globl test_multi_ds_nostride64
 .p2align 8
 .type test_multi_ds_nostride64,@function
 test_multi_ds_nostride64:
-  ds_load_2addr_b32 v[0:1], v4 offset0:1 offset1:2
-  ds_load_2addr_b32 v[2:3], v4 offset0:3 offset1:4
+  ds_load_2addr_b32 v[0:1], v4 offset0:64 offset1:65
+  ds_load_2addr_b32 v[2:3], v4 offset0:66 offset1:67
   s_wait_dscnt 0x0
   s_endpgm
   s_nop 0

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
@@ -6,12 +6,13 @@
 // COM: in applyTrampolinePatchesImpl across multiple variant types in a
 // COM: single trampoline pass.
 // COM:
-// COM: These differ from the stride64 forms only in the byte-offset scale
-// COM: applied to each per-operand index (ElemBytes vs 64 * ElemBytes), so
-// COM: the trampoline shape (s_branch forward + sled + s_branch back) and
-// COM: the s_wait_dscnt handling are shared with the stride64 path. Each
-// COM: split emits its own s_wait_dscnt 0x0 drain after the two
-// COM: single-address ops; a pre-existing downstream drain is left in place.
+// COM: These differ from the stride64 forms in the byte-offset scale applied
+// COM: to each per-operand index (ElemBytes vs 64 * ElemBytes). Every
+// COM: non-stride family whose scaled offsets fit the two DS2 eight-bit fields
+// COM: is rewritten in place. Only bytes 0 and 1 change; opcode, registers,
+// COM: modifiers, instruction count, waits, and arbitrary-entry behavior stay
+// COM: identical. The fallback kernel pins the established split path when a
+// COM: scaled field is not representable.
 // COM:
 // COM: Companion tests:
 // COM:   hotswap-trampoline-ds-nostride64-multi.s -- drain insertion
@@ -22,7 +23,8 @@
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
@@ -34,15 +36,11 @@
 
 // ---- Kernel 1: ds_load_2addr_b32 (non-stride64, byte offset = idx*4) -------
 // COM: Kernel 1 (b32 load, non-stride64): offsets index*4. Source
-// COM: offset0:4 offset1:8 -> byte offsets 16 and 32. The input wait is
-// COM: s_wait_dscnt 0x0 (drain) and stays at 0x0 after the split.
+// COM: offset0:4 offset1:8 -> byte offsets 16 and 32.
 // DISASM-LABEL: <test_ds_load_b32_nostride64>:
-// DISASM-NOT: ds_load_2addr_b32
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_load_b32 v0, v2 offset:16
-// DISASM-NEXT: ds_load_b32 v1, v2 offset:32
-// DISASM: s_branch
+// DISASM-NEXT: ds_load_2addr_b32 v[0:1], v2 offset0:16 offset1:32
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_load_b32_nostride64
 .p2align 8
@@ -73,14 +71,11 @@ test_ds_load_b32_nostride64:
 // ---- Kernel 2: ds_load_2addr_b64 (non-stride64, byte offset = idx*8) -------
 // COM: Kernel 2 (b64 load, non-stride64): offsets index*8. Source
 // COM: offset0:1 offset1:2 -> byte offsets 8 and 16. b64 destinations
-// COM: format as v[X:Y] register pairs; drain wait stays at 0x0.
+// COM: format as v[X:Y] register pairs.
 // DISASM-LABEL: <test_ds_load_b64_nostride64>:
-// DISASM-NOT: ds_load_2addr_b64
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_load_b64 v[0:1], v4 offset:8
-// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:16
-// DISASM: s_branch
+// DISASM-NEXT: ds_load_2addr_b64 v[0:3], v4 offset0:8 offset1:16
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_load_b64_nostride64
 .p2align 8
@@ -111,14 +106,11 @@ test_ds_load_b64_nostride64:
 // ---- Kernel 3: ds_store_2addr_b32 (non-stride64 store operand layout) ------
 // COM: Kernel 3 (b32 store, non-stride64): store operand layout
 // COM: (addr, data0, data1). Source offset0:1 offset1:2 -> byte
-// COM: offsets 4 and 8; drain wait stays at 0x0.
+// COM: offsets 4 and 8.
 // DISASM-LABEL: <test_ds_store_b32_nostride64>:
-// DISASM-NOT: ds_store_2addr_b32
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_store_b32 v2, v0 offset:4
-// DISASM-NEXT: ds_store_b32 v2, v1 offset:8
-// DISASM: s_branch
+// DISASM-NEXT: ds_store_2addr_b32 v2, v0, v1 offset0:4 offset1:8
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_store_b32_nostride64
 .p2align 8
@@ -149,14 +141,11 @@ test_ds_store_b32_nostride64:
 // ---- Kernel 4: ds_storexchg_2addr_rtn_b32 (non-stride64 exchange layout) ---
 // COM: Kernel 4 (b32 exchange, non-stride64): exchange operand layout
 // COM: (dst, addr, data0, data1). Source offset0:1 offset1:3 -> byte
-// COM: offsets 4 and 12; drain wait stays at 0x0.
+// COM: offsets 4 and 12.
 // DISASM-LABEL: <test_ds_xchg_b32_nostride64>:
-// DISASM-NOT: ds_storexchg_2addr_rtn_b32
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_storexchg_rtn_b32 v0, v2, v3 offset:4
-// DISASM-NEXT: ds_storexchg_rtn_b32 v1, v2, v4 offset:12
-// DISASM: s_branch
+// DISASM-NEXT: ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 offset0:4 offset1:12
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_xchg_b32_nostride64
 .p2align 8
@@ -185,19 +174,13 @@ test_ds_xchg_b32_nostride64:
 .size test_ds_xchg_b32_nostride64, .Ltest_ds_xchg_b32_nostride64_end-test_ds_xchg_b32_nostride64
 
 // ---- Kernel 5: ds_store_2addr_b64 (non-stride64 store, b64 data pairs) -----
-// COM: Kernel 5 (b64 store, non-stride64): store operand layout (addr,
-// COM: data0_pair, data1_pair). Source offset0:1 offset1:2 -> byte
-// COM: offsets 8 and 16. b64 data operands format as v[X:Y] register
-// COM: pairs (exercises fmtRegOperand on the data side, complementing
-// COM: kernel 2 which exercises it on the destination side); drain
-// COM: wait stays at 0x0.
+// COM: Kernel 5 (b64 store, non-stride64): byte offsets 8 and 16 still fit
+// COM: the DS2 encoding's two eight-bit fields. Re-encode those fields in
+// COM: place for A0 instead of splitting the instruction or using a sled.
 // DISASM-LABEL: <test_ds_store_b64_nostride64>:
-// DISASM-NOT: ds_store_2addr_b64
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_store_b64 v4, v[0:1] offset:8
-// DISASM-NEXT: ds_store_b64 v4, v[2:3] offset:16
-// DISASM: s_branch
+// DISASM-NEXT: ds_store_2addr_b64 v4, v[0:1], v[2:3] offset0:8 offset1:16
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_store_b64_nostride64
 .p2align 8
@@ -225,21 +208,51 @@ test_ds_store_b64_nostride64:
 .Ltest_ds_store_b64_nostride64_end:
 .size test_ds_store_b64_nostride64, .Ltest_ds_store_b64_nostride64_end-test_ds_store_b64_nostride64
 
+// ---- Kernel 5b: b64 scaled offset no longer fits the DS2 field -------------
+// COM: Raw offsets 32 and 33 scale to 256 and 264. They fit the DS1 16-bit
+// COM: field but not the DS2 8-bit fields, so retain the established split
+// COM: path rather than truncating an in-place rewrite.
+// DISASM-LABEL: <test_ds_store_b64_nostride64_fallback>:
+// DISASM-NOT: ds_store_2addr_b64
+// DISASM: s_branch
+// DISASM: ds_store_b64 v4, v[0:1] offset:256
+// DISASM-NEXT: ds_store_b64 v4, v[2:3] offset:264
+
+.globl test_ds_store_b64_nostride64_fallback
+.p2align 8
+.type test_ds_store_b64_nostride64_fallback,@function
+test_ds_store_b64_nostride64_fallback:
+  ds_store_2addr_b64 v4, v[0:1], v[2:3] offset0:32 offset1:33
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_store_b64_nostride64_fallback_end:
+.size test_ds_store_b64_nostride64_fallback, .Ltest_ds_store_b64_nostride64_fallback_end-test_ds_store_b64_nostride64_fallback
+
 // ---- Kernel 6: ds_storexchg_2addr_rtn_b64 (non-stride64 b64 exchange) ------
 // COM: Kernel 6 (b64 exchange, non-stride64): exchange operand layout
 // COM: (dst_pair, addr, data0_pair, data1_pair). Source offset0:1
 // COM: offset1:2 -> byte offsets 8 and 16. Both vdst halves AND the data
-// COM: operands format as v[X:Y] register pairs (exercises splitDstPair
-// COM: AND fmtRegOperand on b64 within the xchg dispatch path, complementing
-// COM: kernel 4 which exercises the b32 xchg layout); drain wait stays
-// COM: at 0x0.
+// COM: operands format as v[X:Y] register pairs.
 // DISASM-LABEL: <test_ds_xchg_b64_nostride64>:
-// DISASM-NOT: ds_storexchg_2addr_rtn_b64
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_storexchg_rtn_b64 v[0:1], v8, v[4:5] offset:8
-// DISASM-NEXT: ds_storexchg_rtn_b64 v[2:3], v8, v[6:7] offset:16
-// DISASM: s_branch
+// DISASM-NEXT: ds_storexchg_2addr_rtn_b64 v[0:3], v8, v[4:5], v[6:7] offset0:8 offset1:16
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
 
 .globl test_ds_xchg_b64_nostride64
 .p2align 8
@@ -272,30 +285,16 @@ test_ds_xchg_b64_nostride64:
 // COM: ds_load_2addr_b32, ds_store_2addr_b32, and ds_storexchg_2addr_rtn_b32
 // COM: before a single drain s_wait_dscnt 0x0. Verifies that the per-
 // COM: instruction dispatcher in applyTrampolinePatchesImpl correctly
-// COM: routes each variant to its own expansion type without state leakage
-// COM: across types in a single trampoline pass; drain wait stays at 0x0
-// COM: across all three split sites. Sleds appear in source order: load,
-// COM: store, xchg. All offsets scale by ElemBytes=4.
+// COM: routes each variant to the common byte-field rewrite without state
+// COM: leakage across types. All offsets scale by ElemBytes=4.
 // COM:   ds_load_2addr_b32  offset0:1 offset1:2 -> byte 4, 8
 // COM:   ds_store_2addr_b32 offset0:3 offset1:4 -> byte 12, 16
 // COM:   ds_storexchg_*_b32 offset0:5 offset1:6 -> byte 20, 24
 // DISASM-LABEL: <test_ds_combo_nostride64>:
-// DISASM-NOT: ds_load_2addr_b32
-// DISASM-NOT: ds_store_2addr_b32
-// DISASM-NOT: ds_storexchg_2addr_rtn_b32
-// DISASM: s_branch
-// DISASM: s_branch
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// COM: Sled 1: load expansion.
-// DISASM: ds_load_b32 v0, v8 offset:4
-// DISASM-NEXT: ds_load_b32 v1, v8 offset:8
-// COM: Sled 2: store expansion.
-// DISASM: ds_store_b32 v8, v2 offset:12
-// DISASM-NEXT: ds_store_b32 v8, v3 offset:16
-// COM: Sled 3: xchg expansion.
-// DISASM: ds_storexchg_rtn_b32 v4, v8, v6 offset:20
-// DISASM-NEXT: ds_storexchg_rtn_b32 v5, v8, v7 offset:24
+// DISASM-NEXT: ds_load_2addr_b32 v[0:1], v8 offset0:4 offset1:8
+// DISASM-NEXT: ds_store_2addr_b32 v8, v2, v3 offset0:12 offset1:16
+// DISASM-NEXT: ds_storexchg_2addr_rtn_b32 v[4:5], v8, v6, v7 offset0:20 offset1:24
+// DISASM-NEXT: s_wait_dscnt 0x0
 
 .globl test_ds_combo_nostride64
 .p2align 8
@@ -342,12 +341,19 @@ test_ds_combo_nostride64:
 .size test_ds_combo_nostride64, .Ltest_ds_combo_nostride64_end-test_ds_combo_nostride64
 
 // COM: Idempotency: rewriting the output again should produce identical
-// COM: bytes (no DS2 mnemonic remains, second pass is a no-op).
+// COM: bytes. Feeding the output back with its A0 stepping as the source
+// COM: disables B0-to-A0 patches, so the surviving A0-correct DS2 instruction
+// COM: is not scaled a second time.
+// COM: Legacy ISA names without a stepping deliberately declare their source
+// COM: as B0 on every invocation; repeating those arguments is not the
+// COM: idempotence contract for a transformation whose opcode survives.
 // RUN: hotswap-rewrite %t.out.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --check-idempotent \
-// RUN:   | %FileCheck --check-prefix=IDEM %s
-// IDEM: IDEMPOTENT: YES
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
 
 .rodata
 .p2align 8
@@ -372,6 +378,11 @@ test_ds_combo_nostride64:
 .end_amdhsa_kernel
 
 .amdhsa_kernel test_ds_store_b64_nostride64
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds_store_b64_nostride64_fallback
   .amdhsa_next_free_vgpr 5
   .amdhsa_next_free_sgpr 1
 .end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
@@ -8,11 +8,10 @@
 // COM:
 // COM: These differ from the stride64 forms in the byte-offset scale applied
 // COM: to each per-operand index (ElemBytes vs 64 * ElemBytes). Every
-// COM: non-stride family whose scaled offsets fit the two DS2 eight-bit fields
-// COM: is rewritten in place. Only bytes 0 and 1 change; opcode, registers,
-// COM: modifiers, instruction count, waits, and arbitrary-entry behavior stay
-// COM: identical. The fallback kernel pins the established split path when a
-// COM: scaled field is not representable.
+// COM: non-stride family is lowered through a trampoline to two single-address
+// COM: operations followed by an explicit DS drain. This includes cases whose
+// COM: scaled offsets would fit the original DS2 fields: re-encoding only those
+// COM: fields is not equivalent on hardware.
 // COM:
 // COM: Companion tests:
 // COM:   hotswap-trampoline-ds-nostride64-multi.s -- drain insertion
@@ -38,9 +37,9 @@
 // COM: Kernel 1 (b32 load, non-stride64): offsets index*4. Source
 // COM: offset0:4 offset1:8 -> byte offsets 16 and 32.
 // DISASM-LABEL: <test_ds_load_b32_nostride64>:
-// DISASM-NEXT: ds_load_2addr_b32 v[0:1], v2 offset0:16 offset1:32
+// DISASM: ds_load_b32 v0, v2 offset:16
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:32
 // DISASM-NEXT: s_wait_dscnt 0x0
-// DISASM-NEXT: s_endpgm
 
 .globl test_ds_load_b32_nostride64
 .p2align 8
@@ -73,9 +72,9 @@ test_ds_load_b32_nostride64:
 // COM: offset0:1 offset1:2 -> byte offsets 8 and 16. b64 destinations
 // COM: format as v[X:Y] register pairs.
 // DISASM-LABEL: <test_ds_load_b64_nostride64>:
-// DISASM-NEXT: ds_load_2addr_b64 v[0:3], v4 offset0:8 offset1:16
+// DISASM: ds_load_b64 v[0:1], v4 offset:8
+// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:16
 // DISASM-NEXT: s_wait_dscnt 0x0
-// DISASM-NEXT: s_endpgm
 
 .globl test_ds_load_b64_nostride64
 .p2align 8
@@ -108,9 +107,9 @@ test_ds_load_b64_nostride64:
 // COM: (addr, data0, data1). Source offset0:1 offset1:2 -> byte
 // COM: offsets 4 and 8.
 // DISASM-LABEL: <test_ds_store_b32_nostride64>:
-// DISASM-NEXT: ds_store_2addr_b32 v2, v0, v1 offset0:4 offset1:8
+// DISASM: ds_store_b32 v2, v0 offset:4
+// DISASM-NEXT: ds_store_b32 v2, v1 offset:8
 // DISASM-NEXT: s_wait_dscnt 0x0
-// DISASM-NEXT: s_endpgm
 
 .globl test_ds_store_b32_nostride64
 .p2align 8
@@ -143,9 +142,9 @@ test_ds_store_b32_nostride64:
 // COM: (dst, addr, data0, data1). Source offset0:1 offset1:3 -> byte
 // COM: offsets 4 and 12.
 // DISASM-LABEL: <test_ds_xchg_b32_nostride64>:
-// DISASM-NEXT: ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 offset0:4 offset1:12
+// DISASM: ds_storexchg_rtn_b32 v0, v2, v3 offset:4
+// DISASM-NEXT: ds_storexchg_rtn_b32 v1, v2, v4 offset:12
 // DISASM-NEXT: s_wait_dscnt 0x0
-// DISASM-NEXT: s_endpgm
 
 .globl test_ds_xchg_b32_nostride64
 .p2align 8
@@ -174,13 +173,12 @@ test_ds_xchg_b32_nostride64:
 .size test_ds_xchg_b32_nostride64, .Ltest_ds_xchg_b32_nostride64_end-test_ds_xchg_b32_nostride64
 
 // ---- Kernel 5: ds_store_2addr_b64 (non-stride64 store, b64 data pairs) -----
-// COM: Kernel 5 (b64 store, non-stride64): byte offsets 8 and 16 still fit
-// COM: the DS2 encoding's two eight-bit fields. Re-encode those fields in
-// COM: place for A0 instead of splitting the instruction or using a sled.
+// COM: Kernel 5 (b64 store, non-stride64): byte offsets 8 and 16 still fit the
+// COM: DS2 fields, but hardware correctness still requires the split path.
 // DISASM-LABEL: <test_ds_store_b64_nostride64>:
-// DISASM-NEXT: ds_store_2addr_b64 v4, v[0:1], v[2:3] offset0:8 offset1:16
+// DISASM: ds_store_b64 v4, v[0:1] offset:8
+// DISASM-NEXT: ds_store_b64 v4, v[2:3] offset:16
 // DISASM-NEXT: s_wait_dscnt 0x0
-// DISASM-NEXT: s_endpgm
 
 .globl test_ds_store_b64_nostride64
 .p2align 8
@@ -210,8 +208,8 @@ test_ds_store_b64_nostride64:
 
 // ---- Kernel 5b: b64 scaled offset no longer fits the DS2 field -------------
 // COM: Raw offsets 32 and 33 scale to 256 and 264. They fit the DS1 16-bit
-// COM: field but not the DS2 8-bit fields, so retain the established split
-// COM: path rather than truncating an in-place rewrite.
+// COM: field but not the DS2 8-bit fields. Verify that the common split path
+// COM: also preserves these larger offsets.
 // DISASM-LABEL: <test_ds_store_b64_nostride64_fallback>:
 // DISASM-NOT: ds_store_2addr_b64
 // DISASM: s_branch
@@ -250,9 +248,9 @@ test_ds_store_b64_nostride64_fallback:
 // COM: offset1:2 -> byte offsets 8 and 16. Both vdst halves AND the data
 // COM: operands format as v[X:Y] register pairs.
 // DISASM-LABEL: <test_ds_xchg_b64_nostride64>:
-// DISASM-NEXT: ds_storexchg_2addr_rtn_b64 v[0:3], v8, v[4:5], v[6:7] offset0:8 offset1:16
+// DISASM: ds_storexchg_rtn_b64 v[0:1], v8, v[4:5] offset:8
+// DISASM-NEXT: ds_storexchg_rtn_b64 v[2:3], v8, v[6:7] offset:16
 // DISASM-NEXT: s_wait_dscnt 0x0
-// DISASM-NEXT: s_endpgm
 
 .globl test_ds_xchg_b64_nostride64
 .p2align 8
@@ -285,15 +283,20 @@ test_ds_xchg_b64_nostride64:
 // COM: ds_load_2addr_b32, ds_store_2addr_b32, and ds_storexchg_2addr_rtn_b32
 // COM: before a single drain s_wait_dscnt 0x0. Verifies that the per-
 // COM: instruction dispatcher in applyTrampolinePatchesImpl correctly
-// COM: routes each variant to the common byte-field rewrite without state
+// COM: routes each variant to the common split lowering without state
 // COM: leakage across types. All offsets scale by ElemBytes=4.
 // COM:   ds_load_2addr_b32  offset0:1 offset1:2 -> byte 4, 8
 // COM:   ds_store_2addr_b32 offset0:3 offset1:4 -> byte 12, 16
 // COM:   ds_storexchg_*_b32 offset0:5 offset1:6 -> byte 20, 24
 // DISASM-LABEL: <test_ds_combo_nostride64>:
-// DISASM-NEXT: ds_load_2addr_b32 v[0:1], v8 offset0:4 offset1:8
-// DISASM-NEXT: ds_store_2addr_b32 v8, v2, v3 offset0:12 offset1:16
-// DISASM-NEXT: ds_storexchg_2addr_rtn_b32 v[4:5], v8, v6, v7 offset0:20 offset1:24
+// DISASM: ds_load_b32 v0, v8 offset:4
+// DISASM-NEXT: ds_load_b32 v1, v8 offset:8
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM: ds_store_b32 v8, v2 offset:12
+// DISASM-NEXT: ds_store_b32 v8, v3 offset:16
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM: ds_storexchg_rtn_b32 v4, v8, v6 offset:20
+// DISASM-NEXT: ds_storexchg_rtn_b32 v5, v8, v7 offset:24
 // DISASM-NEXT: s_wait_dscnt 0x0
 
 .globl test_ds_combo_nostride64
@@ -342,11 +345,11 @@ test_ds_combo_nostride64:
 
 // COM: Idempotency: rewriting the output again should produce identical
 // COM: bytes. Feeding the output back with its A0 stepping as the source
-// COM: disables B0-to-A0 patches, so the surviving A0-correct DS2 instruction
-// COM: is not scaled a second time.
+// COM: disables B0-to-A0 patches, so the A0 split operations are not changed
+// COM: or scaled a second time.
 // COM: Legacy ISA names without a stepping deliberately declare their source
-// COM: as B0 on every invocation; repeating those arguments is not the
-// COM: idempotence contract for a transformation whose opcode survives.
+// COM: as B0 on every invocation. Use the explicit A0 source here so the
+// COM: idempotence check remains independent of other B0 patch families.
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-overlap-cyclic.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-overlap-cyclic.s
@@ -18,7 +18,7 @@
 .p2align 8
 .type test_ds_overlap_cyclic,@function
 test_ds_overlap_cyclic:
-  ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset0:0 offset1:1
+  ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset0:32 offset1:33
   s_wait_dscnt 0
   s_endpgm
 .Ltest_ds_overlap_cyclic_end:

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
@@ -18,28 +18,28 @@
 // DISASM-LABEL: <test_ds_overlap>:
 
 // COM: Address overlaps the first b64 destination half: issue half 1 first.
-// DISASM:      ds_load_b64 v[14:15], v12 offset:8
-// DISASM-NEXT: ds_load_b64 v[12:13], v12
+// DISASM:      ds_load_b64 v[14:15], v12 offset:264
+// DISASM-NEXT: ds_load_b64 v[12:13], v12 offset:256
 
 // COM: The same rule applies to b32.
-// DISASM:      ds_load_b32 v5, v4 offset:8
-// DISASM-NEXT: ds_load_b32 v4, v4 offset:4
+// DISASM:      ds_load_b32 v5, v4 offset:260
+// DISASM-NEXT: ds_load_b32 v4, v4 offset:256
 
 // COM: Address overlaps the second half: natural order is already safe.
-// DISASM:      ds_load_b64 v[16:17], v18
-// DISASM-NEXT: ds_load_b64 v[18:19], v18 offset:8
+// DISASM:      ds_load_b64 v[16:17], v18 offset:256
+// DISASM-NEXT: ds_load_b64 v[18:19], v18 offset:264
 
 // COM: Exchange op0 would clobber op1's address, so reverse the operations.
-// DISASM:      ds_storexchg_rtn_b64 v[10:11], v8, v[14:15] offset:8
-// DISASM-NEXT: ds_storexchg_rtn_b64 v[8:9], v8, v[12:13]
+// DISASM:      ds_storexchg_rtn_b64 v[10:11], v8, v[14:15] offset:264
+// DISASM-NEXT: ds_storexchg_rtn_b64 v[8:9], v8, v[12:13] offset:256
 
 // COM: A data1 dependency also reverses a b32 exchange.
-// DISASM:      ds_storexchg_rtn_b32 v31, v40, v30 offset:4
-// DISASM-NEXT: ds_storexchg_rtn_b32 v30, v40, v41
+// DISASM:      ds_storexchg_rtn_b32 v31, v40, v30 offset:260
+// DISASM-NEXT: ds_storexchg_rtn_b32 v30, v40, v41 offset:256
 
 // COM: A data0 dependency on destination half 1 keeps the natural order.
-// DISASM:      ds_storexchg_rtn_b32 v32, v40, v33
-// DISASM-NEXT: ds_storexchg_rtn_b32 v33, v40, v41 offset:4
+// DISASM:      ds_storexchg_rtn_b32 v32, v40, v33 offset:256
+// DISASM-NEXT: ds_storexchg_rtn_b32 v33, v40, v41 offset:260
 
 // COM: Stride64 loads and exchanges use the same dependency ordering while
 // COM: scaling offset1 by 64 elements.
@@ -54,12 +54,12 @@
 .p2align 8
 .type test_ds_overlap,@function
 test_ds_overlap:
-  ds_load_2addr_b64 v[12:15], v12 offset0:0 offset1:1
-  ds_load_2addr_b32 v[4:5], v4 offset0:1 offset1:2
-  ds_load_2addr_b64 v[16:19], v18 offset0:0 offset1:1
-  ds_storexchg_2addr_rtn_b64 v[8:11], v8, v[12:13], v[14:15] offset0:0 offset1:1
-  ds_storexchg_2addr_rtn_b32 v[30:31], v40, v41, v30 offset0:0 offset1:1
-  ds_storexchg_2addr_rtn_b32 v[32:33], v40, v33, v41 offset0:0 offset1:1
+  ds_load_2addr_b64 v[12:15], v12 offset0:32 offset1:33
+  ds_load_2addr_b32 v[4:5], v4 offset0:64 offset1:65
+  ds_load_2addr_b64 v[16:19], v18 offset0:32 offset1:33
+  ds_storexchg_2addr_rtn_b64 v[8:11], v8, v[12:13], v[14:15] offset0:32 offset1:33
+  ds_storexchg_2addr_rtn_b32 v[30:31], v40, v41, v30 offset0:64 offset1:65
+  ds_storexchg_2addr_rtn_b32 v[32:33], v40, v33, v41 offset0:64 offset1:65
   ds_load_2addr_stride64_b64 v[42:45], v42 offset0:0 offset1:1
   ds_storexchg_2addr_stride64_rtn_b64 v[46:49], v46, v[50:51], v[52:53] offset0:0 offset1:1
   s_wait_dscnt 0x0

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-vgpr-msb.s
@@ -1,5 +1,6 @@
 // Verify that splitting a two-address DS load whose second destination crosses
-// v255 rebases that half to v0 under a temporary destination VGPR-MSB mode.
+// the active VGPR bank rebases that half to v0 under a temporary destination
+// VGPR-MSB mode without losing the nonzero source or destination bank.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
@@ -10,11 +11,12 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 // DISASM-LABEL: <test_ds_vgpr_msb>:
-// DISASM:      s_branch
+// DISASM:      s_set_vgpr_msb 0x41
+// DISASM-NEXT: s_branch
 // DISASM:      ds_load_b64 v[254:255], v88 offset:680
-// DISASM-NEXT: s_set_vgpr_msb 64
-// DISASM-NEXT: ds_load_b64 v[0:1]{{.*v\[256:257\].*}}v88 offset:688
-// DISASM-NEXT: s_set_vgpr_msb 0x4000
+// DISASM-NEXT: s_set_vgpr_msb 0x4181
+// DISASM-NEXT: ds_load_b64 v[0:1]{{.*v\[512:513\].*}}v88{{.*v344.*}}offset:688
+// DISASM-NEXT: s_set_vgpr_msb 0x8141
 // DISASM-NEXT: s_wait_dscnt 0x0
 // DISASM:      s_branch
 
@@ -29,7 +31,7 @@
 .p2align 8
 .type test_ds_vgpr_msb,@function
 test_ds_vgpr_msb:
-  s_set_vgpr_msb 0
+  s_set_vgpr_msb 0x41
   ds_load_2addr_b64 v[254:257], v88 offset0:85 offset1:86
   s_wait_dscnt 0x0
   s_endpgm

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-vgpr-msb.s
@@ -1,0 +1,62 @@
+// Verify that splitting a two-address DS load whose second destination crosses
+// v255 rebases that half to v0 under a temporary destination VGPR-MSB mode.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_ds_vgpr_msb>:
+// DISASM:      s_branch
+// DISASM:      ds_load_b64 v[254:255], v88 offset:680
+// DISASM-NEXT: s_set_vgpr_msb 64
+// DISASM-NEXT: ds_load_b64 v[0:1]{{.*v\[256:257\].*}}v88 offset:688
+// DISASM-NEXT: s_set_vgpr_msb 0x4000
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM:      s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds_vgpr_msb
+.p2align 8
+.type test_ds_vgpr_msb,@function
+test_ds_vgpr_msb:
+  s_set_vgpr_msb 0
+  ds_load_2addr_b64 v[254:257], v88 offset0:85 offset1:86
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_ds_vgpr_msb_end:
+.size test_ds_vgpr_msb, .Ltest_ds_vgpr_msb_end-test_ds_vgpr_msb
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds_vgpr_msb
+  .amdhsa_next_free_vgpr 688
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_ds_vgpr_msb
+      .symbol: test_ds_vgpr_msb.kd
+      .sgpr_count: 2
+      .vgpr_count: 688
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-hierarchical-mirrored.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-hierarchical-mirrored.s
@@ -1,0 +1,147 @@
+// COM: Hundreds of pair-only far sites must not consume one independent
+// COM: source-to-gateway island chain apiece. One affine entry maps source PCs
+// COM: into a global sparse prefix; bounded regional gateways then map those
+// COM: PCs into branch-reachable sparse body stubs.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: planned 1 hierarchical mirrored gateway group(s) with {{[2-9][0-9]*}} bounded region(s) for 300 pair-only source site(s)
+// LOG: hotswap: planned 1 mirrored-stub gateway group(s) for 10 pair-only source site(s)
+// LOG-NOT: no safe short-branch gateway
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-readobj --notes --symbols --sections %t.out.elf > /dev/null
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <source0>:
+// DISASM-NEXT: s_call_i64 s[104:105],
+// DISASM-NEXT: s_{{(nop|branch)}}
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.macro PATCH_SOURCE name, binding
+  .local \name\()_targeter
+  .type \name\()_targeter,@function
+\name\()_targeter:
+  s_branch \name\()_after
+  s_endpgm
+  .size \name\()_targeter, .-\name\()_targeter
+
+  \binding \name
+  .type \name,@function
+\name:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+\name\()_after:
+  s_mov_b32 s103, s103
+  s_mov_b32 s0, vcc_lo
+  s_endpgm
+  .size \name, .-\name
+.endm
+
+.macro AUTO_SOURCE
+  PATCH_SOURCE auto_source\@, .local
+.endm
+
+.macro RESIDUAL_SOURCE
+  .local residual_source\@_targeter
+  .type residual_source\@_targeter,@function
+residual_source\@_targeter:
+  s_branch residual_source\@_after
+  s_endpgm
+  .size residual_source\@_targeter, .-residual_source\@_targeter
+
+  .local residual_source\@
+  .type residual_source\@,@function
+residual_source\@:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+residual_source\@_after:
+  // Keep the hierarchical population's s[104:105] pair live so these ten
+  // sites form a separate, ordinary mirrored-stub group.
+  s_mov_b32 s0, s104
+  s_mov_b32 s1, s105
+  s_mov_b32 s103, s103
+  s_mov_b32 s2, vcc_lo
+  s_endpgm
+  .size residual_source\@, .-residual_source\@
+.endm
+
+PATCH_SOURCE source0, .globl
+.rept 120
+  s_mov_b32 s0, s1
+.endr
+
+.rept 149
+  AUTO_SOURCE
+  .rept 120
+    s_mov_b32 s0, s1
+  .endr
+.endr
+
+// This external, no-fallthrough padding supplies the common 12-byte affine
+// entry. The source population spans more than one bounded regional prefix.
+s_endpgm
+.local gateway_pad
+gateway_pad:
+  .rept 3
+    s_nop 0
+  .endr
+
+.rept 10
+  RESIDUAL_SOURCE
+  .rept 8
+    s_mov_b32 s0, s1
+  .endr
+.endr
+
+// Keep an independent 12-byte gateway available for the residual group. This
+// makes the regular mirrored planner run after hierarchical prefixes have
+// already been installed and catches either planner overwriting those sizes.
+s_endpgm
+.local residual_gateway_pad
+residual_gateway_pad:
+  .rept 3
+    s_nop 0
+  .endr
+
+.rept 150
+  AUTO_SOURCE
+  .rept 120
+    s_mov_b32 s0, s1
+  .endr
+.endr
+
+// Keep the trampoline pool outside short-branch reach of every source.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel source0
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 104
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: source0
+      .symbol: source0.kd
+      .sgpr_count: 106
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
@@ -1,16 +1,18 @@
 // COM: A far eight-byte trampoline site may tentatively reserve one SGPR to
 // COM: preserve live wave32 VCC_LO. Direct control-flow and a following branch
-// COM: prevent expansion to the required 12-byte source landing, so the plan
-// COM: must downgrade cleanly to the registerless island route. Its second
-// COM: source dword is the owner-reserved final return relay, so it branches
-// COM: to the continuation instead of remaining padding.
+// COM: prevent expansion to the required source landing. Promote exact
+// COM: gateway capacity before ordinary relay planning, save VCC_LO in the
+// COM: reserved SGPR on the outbound route, and restore it in a short-branch
+// COM: gateway on the return route.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
 // LOG: hotswap: safe far return: deferring live wave32 VCC_LO preservation in s105
-// LOG: hotswap: deferred live-VCC preservation at 0x{{[0-9A-F]+}} fell back to a registerless far return
+// LOG: hotswap: deferred live-VCC preservation at 0x{{[0-9A-F]+}} will use a round-trip restore gateway
+// LOG: hotswap: pre-promoted {{[0-9]+}} gateway window(s) covering 2 isolated live-VCC source(s)
+// LOG: hotswap: assigned 2 round-trip VCC gateway(s) from promoted capacity
 // LOG: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
@@ -18,13 +20,22 @@
 // DISASM-NEXT: s_branch 0
 // DISASM-NEXT: s_mov_b32 s104, 0
 // DISASM-NEXT: s_branch
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
 // DISASM-NEXT: s_cbranch_vccz
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_cbranch_vccz
+// DISASM: s_mov_b32 s105, vcc_lo
+// DISASM-NEXT: s_get_pc_i64 vcc
+// DISASM-NEXT: s_add_nc_u64 vcc
+// DISASM-NEXT: s_set_pc_i64 vcc
+// DISASM-NEXT: s_mov_b32 vcc_lo, s105
+// DISASM-NEXT: s_branch
 
 // RUN: %llvm-readelf --notes %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=METADATA %s
 // METADATA: .name:           test_deferred_vcc
-// METADATA: .sgpr_count:     105
+// METADATA: .sgpr_count:     108
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -39,6 +50,8 @@
 test_deferred_vcc:
   s_branch 0
   s_mov_b32 s104, 0
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_cbranch_vccz 0
   ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
   s_cbranch_vccz 0
 .irp live_reg, s0, s2, s4, s6, s8, s10, s12, s14, s16, s18, s20, s22, s24, s26, s28, s30, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104

--- a/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
@@ -1,9 +1,9 @@
 // COM: A far eight-byte trampoline site may tentatively reserve one SGPR to
 // COM: preserve live wave32 VCC_LO. Direct control-flow and a following branch
 // COM: prevent expansion to the required 12-byte source landing, so the plan
-// COM: must downgrade cleanly to the registerless island route. The robust
-// COM: return allocator may use the source's second dword as the final
-// COM: no-op branch island back to the continuation.
+// COM: must downgrade cleanly to the registerless island route. Its second
+// COM: source dword is the owner-reserved final return relay, so it branches
+// COM: to the continuation instead of remaining padding.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
@@ -18,7 +18,7 @@
 // DISASM-NEXT: s_branch 0
 // DISASM-NEXT: s_mov_b32 s104, 0
 // DISASM-NEXT: s_branch
-// DISASM-NEXT: s_branch 0
+// DISASM-NEXT: s_branch
 // DISASM-NEXT: s_cbranch_vccz
 
 // RUN: %llvm-readelf --notes %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
@@ -1,0 +1,91 @@
+// COM: A far eight-byte trampoline site may tentatively reserve one SGPR to
+// COM: preserve live wave32 VCC_LO. Direct control-flow and a following branch
+// COM: prevent expansion to the required 12-byte source landing, so the plan
+// COM: must downgrade cleanly to the registerless island route.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: safe far return: deferring live wave32 VCC_LO preservation in s105
+// LOG: hotswap: deferred live-VCC preservation at 0x{{[0-9A-F]+}} fell back to a registerless far return
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_deferred_vcc>:
+// DISASM-NEXT: s_branch 0
+// DISASM-NEXT: s_mov_b32 s104, 0
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop
+// DISASM-NEXT: s_cbranch_vccz
+
+// RUN: %llvm-readelf --notes %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=METADATA %s
+// METADATA: .name:           test_deferred_vcc
+// METADATA: .sgpr_count:     105
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_deferred_vcc
+.p2align 8
+.type test_deferred_vcc,@function
+test_deferred_vcc:
+  s_branch 0
+  s_mov_b32 s104, 0
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_cbranch_vccz 0
+.irp live_reg, s0, s2, s4, s6, s8, s10, s12, s14, s16, s18, s20, s22, s24, s26, s28, s30, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104
+  s_mov_b32 s1, \live_reg
+.endr
+  s_endpgm
+.size test_deferred_vcc, .-test_deferred_vcc
+
+.type gateway_0,@function
+gateway_0:
+  s_endpgm
+.size gateway_0, .-gateway_0
+.fill 32, 1, 0
+
+.rept 20000
+  s_mov_b32 s0, s1
+.endr
+
+.type gateway_1,@function
+gateway_1:
+  s_endpgm
+.size gateway_1, .-gateway_1
+.fill 32, 1, 0
+
+.rept 20000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_deferred_vcc
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 105
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_deferred_vcc
+      .symbol: test_deferred_vcc.kd
+      .sgpr_count: 105
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
@@ -50,8 +50,8 @@ test_deferred_vcc:
 .type gateway_0,@function
 gateway_0:
   s_endpgm
+  .fill 20, 1, 0
 .size gateway_0, .-gateway_0
-.fill 32, 1, 0
 
 .rept 20000
   s_mov_b32 s0, s1
@@ -60,8 +60,8 @@ gateway_0:
 .type gateway_1,@function
 gateway_1:
   s_endpgm
+  .fill 20, 1, 0
 .size gateway_1, .-gateway_1
-.fill 32, 1, 0
 
 .rept 20000
   s_mov_b32 s0, s1

--- a/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-live-vcc-deferred.s
@@ -1,7 +1,9 @@
 // COM: A far eight-byte trampoline site may tentatively reserve one SGPR to
 // COM: preserve live wave32 VCC_LO. Direct control-flow and a following branch
 // COM: prevent expansion to the required 12-byte source landing, so the plan
-// COM: must downgrade cleanly to the registerless island route.
+// COM: must downgrade cleanly to the registerless island route. The robust
+// COM: return allocator may use the source's second dword as the final
+// COM: no-op branch island back to the continuation.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
@@ -16,7 +18,7 @@
 // DISASM-NEXT: s_branch 0
 // DISASM-NEXT: s_mov_b32 s104, 0
 // DISASM-NEXT: s_branch
-// DISASM-NEXT: s_nop
+// DISASM-NEXT: s_branch 0
 // DISASM-NEXT: s_cbranch_vccz
 
 // RUN: %llvm-readelf --notes %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -38,14 +38,45 @@
 // RUN:   | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES
 
-// COM: A kernel with no aligned two-SGPR block fails closed instead of
-// COM: emitting the unsafe return or clobbering a live register.
+// COM: A kernel with no globally unused aligned two-SGPR block can reuse a
+// COM: pair whose incoming values are dead in both the replacement and every
+// COM: continuation path.
 // RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s105, 0/' \
 // RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 106/' \
 // RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.full-sgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.full-sgpr.s -o %t.full-sgpr.elf
-// RUN: hotswap-rewrite %t.full-sgpr.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.full-sgpr.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.full-sgpr.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=FULL-PAIR-LOG %s
+// FULL-PAIR-LOG: hotswap: safe far return: reusing locally dead s[104:105]
+// FULL-PAIR-LOG: RESULT: SUCCESS
+
+// COM: Search every aligned pair, not just the highest eight. Every pair above
+// COM: s[30:31] has a reachable incoming-value read; s[30:31] is overwritten
+// COM: first and is therefore the highest locally dead pair.
+// RUN: sed -e 's|^// LOW-PAIR-ONLY:|  |' %t.full-sgpr.s > %t.low-pair.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.low-pair.s -o %t.low-pair.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.low-pair.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.low-pair.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=LOW-PAIR-LOG %s
+// LOW-PAIR-LOG: hotswap: safe far return: reusing locally dead s[30:31]
+// LOW-PAIR-LOG: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.low-pair.out.elf \
+// RUN:   | %FileCheck --check-prefix=LOW-PAIR-DISASM %s
+// LOW-PAIR-DISASM: s_get_pc_i64 s[30:31]
+// LOW-PAIR-DISASM-NEXT: s_add_nc_u64 s[30:31], s[30:31],
+// LOW-PAIR-DISASM-NEXT: s_set_pc_i64 s[30:31]
+
+// COM: If every aligned pair is live, the rewrite still fails closed.
+// RUN: sed -e 's|^// ALL-PAIRS-LIVE:|  |' %t.full-sgpr.s \
+// RUN:   > %t.all-pairs-live.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.all-pairs-live.s -o %t.all-pairs-live.elf
+// RUN: hotswap-rewrite %t.all-pairs-live.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
 // FAIL: RESULT: ERROR
@@ -67,6 +98,13 @@
 test_far:
   s_mov_b64 vcc, -1
   tensor_load_to_lds s[0:3], s[4:11]
+// LOW-PAIR-ONLY:s_mov_b64 s[30:31], 0
+// LOW-PAIR-ONLY:.irp live_reg, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104
+// LOW-PAIR-ONLY:s_mov_b32 s1, \live_reg
+// LOW-PAIR-ONLY:.endr
+// ALL-PAIRS-LIVE:.irp live_reg, s0, s2, s4, s6, s8, s10, s12, s14, s16, s18, s20, s22, s24, s26, s28, s30, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104
+// ALL-PAIRS-LIVE:s_mov_b32 s1, \live_reg
+// ALL-PAIRS-LIVE:.endr
   s_endpgm
 .size test_far, .-test_far
 

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -203,13 +203,14 @@ test_far:
   s_endpgm
 .size test_far, .-test_far
 
-// Provide external zero-filled alignment space after a separate
-// no-fallthrough function.
+// Provide zero-filled alignment space owned by a separate no-fallthrough
+// function. The whole-object gateway planner may use it, but the patch pass
+// must not claim it as local replacement space for test_far.
 .type gateway_barrier,@function
 gateway_barrier:
   s_endpgm
-.size gateway_barrier, .-gateway_barrier
 .fill 32, 1, 0
+.size gateway_barrier, .-gateway_barrier
 
   // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
   // s_branch's +-128 KB reach from the tensor_load above (forces the
@@ -223,8 +224,8 @@ gateway_barrier:
 .type midpoint_gateway_barrier,@function
 midpoint_gateway_barrier:
   s_endpgm
-.size midpoint_gateway_barrier, .-midpoint_gateway_barrier
 .fill 32, 1, 0
+.size midpoint_gateway_barrier, .-midpoint_gateway_barrier
 
   .rept 20000
     s_mov_b32 s0, s1

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -38,25 +38,48 @@
 // RUN:   | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES
 
-// COM: A kernel with no globally unused aligned two-SGPR block can reuse a
-// COM: pair whose incoming values are dead in both the replacement and every
-// COM: continuation path.
-// RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s105, 0/' \
-// RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 106/' \
-// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.full-sgpr.s
+// COM: A kernel with no aligned numbered SGPR pair can reuse VCC when the
+// COM: replacement does not consume its incoming value and the continuation
+// COM: ends before reading it.
+// RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s104, 0/' \
+// RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 105/' \
+// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 105/' %s > %t.full-sgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.full-sgpr.s -o %t.full-sgpr.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.full-sgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.full-sgpr.out.elf 2>&1 \
-// RUN:   | %FileCheck --check-prefix=FULL-PAIR-LOG %s
-// FULL-PAIR-LOG: hotswap: safe far return: reusing locally dead s[104:105]
-// FULL-PAIR-LOG: RESULT: SUCCESS
+// RUN:   | %FileCheck --check-prefix=FULL-LOG %s
+// FULL-LOG: hotswap: safe far return: reusing dead VCC
+// FULL-LOG: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.full-sgpr.out.elf \
+// RUN:   | %FileCheck --check-prefix=FULL-DISASM %s
+// FULL-DISASM: s_get_pc_i64 vcc
+// FULL-DISASM-NEXT: s_add_nc_u64 vcc, vcc,
+// FULL-DISASM-NEXT: s_set_pc_i64 vcc
+// FULL-DISASM: s_get_pc_i64 vcc
+// FULL-DISASM-NEXT: s_add_nc_u64 vcc, vcc,
+// FULL-DISASM-NEXT: s_set_pc_i64 vcc
+
+// COM: A live VCC can instead use an already-allocated numbered pair after
+// COM: CFG liveness proves that neither half is consumed by the replacement or
+// COM: continuation before being redefined.
+// RUN: sed '/^  tensor_load_to_lds/a\  s_cbranch_vccz 0' %t.full-sgpr.s \
+// RUN:   > %t.local-pair.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.local-pair.s -o %t.local-pair.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.local-pair.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.local-pair.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=LOCAL-PAIR-LOG %s
+// LOCAL-PAIR-LOG: hotswap: safe far return: reusing locally dead s[104:105]
+// LOCAL-PAIR-LOG: RESULT: SUCCESS
 
 // COM: Search every aligned pair, not just the highest eight. Every pair above
 // COM: s[30:31] has a reachable incoming-value read; s[30:31] is overwritten
 // COM: first and is therefore the highest locally dead pair.
-// RUN: sed -e 's|^// LOW-PAIR-ONLY:|  |' %t.full-sgpr.s > %t.low-pair.s
+// RUN: sed -e '/^  tensor_load_to_lds/a\  s_cbranch_vccz 0' \
+// RUN:   -e 's|^// LOW-PAIR-ONLY:|  |' %t.full-sgpr.s > %t.low-pair.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.low-pair.s -o %t.low-pair.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.low-pair.elf \
@@ -71,15 +94,85 @@
 // LOW-PAIR-DISASM-NEXT: s_add_nc_u64 s[30:31], s[30:31],
 // LOW-PAIR-DISASM-NEXT: s_set_pc_i64 s[30:31]
 
-// COM: If every aligned pair is live, the rewrite still fails closed.
-// RUN: sed -e 's|^// ALL-PAIRS-LIVE:|  |' %t.full-sgpr.s \
-// RUN:   > %t.all-pairs-live.s
+// COM: When the continuation reads VCC before redefining it, a wave32 rewrite
+// COM: preserves VCC_LO in the one remaining numbered SGPR. The source reaches
+// COM: a save/set-PC gateway, and its tail becomes the restore landing pad.
+// RUN: sed 's|^// LIVE-ONLY:|  |' %t.full-sgpr.s > %t.live-vcc.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
-// RUN:   %t.all-pairs-live.s -o %t.all-pairs-live.elf
-// RUN: hotswap-rewrite %t.all-pairs-live.elf \
+// RUN:   %t.live-vcc.s -o %t.live-vcc.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.live-vcc.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
-// FAIL: RESULT: ERROR
+// RUN:   --output %t.live-vcc.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=LIVE-LOG %s
+// LIVE-LOG: hotswap: safe far return: deferring live wave32 VCC_LO preservation in s105
+// LIVE-LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// LIVE-LOG: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.live-vcc.out.elf \
+// RUN:   | %FileCheck --check-prefix=LIVE-DISASM %s
+// LIVE-DISASM-LABEL: <test_far>:
+// LIVE-DISASM: s_branch
+// LIVE-DISASM-NEXT: s_mov_b32 vcc_lo, s105
+// LIVE-DISASM-NEXT: s_delay_alu instid0(SALU_CYCLE_1)
+// LIVE-DISASM: s_cbranch_vccz
+// LIVE-DISASM: s_mov_b32 s105, vcc_lo
+// LIVE-DISASM-NEXT: s_get_pc_i64 vcc
+
+// COM: Fragment both ordinary NOP windows below 20 bytes. The live-VCC
+// COM: source then needs an eight-byte save/branch primary and a disjoint
+// COM: sixteen-byte VCC-backed set-PC secondary. Both the pool-side restore
+// COM: before the replacement and the source-side continuation restore carry
+// COM: the required one-cycle SALU delay.
+// RUN: sed -e 's|^// LIVE-ONLY:|  |' \
+// RUN:   -e 's/\.fill 32, 1, 0/.fill 16, 1, 0/g' \
+// RUN:   %t.full-sgpr.s > %t.split-vcc.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.split-vcc.s -o %t.split-vcc.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.split-vcc.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.split-vcc.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=SPLIT-LOG %s
+// SPLIT-LOG: hotswap: assigned 1 split VCC-preserving gateway(s)
+// SPLIT-LOG: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.split-vcc.out.elf \
+// RUN:   | %FileCheck --check-prefix=SPLIT-DISASM %s
+// SPLIT-DISASM-LABEL: <test_far>:
+// SPLIT-DISASM-NEXT: s_mov_b32 s104, 0
+// SPLIT-DISASM-NEXT: s_branch
+// SPLIT-DISASM-NEXT: s_mov_b32 vcc_lo, s105
+// SPLIT-DISASM-NEXT: s_delay_alu instid0(SALU_CYCLE_1)
+// SPLIT-DISASM-LABEL: <gateway_barrier>:
+// SPLIT-DISASM-NEXT: s_endpgm
+// SPLIT-DISASM-NEXT: s_mov_b32 s105, vcc_lo
+// SPLIT-DISASM-NEXT: s_branch
+// SPLIT-DISASM-LABEL: <midpoint_gateway_barrier>:
+// SPLIT-DISASM-NEXT: s_endpgm
+// SPLIT-DISASM-NEXT: s_get_pc_i64 vcc
+// SPLIT-DISASM-NEXT: s_add_nc_u64 vcc, vcc,
+// SPLIT-DISASM-NEXT: s_set_pc_i64 vcc
+// SPLIT-DISASM: s_mov_b32 vcc_lo, s105
+// SPLIT-DISASM-NEXT: s_delay_alu instid0(SALU_CYCLE_1)
+// SPLIT-DISASM: tensor_load_to_lds
+// RUN: hotswap-rewrite %t.split-vcc.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=SPLIT-IDEM %s
+// SPLIT-IDEM: IDEMPOTENT: YES
+
+// COM: Seven nearby trampolines raise the object-wide count above the old
+// COM: blanket affine-reservation threshold, but the sole far source preserves
+// COM: live VCC and is not an affine candidate. Its exact 20-byte gateway must
+// COM: remain intact instead of being carved into unusable 8+12-byte pieces.
+// RUN: sed -e 's|^// LIVE-ONLY:|  |' \
+// RUN:   -e 's|^// EXACT20-ONLY:|  |' \
+// RUN:   -e 's/\.fill 32, 1, 0/.fill 20, 1, 0/g' \
+// RUN:   %t.full-sgpr.s > %t.exact20.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.exact20.s -o %t.exact20.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.exact20.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.exact20.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=EXACT20-LOG %s
+// EXACT20-LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// EXACT20-LOG: RESULT: SUCCESS
 
 // COM: A metadata-less object also fails closed because scratch usage cannot
 // COM: be charged to its owning kernel.
@@ -89,6 +182,7 @@
 // RUN: hotswap-rewrite %t.nometa.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
+// FAIL: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -102,9 +196,10 @@ test_far:
 // LOW-PAIR-ONLY:.irp live_reg, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104
 // LOW-PAIR-ONLY:s_mov_b32 s1, \live_reg
 // LOW-PAIR-ONLY:.endr
-// ALL-PAIRS-LIVE:.irp live_reg, s0, s2, s4, s6, s8, s10, s12, s14, s16, s18, s20, s22, s24, s26, s28, s30, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104
-// ALL-PAIRS-LIVE:s_mov_b32 s1, \live_reg
-// ALL-PAIRS-LIVE:.endr
+// LIVE-ONLY:s_cbranch_vccz 0
+// LIVE-ONLY:.irp live_reg, s0, s2, s4, s6, s8, s10, s12, s14, s16, s18, s20, s22, s24, s26, s28, s30, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104
+// LIVE-ONLY:s_mov_b32 s1, \live_reg
+// LIVE-ONLY:.endr
   s_endpgm
 .size test_far, .-test_far
 
@@ -119,17 +214,44 @@ gateway_barrier:
   // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
   // s_branch's +-128 KB reach from the tensor_load above (forces the
   // long-branch path).
-  .rept 40000
+  .rept 20000
+    s_mov_b32 s0, s1
+  .endr
+
+// A safe midpoint sled gives a registerless far edge an s_branch island in
+// each direction.
+.type midpoint_gateway_barrier,@function
+midpoint_gateway_barrier:
+  s_endpgm
+.size midpoint_gateway_barrier, .-midpoint_gateway_barrier
+.fill 32, 1, 0
+
+  .rept 20000
     s_mov_b32 s0, s1
   .endr
 .Ltest_far_end:
+
+// EXACT20-ONLY:.globl near_sites
+// EXACT20-ONLY:.type near_sites,@function
+// EXACT20-ONLY:near_sites:
+// EXACT20-ONLY:.rept 7
+// EXACT20-ONLY:  tensor_load_to_lds s[0:3], s[4:11]
+// EXACT20-ONLY:  s_mov_b32 s0, s1
+// EXACT20-ONLY:.endr
+// EXACT20-ONLY:  s_endpgm
+// EXACT20-ONLY:.size near_sites, .-near_sites
 
 .rodata
 .p2align 8
 .amdhsa_kernel test_far
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 12
+  .amdhsa_wavefront_size32 1
 .end_amdhsa_kernel
+// EXACT20-ONLY:.amdhsa_kernel near_sites
+// EXACT20-ONLY:  .amdhsa_next_free_vgpr 1
+// EXACT20-ONLY:  .amdhsa_next_free_sgpr 12
+// EXACT20-ONLY:.end_amdhsa_kernel
 
 .amdgpu_metadata
   amdhsa.version:
@@ -144,6 +266,16 @@ gateway_barrier:
       .group_segment_fixed_size: 0
       .private_segment_fixed_size: 0
       .kernarg_segment_align: 8
-      .wavefront_size: 64
+      .wavefront_size: 32
       .max_flat_workgroup_size: 256
+// EXACT20-ONLY:  - .name: near_sites
+// EXACT20-ONLY:    .symbol: near_sites.kd
+// EXACT20-ONLY:    .sgpr_count: 14
+// EXACT20-ONLY:    .vgpr_count: 1
+// EXACT20-ONLY:    .kernarg_segment_size: 0
+// EXACT20-ONLY:    .group_segment_fixed_size: 0
+// EXACT20-ONLY:    .private_segment_fixed_size: 0
+// EXACT20-ONLY:    .kernarg_segment_align: 8
+// EXACT20-ONLY:    .wavefront_size: 64
+// EXACT20-ONLY:    .max_flat_workgroup_size: 256
 .end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-mirrored-stub-gateway.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-mirrored-stub-gateway.s
@@ -1,0 +1,114 @@
+// COM: Dense far sites can exhaust numbered SGPRs and leave only the pair
+// COM: already reserved for their return edge. The source PC plus one shared
+// COM: relocation-neutral delta selects a sparse branch stub in the pool.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: shared far-dispatch skipped 10 site(s) without four safe SGPRs
+// LOG: hotswap: planned 1 mirrored-stub gateway group(s) for 10 pair-only source site(s)
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <source0>:
+// DISASM-NEXT: s_call_i64 s[104:105],
+// DISASM-NEXT: s_{{(nop|branch)}}
+// DISASM-LABEL: <gateway_pad>:
+// DISASM-NEXT: s_add_nc_u64 s[104:105], s[104:105],
+// DISASM-NEXT: s_set_pc_i64 s[104:105]
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// COM: An in-function NOP run belongs only to that function. Even though the
+// COM: foreign run is branch-reachable from every source below, the affine
+// COM: planner must not use it as a gateway for a different function.
+// RUN: sed 's|^// FOREIGN-ONLY:|  |' %s > %t.foreign.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.foreign.s -o %t.foreign.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.foreign.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=FOREIGN %s
+// FOREIGN-NOT: hotswap: planned {{.*}} mirrored-stub gateway group
+// FOREIGN: hotswap: error: no safe short-branch gateway for far site
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.macro PATCH_SOURCE name, binding
+  \binding \name
+  .type \name,@function
+\name:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+\name\()_after:
+  s_mov_b32 s103, s103
+  s_mov_b32 s0, vcc_lo
+  s_endpgm
+  .size \name, .-\name
+.endm
+
+.local targeter
+.type targeter,@function
+targeter:
+  s_branch source0_after
+  s_branch source1_after
+  s_branch source2_after
+  s_branch source3_after
+  s_branch source4_after
+  s_branch source5_after
+  s_branch source6_after
+  s_branch source7_after
+  s_branch source8_after
+  s_branch source9_after
+  s_endpgm
+  .size targeter, .-targeter
+
+PATCH_SOURCE source0, .globl
+.local gateway_pad
+// FOREIGN-ONLY:.type gateway_pad,@function
+gateway_pad:
+  .rept 3
+    s_nop 0
+  .endr
+// FOREIGN-ONLY:.size gateway_pad, .-gateway_pad
+PATCH_SOURCE source1, .local
+PATCH_SOURCE source2, .local
+PATCH_SOURCE source3, .local
+PATCH_SOURCE source4, .local
+PATCH_SOURCE source5, .local
+PATCH_SOURCE source6, .local
+PATCH_SOURCE source7, .local
+PATCH_SOURCE source8, .local
+PATCH_SOURCE source9, .local
+
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel source0
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 104
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: source0
+      .symbol: source0.kd
+      .sgpr_count: 106
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-pair-backed-promotion.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-pair-backed-promotion.s
@@ -1,0 +1,134 @@
+// COM: An eight-byte far patch source has room for only its one-dword forward
+// COM: branch and one unreachable relay dword. A locally dead SGPR pair makes
+// COM: the trampoline return pair-backed, but there is no variable-width
+// COM: gateway and the source-to-pool corridor is wider than two s_branch
+// COM: spans. The forward branch allocator must promote safe straight-line
+// COM: source windows even though the owner has an SGPR-backed set-PC return.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: affine planner considering 1 pair-only source site(s)
+// LOG: hotswap: ordinary gateway planner collected 1 pending site(s)
+// LOG: hotswap: promoted safe straight-line source at {{.*}} to provide forward-capacity relay window
+// LOG: hotswap: promoted safe straight-line source at {{.*}} to provide forward-capacity relay window
+// LOG: hotswap: assigned 1 forward s_branch island chain(s)
+// LOG: hotswap: promoted 2 safe straight-line source(s) for branch-island capacity
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d --no-symbolize-operands %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <pair_backed_source>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <promotion_candidate>:
+// DISASM-NEXT: s_mov_b32 s0, s1
+// DISASM-NEXT: s_mov_b32 s0, s2
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+// DISASM: ds_load_b32
+// DISASM-NEXT: ds_load_b32
+// DISASM-NEXT: s_wait_dscnt
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local targeter
+.type targeter,@function
+targeter:
+  s_branch pair_backed_source_after
+  s_endpgm
+.size targeter, .-targeter
+
+// Put the source near the positive s_branch boundary of the page-aligned
+// trampoline pool.
+.rept 690
+  s_mov_b32 s0, s1
+.endr
+
+.globl pair_backed_source
+.type pair_backed_source,@function
+pair_backed_source:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+pair_backed_source_after:
+  // The numbered SGPRs are dead here, so the trampoline return uses a local
+  // SGPR pair rather than the registerless return planner.
+  s_mov_b32 s0, s1
+  s_endpgm
+.size pair_backed_source, .-pair_backed_source
+
+// Only typed function bodies are promotion candidates. The untyped filler
+// cannot become an accidental gateway.
+.rept 15400
+  s_mov_b32 s0, s1
+.endr
+
+.globl promotion_candidate
+.type promotion_candidate,@function
+promotion_candidate:
+  s_mov_b32 s0, s1
+  s_mov_b32 s0, s2
+  s_mov_b32 s0, s3
+  s_mov_b32 s0, s4
+  s_mov_b32 s0, s5
+  s_mov_b32 s0, s6
+  s_mov_b32 s0, s7
+  s_mov_b32 s0, s8
+  s_endpgm
+.size promotion_candidate, .-promotion_candidate
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.globl promotion_candidate_far
+.type promotion_candidate_far,@function
+promotion_candidate_far:
+  s_mov_b32 s0, s9
+  s_mov_b32 s0, s10
+  s_mov_b32 s0, s11
+  s_mov_b32 s0, s12
+  s_mov_b32 s0, s13
+  s_mov_b32 s0, s14
+  s_mov_b32 s0, s15
+  s_mov_b32 s0, s16
+  s_endpgm
+.size promotion_candidate_far, .-promotion_candidate_far
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel pair_backed_source
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 17
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: pair_backed_source
+      .symbol: pair_backed_source.kd
+      .sgpr_count: 17
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-pair-backed-promotion.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-pair-backed-promotion.s
@@ -25,6 +25,7 @@
 // DISASM-LABEL: <promotion_candidate>:
 // DISASM-NEXT: s_mov_b32 s0, s1
 // DISASM-NEXT: s_mov_b32 s0, s2
+// DISASM-NEXT: s_mov_b32 s0, s3
 // DISASM-NEXT: s_get_pc_i64
 // DISASM-NEXT: s_add_nc_u64
 // DISASM-NEXT: s_set_pc_i64

--- a/amd/comgr/test-lit/hotswap-trampoline-registerless-owner-tail.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-registerless-owner-tail.s
@@ -1,0 +1,169 @@
+// COM: A far trampoline can have a directly reachable forward edge while its
+// COM: longer copied body makes the return edge just exceed s_branch range.
+// COM: With no scratch pair at the original source, the return allocator must
+// COM: promote safe straight-line windows across a gap wider than two s_branch
+// COM: spans. Each demand-sized promoted window supplies two suffix dwords:
+// COM: the return chain consumes the first and the registerless forward chain
+// COM: reuses the same source window's second slot. All numbered SGPRs are live
+// COM: after every window, so both promotions must use proven-dead VCC.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: safe far return: no register pair at
+// LOG: hotswap: promoted safe straight-line source at {{.*}} to provide return-capacity relay window {{.*}} with 2 slot(s) using VCC
+// LOG: hotswap: promoted safe straight-line source at {{.*}} to provide return-capacity relay window {{.*}} with 2 slot(s) using VCC
+// LOG: hotswap: assigned 1 forward s_branch island chain(s)
+// LOG: hotswap: assigned 1 return s_branch island chain(s)
+// LOG: hotswap: promoted 2 safe straight-line source(s) for branch-island capacity
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d --no-symbolize-operands %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <registerless_source>:
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <promotion_candidate>:
+// DISASM-NEXT: s_mov_b32 s0, s1
+// DISASM-NEXT: s_get_pc_i64 vcc
+// DISASM-NEXT: s_add_nc_u64 vcc, vcc,
+// DISASM-NEXT: s_set_pc_i64 vcc
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_mov_b32 s0, s8
+// DISASM-LABEL: <promotion_candidate_far>:
+// DISASM-NEXT: s_mov_b32 s0, s17
+// DISASM-NEXT: s_get_pc_i64 vcc
+// DISASM-NEXT: s_add_nc_u64 vcc, vcc,
+// DISASM-NEXT: s_set_pc_i64 vcc
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_mov_b32 s0, s24
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local targeter
+.type targeter,@function
+targeter:
+  s_branch registerless_source_after
+  s_endpgm
+  .size targeter, .-targeter
+
+// Put the source close to the positive s_branch boundary of the page-aligned
+// trampoline pool. The count is tuned together with the tail padding below.
+.rept 690
+  s_mov_b32 s0, s1
+.endr
+
+.globl registerless_source
+.type registerless_source,@function
+registerless_source:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+registerless_source_after:
+  // Keep every numbered pair live-in so neither local nor object-wide
+  // scratch analysis can manufacture a set-PC return pair.
+  .irp reg,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105
+    s_mov_b32 s\reg, s\reg
+  .endr
+  s_mov_b32 s0, vcc_lo
+  s_endpgm
+  .size registerless_source, .-registerless_source
+
+// Keep the candidate near the midpoint of the source-to-pool span.
+.rept 15400
+  s_mov_b32 s0, s1
+.endr
+
+.globl promotion_candidate
+.type promotion_candidate,@function
+promotion_candidate:
+  // Distinct source operands make each six-instruction relocated body
+  // identifiable in the appended pool.
+  s_mov_b32 s0, s1
+  s_mov_b32 s0, s2
+  s_mov_b32 s0, s3
+  s_mov_b32 s0, s4
+  s_mov_b32 s0, s5
+  s_mov_b32 s0, s6
+  s_mov_b32 s0, s7
+  s_mov_b32 s0, s8
+  s_mov_b32 s0, s9
+  s_mov_b32 s0, s10
+  s_mov_b32 s0, s11
+  s_mov_b32 s0, s12
+  s_mov_b32 s0, s13
+  s_mov_b32 s0, s14
+  s_mov_b32 s0, s15
+  s_mov_b32 s0, s16
+  // The relocatable prefix does not need incoming VCC, while every numbered
+  // pair remains live at its continuation. This selects dead VCC conservatively.
+  .irp reg,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105
+    s_mov_b32 s\reg, s\reg
+  .endr
+  s_endpgm
+  .size promotion_candidate, .-promotion_candidate
+
+// The second promotion region is over one branch span from the first, and the
+// final pool is over one further span away.
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.globl promotion_candidate_far
+.type promotion_candidate_far,@function
+promotion_candidate_far:
+  s_mov_b32 s0, s17
+  s_mov_b32 s0, s18
+  s_mov_b32 s0, s19
+  s_mov_b32 s0, s20
+  s_mov_b32 s0, s21
+  s_mov_b32 s0, s22
+  s_mov_b32 s0, s23
+  s_mov_b32 s0, s24
+  s_mov_b32 s0, s25
+  s_mov_b32 s0, s26
+  s_mov_b32 s0, s27
+  s_mov_b32 s0, s28
+  s_mov_b32 s0, s29
+  s_mov_b32 s0, s30
+  s_mov_b32 s0, s31
+  s_mov_b32 s0, s32
+  .irp reg,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105
+    s_mov_b32 s\reg, s\reg
+  .endr
+  s_endpgm
+  .size promotion_candidate_far, .-promotion_candidate_far
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel registerless_source
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: registerless_source
+      .symbol: registerless_source.kd
+      .sgpr_count: 106
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-shared-gateway-ownership.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-shared-gateway-ownership.s
@@ -1,0 +1,82 @@
+// COM: A shared dispatcher gateway and every source it serves must belong to
+// COM: the same function. An otherwise reachable NOP run in a foreign function
+// COM: is not a legal gateway.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=GOOD %s
+// GOOD: hotswap: planned 1 shared far-dispatch gateway group(s) for 10 source site(s)
+// GOOD: RESULT: SUCCESS
+
+// RUN: sed 's|^// FOREIGN-ONLY:|  |' %s > %t.foreign.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.foreign.s -o %t.foreign.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.foreign.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=FOREIGN %s
+// FOREIGN-NOT: hotswap: planned {{.*}} shared far-dispatch gateway group
+// FOREIGN: hotswap: error: no safe short-branch gateway for far site
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.macro PATCH_SOURCE number
+  s_branch source\number\()_after
+source\number:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+source\number\()_after:
+.endm
+
+.globl sources
+.type sources,@function
+sources:
+PATCH_SOURCE 0
+PATCH_SOURCE 1
+PATCH_SOURCE 2
+PATCH_SOURCE 3
+PATCH_SOURCE 4
+PATCH_SOURCE 5
+PATCH_SOURCE 6
+PATCH_SOURCE 7
+PATCH_SOURCE 8
+PATCH_SOURCE 9
+  s_endpgm
+.size sources, .-sources
+
+.local gateway_pad
+// FOREIGN-ONLY:.type gateway_pad,@function
+gateway_pad:
+  .rept 5
+    s_nop 0
+  .endr
+// FOREIGN-ONLY:.size gateway_pad, .-gateway_pad
+
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel sources
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 96
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: sources
+      .symbol: sources.kd
+      .sgpr_count: 98
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-shared-relay-chain.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-shared-relay-chain.s
@@ -1,0 +1,82 @@
+// COM: A shared dispatcher may admit a distant source through another
+// COM: member's second dword. Each newly admitted member must publish its
+// COM: source+4 tail, never its source s_call at source+0, as the next relay.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: planned 1 shared far-dispatch gateway group(s) for 8 source site(s)
+// LOG: RESULT: SUCCESS
+
+// COM: source5 is admitted through source7's tail, then publishes its own tail
+// COM: for source3. That second hop locks the newly admitted anchor at
+// COM: source+4 instead of source+0.
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <source5>:
+// DISASM-NEXT: s_call_i64
+// DISASM-NEXT: s_branch
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.macro PATCH_SOURCE number
+  s_branch source\number\()_after
+source\number:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+source\number\()_after:
+  .rept 15000
+    s_mov_b32 s0, s1
+  .endr
+.endm
+
+.globl chain
+.type chain,@function
+chain:
+PATCH_SOURCE 0
+PATCH_SOURCE 1
+PATCH_SOURCE 2
+PATCH_SOURCE 3
+PATCH_SOURCE 4
+PATCH_SOURCE 5
+PATCH_SOURCE 6
+PATCH_SOURCE 7
+PATCH_SOURCE 8
+  s_branch source9_after
+source9:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+source9_after:
+  s_mov_b32 s0, s1
+gateway_pad:
+  .rept 5
+    s_nop 0
+  .endr
+  .rept 15000
+    s_mov_b32 s0, s1
+  .endr
+  s_endpgm
+.size chain, .-chain
+
+.rodata
+.p2align 8
+.amdhsa_kernel chain
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 32
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: chain
+      .symbol: chain.kd
+      .sgpr_count: 34
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-source-tail-islands.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-source-tail-islands.s
@@ -1,0 +1,86 @@
+// COM: Far eight-byte patch sites have no padding inside their tiny owning
+// COM: functions. Their unreachable second dwords form a registerless relay
+// COM: chain to the appended trampoline pool.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: assigned 1 forward s_branch island chain(s)
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <source0>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop
+// DISASM-LABEL: <source1>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl source0
+.p2align 8
+.type source0,@function
+source0:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_endpgm
+.size source0, .-source0
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.globl source1
+.type source1,@function
+source1:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_endpgm
+.size source1, .-source1
+
+.rept 12500
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel source0
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+.amdhsa_kernel source1
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: source0
+      .symbol: source0.kd
+      .sgpr_count: 14
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: source1
+      .symbol: source1.kd
+      .sgpr_count: 14
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-mask-already-zero.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-mask-already-zero.s
@@ -1,0 +1,110 @@
+// COM: A tensor descriptor whose base has a provably zero low half needs no
+// COM: rewrite. Both CFG paths seed s4 with zero and then use only self-writes
+// COM: that cannot introduce a low bit. Foreign reads after the tensor are
+// COM: harmless because this proof changes neither the definition nor the
+// COM: tensor. A variant with one nonzero seed must reject the no-op proof and
+// COM: use the save/clear/tensor/restore fallback.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=ZERO %s
+// ZERO: descriptor workgroup_mask is already zero on every path
+// ZERO: hotswap: applied 0 instruction patches
+// ZERO: RESULT: SUCCESS
+// RUN: cmp %t.elf %t.out.elf
+
+// COM: An unresolved set-PC is a possible alternate entry to the tensor. The
+// COM: modeled zero path cannot prove anything about s4 on that hidden edge.
+// RUN: sed 's/^\.set opaque_tensor_entry, 0$/.set opaque_tensor_entry, 1/' \
+// RUN:   %s > %t.opaque.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.opaque.s -o %t.opaque.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.opaque.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.opaque.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=NONZERO %s
+
+// RUN: sed 's/^\.set nonzero_path, 0$/.set nonzero_path, 1/' \
+// RUN:   %s > %t.nonzero.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.nonzero.s -o %t.nonzero.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nonzero.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.nonzero.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=NONZERO %s
+// NONZERO-NOT: descriptor workgroup_mask is already zero on every path
+// NONZERO: tensor_load_to_lds: s4 live, save/restore via s12
+// NONZERO: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.nonzero.out.elf \
+// RUN:   | %FileCheck --check-prefix=NONZERO-DIS %s
+// NONZERO-DIS-LABEL: <test_tensor_mask_already_zero>:
+// NONZERO-DIS: s_and_b32 s4, s4, 0xfff7ffff
+// NONZERO-DIS: s_mov_b32 s12, s4
+// NONZERO-DIS-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// NONZERO-DIS-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// NONZERO-DIS-NEXT: s_mov_b32 s4, s12
+
+.set nonzero_path, 0
+.set opaque_tensor_entry, 0
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_tensor_mask_already_zero
+.p2align 8
+.type test_tensor_mask_already_zero,@function
+test_tensor_mask_already_zero:
+.if opaque_tensor_entry
+  s_cbranch_scc0 .Lopaque_entry
+.endif
+  s_cbranch_execz .Lsecond
+  s_mov_b32 s4, 0
+  s_branch .Lbuild
+.Lsecond:
+.if nonzero_path
+  s_mov_b32 s4, 1
+.else
+  s_mov_b32 s4, 0
+.endif
+.Lbuild:
+  s_and_b32 s4, s4, 0xfffcffff
+  s_or_b32 s4, s4, 0x10000
+  s_and_b32 s4, s4, 0xfff7ffff
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s0, s4
+  s_endpgm
+  .rept 8
+    s_nop 0
+  .endr
+.if opaque_tensor_entry
+.Lopaque_entry:
+  s_mov_b32 s4, 1
+  s_set_pc_i64 s[10:11]
+.endif
+.Ltest_tensor_mask_already_zero_end:
+.size test_tensor_mask_already_zero, .Ltest_tensor_mask_already_zero_end-test_tensor_mask_already_zero
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_mask_already_zero
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_mask_already_zero
+      .symbol: test_tensor_mask_already_zero.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-mask-bounded-return.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-mask-bounded-return.s
@@ -1,0 +1,99 @@
+// COM: Tensor CFGs may consume exact target sets from the object-wide bounded
+// COM: return audit. The default helper returns to an in-function continuation,
+// COM: so its otherwise-indirect set-PC is a closed edge and the zero-mask
+// COM: proof succeeds. The variant's proven return target is outside the
+// COM: tensor function, which this local CFG rejects conservatively.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOCAL %s
+// LOCAL: descriptor workgroup_mask is already zero on every path
+// LOCAL: hotswap: applied 0 instruction patches
+// LOCAL: RESULT: SUCCESS
+// RUN: cmp %t.elf %t.out.elf
+
+// RUN: sed 's/^\.set outside_return, 0$/.set outside_return, 1/' \
+// RUN:   %s > %t.outside.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.outside.s -o %t.outside.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.outside.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.outside.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=OUTSIDE %s
+// OUTSIDE: tensor CFG rejected bounded transfer at 0x{{[0-9A-F]+}} with out-of-range target
+// OUTSIDE-NOT: descriptor workgroup_mask is already zero on every path
+// OUTSIDE: tensor_load_to_lds: s4 dead, no save/restore needed
+// OUTSIDE: RESULT: SUCCESS
+
+.set outside_return, 0
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.if outside_return
+.type tensor_bounded_return_callee,@function
+tensor_bounded_return_callee:
+  s_mov_b32 s4, 0
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s4, 0
+  s_set_pc_i64 s[0:1]
+.Ltensor_bounded_return_callee_end:
+.size tensor_bounded_return_callee, .Ltensor_bounded_return_callee_end-tensor_bounded_return_callee
+
+.globl test_tensor_mask_bounded_return
+.p2align 8
+.type test_tensor_mask_bounded_return,@function
+test_tensor_mask_bounded_return:
+.Loutside_getpc:
+  s_get_pc_i64 s[2:3]
+  // The aligned caller begins at .text+0x100; captured PC is .text+0x104.
+  s_add_nc_u64 s[2:3], s[2:3], -260
+  s_swap_pc_i64 s[0:1], s[2:3]
+  s_endpgm
+.Ltest_tensor_mask_bounded_return_end:
+.size test_tensor_mask_bounded_return, .Ltest_tensor_mask_bounded_return_end-test_tensor_mask_bounded_return
+.else
+.globl test_tensor_mask_bounded_return
+.p2align 8
+.type test_tensor_mask_bounded_return,@function
+test_tensor_mask_bounded_return:
+  s_mov_b32 s4, 0
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s4, 0
+.Llocal_getpc:
+  s_get_pc_i64 s[2:3]
+  // Captured PC is .text+0x18 and the helper begins at .text+0x24.
+  s_add_nc_u64 s[2:3], s[2:3], 12
+  s_swap_pc_i64 s[0:1], s[2:3]
+.Lcontinuation:
+  s_endpgm
+.Lhelper:
+  s_set_pc_i64 s[0:1]
+.Ltest_tensor_mask_bounded_return_end:
+.size test_tensor_mask_bounded_return, .Ltest_tensor_mask_bounded_return_end-test_tensor_mask_bounded_return
+.endif
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_mask_bounded_return
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_mask_bounded_return
+      .symbol: test_tensor_mask_bounded_return.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-mask-local-setpc.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-mask-local-setpc.s
@@ -1,0 +1,156 @@
+// COM: A broad tensor function may contain a compiler-emitted reusable-PC
+// COM: tail jump. Resolve only the exact adjacent get-PC/carry-add/set-PC
+// COM: sequence to its in-range instruction boundary. Both the tensor path and
+// COM: the jump target kill s4 after the tensor mask definition, so the
+// COM: definition-time low16 clear is safe.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: cleared workgroup_mask at descriptor definition 0x{{[0-9A-F]+}} (s4)
+// API-NOT: tensor_load_to_lds: s4
+// API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DIS %s
+// DIS-LABEL: <test_tensor_mask_local_setpc>:
+// DIS: s_and_b32 s4, s4, 0xfff70000
+// DIS-NOT: s_pack_hh_b32_b16
+// DIS: tensor_load_to_lds s[0:3], s[4:11]
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.set wrong_pair, 0
+.set intervening_def, 0
+.set outside_target, 0
+.set interior_entry, 0
+.set declared_entry, 0
+
+// COM: A wrong transfer pair, an intervening target-pair definition, or an
+// COM: otherwise exact sequence whose target is outside the function must
+// COM: remain opaque. Each variant therefore rejects the definition rewrite
+// COM: and uses the at-site fallback.
+// RUN: sed 's/^\.set wrong_pair, 0$/.set wrong_pair, 1/' \
+// RUN:   %s > %t.wrong-pair.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.wrong-pair.s -o %t.wrong-pair.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.wrong-pair.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.wrong-pair.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=OPAQUE %s
+// RUN: sed 's/^\.set intervening_def, 0$/.set intervening_def, 1/' \
+// RUN:   %s > %t.intervening.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.intervening.s -o %t.intervening.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.intervening.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.intervening.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=OPAQUE %s
+// RUN: sed 's/^\.set outside_target, 0$/.set outside_target, 1/' \
+// RUN:   %s > %t.outside.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.outside.s -o %t.outside.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.outside.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.outside.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=OPAQUE %s
+// RUN: sed 's/^\.set interior_entry, 0$/.set interior_entry, 1/' \
+// RUN:   %s > %t.interior.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.interior.s -o %t.interior.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.interior.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.interior.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=OPAQUE %s
+// RUN: sed 's/^\.set declared_entry, 0$/.set declared_entry, 1/' \
+// RUN:   %s > %t.declared.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.declared.s -o %t.declared.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.declared.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.declared.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=OPAQUE %s
+// OPAQUE-NOT: cleared workgroup_mask at descriptor definition
+// OPAQUE: tensor_load_to_lds: s4 dead, no save/restore needed
+// OPAQUE: RESULT: SUCCESS
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_tensor_mask_local_setpc
+.p2align 8
+.type test_tensor_mask_local_setpc,@function
+test_tensor_mask_local_setpc:
+  s_and_b32 s4, s4, 0xfff7ffff
+  s_cmp_eq_u32 s0, s0
+.if interior_entry
+  s_cbranch_scc0 .Ladd_low
+.endif
+  s_cbranch_execz .Ltensor
+.Lgetpc:
+  s_get_pc_i64 s[70:71]
+.if outside_target
+  s_add_co_i32 s72, .Loutside_target-(.Lgetpc+4)-4, 4
+.else
+  s_add_co_i32 s72, .Ltarget-(.Lgetpc+4)-4, 4
+.endif
+.Ladd_low:
+.if declared_entry
+.globl test_tensor_mask_local_setpc_interior
+.type test_tensor_mask_local_setpc_interior,@function
+test_tensor_mask_local_setpc_interior:
+.endif
+  s_add_co_u32 s70, s70, s72
+.if declared_entry
+.size test_tensor_mask_local_setpc_interior, .-test_tensor_mask_local_setpc_interior
+.endif
+  s_add_co_ci_u32 s71, s71, 0
+.if intervening_def
+  s_mov_b32 s70, 0
+.endif
+.if wrong_pair
+  s_set_pc_i64 s[74:75]
+.else
+  s_set_pc_i64 s[70:71]
+.endif
+.Ltensor:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s4, 0
+  s_cmp_eq_u32 s0, s0
+  s_endpgm
+.Ltarget:
+  s_mov_b32 s4, 0
+  s_cmp_eq_u32 s0, s0
+  s_endpgm
+.Ltest_tensor_mask_local_setpc_end:
+.size test_tensor_mask_local_setpc, .Ltest_tensor_mask_local_setpc_end-test_tensor_mask_local_setpc
+
+.Loutside:
+  s_nop 0
+.Loutside_target:
+  s_endpgm
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_mask_local_setpc
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 76
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_mask_local_setpc
+      .symbol: test_tensor_mask_local_setpc.kd
+      .sgpr_count: 76
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-mask-signed-setpc.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-mask-signed-setpc.s
@@ -1,0 +1,92 @@
+// COM: Recognize only Tensile's exact contiguous signed-direction reusable-PC
+// COM: transfer. Both arithmetic arms compute the same local target. A direct
+// COM: entry into the positive arm invalidates that target proof and forces
+// COM: the tensor's at-site fallback.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOCAL %s
+// LOCAL: cleared workgroup_mask at descriptor definition 0x{{[0-9A-F]+}} (s4)
+// LOCAL-NOT: tensor_load_to_lds: s4
+// LOCAL: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DIS %s
+// DIS: s_and_b32 s4, s4, 0xfff70000
+// DIS-NOT: s_pack_hh_b32_b16
+// DIS: tensor_load_to_lds s[0:3], s[4:11]
+
+// RUN: sed 's/^\.set alternate_arm_entry, 0$/.set alternate_arm_entry, 1/' \
+// RUN:   %s > %t.alternate.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.alternate.s -o %t.alternate.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.alternate.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.alternate.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=ALTERNATE %s
+// ALTERNATE: tensor CFG rejected alternate entry into reusable-PC sequence
+// ALTERNATE-NOT: cleared workgroup_mask at descriptor definition
+// ALTERNATE: tensor_load_to_lds: s4 dead, no save/restore needed
+// ALTERNATE: RESULT: SUCCESS
+
+.set alternate_arm_entry, 0
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_tensor_mask_signed_setpc
+.p2align 8
+.type test_tensor_mask_signed_setpc,@function
+test_tensor_mask_signed_setpc:
+  s_and_b32 s4, s4, 0xfff7ffff
+  s_cmp_eq_u32 s0, s0
+.if alternate_arm_entry
+  s_cbranch_scc0 .Lpositive
+.endif
+  s_cbranch_execz .Ltensor
+.Lgetpc:
+  s_get_pc_i64 s[70:71]
+  s_add_co_i32 s72, .Ltarget-(.Lgetpc+4), 0
+  s_cmp_ge_i32 s72, 0
+  s_cbranch_scc1 .Lpositive
+  s_abs_i32 s72, s72
+  s_sub_co_u32 s70, s70, s72
+  s_sub_co_ci_u32 s71, s71, 0
+  s_set_pc_i64 s[70:71]
+.Lpositive:
+  s_add_co_u32 s70, s70, s72
+  s_add_co_ci_u32 s71, s71, 0
+  s_set_pc_i64 s[70:71]
+.Ltensor:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s4, 0
+  s_cmp_eq_u32 s0, s0
+  s_endpgm
+.Ltarget:
+  s_mov_b32 s4, 0
+  s_cmp_eq_u32 s0, s0
+  s_endpgm
+.Ltest_tensor_mask_signed_setpc_end:
+.size test_tensor_mask_signed_setpc, .Ltest_tensor_mask_signed_setpc_end-test_tensor_mask_signed_setpc
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_mask_signed_setpc
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 73
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_mask_signed_setpc
+      .symbol: test_tensor_mask_signed_setpc.kd
+      .sgpr_count: 73
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-scale16-32x16-refuse.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16-32x16-refuse.s
@@ -1,40 +1,102 @@
-// COM: Fail-closed gate for the 32x16 FP4 block-16 scaled WMMA. The M=32 form
-// COM: needs an M-split on top of the K-split and has no exact lowering yet,
-// COM: so the rewrite refuses it: any unlowerable v_wmma_scale16_f32_* makes the
-// COM: rewrite return an error instead of emitting a wrong code object.
+// COM: Fail-closed overlap gates for the staged M+K lowering. Each variant is
+// COM: assembled into its own object so every rejection is exercised
+// COM: independently.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=1 %s -o %t.da.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.da.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=D-A %s
+// D-A: destination overlaps matrix A
+// D-A: RESULT: ERROR
 
-// COM: Default mode: presence of the unlowerable form fails the rewrite.
-// RUN: hotswap-rewrite %t.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR \
-// RUN:   | %FileCheck --check-prefix=REFUSE %s
-// REFUSE: RESULT: ERROR
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=2 %s -o %t.db.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.db.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=D-B %s
+// D-B: destination overlaps matrix B
+// D-B: RESULT: ERROR
 
-// COM: Strict mode: same fail-closed result.
-// RUN: hotswap-rewrite %t.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --strict-mode --expect-status ERROR \
-// RUN:   | %FileCheck --check-prefix=REFUSE %s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=3 %s -o %t.ab.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.ab.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=A-B %s
+// A-B: matrix A overlaps matrix B
+// A-B: RESULT: ERROR
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=4 %s -o %t.dc.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.dc.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=D-C %s
+// D-C: partial destination/src2 overlap
+// D-C: RESULT: ERROR
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=5 %s -o %t.ac.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.ac.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=A-C %s
+// A-C: matrix A overlaps src2
+// A-C: RESULT: ERROR
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=6 %s -o %t.scale-matrix.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.scale-matrix.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=SCALE %s
+// SCALE: scale pair overlaps a staged matrix operand
+// SCALE: RESULT: ERROR
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=7 %s -o %t.scale-scale.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.scale-scale.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=SCALE %s
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
 
-// --- Scale16 32x16 FP4 (block-16) -> refuse (fail closed) ---
-.globl test_wmma_scale16_32x16
+.globl test_wmma_scale16_32x16_refuse
 .p2align 8
-.type test_wmma_scale16_32x16,@function
-test_wmma_scale16_32x16:
-  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v[40:41], v[42:43]
+.type test_wmma_scale16_32x16_refuse,@function
+test_wmma_scale16_32x16_refuse:
+.if CASE == 1
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[8:23], v[32:39], v[0:15], v[40:41], v[42:43]
+.elseif CASE == 2
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[8:15], v[0:15], v[40:41], v[42:43]
+.elseif CASE == 3
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[24:31], v[0:15], v[40:41], v[42:43]
+.elseif CASE == 4
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[24:39], v[40:47], v[8:23], v[48:49], v[50:51]
+.elseif CASE == 5
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[16:31], v[40:41], v[42:43]
+.elseif CASE == 6
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v[16:17], v[42:43]
+.elseif CASE == 7
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v[40:41], v[40:41]
+.else
+  .error "unknown CASE"
+.endif
   s_endpgm
-.Ltest_wmma_scale16_32x16_end:
-.size test_wmma_scale16_32x16, .Ltest_wmma_scale16_32x16_end-test_wmma_scale16_32x16
+.Ltest_wmma_scale16_32x16_refuse_end:
+.size test_wmma_scale16_32x16_refuse, .Ltest_wmma_scale16_32x16_refuse_end-test_wmma_scale16_32x16_refuse
 
 .rodata
 .p2align 8
-.amdhsa_kernel test_wmma_scale16_32x16
-  .amdhsa_next_free_vgpr 44
+.amdhsa_kernel test_wmma_scale16_32x16_refuse
+  .amdhsa_next_free_vgpr 52
   .amdhsa_next_free_sgpr 2
   .amdhsa_wavefront_size32 1
 .end_amdhsa_kernel
@@ -44,10 +106,10 @@ test_wmma_scale16_32x16:
     - 3
     - 0
   amdhsa.kernels:
-    - .name: test_wmma_scale16_32x16
-      .symbol: test_wmma_scale16_32x16.kd
+    - .name: test_wmma_scale16_32x16_refuse
+      .symbol: test_wmma_scale16_32x16_refuse.kd
       .sgpr_count: 2
-      .vgpr_count: 44
+      .vgpr_count: 52
       .kernarg_segment_size: 0
       .group_segment_fixed_size: 0
       .private_segment_fixed_size: 0

--- a/amd/comgr/test-lit/hotswap-wmma-scale16-32x16.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16-32x16.s
@@ -1,0 +1,146 @@
+// COM: Exact decomposition of the corpus's M=32 FP4 block-16 scaled WMMA.
+// COM: The schedule is low-M/low-K, high-M/low-K, low-M/high-K,
+// COM: high-M/high-K. The low passes read the original C halves and even scale
+// COM: bytes; the high passes accumulate from D and use odd scale bytes. Only
+// COM: the four A registers overwritten by each FP4 mask are saved, and the
+// COM: first save slot is reused as the reversible scale-pair permutation
+// COM: temporary.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: physical forward-dead proof at offset
+// API-SAME: found 4 VGPRs
+// API: wmma_scale16: exact M+K split
+// API-SAME: four saved-A VGPRs, tmp=v55, +0 vgpr, 4 WMMAs
+// API-NOT: error:
+// API: liveness: kernel test_wmma_scale16_32x16:
+// API-SAME: scratch_reused=4, scratch_above_kd=0
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_scale16_32x16>:
+// DISASM-NOT: v_wmma_scale16
+// DISASM: s_branch
+// DISASM: s_endpgm
+//
+// COM: Forward byte split and its exact inverse. These selectors implement
+// COM: [0,2,4,6] / [1,3,5,7], then restore the two original dwords exactly.
+// DISASM: v_mov_b32_e32 v[[TMP:[0-9]+]], v40
+// DISASM-NEXT: v_perm_b32 v40, v[[TMP]], v41, 0x6040200
+// DISASM-NEXT: v_perm_b32 v41, v[[TMP]], v41, 0x7050301
+// DISASM: v_mov_b32_e32 v[[TMP]], v42
+// DISASM-NEXT: v_perm_b32 v42, v[[TMP]], v43, 0x6040200
+// DISASM-NEXT: v_perm_b32 v43, v[[TMP]], v43, 0x7050301
+//
+// COM: D==C, low-low-high-high order. Reuse hints are stripped, and the
+// COM: original C modifier appears only on the two low-K passes.
+// DISASM-NOT: matrix_a_reuse
+// DISASM-NOT: matrix_b_reuse
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[0:7], v40, v42{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4{{.*}}neg_lo:[0,0,1]
+// DISASM: v_nop
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[8:15], v[24:31], v[32:39], v[8:15], v40, v42{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4{{.*}}neg_lo:[0,0,1]
+// DISASM: v_nop
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[0:7], v41, v43{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NOT: neg_lo
+// DISASM: v_nop
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[8:15], v[24:31], v[32:39], v[8:15], v41, v43{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NOT: neg_lo
+// DISASM: v_nop
+// DISASM: v_mov_b32_e32 v[[TMP]], v40
+// DISASM-NEXT: v_perm_b32 v40, v[[TMP]], v41, 0x5010400
+// DISASM-NEXT: v_perm_b32 v41, v[[TMP]], v41, 0x7030602
+// DISASM: v_mov_b32_e32 v[[TMP]], v42
+// DISASM-NEXT: v_perm_b32 v42, v[[TMP]], v43, 0x5010400
+// DISASM-NEXT: v_perm_b32 v43, v[[TMP]], v43, 0x7030602
+//
+// COM: The second lowering permits matrix B to overlap C. Its first low pass
+// COM: therefore has the same v[32:39] range in src1 and src2.
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[32:39], v48, v50
+// DISASM-NOT: v_wmma_scale16
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+// Reduced opaque sequence from the f4gemm corpus. The A0 decoder splits this
+// legacy B0 VOP3 into two unknown dwords. The sequence before the WMMA tests
+// local MODE recovery; the sequence after it tests forward physical liveness.
+.macro opaque_b0_vop3
+  .long 0xd0310000
+  .long 0x00100000
+  v_cmp_ge_u16_e32 vcc_lo, s32, v18.l
+.endm
+
+.globl test_wmma_scale16_32x16
+.p2align 8
+.type test_wmma_scale16_32x16,@function
+test_wmma_scale16_32x16:
+  s_set_vgpr_msb 0
+  opaque_b0_vop3
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v[40:41], v[42:43] matrix_a_scale:MATRIX_SCALE_ROW1 matrix_b_scale:MATRIX_SCALE_ROW1 matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_a_reuse matrix_b_reuse neg_lo:[0,0,1]
+  opaque_b0_vop3
+  v_mov_b32 v52, 0
+  v_mov_b32 v53, 0
+  v_mov_b32 v54, 0
+  v_mov_b32 v55, 0
+  s_branch test_wmma_scale16_32x16_bc_overlap
+.Ltest_wmma_scale16_32x16_end:
+.size test_wmma_scale16_32x16, .Ltest_wmma_scale16_32x16_end-test_wmma_scale16_32x16
+
+.globl test_wmma_scale16_32x16_bc_overlap
+.p2align 8
+.type test_wmma_scale16_32x16_bc_overlap,@function
+test_wmma_scale16_32x16_bc_overlap:
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[32:47], v[48:49], v[50:51] matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3
+  s_endpgm
+.Ltest_wmma_scale16_32x16_bc_overlap_end:
+.size test_wmma_scale16_32x16_bc_overlap, .Ltest_wmma_scale16_32x16_bc_overlap_end-test_wmma_scale16_32x16_bc_overlap
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_scale16_32x16
+  .amdhsa_next_free_vgpr 1024
+  .amdhsa_next_free_sgpr 34
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_wmma_scale16_32x16_bc_overlap
+  .amdhsa_next_free_vgpr 52
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_scale16_32x16
+      .symbol: test_wmma_scale16_32x16.kd
+      .sgpr_count: 34
+      .vgpr_count: 1024
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+    - .name: test_wmma_scale16_32x16_bc_overlap
+      .symbol: test_wmma_scale16_32x16_bc_overlap.kd
+      .sgpr_count: 2
+      .vgpr_count: 52
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-scale16-fp4.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16-fp4.s
@@ -17,14 +17,14 @@
 // COM: VGPR select, never a lane mask, so no v_cndmask appears in either pass.
 // DISASM-NOT: v_cndmask_b32_e64
 // DISASM: v_mov_b32{{(_e32)?}} v{{[0-9]+}}, 0
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:39], v[0:7],{{.*}}matrix_a_fmt:MATRIX_FMT_FP4
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[0:7],{{.*}}matrix_a_fmt:MATRIX_FMT_FP4
 // COM: exactly one gfx1250 hazard v_nop before the pass-high masked-A VALU.
 // DISASM-COUNT-1: v_nop
 // DISASM-NEXT: v_mov_b32{{(_e32)?}} v{{[0-9]+}}, 0
 // DISASM-NOT: v_cndmask_b32_e64
 // COM: pass-high keeps the high-16 subblock VGPRs, odd-byte scale gather,
 // COM: accumulating onto pass-low through v[0:7].
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:39], v[0:7],{{.*}}matrix_a_fmt:MATRIX_FMT_FP4
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[0:7],{{.*}}matrix_a_fmt:MATRIX_FMT_FP4
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-wmma-scale16-large-vgpr-count.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16-large-vgpr-count.s
@@ -1,0 +1,75 @@
+// A kernel may allocate more than 256 physical VGPRs through gfx1250's
+// VGPR-MSB mode. The scale16 lowering's generated assembly must still use
+// encodable v0-v255 names and select its above-KD scratch bank explicitly.
+// The bump is occupancy-neutral (the original and rewritten allocations both
+// admit one wave/EU), despite the maximum-workgroup metadata asking for two.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: wmma_scale16: exact K-split
+// API-NOT: register index is out of range
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_scale16_large_vgpr_count>:
+// DISASM-NOT: v_wmma_scale16
+// DISASM: v_mov_b32_e32 v191 /*v703*/, v255
+// DISASM-NEXT: s_set_vgpr_msb 0xa0a1
+// DISASM-NEXT: v_mov_b32_e32 v192 /*v704*/, v0 /*v256*/
+// DISASM: s_set_vgpr_msb 0xa00a
+// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[182:189] /*v[694:701]*/, v[190:197] /*v[702:709]*/, 0,
+// DISASM: s_set_vgpr_msb 0x880a
+// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[182:189] /*v[694:701]*/, v[190:197] /*v[702:709]*/, v[38:45],
+// DISASM-NEXT: s_set_vgpr_msb 0xa00
+// DISASM: s_set_vgpr_msb 0xa00a
+// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[182:189] /*v[694:701]*/, v[190:197] /*v[702:709]*/, 0,
+// DISASM: s_set_vgpr_msb 0x880a
+// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[182:189] /*v[694:701]*/, v[190:197] /*v[702:709]*/, v[38:45],
+// DISASM-NEXT: s_set_vgpr_msb 0xa00
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_scale16_large_vgpr_count
+.p2align 8
+.type test_wmma_scale16_large_vgpr_count,@function
+test_wmma_scale16_large_vgpr_count:
+  s_set_vgpr_msb 0x100
+  v_mov_b32 v10, v10
+  v_wmma_scale16_f32_16x16x128_f8f6f4 v[38:45], v[174:181], v[254:261], 0, v[0:1], v[18:19] matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4 matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3
+  v_wmma_scale16_f32_16x16x128_f8f6f4 v[38:45], v[174:181], v[240:247], 0, v[0:1], v[18:19] matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4 matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3
+  s_endpgm
+.Ltest_wmma_scale16_large_vgpr_count_end:
+.size test_wmma_scale16_large_vgpr_count, .Ltest_wmma_scale16_large_vgpr_count_end-test_wmma_scale16_large_vgpr_count
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_scale16_large_vgpr_count
+  .amdhsa_next_free_vgpr 688
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_scale16_large_vgpr_count
+      .symbol: test_wmma_scale16_large_vgpr_count.kd
+      .sgpr_count: 2
+      .vgpr_count: 688
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-scale16.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16.s
@@ -1,8 +1,9 @@
 // COM: The target gfx1250 has no block-16 scaled WMMA, so the rewrite lowers
 // COM: 16x16x128_f8f6f4 exactly into two block-32 WMMAs chained through the
 // COM: accumulator: each pass masks matrix A to one 16-K subblock (a lane mask
-// COM: for FP8) and byte-gathers the matching block-16 scales. When the scratch
-// COM: budget is unavailable it fails closed (see the 32x16 refuse test).
+// COM: for FP8), copies matrix B into the same scratch bank, and byte-gathers
+// COM: the matching block-16 scales. When the scratch budget is unavailable it
+// COM: fails closed (see the 32x16 refuse test).
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
@@ -18,13 +19,13 @@
 // DISASM-NOT: v_wmma_scale16
 // DISASM: s_mov_b32 s{{[0-9]+}}, 0xffff {{.*$}}
 // DISASM: v_cndmask_b32_e64
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:47], v[0:7],
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[0:7],
 // COM: exactly one gfx1250 hazard v_nop before the pass-high lane-mask VALU that
 // COM: overwrites the masked-A scratch block.
 // DISASM-COUNT-1: v_nop
 // DISASM-NEXT: s_mov_b32 s{{[0-9]+}}, 0xffff0000
 // DISASM: v_cndmask_b32_e64
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:47], v[0:7],
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[0:7],
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -118,6 +118,9 @@ config.substitutions.append(
 config.substitutions.append(
     ("%llvm-readelf", _fwd(config.llvm_tools_dir, "llvm-readelf"))
 )
+config.substitutions.append(
+    ("%llvm-readobj", _fwd(config.llvm_tools_dir, "llvm-readobj"))
+)
 config.substitutions.append(("%ld.lld", _fwd(config.llvm_tools_dir, "ld.lld")))
 config.substitutions.append(("%yaml2obj", _fwd(config.llvm_tools_dir, "yaml2obj")))
 config.substitutions.append(("%FileCheck", _fwd(config.llvm_tools_dir, "FileCheck")))

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1637,6 +1637,413 @@ TEST(AssembleDecode, SNopRoundTrip) {
   EXPECT_EQ(Decoded[0].Mnemonic, "s_nop");
 }
 
+static std::optional<llvm::BitVector> getTestLiveSgprsAtContinuation(
+    llvm::StringRef Assembly, uint64_t InstOffset = 0,
+    uint32_t InstSize = MinInstSize, unsigned MaxSgprs = 106) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  if (!S.Valid)
+    return std::nullopt;
+  llvm::SmallVector<uint8_t> Text = assembleInstructions(Assembly, S);
+  if (Text.empty())
+    return std::nullopt;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  if (!ViewOrErr)
+    return std::nullopt;
+  ElfView &View = *ViewOrErr;
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(View.textData(), View.textSize(), S, Decoded))
+    return std::nullopt;
+
+  RewriteConfig Config;
+  Config.MaxSgprs = MaxSgprs;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+  return getLiveSgprsAtContinuation(Ctx, InstOffset, InstSize);
+}
+
+TEST(RegisterLiveness, TiedAccumulatorDefCountsAsIncomingRead) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("v_fmac_f32_e32 v5, v1, v2", S);
+  ASSERT_EQ(Bytes.size(), MinInstSize);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  const InternalDecodedInst &DI = Decoded[0];
+  const llvm::MCInstrDesc &Desc = S.MCII->get(DI.Inst.getOpcode());
+  ASSERT_GE(Desc.getNumDefs(), 1u);
+  ASSERT_GE(DI.Inst.getNumOperands(), 1u);
+  ASSERT_TRUE(DI.Inst.getOperand(0).isReg());
+
+  bool HasTiedAccumulatorUse = false;
+  for (unsigned I = Desc.getNumDefs(); I != Desc.getNumOperands(); ++I)
+    HasTiedAccumulatorUse |=
+        Desc.getOperandConstraint(I, llvm::MCOI::TIED_TO) == 0;
+  ASSERT_TRUE(HasTiedAccumulatorUse);
+
+  llvm::MCRegister Accumulator(DI.Inst.getOperand(0).getReg());
+  EXPECT_TRUE(instructionReadsRegister(DI, S, Accumulator));
+}
+
+TEST(RegisterLiveness, TargetHasNoVariadicDefOpcodes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  unsigned VariadicDefOpcodes = 0;
+  for (unsigned I = 0; I != S.MCII->getNumOpcodes(); ++I) {
+    const llvm::MCInstrDesc &Candidate = S.MCII->get(I);
+    if (Candidate.isVariadic() && Candidate.variadicOpsAreDefs())
+      ++VariadicDefOpcodes;
+  }
+  // The implementation classifies variadic defs precisely for future
+  // subtargets. GFX1250 currently has no such descriptor, so pin that target
+  // fact instead of inventing an invalid MCInst.
+  EXPECT_EQ(VariadicDefOpcodes, 0u);
+}
+
+TEST(RegisterLiveness, ReplacementReadsBeforeOverwrite) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> ReadThenWrite =
+      assembleInstructions("s_mov_b32 s1, s0\ns_mov_b32 s0, 0", S);
+  llvm::SmallVector<uint8_t> WriteThenRead =
+      assembleInstructions("s_mov_b32 s0, 0\ns_mov_b32 s1, s0", S);
+  llvm::SmallVector<uint8_t> RegisterBytes =
+      assembleSingleInst("s_mov_b32 s1, s0", S);
+  ASSERT_FALSE(ReadThenWrite.empty());
+  ASSERT_FALSE(WriteThenRead.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(RegisterBytes.data(), RegisterBytes.size(), S,
+                                Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  ASSERT_TRUE(Decoded[0].Inst.getOperand(1).isReg());
+  llvm::MCRegister Sgpr0(Decoded[0].Inst.getOperand(1).getReg());
+
+  EXPECT_TRUE(replacementNeedsIncomingRegister(ReadThenWrite, S, Sgpr0));
+  EXPECT_FALSE(replacementNeedsIncomingRegister(WriteThenRead, S, Sgpr0));
+
+  std::array<uint8_t, MinInstSize> Undecodable;
+  Undecodable.fill(0xff);
+  EXPECT_TRUE(replacementNeedsIncomingRegister(Undecodable, S, Sgpr0));
+}
+
+TEST(RegisterLiveness, ReplacementBatchHandlesEmptyAndFailClosedInputs) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::optional<llvm::BitVector> Empty =
+      getReplacementIncomingSgprs(/*Replacement=*/{}, S, /*MaxSgprs=*/106);
+  ASSERT_TRUE(Empty);
+  EXPECT_TRUE(Empty->none());
+
+  llvm::SmallVector<uint8_t> Branch = assembleSingleInst("s_branch 0", S);
+  EXPECT_FALSE(getReplacementIncomingSgprs(Branch, S, /*MaxSgprs=*/106));
+
+  std::array<uint8_t, MinInstSize> Undecodable;
+  Undecodable.fill(0xff);
+  EXPECT_FALSE(getReplacementIncomingSgprs(Undecodable, S, /*MaxSgprs=*/106));
+  EXPECT_FALSE(getReplacementIncomingSgprs(
+      /*Replacement=*/{}, S, std::numeric_limits<unsigned>::max()));
+}
+
+TEST(RegisterLiveness, ConditionalDiamondUnionsBothPaths) {
+  std::optional<llvm::BitVector> Live =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_cbranch_scc1 2\n"
+                                     "s_mov_b32 s0, 0\n"
+                                     "s_branch 1\n"
+                                     "s_mov_b32 s1, s0\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Live);
+  EXPECT_TRUE(Live->test(0));
+  EXPECT_FALSE(Live->test(2));
+}
+
+TEST(RegisterLiveness, LoopConvergesAndPreservesLoopCarriedUse) {
+  std::optional<llvm::BitVector> Live =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     ".Lloop:\n"
+                                     "s_mov_b32 s1, s0\n"
+                                     "s_cbranch_scc1 .Lloop\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Live);
+  EXPECT_TRUE(Live->test(0));
+  EXPECT_FALSE(Live->test(2));
+}
+
+TEST(RegisterLiveness, ExplicitWriteKillsIncomingValueBeforeLaterRead) {
+  std::optional<llvm::BitVector> Live =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_mov_b32 s0, 0\n"
+                                     "s_mov_b32 s1, s0\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Live);
+  EXPECT_FALSE(Live->test(0));
+}
+
+TEST(RegisterLiveness, OutOfFunctionAndNonBoundaryBranchesFailClosed) {
+  std::optional<llvm::BitVector> Outside =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_branch 100\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Outside);
+  EXPECT_TRUE(Outside->all());
+
+  std::optional<llvm::BitVector> NonBoundary =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_branch 1\n"
+                                     "s_mov_b32 s0, 0x12345678\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(NonBoundary);
+  EXPECT_TRUE(NonBoundary->all());
+}
+
+TEST(RegisterLiveness, IndirectCallAndReturnBoundariesFailClosed) {
+  std::optional<llvm::BitVector> Indirect =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_set_pc_i64 s[0:1]\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Indirect);
+  EXPECT_TRUE(Indirect->all());
+
+  std::optional<llvm::BitVector> Call =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_call_i64 s[30:31], 0\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Call);
+  EXPECT_TRUE(Call->test(4));
+
+  std::optional<llvm::BitVector> Return =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_rfe_b64 s[0:1]\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(Return);
+  EXPECT_TRUE(Return->test(4));
+}
+
+TEST(RegisterLiveness, TracksSubregisterAndImplicitVccOverlap) {
+  std::optional<llvm::BitVector> PairUse =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_mov_b64 s[2:3], s[0:1]\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(PairUse);
+  EXPECT_TRUE(PairUse->test(0));
+  EXPECT_TRUE(PairUse->test(1));
+
+  std::optional<llvm::BitVector> ImplicitUse =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "s_cbranch_vccnz .Lend\n"
+                                     "s_endpgm\n"
+                                     ".Lend:\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(ImplicitUse);
+  EXPECT_TRUE(ImplicitUse->test(106));
+
+  std::optional<llvm::BitVector> ImplicitDef =
+      getTestLiveSgprsAtContinuation("s_nop 0\n"
+                                     "v_cmp_eq_u32_e32 v0, v1\n"
+                                     "s_cbranch_vccnz .Lend\n"
+                                     ".Lend:\n"
+                                     "s_endpgm");
+  ASSERT_TRUE(ImplicitDef);
+  EXPECT_FALSE(ImplicitDef->test(106));
+}
+
+TEST(RegisterLiveness, RejectsFunctionEndAndContinuationOverflow) {
+  std::optional<llvm::BitVector> AtEnd = getTestLiveSgprsAtContinuation(
+      "s_nop 0\n"
+      "s_endpgm",
+      /*InstOffset=*/MinInstSize, /*InstSize=*/MinInstSize);
+  EXPECT_FALSE(AtEnd);
+
+  std::optional<llvm::BitVector> Overflow = getTestLiveSgprsAtContinuation(
+      "s_nop 0\n"
+      "s_endpgm",
+      /*InstOffset=*/std::numeric_limits<uint64_t>::max() - 1,
+      /*InstSize=*/MinInstSize);
+  EXPECT_FALSE(Overflow);
+}
+
+TEST(RegisterLiveness, UsesCurrentTextAfterEarlierPatchMutation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleInstructions("s_nop 0\n"
+                                                         "s_mov_b32 s0, 0\n"
+                                                         "s_endpgm",
+                                                         S);
+  ASSERT_EQ(Text.size(), 3u * MinInstSize);
+
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> OriginalDecoded;
+  ASSERT_TRUE(
+      decodeTextSection(View.textData(), View.textSize(), S, OriginalDecoded));
+  ASSERT_EQ(OriginalDecoded.size(), 3u);
+  ASSERT_TRUE(OriginalDecoded[1].Inst.getOperand(0).isReg());
+  llvm::MCRegister Sgpr0(OriginalDecoded[1].Inst.getOperand(0).getReg());
+
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   OriginalDecoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+
+  EXPECT_TRUE(isRegisterDefinitelyDeadAtContinuation(
+      Ctx, /*InstOffset=*/0, /*InstSize=*/MinInstSize, Sgpr0));
+  ASSERT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Generation,
+            0u);
+  EXPECT_TRUE(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Valid);
+  ASSERT_TRUE(getLiveSgprsAtContinuation(Ctx, /*InstOffset=*/0,
+                                         /*InstSize=*/MinInstSize));
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+
+  // An undecodable current instruction cannot support a liveness proof.
+  std::array<uint8_t, MinInstSize> Undecodable;
+  Undecodable.fill(0xff);
+  std::memcpy(View.textData() + MinInstSize, Undecodable.data(),
+              Undecodable.size());
+  noteCurrentTextMutation(Ctx);
+  EXPECT_FALSE(isRegisterDefinitelyDeadAtContinuation(
+      Ctx, /*InstOffset=*/0, /*InstSize=*/MinInstSize, Sgpr0));
+  ASSERT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Generation,
+            1u);
+  EXPECT_FALSE(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Valid);
+
+  // Model an earlier patch that consumed a later NOP sled. The original
+  // decoded snapshot still says the continuation overwrites s0, while the
+  // current text now reads its incoming value first.
+  llvm::SmallVector<uint8_t> Patched =
+      assembleSingleInst("s_mov_b32 s1, s0", S);
+  ASSERT_EQ(Patched.size(), MinInstSize);
+  std::memcpy(View.textData() + MinInstSize, Patched.data(), Patched.size());
+  noteCurrentTextMutation(Ctx);
+  ASSERT_EQ(OriginalDecoded[1].Mnemonic, "s_mov_b32");
+  ASSERT_TRUE(OriginalDecoded[1].Inst.getOperand(1).isImm());
+
+  EXPECT_FALSE(isRegisterDefinitelyDeadAtContinuation(
+      Ctx, /*InstOffset=*/0, /*InstSize=*/MinInstSize, Sgpr0));
+  ASSERT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Generation,
+            2u);
+  EXPECT_TRUE(Ctx.CurrentFunctionSgprLivenessCache.begin()->second.Valid);
+}
+
+TEST(RegisterLiveness, HighCardinalityFunctionUsesOneBoundedBatch) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  constexpr size_t InstructionCount = 16384;
+  llvm::SmallVector<uint8_t> Text;
+  Text.reserve((InstructionCount + 2) * MinInstSize);
+  for (size_t I = 0; I != InstructionCount; ++I)
+    Text.append(S.SNopBytes);
+  llvm::SmallVector<uint8_t> Tail =
+      assembleInstructions("s_mov_b32 s1, s0\ns_endpgm", S);
+  ASSERT_EQ(Tail.size(), 2u * MinInstSize);
+  Text.append(Tail);
+
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+  std::vector<InternalDecodedInst> OriginalDecoded;
+  ASSERT_TRUE(
+      decodeTextSection(View.textData(), View.textSize(), S, OriginalDecoded));
+
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   OriginalDecoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+
+  std::optional<llvm::BitVector> Live = getLiveSgprsAtContinuation(
+      Ctx, /*InstOffset=*/0, /*InstSize=*/MinInstSize);
+  ASSERT_TRUE(Live);
+  ASSERT_EQ(Live->size(), 107u);
+  EXPECT_TRUE(Live->test(0));
+  EXPECT_FALSE(Live->test(2));
+  ASSERT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+  const CurrentFunctionSgprLiveness &Cached =
+      Ctx.CurrentFunctionSgprLivenessCache.begin()->second;
+  EXPECT_EQ(Cached.LiveBefore.size(), InstructionCount + 2);
+  EXPECT_EQ(Cached.InstructionIndices.size(), InstructionCount + 2);
+
+  std::optional<llvm::BitVector> Second = getLiveSgprsAtContinuation(
+      Ctx, /*InstOffset=*/InstructionCount / 2 * MinInstSize,
+      /*InstSize=*/MinInstSize);
+  ASSERT_TRUE(Second);
+  EXPECT_TRUE(Second->test(0));
+  EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
+}
+
 TEST(AssembleDecode, SingleInstructionRejectsSequence) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -2590,6 +2590,44 @@ TEST(CollectDirectBranchTargets, RejectsUndecodedMaterializationSlot) {
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
+TEST(CollectDirectBranchTargets, UndecodedVectorAluDoesNotCreateIndirectEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // Reduced from a B0 f4gemm code object. The A0 MC decoder does not know this
+  // legacy-VOP3-major 0x34 vector instruction, but its encoding class cannot
+  // affect scalar control flow or MODE.
+  const uint8_t Bytes[] = {0x00, 0x00, 0x31, 0xd0, 0x00, 0x00, 0x10, 0x00};
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes, sizeof(Bytes), S, Decoded));
+  ASSERT_FALSE(Decoded.empty());
+  ASSERT_FALSE(Decoded.front().DecodeSucceeded);
+
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, sizeof(Bytes), /*DeclaredEntries=*/{0},
+      /*FunctionRanges=*/{}, /*ExternalEntries=*/{}, Bytes);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets, UndecodedScalarClassRemainsUnbounded) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  const uint8_t Bytes[] = {0xff, 0xff, 0xff, 0xff};
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes, sizeof(Bytes), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  ASSERT_FALSE(Decoded.front().DecodeSucceeded);
+
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, sizeof(Bytes), /*DeclaredEntries=*/{0},
+      /*FunctionRanges=*/{}, /*ExternalEntries=*/{}, Bytes);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
 TEST(CollectDirectBranchTargets, RejectsUnboundedIndirectEntry) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -4298,6 +4336,225 @@ TEST(SafeSgprScratchBlock, OwnerlessCommitFailureIsAtomic) {
   EXPECT_EQ(Ctx.AllKernelSgprRequirement, 0u);
   EXPECT_TRUE(Ctx.KernelSgprRequirements.empty());
   EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 0u);
+}
+
+TEST(ForwardDeadVgprs, OpaqueBeforeKillRejects) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Opaque = true;
+  Nodes[1].FullDefs.set(Candidate);
+  Nodes[1].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, KillBeforeOpaqueAccepts) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].FullDefs.set(Candidate);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].Opaque = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_TRUE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, ExternalExitBeforeKillRejects) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].HasUnsafeExit = true;
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].FullDefs.set(Candidate);
+  Nodes[1].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, KillBeforeExternalExitAccepts) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].FullDefs.set(Candidate);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].HasUnsafeExit = true;
+  Nodes[1].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_TRUE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, OneUseBeforeKillBranchRejects) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  for (unsigned I = 0; I != 3; ++I)
+    Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Successors.push_back(1);
+  Nodes[0].Successors.push_back(2);
+  Nodes[1].Uses.set(Candidate);
+  Nodes[1].SafeTerminal = true;
+  Nodes[2].FullDefs.set(Candidate);
+  Nodes[2].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, AllBranchesKillAccepts) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  for (unsigned I = 0; I != 3; ++I)
+    Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Successors.push_back(1);
+  Nodes[0].Successors.push_back(2);
+  Nodes[1].FullDefs.set(Candidate);
+  Nodes[1].SafeTerminal = true;
+  Nodes[2].FullDefs.set(Candidate);
+  Nodes[2].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_TRUE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, LoopPathWithoutKillRejects) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].Successors.push_back(0);
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, LoopWithFullKillAccepts) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].FullDefs.set(Candidate);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].Successors.push_back(0);
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_TRUE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, BackedgeUseBeforePatchedSiteRejects) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  for (unsigned I = 0; I != 3; ++I)
+    Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].Uses.set(Candidate);
+  Nodes[1].Successors.push_back(2);
+  Nodes[2].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, BackedgeWithoutUseToPatchedSiteAccepts) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  for (unsigned I = 0; I != 3; ++I)
+    Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].Successors.push_back(2);
+  Nodes[2].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_TRUE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, PartialDefinitionIsUseNotKill) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  // Partial/tied definitions consume the incoming full dword and therefore
+  // belong in Uses, never FullDefs.
+  Nodes[0].Uses.set(Candidate);
+  Nodes[0].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(WmmaScale16, PhysicalVgprRangeMustFitOneBank) {
+  EXPECT_TRUE(physicalVgprRangeFitsOneBank(0, 16, 1024));
+  EXPECT_TRUE(physicalVgprRangeFitsOneBank(248, 8, 1024));
+  EXPECT_TRUE(physicalVgprRangeFitsOneBank(1016, 8, 1024));
+
+  EXPECT_FALSE(physicalVgprRangeFitsOneBank(0, 0, 1024));
+  EXPECT_FALSE(physicalVgprRangeFitsOneBank(249, 8, 1024));
+  EXPECT_FALSE(physicalVgprRangeFitsOneBank(255, 2, 1024));
+  EXPECT_FALSE(physicalVgprRangeFitsOneBank(1017, 8, 1024));
+  EXPECT_FALSE(physicalVgprRangeFitsOneBank(1024, 1, 1024));
+}
+
+TEST(WmmaScale16, UnrecognizedVectorRegisterCannotDisappearFromProof) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  ASSERT_NE(S.MRI, nullptr);
+
+  auto FindRegister = [&](llvm::StringRef Name) {
+    for (unsigned Reg = 1; Reg != S.MRI->getNumRegs(); ++Reg)
+      if (Name == S.MRI->getName(Reg))
+        return llvm::MCRegister(Reg);
+    return llvm::MCRegister();
+  };
+
+  // AGPRs are vector registers but are deliberately not representable as an
+  // encoded v0..v255 range. Such an operand must invalidate the physical-VGPR
+  // proof; it cannot be ignored like a scalar register.
+  llvm::MCRegister Agpr0 = FindRegister("AGPR0");
+  llvm::MCRegister Sgpr0 = FindRegister("SGPR0");
+  ASSERT_TRUE(Agpr0);
+  ASSERT_TRUE(Sgpr0);
+  EXPECT_TRUE(isVectorRegisterOrAlias(Agpr0, *S.MRI));
+  EXPECT_FALSE(isVectorRegisterOrAlias(Sgpr0, *S.MRI));
 }
 
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -938,10 +938,12 @@ TEST(CollectDirectBranchTargets, MarksRegisterTargetCallUnresolved) {
                                  /*TextSize=*/0x1000, /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
-TEST(CollectDirectBranchTargets, IgnoresSetPcWithoutTreatingItAsCall) {
+TEST(CollectDirectBranchTargets,
+     MarksUnboundedSetPcEntryWithoutTreatingItAsUnresolvedCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
@@ -961,6 +963,7 @@ TEST(CollectDirectBranchTargets, IgnoresSetPcWithoutTreatingItAsCall) {
                                  /*TextSize=*/0x1000, /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
@@ -997,6 +1000,32 @@ TEST(CollectDirectBranchTargets,
                                  /*DeclaredEntries=*/{}, FunctionRanges);
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, HandlesManyCallsWithoutCartesianGrouping) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_call_i64 s[30:31], 0", S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Prototype;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Prototype));
+  ASSERT_EQ(Prototype.size(), 1u);
+
+  constexpr size_t Count = 8192;
+  std::vector<InternalDecodedInst> Decoded(Count, Prototype.front());
+  for (size_t I = 0; I != Count; ++I)
+    Decoded[I].Offset = I * MinInstSize;
+  const uint64_t TextSize = Count * MinInstSize;
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, TextSize, DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(MinInstSize));
+  EXPECT_TRUE(Info->Targets.contains(TextSize));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
@@ -1213,7 +1242,8 @@ TEST(CollectDirectBranchTargets, RejectsDeclaredEntryIntoMaterialization) {
   std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries);
   ASSERT_TRUE(Info);
-  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries.front()));
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
@@ -1296,7 +1326,7 @@ TEST(CollectDirectBranchTargets, BoundsCanonicalSetPcReturn) {
   // matching the production CFG, but it preserves the pair as well. The
   // materialized call is therefore the return's sole possible source.
   std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
-      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/Bytes.size(), DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
   ASSERT_EQ(Info->Targets.size(), 3u);
@@ -1332,7 +1362,8 @@ TEST(CollectDirectBranchTargets, RejectsClobberedSetPcReturn) {
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
-  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries.front()));
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
@@ -1463,7 +1494,8 @@ TEST(CollectDirectBranchTargets,
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
-  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries.front()));
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
@@ -1493,7 +1525,8 @@ TEST(CollectDirectBranchTargets, RejectsExternalAliasAtLocalFunctionEntry) {
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges, ExternalEntries);
   ASSERT_TRUE(Info);
-  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries.front()));
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
@@ -1525,8 +1558,166 @@ TEST(CollectDirectBranchTargets,
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
-  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_EQ(Info->Targets.size(), 2u);
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries[0]));
+  EXPECT_TRUE(Info->Targets.contains(DeclaredEntries[1]));
   EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsExactSetPcEntryIntoCallDefinedReturnFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                           "s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], -24\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 9u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[2].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> FunctionRanges{
+      {0, Decoded[2].Offset}, {Decoded[2].Offset, Bytes.size()}};
+
+  // The first call would otherwise prove the helper's link pair. The exact
+  // jump later in the caller reaches the helper without defining s[30:31].
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[1].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsCallReachedExactEntryIntoReturnFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_call_i64 s[4:5], 3\n"
+                           "s_call_i64 s[30:31], -4\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_get_pc_i64 s[6:7]\n"
+                           "s_add_nc_u64 s[6:7], s[6:7], -28\n"
+                           "s_set_pc_i64 s[6:7]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 9u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[2].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> FunctionRanges{
+      {0, Decoded[2].Offset}, {Decoded[2].Offset, Bytes.size()}};
+
+  // The endpgm at 16 blocks layout reachability to the materialization. Only
+  // the finite call at 8 reaches it; that edge must still participate in the
+  // exact-jump alternate-entry proof for the helper at zero.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[1].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     DoesNotPublishBoundedReturnsAfterNonClosedAudit) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                           "s_set_pc_i64 s[8:9]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[2].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> FunctionRanges{
+      {0, Decoded[2].Offset}, {Decoded[2].Offset, Bytes.size()}};
+
+  // The local call initially proves the helper return, but its continuation
+  // reaches an open indirect transfer. A non-closed object-wide audit must
+  // retract every bounded-return fact before publishing the final result.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[1].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsLocalCallContinuationAtReturnFunctionEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_nop 0\n"
+                           "s_call_i64 s[4:5], 3\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_call_i64 s[30:31], -5\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 8u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[6].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {Decoded[2].Offset, Decoded[4].Offset}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[3].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsFiniteExternalCallContinuationAtReturnFunctionEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 0x100\n"
+                           "s_swap_pc_i64 s[4:5], s[0:1]\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_call_i64 s[30:31], -3\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 7u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[5].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {Decoded[3].Offset, Decoded[5].Offset}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[4].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
 }
 
 TEST(CollectDirectBranchTargets, AllowsUnreachablePaddingBeforeReturnFunction) {
@@ -1555,7 +1746,7 @@ TEST(CollectDirectBranchTargets, AllowsUnreachablePaddingBeforeReturnFunction) {
   // fallthrough chain terminates at an unconditional branch. This mirrors the
   // padding before the production HSACO's second helper.
   std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
-      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/Bytes.size(), DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.contains(Decoded[3].Offset));
@@ -1648,77 +1839,736 @@ TEST(CollectDirectBranchTargets, ProtectsExternalPcRelativeCallContinuation) {
 }
 
 TEST(CollectDirectBranchTargets,
-     RejectsExternalPcMaterializedCallContinuationAtTextEnd) {
+     BoundsExactSetPcEdgeThatEnablesDifferentPairSelector) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleInstructions("s_get_pc_i64 s[0:1]\n"
-                           "s_add_nc_u64 s[0:1], s[0:1], 0x100\n"
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_endpgm\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_co_i32 s2, 0xfe8, 4\n"
+                           "s_add_co_u32 s0, s0, s2\n"
+                           "s_add_co_ci_u32 s1, s1, 0\n"
                            "s_swap_pc_i64 s[30:31], s[0:1]",
                            S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 9u);
+  ASSERT_EQ(Decoded[4].Offset, 16u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+
+  // The exact s[4:5] jump reaches a selector built in s[0:1]. Its call target
+  // is the finite external address 0x1000 and its local continuation must be
+  // retained.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries, FunctionRanges,
+      /*ExternalEntries=*/{}, Bytes);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[8].Offset));
+  EXPECT_TRUE(Info->Targets.contains(0));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[4].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[8].Offset + Decoded[8].Size));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RebuildsLeastSetPcFixedPointAfterUpstreamRejection) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_endpgm\n"
+                           "s_get_pc_i64 s[6:7]\n"
+                           "s_add_nc_u64 s[6:7], s[6:7], 0x100\n"
+                           "s_set_pc_i64 s[6:7]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 7u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[1].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+
+  // The alternate entry invalidates A. B was reachable only through A, so a
+  // fresh least-fixed-point rebuild must not retain B as a sticky proof.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries, FunctionRanges,
+      /*ExternalEntries=*/{}, Bytes);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[6].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsGappedExactSetPcSequence) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 0x100\n"
+                           "s_set_pc_i64 s[4:5]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
   ASSERT_EQ(Decoded.size(), 3u);
-  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
-                                          /*TextSize=*/Bytes.size(),
-                                          /*DeclaredEntries=*/{}));
+  Decoded[1].Offset += MinInstSize;
+  Decoded[2].Offset += MinInstSize;
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size() + MinInstSize}};
+
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size() + MinInstSize, DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  // The set-PC itself is unreachable across the decode gap.
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsExactSetPcTargetInInstructionInterior) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_add_co_i32 s6, 0x100, 4\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 5u);
+  ASSERT_EQ(Decoded[3].Size, 2 * MinInstSize);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+
+  // PC=4 plus 12 targets offset 16, the second dword of Decoded[3].
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsOverlappingSetPcDeltaRegister) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_co_i32 s0, 0x100, 4\n"
+                           "s_add_co_u32 s0, s0, s0\n"
+                           "s_add_co_ci_u32 s1, s1, 0\n"
+                           "s_set_pc_i64 s[0:1]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 5u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
 }
 
 TEST(CollectDirectBranchTargets,
-     RejectsExternalAbsoluteCallContinuationAtTextEnd) {
+     RejectsSecondDwordEntryIntoExactSetPcMaterialization) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_swap_pc_i64 s[30:31], 0x210", S);
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_co_i32 s2, 0xfc, 4\n"
+                           "s_add_co_u32 s0, s0, s2\n"
+                           "s_add_co_ci_u32 s1, s1, 0\n"
+                           "s_set_pc_i64 s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 1u);
-  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x220,
-                                          /*TextSize=*/Bytes.size(),
-                                          /*DeclaredEntries=*/{}));
+  ASSERT_EQ(Decoded.size(), 5u);
+  ASSERT_EQ(Decoded[1].Size, 2 * MinInstSize);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[1].Offset +
+                                                        MinInstSize};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets, BoundsExactSetPcTargetOutsideText) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 0x100\n"
+                           "s_set_pc_i64 s[4:5]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(0));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
 TEST(CollectDirectBranchTargets,
-     RejectsExternalPcRelativeCallContinuationAtTextEnd) {
+     BoundsBothSignedSetPcDirectionsAndWrappedExternalTarget) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
-  llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_call_i64 s[30:31], 2", S);
-  ASSERT_FALSE(Bytes.empty());
-
-  std::vector<InternalDecodedInst> Decoded;
-  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 1u);
-  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
-                                          /*TextSize=*/Bytes.size(),
-                                          /*DeclaredEntries=*/{}));
+  for (llvm::StringRef Literal : {"0x24", "0xfc", "0xfffffff8", "0x7fffffff"}) {
+    SCOPED_TRACE(Literal);
+    llvm::SmallString<512> Assembly;
+    Assembly += "s_get_pc_i64 s[4:5]\ns_add_co_i32 s6, ";
+    Assembly += Literal;
+    Assembly += ", 4\n"
+                "s_cmp_ge_i32 s6, 0\n"
+                "s_cbranch_scc1 4\n"
+                "s_abs_i32 s6, s6\n"
+                "s_sub_co_u32 s4, s4, s6\n"
+                "s_sub_co_ci_u32 s5, s5, 0\n"
+                "s_set_pc_i64 s[4:5]\n"
+                "s_add_co_u32 s4, s4, s6\n"
+                "s_add_co_ci_u32 s5, s5, 0\n"
+                "s_set_pc_i64 s[4:5]\n"
+                "s_endpgm";
+    llvm::SmallVector<uint8_t> Bytes = assembleInstructions(Assembly, S);
+    ASSERT_FALSE(Bytes.empty());
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+    ASSERT_EQ(Decoded.size(), 12u);
+    llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+    llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+        {0, Bytes.size()}};
+    std::optional<DirectControlFlowInfo> Info =
+        collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                   DeclaredEntries, FunctionRanges);
+    ASSERT_TRUE(Info);
+    EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[7].Offset));
+    EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[10].Offset));
+    if (Literal == "0x24") {
+      // PC=4 plus (0x24+4) lands just after the complete two-arm sequence.
+      EXPECT_TRUE(Info->Targets.contains(Decoded[11].Offset));
+    }
+    EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+    EXPECT_FALSE(Info->HasUnresolvedTargets);
+  }
 }
 
-TEST(CollectDirectBranchTargets, RejectsInvalidCallContinuationArithmetic) {
+TEST(CollectDirectBranchTargets, RejectsExactSetPcSelfInteriorTarget) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_swap_pc_i64 s[30:31], 0x210", S);
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_co_i32 s6, 4, 4\n"
+                           "s_cmp_ge_i32 s6, 0\n"
+                           "s_cbranch_scc1 4\n"
+                           "s_abs_i32 s6, s6\n"
+                           "s_sub_co_u32 s4, s4, s6\n"
+                           "s_sub_co_ci_u32 s5, s5, 0\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_add_co_u32 s4, s4, s6\n"
+                           "s_add_co_ci_u32 s5, s5, 0\n"
+                           "s_set_pc_i64 s[4:5]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 11u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[7].Offset));
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[10].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     DoesNotSelfAuthorizeDisconnectedExactCycleAndHonorsExternalRoot) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_endpgm\n"
+                           "s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 8\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_get_pc_i64 s[6:7]\n"
+                           "s_add_nc_u64 s[6:7], s[6:7], -16\n"
+                           "s_set_pc_i64 s[6:7]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 7u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+
+  std::optional<DirectControlFlowInfo> DeadInfo =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(DeadInfo);
+  EXPECT_FALSE(DeadInfo->BoundedIndirectTransfers.contains(Decoded[3].Offset));
+  EXPECT_FALSE(DeadInfo->BoundedIndirectTransfers.contains(Decoded[6].Offset));
+  EXPECT_FALSE(DeadInfo->HasUnboundedIndirectEntries);
+
+  llvm::SmallVector<uint64_t, 1> ExternalEntries{Decoded[1].Offset};
+  std::optional<DirectControlFlowInfo> RootedInfo = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries, FunctionRanges,
+      ExternalEntries);
+  ASSERT_TRUE(RootedInfo);
+  EXPECT_TRUE(RootedInfo->BoundedIndirectTransfers.contains(Decoded[3].Offset));
+  EXPECT_TRUE(RootedInfo->BoundedIndirectTransfers.contains(Decoded[6].Offset));
+  EXPECT_TRUE(RootedInfo->Targets.contains(Decoded[1].Offset));
+  EXPECT_TRUE(RootedInfo->Targets.contains(Decoded[4].Offset));
+  EXPECT_FALSE(RootedInfo->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(RootedInfo->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsNonBoundaryExternalEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_endpgm\n"
+                           "s_add_co_i32 s2, 0x100, 4\n"
+                           "s_endpgm",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 1u);
+  ASSERT_EQ(Decoded.size(), 3u);
+  ASSERT_EQ(Decoded[1].Size, 2 * MinInstSize);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<uint64_t, 1> ExternalEntries{Decoded[1].Offset +
+                                                 MinInstSize};
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries,
+      /*FunctionRanges=*/{}, ExternalEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(ExternalEntries.front()));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
 
-  Decoded[0].Offset = 1;
-  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x220,
-                                          /*TextSize=*/0x40,
-                                          /*DeclaredEntries=*/{}));
+TEST(CollectDirectBranchTargets, RejectsNonBoundaryDirectAndCallTargets) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  for (llvm::StringRef Transfer :
+       {"s_branch 1\n", "s_call_i64 s[30:31], 1\n"}) {
+    SCOPED_TRACE(Transfer);
+    llvm::SmallString<128> Assembly(Transfer);
+    Assembly += "s_add_co_i32 s2, 0x100, 4\ns_endpgm";
+    llvm::SmallVector<uint8_t> Bytes = assembleInstructions(Assembly, S);
+    ASSERT_FALSE(Bytes.empty());
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+    ASSERT_EQ(Decoded.size(), 3u);
+    ASSERT_EQ(Decoded[1].Size, 2 * MinInstSize);
+    llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+    std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+        Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+    ASSERT_TRUE(Info);
+    EXPECT_TRUE(Info->Targets.contains(2 * MinInstSize));
+    EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+    EXPECT_FALSE(Info->HasUnresolvedTargets);
+  }
+}
 
-  Decoded[0].Offset = std::numeric_limits<uint64_t>::max() - 1;
-  EXPECT_FALSE(collectDirectBranchTargets(
-      Decoded, S, /*TextAddr=*/0,
-      /*TextSize=*/std::numeric_limits<uint64_t>::max(),
-      /*DeclaredEntries=*/{}));
+TEST(CollectDirectBranchTargets,
+     BoundsSymbolLessReturnAndUnionsAllContinuations) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_call_i64 s[30:31], 1\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 5u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[0].Offset + Decoded[0].Size));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[1].Offset + Decoded[1].Size));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[3].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[4].Offset));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, BoundsTwoIndependentSymbolLessReturnRegions) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 5\n"
+                           "s_endpgm\n"
+                           "s_call_i64 s[28:29], 5\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[28:29]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 10u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[2].Offset};
+
+  // Both regions are independently call-defined and neither may cause the
+  // other's still-provisional return to be treated as an open indirect entry.
+  // They must be inferred together and accepted by the joint closed audit.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[7].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[9].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[6].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[8].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[0].Offset + Decoded[0].Size));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[2].Offset + Decoded[2].Size));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsJointSymbolLessReturnEntryBetweenRegions) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 4\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[28:29]\n"
+                           "s_call_i64 s[28:29], -3\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 7u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[3].Offset};
+
+  // The first region's return continuation is the second region's entry, but
+  // it does not define that region's s[28:29] link pair. Provisional returns
+  // inferred in one pass must not mutually authorize this alternate entry.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[6].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsWrongPairAndClobberedSymbolLessReturns) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  for (llvm::StringRef Body : {"s_nop 0\ns_set_pc_i64 s[28:29]",
+                               "s_mov_b32 s30, 0\ns_set_pc_i64 s[30:31]"}) {
+    SCOPED_TRACE(Body);
+    llvm::SmallString<128> Assembly(
+        "s_call_i64 s[30:31], 2\ns_endpgm\ns_endpgm\n");
+    Assembly += Body;
+    llvm::SmallVector<uint8_t> Bytes = assembleInstructions(Assembly, S);
+    ASSERT_FALSE(Bytes.empty());
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+    ASSERT_EQ(Decoded.size(), 5u);
+    llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+    std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+        Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+    ASSERT_TRUE(Info);
+    EXPECT_FALSE(
+        Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+    EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+    EXPECT_FALSE(Info->HasUnresolvedTargets);
+  }
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsNestedCallAndFallthroughSymbolLessReturns) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> NestedBytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_call_i64 s[4:5], 1\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(NestedBytes.empty());
+  std::vector<InternalDecodedInst> Nested;
+  ASSERT_TRUE(
+      decodeTextSection(NestedBytes.data(), NestedBytes.size(), S, Nested));
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  std::optional<DirectControlFlowInfo> NestedInfo = collectDirectBranchTargets(
+      Nested, S, /*TextAddr=*/0, NestedBytes.size(), DeclaredEntries);
+  ASSERT_TRUE(NestedInfo);
+  EXPECT_FALSE(NestedInfo->BoundedIndirectTransfers.contains(Nested[4].Offset));
+  EXPECT_TRUE(NestedInfo->HasUnboundedIndirectEntries);
+
+  llvm::SmallVector<uint8_t> FallthroughBytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(FallthroughBytes.empty());
+  std::vector<InternalDecodedInst> Fallthrough;
+  ASSERT_TRUE(decodeTextSection(FallthroughBytes.data(),
+                                FallthroughBytes.size(), S, Fallthrough));
+  std::optional<DirectControlFlowInfo> FallthroughInfo =
+      collectDirectBranchTargets(Fallthrough, S, /*TextAddr=*/0,
+                                 FallthroughBytes.size(), DeclaredEntries);
+  ASSERT_TRUE(FallthroughInfo);
+  EXPECT_FALSE(FallthroughInfo->BoundedIndirectTransfers.contains(
+      Fallthrough.back().Offset));
+  EXPECT_TRUE(FallthroughInfo->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsUnknownAndExternalEntriesIntoSymbolLessReturn) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_set_pc_i64 s[8:9]\n"
+                           "s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[1].Offset};
+  std::optional<DirectControlFlowInfo> UnknownInfo = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(UnknownInfo);
+  EXPECT_FALSE(
+      UnknownInfo->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_TRUE(UnknownInfo->HasUnboundedIndirectEntries);
+
+  llvm::SmallVector<uint64_t, 1> ExternalEntries{Decoded[4].Offset};
+  std::optional<DirectControlFlowInfo> ExternalInfo =
+      collectDirectBranchTargets(
+          llvm::ArrayRef<InternalDecodedInst>(Decoded).drop_front(), S,
+          /*TextAddr=*/0, Bytes.size(),
+          /*DeclaredEntries=*/{Decoded[1].Offset},
+          /*FunctionRanges=*/{}, ExternalEntries);
+  ASSERT_TRUE(ExternalInfo);
+  EXPECT_FALSE(
+      ExternalInfo->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_TRUE(ExternalInfo->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsGapAndSecondDwordEntryIntoSymbolLessReturn) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> GapBytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(GapBytes.empty());
+  std::vector<InternalDecodedInst> Gap;
+  ASSERT_TRUE(decodeTextSection(GapBytes.data(), GapBytes.size(), S, Gap));
+  ASSERT_EQ(Gap.size(), 5u);
+  Gap.back().Offset += MinInstSize;
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  std::optional<DirectControlFlowInfo> GapInfo = collectDirectBranchTargets(
+      Gap, S, /*TextAddr=*/0, GapBytes.size() + MinInstSize, DeclaredEntries);
+  ASSERT_TRUE(GapInfo);
+  EXPECT_FALSE(GapInfo->BoundedIndirectTransfers.contains(Gap.back().Offset));
+
+  llvm::SmallVector<uint8_t> MidBytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_add_co_i32 s2, 0x100, 4\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(MidBytes.empty());
+  std::vector<InternalDecodedInst> Mid;
+  ASSERT_TRUE(decodeTextSection(MidBytes.data(), MidBytes.size(), S, Mid));
+  ASSERT_EQ(Mid.size(), 5u);
+  ASSERT_EQ(Mid[3].Size, 2 * MinInstSize);
+  llvm::SmallVector<uint64_t, 2> MidEntries{0, Mid[3].Offset + MinInstSize};
+  std::optional<DirectControlFlowInfo> MidInfo = collectDirectBranchTargets(
+      Mid, S, /*TextAddr=*/0, MidBytes.size(), MidEntries);
+  ASSERT_TRUE(MidInfo);
+  EXPECT_FALSE(MidInfo->BoundedIndirectTransfers.contains(Mid.back().Offset));
+  EXPECT_TRUE(MidInfo->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsDirectAndDeclaredBypassIntoSymbolLessReturn) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 4\n"
+                           "s_endpgm\n"
+                           "s_branch 3\n"
+                           "s_call_i64 s[4:5], 2\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 8u);
+  llvm::SmallVector<uint64_t, 3> DirectRoots{0, Decoded[2].Offset,
+                                             Decoded[3].Offset};
+  std::optional<DirectControlFlowInfo> DirectInfo = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DirectRoots);
+  ASSERT_TRUE(DirectInfo);
+  EXPECT_FALSE(
+      DirectInfo->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_TRUE(DirectInfo->HasUnboundedIndirectEntries);
+
+  llvm::SmallVector<uint8_t> DeclaredBytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(DeclaredBytes.empty());
+  std::vector<InternalDecodedInst> Declared;
+  ASSERT_TRUE(decodeTextSection(DeclaredBytes.data(), DeclaredBytes.size(), S,
+                                Declared));
+  llvm::SmallVector<uint64_t, 2> DeclaredBypass{0, Declared[3].Offset};
+  std::optional<DirectControlFlowInfo> DeclaredInfo =
+      collectDirectBranchTargets(Declared, S, /*TextAddr=*/0,
+                                 DeclaredBytes.size(), DeclaredBypass);
+  ASSERT_TRUE(DeclaredInfo);
+  EXPECT_FALSE(
+      DeclaredInfo->BoundedIndirectTransfers.contains(Declared.back().Offset));
+  EXPECT_TRUE(DeclaredInfo->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsFunctionRangeEntryInsideExactSetPcMaterialization) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 4u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> FunctionRanges{
+      {0, Bytes.size()}, {Decoded[1].Offset, Bytes.size()}};
+
+  // Exercise the internal API defensively without duplicating the second
+  // range start in DeclaredEntries. It is still an alternate root into the
+  // exact materialization and must invalidate that bounded transfer.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsFunctionRangeEntryInsideSymbolLessReturnRegion) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 2\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {Decoded[4].Offset, Bytes.size()}};
+
+  // The function-range start is a second root into the inferred region after
+  // its call entry. It bypasses the call-defined link pair even when callers
+  // of this internal API omit that begin from DeclaredEntries.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[5].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
 }
 
 TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1799,6 +1799,21 @@ TEST(CollectDirectBranchTargets,
   EXPECT_FALSE(ExactCanonicalLeaf->HasUnresolvedTargets);
   EXPECT_FALSE(ExactCanonicalLeaf->HasUnboundedIndirectEntries);
 
+  // A separate finite call enters the add of the exact singleton call above,
+  // bypassing its defining get-PC. The canonical callee frame remains valid,
+  // but the exact closure must reject this alternate materialization entry
+  // rather than using the fallback to publish both calls as bounded.
+  std::string InteriorCaller = "s_call_i64 s[4:5], 2\n"
+                               "s_endpgm\n" +
+                               ExactCaller + LeafFrame;
+  std::optional<DirectControlFlowInfo> InteriorCanonicalLeaf =
+      Audit(InteriorCaller, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/2, /*ExternalEntries=*/{},
+            /*Target1BeginIndex=*/6);
+  ASSERT_TRUE(InteriorCanonicalLeaf);
+  EXPECT_TRUE(InteriorCanonicalLeaf->HasUnresolvedTargets);
+  EXPECT_TRUE(InteriorCanonicalLeaf->HasUnboundedIndirectEntries);
+
   // Canonical compiler tail thunk: save the incoming link, materialize a
   // different STT_FUNC entry, restore the link, and jump without replacing
   // s[30:31]. The target returns directly to the thunk's original caller.

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1826,6 +1826,29 @@ TEST(CollectDirectBranchTargets,
   EXPECT_FALSE(RepeatedCanonicalLeaf->HasUnresolvedTargets);
   EXPECT_FALSE(RepeatedCanonicalLeaf->HasUnboundedIndirectEntries);
 
+  // An independent opaque set-PC cannot be closed by preserving the reusable
+  // call target. The object must remain open even when its repeated calls are
+  // separately finite.
+  std::string OpenRepeatedCaller = "s_get_pc_i64 s[0:1]\n"
+                                   "s_add_nc_u64 s[0:1], s[0:1], 20\n"
+                                   "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                                   "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                                   "s_set_pc_i64 s[2:3]\n"
+                                   "s_endpgm\n";
+  llvm::SmallVector<uint8_t> OpenRepeatedCallerBytes =
+      assembleInstructions(OpenRepeatedCaller, S);
+  std::vector<InternalDecodedInst> OpenRepeatedCallerDecoded;
+  ASSERT_TRUE(decodeTextSection(OpenRepeatedCallerBytes.data(),
+                                OpenRepeatedCallerBytes.size(), S,
+                                OpenRepeatedCallerDecoded));
+  ASSERT_EQ(OpenRepeatedCallerDecoded.size(), 6u);
+  std::optional<DirectControlFlowInfo> OpenRepeatedCanonicalLeaf = Audit(
+      OpenRepeatedCaller + LeafFrame, {}, 0, FunctionTableElfMutation::None,
+      /*CallerEndIndex=*/OpenRepeatedCallerDecoded.size());
+  ASSERT_TRUE(OpenRepeatedCanonicalLeaf);
+  EXPECT_TRUE(OpenRepeatedCanonicalLeaf->HasUnresolvedTargets);
+  EXPECT_TRUE(OpenRepeatedCanonicalLeaf->HasUnboundedIndirectEntries);
+
   // A separate finite call enters the add of the exact singleton call above,
   // bypassing its defining get-PC. The canonical callee frame remains valid,
   // but the exact closure must reject this alternate materialization entry
@@ -2284,8 +2307,7 @@ TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
   // collectDirectBranchTargets normally sees the complete .text decode. Keep
   // the synthetic production slice faithful to that contract by representing
   // the resolved local target as an instruction boundary.
-  llvm::SmallVector<uint8_t> TargetBytes =
-      assembleInstructions("s_endpgm", S);
+  llvm::SmallVector<uint8_t> TargetBytes = assembleInstructions("s_endpgm", S);
   std::vector<InternalDecodedInst> TargetDecoded;
   ASSERT_TRUE(decodeTextSection(TargetBytes.data(), TargetBytes.size(), S,
                                 TargetDecoded));

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -23,7 +23,9 @@
 #include "llvm/Support/TargetSelect.h"
 #include "gtest/gtest.h"
 
+#include <algorithm>
 #include <cstring>
+#include <iterator>
 #include <limits>
 #include <mutex>
 #include <vector>
@@ -69,6 +71,188 @@ static TargetIdentifier makeGfx1250Ident() {
   TI.Environ = "";
   TI.Processor = "gfx1250";
   return TI;
+}
+
+static std::vector<InternalDecodedInst>
+decodeAsmSequence(const LLVMState &S, llvm::ArrayRef<llvm::StringRef> Lines) {
+  llvm::SmallVector<uint8_t, 32> Bytes;
+  for (llvm::StringRef Line : Lines) {
+    llvm::SmallVector<uint8_t> Encoded = assembleSingleInst(Line, S);
+    EXPECT_FALSE(Encoded.empty()) << Line.str();
+    Bytes.append(Encoded);
+  }
+  std::vector<InternalDecodedInst> Decoded;
+  EXPECT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  return Decoded;
+}
+
+static bool scalarIncomingSgprIsUnsafe(
+    llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &S,
+    uint64_t FunctionBegin, uint64_t FunctionEnd, uint64_t Continuation,
+    llvm::ArrayRef<llvm::MCRegister> NumberedSgprs, unsigned Sgpr) {
+  auto FindInstruction = [&](uint64_t Offset) -> std::optional<size_t> {
+    if (Offset < FunctionBegin || Offset >= FunctionEnd)
+      return std::nullopt;
+    auto It = llvm::lower_bound(
+        Decoded, Offset, [](const InternalDecodedInst &DI, uint64_t Target) {
+          return DI.Offset < Target;
+        });
+    if (It == Decoded.end() || It->Offset != Offset)
+      return std::nullopt;
+    return It - Decoded.begin();
+  };
+  std::optional<size_t> Start = FindInstruction(Continuation);
+  if (!Start)
+    return true;
+
+  llvm::SmallVector<size_t, 8> Worklist(1, *Start);
+  llvm::DenseSet<size_t> Visited;
+  while (!Worklist.empty()) {
+    size_t Index = Worklist.pop_back_val();
+    if (!Visited.insert(Index).second)
+      continue;
+    const InternalDecodedInst &DI = Decoded[Index];
+    if (!DI.DecodeSucceeded || !S.MIA || DI.Offset < FunctionBegin ||
+        DI.Offset >= FunctionEnd)
+      return true;
+
+    llvm::BitVector Uses(NumberedSgprs.size());
+    llvm::BitVector Defs(NumberedSgprs.size());
+    getNumberedSgprUsesAndDefs(DI, S, NumberedSgprs, Uses, Defs);
+    if (Uses.test(Sgpr))
+      return true;
+    if (Defs.test(Sgpr) || DI.Inst.getOpcode() == S.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == S.SEndPgmSavedOpcode)
+      continue;
+
+    auto AddSuccessor = [&](uint64_t Offset) {
+      std::optional<size_t> Successor = FindInstruction(Offset);
+      if (!Successor)
+        return false;
+      Worklist.push_back(*Successor);
+      return true;
+    };
+    if (S.MIA->isCall(DI.Inst) || S.MIA->isIndirectBranch(DI.Inst) ||
+        S.MIA->isReturn(DI.Inst))
+      return true;
+    if (S.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, S);
+      if (!Target || !AddSuccessor(*Target))
+        return true;
+      if (S.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (S.MIA->mayAffectControlFlow(DI.Inst, *S.MRI) &&
+               !S.MIA->isBarrier(DI.Inst)) {
+      return true;
+    }
+    std::optional<uint64_t> Fallthrough =
+        llvm::checkedAddUnsigned(DI.Offset, static_cast<uint64_t>(DI.Size));
+    if (!Fallthrough || !AddSuccessor(*Fallthrough))
+      return true;
+  }
+  return false;
+}
+
+static bool
+scalarIncomingRegisterIsNeeded(llvm::ArrayRef<InternalDecodedInst> Decoded,
+                               const LLVMState &S, uint64_t FunctionBegin,
+                               uint64_t FunctionEnd, uint64_t Continuation,
+                               llvm::MCRegister Register) {
+  auto FindInstruction = [&](uint64_t Offset) -> std::optional<size_t> {
+    if (Offset < FunctionBegin || Offset >= FunctionEnd)
+      return std::nullopt;
+    auto It = llvm::lower_bound(
+        Decoded, Offset, [](const InternalDecodedInst &DI, uint64_t Target) {
+          return DI.Offset < Target;
+        });
+    if (It == Decoded.end() || It->Offset != Offset)
+      return std::nullopt;
+    return It - Decoded.begin();
+  };
+  std::optional<size_t> Start = FindInstruction(Continuation);
+  if (!Start)
+    return true;
+
+  llvm::SmallVector<size_t, 8> Worklist(1, *Start);
+  llvm::DenseSet<size_t> Visited;
+  while (!Worklist.empty()) {
+    size_t Index = Worklist.pop_back_val();
+    if (!Visited.insert(Index).second)
+      continue;
+    const InternalDecodedInst &DI = Decoded[Index];
+    if (!DI.DecodeSucceeded || !S.MIA || DI.Offset < FunctionBegin ||
+        DI.Offset >= FunctionEnd)
+      return true;
+    if (instructionReadsRegister(DI, S, Register))
+      return true;
+    if (instructionFullyWritesRegister(DI, S, Register) ||
+        DI.Inst.getOpcode() == S.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == S.SEndPgmSavedOpcode)
+      continue;
+
+    auto AddSuccessor = [&](uint64_t Offset) {
+      std::optional<size_t> Successor = FindInstruction(Offset);
+      if (!Successor)
+        return false;
+      Worklist.push_back(*Successor);
+      return true;
+    };
+    if (S.MIA->isCall(DI.Inst) || S.MIA->isIndirectBranch(DI.Inst) ||
+        S.MIA->isReturn(DI.Inst))
+      return true;
+    if (S.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, S);
+      if (!Target || !AddSuccessor(*Target))
+        return true;
+      if (S.MIA->isUnconditionalBranch(DI.Inst))
+        continue;
+    } else if (S.MIA->mayAffectControlFlow(DI.Inst, *S.MRI) &&
+               !S.MIA->isBarrier(DI.Inst)) {
+      return true;
+    }
+    std::optional<uint64_t> Fallthrough =
+        llvm::checkedAddUnsigned(DI.Offset, static_cast<uint64_t>(DI.Size));
+    if (!Fallthrough || !AddSuccessor(*Fallthrough))
+      return true;
+  }
+  return false;
+}
+
+static void
+expectBatchRegisterNeedsMatchesScalar(const LLVMState &S,
+                                      llvm::ArrayRef<llvm::StringRef> Lines,
+                                      llvm::MCRegister Register) {
+  std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(S, Lines);
+  ASSERT_FALSE(Decoded.empty());
+  uint64_t FunctionEnd = Decoded.back().Offset + Decoded.back().Size;
+  std::optional<llvm::DenseSet<uint64_t>> Batch = computeIncomingRegisterNeeds(
+      Decoded, S, /*FunctionBegin=*/0, FunctionEnd, Register);
+  ASSERT_TRUE(Batch);
+  for (const InternalDecodedInst &DI : Decoded)
+    EXPECT_EQ(Batch->contains(DI.Offset),
+              scalarIncomingRegisterIsNeeded(Decoded, S, /*FunctionBegin=*/0,
+                                             FunctionEnd, DI.Offset, Register))
+        << "continuation 0x" << llvm::utohexstr(DI.Offset);
+}
+
+static void
+expectBatchSgprProofMatchesScalar(const LLVMState &S,
+                                  llvm::ArrayRef<llvm::StringRef> Lines) {
+  std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(S, Lines);
+  ASSERT_FALSE(Decoded.empty());
+  std::optional<llvm::SmallVector<llvm::MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*S.MRI, /*MaxSgprs=*/106);
+  ASSERT_TRUE(NumberedSgprs);
+  uint64_t FunctionEnd = Decoded.back().Offset + Decoded.back().Size;
+  std::optional<llvm::BitVector> Batch = unsafeIncomingNumberedSgprsInRange(
+      Decoded, S, /*FunctionBegin=*/0, FunctionEnd, /*Continuation=*/0,
+      *NumberedSgprs);
+  ASSERT_TRUE(Batch);
+  for (unsigned I = 0; I != NumberedSgprs->size(); ++I)
+    EXPECT_EQ(Batch->test(I), scalarIncomingSgprIsUnsafe(
+                                  Decoded, S, /*FunctionBegin=*/0, FunctionEnd,
+                                  /*Continuation=*/0, *NumberedSgprs, I))
+        << "s" << I;
 }
 
 // Helper: decode the little-endian 32-bit dword at \p Bytes.
@@ -271,6 +455,269 @@ static std::vector<uint8_t> makeDisplacementTestElf(
   }
 
   return Buf;
+}
+
+enum class FunctionTableElfMutation {
+  None,
+  NoRelro,
+  RelocationGap,
+  WrongRelocationKind,
+  RelocatedSentinel,
+  NonFunctionTarget,
+  NonBoundaryTarget,
+  NonZeroSlot,
+  MisalignedTableSymbol,
+  MalformedSymbolTable,
+  FunctionEndInterior,
+  FunctionSizeOutOfText,
+};
+
+struct FunctionTableTestElf {
+  std::vector<uint8_t> Bytes;
+  std::vector<InternalDecodedInst> Decoded;
+  uint64_t CallOffset = 0;
+};
+
+static FunctionTableTestElf makeFunctionTableTestElf(
+    const LLVMState &S, llvm::StringRef Load,
+    FunctionTableElfMutation Mutation = FunctionTableElfMutation::None,
+    uint64_t TableDelta = 0xFFC, llvm::StringRef CustomAsm = {},
+    size_t CallerBeginIndex = 0,
+    size_t CallerEndIndex = std::numeric_limits<size_t>::max(),
+    size_t Target1BeginIndex = std::numeric_limits<size_t>::max()) {
+  using namespace llvm::ELF;
+
+  static constexpr uint64_t ShOff = sizeof(Elf64_Ehdr);
+  static constexpr uint64_t PhOff = 0x200;
+  static constexpr uint64_t TextOff = 0x300;
+  static constexpr uint64_t TextAddr = 0x1000;
+  static constexpr uint64_t TableAddr = 0x2000;
+  static constexpr size_t TableSlots = 3;
+
+  std::string Asm = CustomAsm.empty()
+                        ? "s_get_pc_i64 s[4:5]\n"
+                          "s_add_nc_u64 s[4:5], s[4:5], " +
+                              std::to_string(TableDelta) + "\n" + Load.str() +
+                              "\n"
+                              "s_wait_kmcnt 0\n"
+                              "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                              "s_endpgm\n"
+                              "s_endpgm\n"
+                              "s_endpgm\n"
+                        : CustomAsm.str();
+  llvm::SmallVector<uint8_t> Text = assembleInstructions(Asm, S);
+  EXPECT_FALSE(Text.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  EXPECT_TRUE(decodeTextSection(Text.data(), Text.size(), S, Decoded));
+  EXPECT_GE(Decoded.size(), 3u);
+  bool HasCustomCallerEnd =
+      CallerEndIndex != std::numeric_limits<size_t>::max();
+  if (!HasCustomCallerEnd)
+    CallerEndIndex = Decoded.size() - 2;
+  if (Target1BeginIndex == std::numeric_limits<size_t>::max())
+    Target1BeginIndex = Decoded.size() - 1;
+  EXPECT_LT(CallerBeginIndex, CallerEndIndex);
+  EXPECT_LT(CallerEndIndex, Target1BeginIndex);
+  EXPECT_LT(Target1BeginIndex, Decoded.size());
+
+  const uint64_t CallerBegin = Decoded[CallerBeginIndex].Offset;
+  const uint64_t CallerEnd = Decoded[CallerEndIndex].Offset;
+  const uint64_t Target0 = TextAddr + CallerEnd;
+  const uint64_t Target1 = TextAddr + Decoded[Target1BeginIndex].Offset;
+  uint64_t CallOffset = 0;
+  bool FoundCall = false;
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (!S.MIA->isCall(DI.Inst))
+      continue;
+    CallOffset = DI.Offset;
+    FoundCall = true;
+    break;
+  }
+  EXPECT_TRUE(FoundCall);
+
+  const char StrTab[] = "\0caller\0target0\0target1\0table\0";
+  const char ShStrTab[] =
+      "\0.text\0.data.rel.ro\0.strtab\0.symtab\0.rela.dyn\0.shstrtab\0";
+  const uint64_t DataOff = alignTo8(TextOff + Text.size());
+  const uint64_t DataSize = TableSlots * sizeof(uint64_t);
+  const uint64_t StrTabOff = alignTo8(DataOff + DataSize);
+  const uint64_t SymTabOff = alignTo8(StrTabOff + sizeof(StrTab));
+  static constexpr size_t SymbolCount = 5;
+  const uint64_t RelaOff =
+      alignTo8(SymTabOff + SymbolCount * sizeof(Elf64_Sym));
+  const size_t RelaCount =
+      Mutation == FunctionTableElfMutation::RelocatedSentinel ? 3 : 2;
+  const uint64_t ShStrTabOff =
+      alignTo8(RelaOff + RelaCount * sizeof(Elf64_Rela));
+  const uint64_t BufSize = alignTo8(ShStrTabOff + sizeof(ShStrTab));
+  std::vector<uint8_t> Buf(BufSize, 0);
+  std::memcpy(Buf.data() + TextOff, Text.data(), Text.size());
+  std::memcpy(Buf.data() + StrTabOff, StrTab, sizeof(StrTab));
+  std::memcpy(Buf.data() + ShStrTabOff, ShStrTab, sizeof(ShStrTab));
+  if (Mutation == FunctionTableElfMutation::NonZeroSlot)
+    Buf[DataOff] = 1;
+
+  Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(EM_AMDGPU);
+  Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ET_DYN;
+  Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_phoff = PhOff;
+  Ehdr.e_shoff = ShOff;
+  Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  Ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  Ehdr.e_phnum = 3;
+  Ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  Ehdr.e_shnum = 7;
+  Ehdr.e_shstrndx = 6;
+  std::memcpy(Buf.data(), &Ehdr, sizeof(Ehdr));
+
+  Elf64_Phdr TextPh{};
+  TextPh.p_type = PT_LOAD;
+  TextPh.p_flags = PF_R | PF_X;
+  TextPh.p_offset = TextOff;
+  TextPh.p_vaddr = TextAddr;
+  TextPh.p_paddr = TextAddr;
+  TextPh.p_filesz = Text.size();
+  TextPh.p_memsz = Text.size();
+  TextPh.p_align = 8;
+  std::memcpy(Buf.data() + PhOff, &TextPh, sizeof(TextPh));
+
+  Elf64_Phdr DataPh{};
+  DataPh.p_type = PT_LOAD;
+  DataPh.p_flags = PF_R | PF_W;
+  DataPh.p_offset = DataOff;
+  DataPh.p_vaddr = TableAddr;
+  DataPh.p_paddr = TableAddr;
+  DataPh.p_filesz = DataSize;
+  DataPh.p_memsz = DataSize;
+  DataPh.p_align = 8;
+  std::memcpy(Buf.data() + PhOff + sizeof(Elf64_Phdr), &DataPh, sizeof(DataPh));
+
+  Elf64_Phdr RelroPh = DataPh;
+  RelroPh.p_type =
+      Mutation == FunctionTableElfMutation::NoRelro ? PT_NOTE : PT_GNU_RELRO;
+  RelroPh.p_flags = PF_R;
+  std::memcpy(Buf.data() + PhOff + 2 * sizeof(Elf64_Phdr), &RelroPh,
+              sizeof(RelroPh));
+
+  Elf64_Shdr TextSh{};
+  TextSh.sh_name = 1;
+  TextSh.sh_type = SHT_PROGBITS;
+  TextSh.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  TextSh.sh_offset = TextOff;
+  TextSh.sh_addr = TextAddr;
+  TextSh.sh_size = Text.size();
+  TextSh.sh_addralign = 4;
+  std::memcpy(Buf.data() + ShOff + sizeof(Elf64_Shdr), &TextSh, sizeof(TextSh));
+
+  Elf64_Shdr DataSh{};
+  DataSh.sh_name = 7;
+  DataSh.sh_type = SHT_PROGBITS;
+  DataSh.sh_flags = SHF_ALLOC | SHF_WRITE;
+  DataSh.sh_offset = DataOff;
+  DataSh.sh_addr = TableAddr;
+  DataSh.sh_size = DataSize;
+  DataSh.sh_addralign = 8;
+  std::memcpy(Buf.data() + ShOff + 2 * sizeof(Elf64_Shdr), &DataSh,
+              sizeof(DataSh));
+
+  Elf64_Shdr StrtabSh{};
+  StrtabSh.sh_name = 20;
+  StrtabSh.sh_type = SHT_STRTAB;
+  StrtabSh.sh_offset = StrTabOff;
+  StrtabSh.sh_size = sizeof(StrTab);
+  std::memcpy(Buf.data() + ShOff + 3 * sizeof(Elf64_Shdr), &StrtabSh,
+              sizeof(StrtabSh));
+
+  Elf64_Shdr SymtabSh{};
+  SymtabSh.sh_name = 28;
+  SymtabSh.sh_type = SHT_SYMTAB;
+  SymtabSh.sh_offset = SymTabOff;
+  SymtabSh.sh_size = SymbolCount * sizeof(Elf64_Sym);
+  SymtabSh.sh_link = 3;
+  SymtabSh.sh_info = SymbolCount;
+  SymtabSh.sh_entsize =
+      Mutation == FunctionTableElfMutation::MalformedSymbolTable
+          ? sizeof(Elf64_Sym) - 1
+          : sizeof(Elf64_Sym);
+  std::memcpy(Buf.data() + ShOff + 4 * sizeof(Elf64_Shdr), &SymtabSh,
+              sizeof(SymtabSh));
+
+  Elf64_Shdr RelaSh{};
+  RelaSh.sh_name = 36;
+  RelaSh.sh_type = SHT_RELA;
+  RelaSh.sh_offset = RelaOff;
+  RelaSh.sh_size = RelaCount * sizeof(Elf64_Rela);
+  RelaSh.sh_link = 4;
+  RelaSh.sh_info = 0;
+  RelaSh.sh_addralign = 8;
+  RelaSh.sh_entsize = sizeof(Elf64_Rela);
+  std::memcpy(Buf.data() + ShOff + 5 * sizeof(Elf64_Shdr), &RelaSh,
+              sizeof(RelaSh));
+
+  Elf64_Shdr ShstrSh{};
+  ShstrSh.sh_name = 46;
+  ShstrSh.sh_type = SHT_STRTAB;
+  ShstrSh.sh_offset = ShStrTabOff;
+  ShstrSh.sh_size = sizeof(ShStrTab);
+  std::memcpy(Buf.data() + ShOff + 6 * sizeof(Elf64_Shdr), &ShstrSh,
+              sizeof(ShstrSh));
+
+  auto writeSymbol = [&](size_t Index, uint32_t Name, uint8_t Type,
+                         uint16_t SectionIndex, uint64_t Value, uint64_t Size) {
+    Elf64_Sym Symbol{};
+    Symbol.st_name = Name;
+    Symbol.setBindingAndType(STB_LOCAL, Type);
+    Symbol.st_shndx = SectionIndex;
+    Symbol.st_value = Value;
+    Symbol.st_size = Size;
+    std::memcpy(Buf.data() + SymTabOff + Index * sizeof(Elf64_Sym), &Symbol,
+                sizeof(Symbol));
+  };
+  uint64_t CallerSize = CallerEnd - CallerBegin;
+  if (Mutation == FunctionTableElfMutation::FunctionEndInterior)
+    CallerSize += 2;
+  else if (Mutation == FunctionTableElfMutation::FunctionSizeOutOfText)
+    CallerSize = Text.size() * 2;
+  writeSymbol(1, 1, STT_FUNC, 1, TextAddr + CallerBegin, CallerSize);
+  writeSymbol(2, 8,
+              Mutation == FunctionTableElfMutation::NonFunctionTarget
+                  ? STT_OBJECT
+                  : STT_FUNC,
+              1, Target0, HasCustomCallerEnd ? Target1 - Target0 : MinInstSize);
+  writeSymbol(3, 16, STT_FUNC, 1, Target1, TextAddr + Text.size() - Target1);
+  writeSymbol(4, 24, STT_OBJECT, 2,
+              Mutation == FunctionTableElfMutation::MisalignedTableSymbol
+                  ? TableAddr + 1
+                  : TableAddr,
+              DataSize);
+
+  auto writeRela = [&](size_t Index, uint64_t Offset, uint32_t Type,
+                       uint64_t Addend) {
+    Elf64_Rela Rela{};
+    Rela.r_offset = Offset;
+    Rela.setSymbolAndType(/*Symbol=*/0, Type);
+    Rela.r_addend = static_cast<int64_t>(Addend);
+    std::memcpy(Buf.data() + RelaOff + Index * sizeof(Elf64_Rela), &Rela,
+                sizeof(Rela));
+  };
+  writeRela(0, TableAddr,
+            Mutation == FunctionTableElfMutation::WrongRelocationKind
+                ? R_AMDGPU_ABS64
+                : R_AMDGPU_RELATIVE64,
+            Mutation == FunctionTableElfMutation::NonBoundaryTarget
+                ? Target0 + 2
+                : Target0);
+  writeRela(1,
+            Mutation == FunctionTableElfMutation::RelocationGap
+                ? TableAddr
+                : TableAddr + sizeof(uint64_t),
+            R_AMDGPU_RELATIVE64, Target1);
+  if (Mutation == FunctionTableElfMutation::RelocatedSentinel)
+    writeRela(2, TableAddr + 2 * sizeof(uint64_t), R_AMDGPU_RELATIVE64,
+              Target0);
+
+  return {std::move(Buf), std::move(Decoded), CallOffset};
 }
 
 // -- initLLVM ----------------------------------------------------------------
@@ -1009,6 +1456,42 @@ TEST(EvaluateDirectControlFlowTarget, EvaluatesGfx1250CallOperandFallback) {
             0x200u + Decoded[0].Size + 2 * MinInstSize);
 }
 
+TEST(CanonicalAbiFrame, RequiresExactWritelaneTiedInput) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>(
+             {"v_writelane_b32 v40, s30, 0", "v_writelane_b32 v41, s30, 0"}));
+  ASSERT_EQ(Decoded.size(), 2u);
+  InternalDecodedInst Write = Decoded[0];
+  ASSERT_EQ(Write.Inst.getNumOperands(), 4u);
+  llvm::MCRegister V40 = Write.Inst.getOperand(0).getReg();
+  llvm::MCRegister S30 = Write.Inst.getOperand(1).getReg();
+  EXPECT_TRUE(
+      matchesCanonicalLaneTransfer(Write, "v_writelane_b32", V40, S30, 0));
+
+  Write.Inst.erase(std::prev(Write.Inst.end()));
+  EXPECT_FALSE(
+      matchesCanonicalLaneTransfer(Write, "v_writelane_b32", V40, S30, 0));
+
+  Write = Decoded[0];
+  llvm::MCRegister V41 = Decoded[1].Inst.getOperand(0).getReg();
+  Write.Inst.getOperand(3).setReg(V41);
+  EXPECT_FALSE(
+      matchesCanonicalLaneTransfer(Write, "v_writelane_b32", V40, S30, 0));
+}
+
+TEST(CanonicalAbiFrame, DistinguishesSaveExecFromPcTransfer) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded =
+      decodeAsmSequence(S, llvm::ArrayRef<llvm::StringRef>(
+                               {"s_or_saveexec_b32 s0, s1", "s_branch 0"}));
+  ASSERT_EQ(Decoded.size(), 2u);
+  EXPECT_FALSE(isTruePcTransfer(Decoded[0], S));
+  EXPECT_TRUE(isTruePcTransfer(Decoded[1], S));
+}
+
 TEST(CollectDirectBranchTargets, MarksRegisterTargetCallUnresolved) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -1031,6 +1514,549 @@ TEST(CollectDirectBranchTargets, MarksRegisterTargetCallUnresolved) {
   EXPECT_TRUE(Info->Targets.empty());
   EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
   EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     LeavesDynamicallyIndexedRelocationBackedFunctionTableUnresolved) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  FunctionTableTestElf Obj = makeFunctionTableTestElf(
+      S, "s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv");
+  llvm::Expected<ElfView> View =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+
+  std::vector<ElfView::FunctionTextRange> Ranges = View->functionTextRanges();
+  llvm::SmallVector<uint64_t, 4> Entries;
+  for (const ElfView::FunctionTextRange &Range : Ranges)
+    Entries.push_back(Range.Begin - View->textAddr());
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Obj.Decoded, S, View->textAddr(), View->textSize(), Entries, Ranges,
+      /*ExternalEntries=*/{},
+      llvm::ArrayRef<uint8_t>(View->textData(), View->textSize()), &*View);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Obj.CallOffset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsMalformedRelocationBackedFunctionPointerTables) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  struct Case {
+    llvm::StringLiteral Load;
+    FunctionTableElfMutation Mutation;
+    uint64_t TableDelta;
+  };
+  const Case Cases[] = {
+      // Exact base provenance is mandatory.
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::None, 0xFF4},
+      // Only aligned, zero-immediate, b64 element-index scaling is accepted.
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 nv",
+       FunctionTableElfMutation::None, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:8 scale_offset nv",
+       FunctionTableElfMutation::None, 0xFFC},
+      // The symbol must describe immutable RELRO data with a complete,
+      // zero-filled RELATIVE64 layout and one unrelocated trailing sentinel.
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::NoRelro, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::RelocationGap, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::WrongRelocationKind, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::RelocatedSentinel, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::NonZeroSlot, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::MisalignedTableSymbol, 0xFFC},
+      // Every addend must name both a defined STT_FUNC and a decoded boundary.
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::NonFunctionTarget, 0xFFC},
+      {"s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+       FunctionTableElfMutation::NonBoundaryTarget, 0xFFC},
+  };
+
+  for (const Case &C : Cases) {
+    FunctionTableTestElf Obj =
+        makeFunctionTableTestElf(S, C.Load, C.Mutation, C.TableDelta);
+    llvm::Expected<ElfView> View =
+        ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+    ASSERT_TRUE((bool)View)
+        << C.Load.str() << ": " << llvm::toString(View.takeError());
+    std::vector<ElfView::FunctionTextRange> Ranges = View->functionTextRanges();
+    llvm::SmallVector<uint64_t, 4> Entries;
+    for (const ElfView::FunctionTextRange &Range : Ranges)
+      Entries.push_back(Range.Begin - View->textAddr());
+    std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+        Obj.Decoded, S, View->textAddr(), View->textSize(), Entries, Ranges,
+        /*ExternalEntries=*/{},
+        llvm::ArrayRef<uint8_t>(View->textData(), View->textSize()), &*View);
+    ASSERT_TRUE(Info) << C.Load.str();
+    EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Obj.CallOffset))
+        << C.Load.str();
+    EXPECT_TRUE(Info->HasUnboundedIndirectEntries) << C.Load.str();
+    EXPECT_TRUE(Info->HasUnresolvedTargets) << C.Load.str();
+  }
+}
+
+TEST(ElfView, MarksFunctionRangesIncompleteOnMalformedSymbolTable) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  FunctionTableTestElf Obj = makeFunctionTableTestElf(
+      S, "s_load_b64 s[0:1], s[4:5], s2 offset:0 scale_offset nv",
+      FunctionTableElfMutation::MalformedSymbolTable);
+  llvm::Expected<ElfView> View =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  EXPECT_TRUE(View->functionTextRanges().empty());
+  EXPECT_FALSE(View->functionTextRangesComplete());
+}
+
+TEST(CollectDirectBranchTargets,
+     BoundsSplitVgprCanonicalFrameWithLongEpilogue) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  auto MakeFrame =
+      [](llvm::StringRef BeforeSaves, llvm::StringRef AfterCall,
+         llvm::StringRef AfterRestores = {}, llvm::StringRef SavedLow = "v41",
+         llvm::StringRef SavedHigh = "v42", llvm::StringRef BeforeCall = {}) {
+        std::string Asm = BeforeSaves.str();
+        Asm += "s_or_saveexec_b32 s0, -1\n";
+        Asm += "v_writelane_b32 " + SavedLow.str() + ", s30, 31\n";
+        Asm += "v_writelane_b32 " + SavedHigh.str() + ", s31, 0\n";
+        Asm += BeforeCall.str();
+        Asm += "s_swap_pc_i64 s[30:31], s[2:3]\n";
+        Asm += AfterCall.str();
+        Asm += "v_readlane_b32 s30, " + SavedLow.str() + ", 31\n";
+        Asm += "v_readlane_b32 s31, " + SavedHigh.str() + ", 0\n";
+        for (unsigned I = 0; I != 70; ++I)
+          Asm += "s_nop 0\n";
+        Asm += AfterRestores.str();
+        Asm += "s_set_pc_i64 s[30:31]\n"
+               "s_endpgm\n"
+               "s_endpgm\n";
+        return Asm;
+      };
+
+  auto Audit =
+      [&](llvm::StringRef Asm,
+          llvm::ArrayRef<uint64_t> NonCallEntries = llvm::ArrayRef<uint64_t>{},
+          size_t CallerBeginIndex = 0,
+          FunctionTableElfMutation Mutation = FunctionTableElfMutation::None,
+          size_t CallerEndIndex = std::numeric_limits<size_t>::max(),
+          llvm::ArrayRef<uint64_t> ExternalEntries = llvm::ArrayRef<uint64_t>{},
+          size_t Target1BeginIndex = std::numeric_limits<size_t>::max()) {
+        FunctionTableTestElf Obj = makeFunctionTableTestElf(
+            S, /*Load=*/"", Mutation,
+            /*TableDelta=*/0xFFC, Asm, CallerBeginIndex, CallerEndIndex,
+            Target1BeginIndex);
+        llvm::Expected<ElfView> View =
+            ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+        EXPECT_TRUE((bool)View) << llvm::toString(View.takeError());
+        if (!View)
+          return std::optional<DirectControlFlowInfo>();
+        std::vector<ElfView::FunctionTextRange> Ranges =
+            View->functionTextRanges();
+        llvm::SmallVector<uint64_t, 4> Entries;
+        for (const ElfView::FunctionTextRange &Range : Ranges)
+          Entries.push_back(Range.Begin - View->textAddr());
+        return collectDirectBranchTargets(
+            Obj.Decoded, S, View->textAddr(), View->textSize(), Entries, Ranges,
+            ExternalEntries,
+            llvm::ArrayRef<uint8_t>(View->textData(), View->textSize()), &*View,
+            NonCallEntries);
+      };
+
+  std::optional<DirectControlFlowInfo> Valid = Audit(MakeFrame("", ""));
+  ASSERT_TRUE(Valid);
+  EXPECT_FALSE(Valid->HasUnresolvedTargets);
+  EXPECT_FALSE(Valid->HasUnboundedIndirectEntries);
+
+  // A compiler may place a call in the preceding local function immediately
+  // before a fallthrough entry. The call's s30 continuation is a valid
+  // incoming link only when no entry bypasses it and the gap preserves it.
+  std::string PrefixFrame = "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                            "s_nop 0\n" +
+                            MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> PrefixFallthrough =
+      Audit(PrefixFrame, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/2);
+  ASSERT_TRUE(PrefixFallthrough);
+  EXPECT_FALSE(PrefixFallthrough->HasUnresolvedTargets);
+  EXPECT_FALSE(PrefixFallthrough->HasUnboundedIndirectEntries);
+
+  const uint64_t PrefixGapEntry[] = {4};
+  std::optional<DirectControlFlowInfo> PrefixRootBypass =
+      Audit(PrefixFrame, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/2, PrefixGapEntry);
+  ASSERT_TRUE(PrefixRootBypass);
+  EXPECT_TRUE(PrefixRootBypass->HasUnresolvedTargets);
+  EXPECT_TRUE(PrefixRootBypass->HasUnboundedIndirectEntries);
+
+  std::string PrefixDirectBypass = "s_cbranch_vccnz 1\n"
+                                   "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                                   "s_nop 0\n" +
+                                   MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> PrefixDirect =
+      Audit(PrefixDirectBypass, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/3);
+  ASSERT_TRUE(PrefixDirect);
+  EXPECT_TRUE(PrefixDirect->HasUnresolvedTargets);
+  EXPECT_TRUE(PrefixDirect->HasUnboundedIndirectEntries);
+
+  std::string PrefixExactBypass = "s_cbranch_vccnz 3\n"
+                                  "s_get_pc_i64 s[4:5]\n"
+                                  "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                                  "s_set_pc_i64 s[4:5]\n"
+                                  "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                                  "s_nop 0\n" +
+                                  MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> PrefixExact =
+      Audit(PrefixExactBypass, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/6);
+  ASSERT_TRUE(PrefixExact);
+  EXPECT_TRUE(PrefixExact->HasUnresolvedTargets);
+  EXPECT_TRUE(PrefixExact->HasUnboundedIndirectEntries);
+
+  std::string PrefixForeignCall = "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                                  "s_swap_pc_i64 s[4:5], s[6:7]\n" +
+                                  MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> PrefixForeign =
+      Audit(PrefixForeignCall, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/2);
+  ASSERT_TRUE(PrefixForeign);
+  EXPECT_TRUE(PrefixForeign->HasUnresolvedTargets);
+  EXPECT_TRUE(PrefixForeign->HasUnboundedIndirectEntries);
+
+  std::string PrefixLinkClobber = "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                                  "s_mov_b32 s30, 0\n" +
+                                  MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> PrefixClobber =
+      Audit(PrefixLinkClobber, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/2);
+  ASSERT_TRUE(PrefixClobber);
+  EXPECT_TRUE(PrefixClobber->HasUnresolvedTargets);
+  EXPECT_TRUE(PrefixClobber->HasUnboundedIndirectEntries);
+
+  // A leaf can use the ABI link SGPRs as scratch after saving them even though
+  // it performs no nested call itself. Exercise that production frame as a
+  // second local STT_FUNC in an object whose first function has an opaque call.
+  std::string CallerFrame = MakeFrame("", "");
+  llvm::SmallVector<uint8_t> CallerBytes = assembleInstructions(CallerFrame, S);
+  std::vector<InternalDecodedInst> CallerDecoded;
+  ASSERT_TRUE(decodeTextSection(CallerBytes.data(), CallerBytes.size(), S,
+                                CallerDecoded));
+  std::string LeafFrame = "v_writelane_b32 v43, s30, 4\n"
+                          "v_writelane_b32 v44, s31, 5\n"
+                          "s_mov_b32 s30, 0\n"
+                          "s_mov_b32 s31, 0\n"
+                          "v_readlane_b32 s30, v43, 4\n"
+                          "v_readlane_b32 s31, v44, 5\n"
+                          "s_set_pc_i64 s[30:31]\n"
+                          "s_endpgm\n";
+  std::optional<DirectControlFlowInfo> LeafWithLinkScratch =
+      Audit(CallerFrame + LeafFrame, {}, 0, FunctionTableElfMutation::None,
+            CallerDecoded.size());
+  ASSERT_TRUE(LeafWithLinkScratch);
+  EXPECT_FALSE(LeafWithLinkScratch->HasUnresolvedTargets);
+  EXPECT_FALSE(LeafWithLinkScratch->HasUnboundedIndirectEntries);
+
+  // Canonical compiler tail thunk: save the incoming link, materialize a
+  // different STT_FUNC entry, restore the link, and jump without replacing
+  // s[30:31]. The target returns directly to the thunk's original caller.
+  std::string TailThunk = "v_writelane_b32 v43, s30, 4\n"
+                          "v_writelane_b32 v44, s31, 5\n"
+                          "s_get_pc_i64 s[0:1]\n"
+                          "s_add_nc_u64 s[0:1], s[0:1], 24\n"
+                          "v_readlane_b32 s30, v43, 4\n"
+                          "v_readlane_b32 s31, v44, 5\n"
+                          "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> CanonicalTail = Audit(
+      TailThunk + MakeFrame("", ""), {}, 0, FunctionTableElfMutation::None,
+      /*CallerEndIndex=*/7);
+  ASSERT_TRUE(CanonicalTail);
+  EXPECT_FALSE(CanonicalTail->HasUnresolvedTargets);
+  EXPECT_FALSE(CanonicalTail->HasUnboundedIndirectEntries);
+
+  // A finite exact jump to a defined noreturn function never needs permission
+  // to enter an s30-returning frame. Do not require its source to have a
+  // canonical save/restore frame merely because the destination is STT_FUNC.
+  std::string ExactNoreturnTarget = "s_cbranch_vccnz 3\n"
+                                    "s_get_pc_i64 s[0:1]\n"
+                                    "s_add_nc_u64 s[0:1], s[0:1], 12\n"
+                                    "s_set_pc_i64 s[0:1]\n"
+                                    "s_set_pc_i64 s[30:31]\n"
+                                    "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                                    "s_endpgm\n"
+                                    "s_endpgm\n";
+  std::optional<DirectControlFlowInfo> NoreturnExact =
+      Audit(ExactNoreturnTarget, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/5);
+  ASSERT_TRUE(NoreturnExact);
+  EXPECT_FALSE(NoreturnExact->HasUnresolvedTargets);
+  EXPECT_FALSE(NoreturnExact->HasUnboundedIndirectEntries);
+
+  // Tail-chain certification is intentionally strict: B cannot use A's
+  // not-yet-certified entry while Phase 1 proves B -> returning C.
+  std::optional<DirectControlFlowInfo> TailChain =
+      Audit(TailThunk + TailThunk + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/7, {},
+            /*Target1BeginIndex=*/14);
+  ASSERT_TRUE(TailChain);
+  EXPECT_TRUE(TailChain->HasUnresolvedTargets);
+  EXPECT_TRUE(TailChain->HasUnboundedIndirectEntries);
+
+  // Permissions are keyed by source instruction. One certified entrant must
+  // not authorize a second, noncanonical source that targets the same frame.
+  std::string SafeTailToThird = "v_writelane_b32 v43, s30, 4\n"
+                                "v_writelane_b32 v44, s31, 5\n"
+                                "s_get_pc_i64 s[0:1]\n"
+                                "s_add_nc_u64 s[0:1], s[0:1], 36\n"
+                                "v_readlane_b32 s30, v43, 4\n"
+                                "v_readlane_b32 s31, v44, 5\n"
+                                "s_set_pc_i64 s[0:1]\n";
+  std::string UnsafeTailToThird = "s_get_pc_i64 s[0:1]\n"
+                                  "s_add_nc_u64 s[0:1], s[0:1], 8\n"
+                                  "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> MixedTailSources =
+      Audit(SafeTailToThird + UnsafeTailToThird + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/7, {},
+            /*Target1BeginIndex=*/10);
+  ASSERT_TRUE(MixedTailSources);
+  EXPECT_TRUE(MixedTailSources->HasUnresolvedTargets);
+  EXPECT_TRUE(MixedTailSources->HasUnboundedIndirectEntries);
+
+  std::string ClobberedTail = "v_writelane_b32 v43, s30, 4\n"
+                              "v_writelane_b32 v44, s31, 5\n"
+                              "s_get_pc_i64 s[0:1]\n"
+                              "s_add_nc_u64 s[0:1], s[0:1], 28\n"
+                              "v_readlane_b32 s30, v43, 4\n"
+                              "v_readlane_b32 s31, v44, 5\n"
+                              "s_mov_b32 s30, 0\n"
+                              "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailLinkClobber = Audit(
+      ClobberedTail + MakeFrame("", ""), {}, 0, FunctionTableElfMutation::None,
+      /*CallerEndIndex=*/8);
+  ASSERT_TRUE(TailLinkClobber);
+  EXPECT_TRUE(TailLinkClobber->HasUnresolvedTargets);
+  EXPECT_TRUE(TailLinkClobber->HasUnboundedIndirectEntries);
+
+  std::string NonzeroModeTail = "v_writelane_b32 v43, s30, 4\n"
+                                "v_writelane_b32 v44, s31, 5\n"
+                                "s_get_pc_i64 s[0:1]\n"
+                                "s_add_nc_u64 s[0:1], s[0:1], 28\n"
+                                "v_readlane_b32 s30, v43, 4\n"
+                                "v_readlane_b32 s31, v44, 5\n"
+                                "s_set_vgpr_msb 1\n"
+                                "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailModeClobber =
+      Audit(NonzeroModeTail + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/8);
+  ASSERT_TRUE(TailModeClobber);
+  EXPECT_TRUE(TailModeClobber->HasUnresolvedTargets);
+  EXPECT_TRUE(TailModeClobber->HasUnboundedIndirectEntries);
+
+  std::string MissingTailRestore = "v_writelane_b32 v43, s30, 4\n"
+                                   "v_writelane_b32 v44, s31, 5\n"
+                                   "s_get_pc_i64 s[0:1]\n"
+                                   "s_add_nc_u64 s[0:1], s[0:1], 16\n"
+                                   "v_readlane_b32 s30, v43, 4\n"
+                                   "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailMissingRestore =
+      Audit(MissingTailRestore + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/6);
+  ASSERT_TRUE(TailMissingRestore);
+  EXPECT_TRUE(TailMissingRestore->HasUnresolvedTargets);
+  EXPECT_TRUE(TailMissingRestore->HasUnboundedIndirectEntries);
+
+  std::string NonCsrTail = "v_writelane_b32 v0, s30, 4\n"
+                           "v_writelane_b32 v1, s31, 5\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 24\n"
+                           "v_readlane_b32 s30, v0, 4\n"
+                           "v_readlane_b32 s31, v1, 5\n"
+                           "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailNonCsr = Audit(
+      NonCsrTail + MakeFrame("", ""), {}, 0, FunctionTableElfMutation::None,
+      /*CallerEndIndex=*/7);
+  ASSERT_TRUE(TailNonCsr);
+  EXPECT_TRUE(TailNonCsr->HasUnresolvedTargets);
+  EXPECT_TRUE(TailNonCsr->HasUnboundedIndirectEntries);
+
+  std::string SavedLaneClobberTail = "v_writelane_b32 v43, s30, 4\n"
+                                     "v_writelane_b32 v44, s31, 5\n"
+                                     "s_get_pc_i64 s[0:1]\n"
+                                     "s_add_nc_u64 s[0:1], s[0:1], 32\n"
+                                     "v_writelane_b32 v43, s0, 4\n"
+                                     "v_readlane_b32 s30, v43, 4\n"
+                                     "v_readlane_b32 s31, v44, 5\n"
+                                     "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailSavedLaneClobber =
+      Audit(SavedLaneClobberTail + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/8);
+  ASSERT_TRUE(TailSavedLaneClobber);
+  EXPECT_TRUE(TailSavedLaneClobber->HasUnresolvedTargets);
+  EXPECT_TRUE(TailSavedLaneClobber->HasUnboundedIndirectEntries);
+
+  std::string InteriorTargetTail = "v_writelane_b32 v43, s30, 4\n"
+                                   "v_writelane_b32 v44, s31, 5\n"
+                                   "s_get_pc_i64 s[0:1]\n"
+                                   "s_add_nc_u64 s[0:1], s[0:1], 28\n"
+                                   "v_readlane_b32 s30, v43, 4\n"
+                                   "v_readlane_b32 s31, v44, 5\n"
+                                   "s_set_pc_i64 s[0:1]\n";
+  std::optional<DirectControlFlowInfo> TailInteriorTarget =
+      Audit(InteriorTargetTail + MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/7);
+  ASSERT_TRUE(TailInteriorTarget);
+  EXPECT_TRUE(TailInteriorTarget->HasUnresolvedTargets);
+  EXPECT_TRUE(TailInteriorTarget->HasUnboundedIndirectEntries);
+
+  const uint64_t TailSaveBypassEntry[] = {16};
+  std::optional<DirectControlFlowInfo> TailSaveBypass = Audit(
+      TailThunk + MakeFrame("", ""), {}, 0, FunctionTableElfMutation::None,
+      /*CallerEndIndex=*/7, TailSaveBypassEntry);
+  ASSERT_TRUE(TailSaveBypass);
+  EXPECT_TRUE(TailSaveBypass->HasUnresolvedTargets);
+  EXPECT_TRUE(TailSaveBypass->HasUnboundedIndirectEntries);
+
+  const uint64_t TailNonCallEntry[] = {0};
+  std::optional<DirectControlFlowInfo> TailNonCallRoot =
+      Audit(TailThunk + MakeFrame("", ""), TailNonCallEntry, 0,
+            FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/7);
+  ASSERT_TRUE(TailNonCallRoot);
+  EXPECT_TRUE(TailNonCallRoot->HasUnresolvedTargets);
+  EXPECT_TRUE(TailNonCallRoot->HasUnboundedIndirectEntries);
+
+  // A loop wholly inside the function is not a new entry, including when its
+  // backedge targets the function's first instruction.  The two saves still
+  // dominate the nested call.
+  std::optional<DirectControlFlowInfo> InternalBackedge =
+      Audit(MakeFrame("", "", "", "v41", "v42", "s_cbranch_vccnz -6\n"));
+  ASSERT_TRUE(InternalBackedge);
+  EXPECT_FALSE(InternalBackedge->HasUnresolvedTargets);
+  EXPECT_FALSE(InternalBackedge->HasUnboundedIndirectEntries);
+
+  // Re-entering the prologue after a nested call would overwrite the
+  // originally saved incoming link with the call's continuation.
+  std::optional<DirectControlFlowInfo> PostCallBackedge =
+      Audit(MakeFrame("", "s_branch -8\n"));
+  ASSERT_TRUE(PostCallBackedge);
+  EXPECT_TRUE(PostCallBackedge->HasUnresolvedTargets);
+  EXPECT_TRUE(PostCallBackedge->HasUnboundedIndirectEntries);
+
+  // The must-link fact has to converge around cycles: the lexically early
+  // Begin backedge is unsafe when a second edge revisits it after the call.
+  std::optional<DirectControlFlowInfo> CyclicPostCallBackedge = Audit(
+      MakeFrame("", "s_branch -3\n", "", "v41", "v42", "s_cbranch_vccnz -6\n"));
+  ASSERT_TRUE(CyclicPostCallBackedge);
+  EXPECT_TRUE(CyclicPostCallBackedge->HasUnresolvedTargets);
+  EXPECT_TRUE(CyclicPostCallBackedge->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> BodyLinkScratch =
+      Audit(MakeFrame("", "s_add_u32 s30, s0, s1\n"));
+  ASSERT_TRUE(BodyLinkScratch);
+  EXPECT_FALSE(BodyLinkScratch->HasUnresolvedTargets);
+  EXPECT_FALSE(BodyLinkScratch->HasUnboundedIndirectEntries);
+
+  // A write to the exact protected lane after the call destroys the saved
+  // low link half. A genuine branch before the saves also prevents the
+  // prologue from dominating the frame, unlike the save-exec instruction.
+  std::optional<DirectControlFlowInfo> Clobbered =
+      Audit(MakeFrame("", "v_writelane_b32 v41, s0, 31\n"));
+  ASSERT_TRUE(Clobbered);
+  EXPECT_TRUE(Clobbered->HasUnresolvedTargets);
+  EXPECT_TRUE(Clobbered->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> Branched =
+      Audit(MakeFrame("s_branch 0\n", ""));
+  ASSERT_TRUE(Branched);
+  EXPECT_TRUE(Branched->HasUnresolvedTargets);
+  EXPECT_TRUE(Branched->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> OutsideBranch =
+      Audit(MakeFrame("s_branch 0\n", ""), {}, /*CallerBeginIndex=*/1);
+  ASSERT_TRUE(OutsideBranch);
+  EXPECT_TRUE(OutsideBranch->HasUnresolvedTargets);
+  EXPECT_TRUE(OutsideBranch->HasUnboundedIndirectEntries);
+
+  std::string ExternalExactSetPc = "s_get_pc_i64 s[4:5]\n"
+                                   "s_add_nc_u64 s[4:5], s[4:5], 28\n"
+                                   "s_set_pc_i64 s[4:5]\n" +
+                                   MakeFrame("", "");
+  std::optional<DirectControlFlowInfo> OutsideExactSetPc =
+      Audit(ExternalExactSetPc, {}, /*CallerBeginIndex=*/3);
+  ASSERT_TRUE(OutsideExactSetPc);
+  EXPECT_TRUE(OutsideExactSetPc->HasUnresolvedTargets);
+  EXPECT_TRUE(OutsideExactSetPc->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> InteriorFunctionEnd = Audit(
+      MakeFrame("", ""), {}, 0, FunctionTableElfMutation::FunctionEndInterior);
+  ASSERT_TRUE(InteriorFunctionEnd);
+  EXPECT_TRUE(InteriorFunctionEnd->HasUnresolvedTargets);
+  EXPECT_TRUE(InteriorFunctionEnd->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> OutOfTextFunctionSize =
+      Audit(MakeFrame("", ""), {}, 0,
+            FunctionTableElfMutation::FunctionSizeOutOfText);
+  ASSERT_TRUE(OutOfTextFunctionSize);
+  EXPECT_TRUE(OutOfTextFunctionSize->HasUnresolvedTargets);
+  EXPECT_TRUE(OutOfTextFunctionSize->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> MalformedSymbolTable = Audit(
+      MakeFrame("", ""), {}, 0, FunctionTableElfMutation::MalformedSymbolTable);
+  ASSERT_TRUE(MalformedSymbolTable);
+  EXPECT_TRUE(MalformedSymbolTable->HasUnresolvedTargets);
+  EXPECT_TRUE(MalformedSymbolTable->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> ClobberedBeforeSave =
+      Audit(MakeFrame("s_mov_b32 s30, 0\n", ""));
+  ASSERT_TRUE(ClobberedBeforeSave);
+  EXPECT_TRUE(ClobberedBeforeSave->HasUnresolvedTargets);
+  EXPECT_TRUE(ClobberedBeforeSave->HasUnboundedIndirectEntries);
+
+  const uint64_t NonCallBegin[] = {0};
+  std::optional<DirectControlFlowInfo> NonCallRoot =
+      Audit(MakeFrame("", ""), NonCallBegin);
+  ASSERT_TRUE(NonCallRoot);
+  EXPECT_TRUE(NonCallRoot->HasUnresolvedTargets);
+  EXPECT_TRUE(NonCallRoot->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> CallerMode =
+      Audit(MakeFrame("s_set_vgpr_msb 1\n", ""));
+  ASSERT_TRUE(CallerMode);
+  EXPECT_TRUE(CallerMode->HasUnresolvedTargets);
+  EXPECT_TRUE(CallerMode->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> ReturnMode =
+      Audit(MakeFrame("", "", "s_set_vgpr_msb 1\n"));
+  ASSERT_TRUE(ReturnMode);
+  EXPECT_TRUE(ReturnMode->HasUnresolvedTargets);
+  EXPECT_TRUE(ReturnMode->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> ClobberedAfterRestore =
+      Audit(MakeFrame("", "", "s_mov_b32 s30, 0\n"));
+  ASSERT_TRUE(ClobberedAfterRestore);
+  EXPECT_TRUE(ClobberedAfterRestore->HasUnresolvedTargets);
+  EXPECT_TRUE(ClobberedAfterRestore->HasUnboundedIndirectEntries);
+
+  std::optional<DirectControlFlowInfo> NonCsr =
+      Audit(MakeFrame("", "", "", "v0", "v1"));
+  ASSERT_TRUE(NonCsr);
+  EXPECT_TRUE(NonCsr->HasUnresolvedTargets);
+  EXPECT_TRUE(NonCsr->HasUnboundedIndirectEntries);
 }
 
 TEST(CollectDirectBranchTargets,
@@ -1317,8 +2343,7 @@ TEST(SourceTailSafety, RejectsProtectedEntriesAndOverlappingRanges) {
       {0, 32, nullptr, nullptr}, {0, 32, nullptr, nullptr}};
   // The same logical global function can appear in both .symtab and .dynsym.
   // Equal bounds add no new interior ownership ambiguity.
-  EXPECT_TRUE(
-      sourceHasUniqueFunctionRange(T, AliasedRanges, /*TextAddr=*/0));
+  EXPECT_TRUE(sourceHasUniqueFunctionRange(T, AliasedRanges, /*TextAddr=*/0));
 
   llvm::SmallVector<ElfView::FunctionTextRange, 2> NestedRanges{
       {0, 64, nullptr, nullptr}, {32, 48, nullptr, nullptr}};
@@ -1327,6 +2352,106 @@ TEST(SourceTailSafety, RejectsProtectedEntriesAndOverlappingRanges) {
   EXPECT_TRUE(sourceHasUniqueFunctionRange(T, NestedRanges, /*TextAddr=*/0));
   T.OriginalOffset = 36;
   EXPECT_FALSE(sourceHasUniqueFunctionRange(T, NestedRanges, /*TextAddr=*/0));
+}
+
+TEST(SourceTailSafety, IndexedRangeQueryMatchesOverlapBoundaries) {
+  Trampoline T;
+  T.OriginalOffset = 8;
+  T.OriginalSize = 12;
+  T.HasFunctionRange = true;
+  T.FunctionStart = 0;
+  T.FunctionEnd = 32;
+
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> SameBeginDifferentEnd{
+      {0, 32, nullptr, nullptr}, {0, 24, nullptr, nullptr}};
+  EXPECT_FALSE(
+      sourceHasUniqueFunctionRange(T, SameBeginDifferentEnd, /*TextAddr=*/0));
+  EXPECT_FALSE(sourceHasUniqueFunctionRangeIndexedForTest(
+      T, SameBeginDifferentEnd, /*TextAddr=*/0));
+
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> PartialOverlap{
+      {8, 40, nullptr, nullptr}, {0, 20, nullptr, nullptr}};
+  T.FunctionStart = 8;
+  T.FunctionEnd = 40;
+  T.OriginalOffset = 16;
+  T.OriginalSize = 8;
+  EXPECT_TRUE(sourceHasUniqueFunctionRange(T, PartialOverlap, /*TextAddr=*/0));
+  EXPECT_TRUE(sourceHasUniqueFunctionRangeIndexedForTest(T, PartialOverlap,
+                                                         /*TextAddr=*/0));
+
+  T.OriginalSize = 4;
+  EXPECT_FALSE(sourceHasUniqueFunctionRange(T, PartialOverlap, /*TextAddr=*/0));
+  EXPECT_FALSE(sourceHasUniqueFunctionRangeIndexedForTest(T, PartialOverlap,
+                                                          /*TextAddr=*/0));
+}
+
+TEST(SourceTailSafety, IndexedRangeQueryMatchesRandomizedLinearOracle) {
+  uint64_t State = 0xC0FFEE1234567890ULL;
+  auto Next = [&]() {
+    State = State * 6364136223846793005ULL + 1442695040888963407ULL;
+    return State;
+  };
+
+  constexpr uint64_t TextAddr = 0x100000;
+  for (unsigned Trial = 0; Trial != 500; ++Trial) {
+    llvm::SmallVector<ElfView::FunctionTextRange, 32> Ranges;
+    unsigned Count = 1 + Next() % 16;
+    for (unsigned I = 0; I != Count; ++I) {
+      uint64_t Begin = (Next() % 64) * MinInstSize;
+      uint64_t End = Begin + (1 + Next() % 24) * MinInstSize;
+      Ranges.push_back({TextAddr + Begin, TextAddr + End, nullptr, nullptr});
+      if ((Next() & 3) == 0)
+        Ranges.push_back(Ranges.back());
+    }
+
+    const ElfView::FunctionTextRange &Selected = Ranges[Next() % Ranges.size()];
+    Trampoline T;
+    T.HasFunctionRange = (Next() & 15) != 0;
+    T.FunctionStart = Selected.Begin - TextAddr;
+    T.FunctionEnd = Selected.End - TextAddr;
+    uint64_t Width = T.FunctionEnd - T.FunctionStart;
+    T.OriginalOffset = T.FunctionStart + Next() % Width;
+    T.OriginalSize = 1 + Next() % (T.FunctionEnd - T.OriginalOffset);
+    if (Trial % 17 == 0)
+      ++T.FunctionEnd;
+
+    bool Linear = sourceHasUniqueFunctionRange(T, Ranges, TextAddr);
+    bool Indexed =
+        sourceHasUniqueFunctionRangeIndexedForTest(T, Ranges, TextAddr);
+    EXPECT_EQ(Indexed, Linear) << "trial " << Trial;
+  }
+}
+
+TEST(SourceTailSafety, ReservesRegisterlessReturnTailBeforeAffinePlanning) {
+  Trampoline T;
+  T.OriginalOffset = 0x100;
+  T.Long = true;
+  T.OriginalSize = 2 * MinInstSize;
+  EXPECT_TRUE(mustReserveSourceTailForRegisterlessReturn(T));
+  EXPECT_FALSE(registerlessSourceAffineGatewayRange(T));
+
+  T.OriginalSize = 7 * MinInstSize;
+  std::optional<std::pair<uint64_t, uint64_t>> Gateway =
+      registerlessSourceAffineGatewayRange(T);
+  ASSERT_TRUE(Gateway);
+  EXPECT_EQ(Gateway->first, T.OriginalOffset + 2 * MinInstSize);
+  EXPECT_EQ(Gateway->second, T.OriginalOffset + 7 * MinInstSize);
+  EXPECT_GT(Gateway->first, T.OriginalOffset + MinInstSize);
+
+  T.UsesSetPCBack = true;
+  EXPECT_FALSE(mustReserveSourceTailForRegisterlessReturn(T));
+  T.UsesSetPCBack = false;
+  T.LongBranchPreservesVcc = true;
+  EXPECT_FALSE(mustReserveSourceTailForRegisterlessReturn(T));
+  T.LongBranchPreservesVcc = false;
+  T.UsesSharedDispatcherForward = true;
+  EXPECT_FALSE(mustReserveSourceTailForRegisterlessReturn(T));
+  T.UsesSharedDispatcherForward = false;
+  T.OriginalSize = MinInstSize;
+  EXPECT_FALSE(mustReserveSourceTailForRegisterlessReturn(T));
+  T.OriginalSize = 2 * MinInstSize;
+  T.Long = false;
+  EXPECT_FALSE(mustReserveSourceTailForRegisterlessReturn(T));
 }
 
 TEST(CollectDirectBranchTargets, RejectsAlternateEntryIntoMaterialization) {
@@ -2889,6 +4014,207 @@ TEST(FindNearestSled, HandlesLargeUnsignedOffsets) {
   EXPECT_EQ(Sled, &Sleds[1]);
 }
 
+TEST(BranchIslandAllocator, AcceptsExactPositiveReachBoundary) {
+  std::vector<NopSled> Gateways = {
+      {MaxSledDistance, MaxSledDistance + MinInstSize, MaxSledDistance,
+       /*FunctionStart=*/0, /*FunctionEnd=*/3 * MaxSledDistance}};
+  BranchIslandAllocatorTestResult Result = runBranchIslandAllocatorForTest(
+      std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
+      /*TargetOffset=*/2 * MaxSledDistance, /*Backward=*/false);
+  ASSERT_TRUE(Result.Success);
+  ASSERT_EQ(Result.Islands.size(), 1u);
+  EXPECT_EQ(Result.Islands.front(), MaxSledDistance);
+}
+
+TEST(BranchIslandAllocator, RollsBackPartialChainAndAliases) {
+  constexpr uint64_t Head = 170000;
+  std::vector<NopSled> Gateways = {
+      {Head, Head + MinInstSize, Head, 0, 400000},
+      {Head, Head + 2 * MinInstSize, Head, 0, 400000}};
+  BranchIslandAllocatorTestResult Result = runBranchIslandAllocatorForTest(
+      std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/300000,
+      /*TargetOffset=*/0, /*Backward=*/true);
+  EXPECT_FALSE(Result.Success);
+  ASSERT_EQ(Result.Gateways.size(), 2u);
+  EXPECT_EQ(Result.Gateways[0].WritePos, Head);
+  EXPECT_EQ(Result.Gateways[1].WritePos, Head);
+  EXPECT_TRUE(Result.Occupied.empty());
+}
+
+TEST(BranchIslandAllocator, HoldsPartialChainAcrossMultiplePromotions) {
+  std::vector<NopSled> Gateways = {
+      {670000, 670000 + MinInstSize, 670000, 0, 900000},
+      {540000, 540000 + MinInstSize, 540000, 0, 900000},
+      {410000, 410000 + MinInstSize, 410000, 0, 900000}};
+  const NopSled Promotions[] = {
+      {280000, 280000 + MinInstSize, 280000, 0, 900000},
+      {150000, 150000 + MinInstSize, 150000, 0, 900000}};
+  BranchIslandAllocatorTestResult Result =
+      runBranchIslandAllocatorWithPromotionsForTest(
+          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/800000,
+          /*TargetOffset=*/20000, /*Backward=*/true, Promotions);
+  ASSERT_TRUE(Result.Success);
+  EXPECT_EQ(Result.Islands, (llvm::SmallVector<uint64_t, 4>{
+                                670000, 540000, 410000, 280000, 150000}));
+  EXPECT_EQ(Result.HeldIslandCountsAtPromotion,
+            (llvm::SmallVector<size_t, 4>{3, 4}));
+}
+
+TEST(BranchIslandAllocator, TerminalFailureRollsBackPromotedPartialChain) {
+  std::vector<NopSled> Gateways = {
+      {670000, 670000 + MinInstSize, 670000, 0, 900000},
+      {540000, 540000 + MinInstSize, 540000, 0, 900000},
+      {410000, 410000 + MinInstSize, 410000, 0, 900000}};
+  const NopSled Promotions[] = {
+      {280000, 280000 + MinInstSize, 280000, 0, 900000}};
+  BranchIslandAllocatorTestResult Result =
+      runBranchIslandAllocatorWithPromotionsForTest(
+          std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/800000,
+          /*TargetOffset=*/20000, /*Backward=*/true, Promotions);
+  ASSERT_FALSE(Result.Success);
+  ASSERT_EQ(Result.Gateways.size(), 4u);
+  EXPECT_EQ(Result.Gateways[0].WritePos, 670000u);
+  EXPECT_EQ(Result.Gateways[1].WritePos, 540000u);
+  EXPECT_EQ(Result.Gateways[2].WritePos, 410000u);
+  EXPECT_EQ(Result.Gateways[3].WritePos, 280000u);
+  EXPECT_TRUE(Result.Occupied.empty());
+  EXPECT_EQ(Result.HeldIslandCountsAtPromotion,
+            (llvm::SmallVector<size_t, 4>{3}));
+}
+
+TEST(BranchIslandAllocator, SkipsGatewayFromDifferentFunction) {
+  std::vector<NopSled> Gateways = {
+      {MaxSledDistance, MaxSledDistance + MinInstSize, MaxSledDistance,
+       /*FunctionStart=*/1, /*FunctionEnd=*/300000},
+      {130000, 130000 + MinInstSize, 130000,
+       /*FunctionStart=*/0, /*FunctionEnd=*/300000},
+      {260000, 260000 + MinInstSize, 260000,
+       /*FunctionStart=*/0, /*FunctionEnd=*/300000}};
+  BranchIslandAllocatorTestResult Result = runBranchIslandAllocatorForTest(
+      std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
+      /*TargetOffset=*/262144, /*Backward=*/false);
+  ASSERT_TRUE(Result.Success);
+  ASSERT_EQ(Result.Islands.size(), 2u);
+  EXPECT_EQ(Result.Islands[0], 130000u);
+  EXPECT_EQ(Result.Islands[1], 260000u);
+}
+
+TEST(BranchIslandAllocator, CoAdvancesEqualPhysicalAliases) {
+  std::vector<NopSled> Gateways = {
+      {MaxSledDistance, MaxSledDistance + 2 * MinInstSize, MaxSledDistance, 0,
+       3 * MaxSledDistance},
+      {MaxSledDistance, MaxSledDistance + 3 * MinInstSize, MaxSledDistance, 0,
+       3 * MaxSledDistance}};
+  BranchIslandAllocatorTestResult Result = runBranchIslandAllocatorForTest(
+      std::move(Gateways), /*OwnerOffset=*/0, /*FromOffset=*/0,
+      /*TargetOffset=*/2 * MaxSledDistance, /*Backward=*/false);
+  ASSERT_TRUE(Result.Success);
+  ASSERT_EQ(Result.Gateways.size(), 2u);
+  EXPECT_EQ(Result.Gateways[0].WritePos, MaxSledDistance + MinInstSize);
+  EXPECT_EQ(Result.Gateways[1].WritePos, MaxSledDistance + MinInstSize);
+  EXPECT_TRUE(Result.Occupied.contains(MaxSledDistance));
+}
+
+TEST(BranchIslandAllocator, SplitsPartialAliasAtOccupiedDword) {
+  llvm::DenseSet<uint64_t> Occupied = {108};
+  std::vector<NopSled> Available = subtractOccupiedBranchGatewaySlotsForTest(
+      {{100, 140, 100, 0, 200}}, Occupied);
+  ASSERT_EQ(Available.size(), 2u);
+  EXPECT_EQ(Available[0].Start, 100u);
+  EXPECT_EQ(Available[0].End, 108u);
+  EXPECT_EQ(Available[1].Start, 112u);
+  EXPECT_EQ(Available[1].End, 140u);
+}
+
+TEST(BranchPromotionSearchRange, ClampsForwardCorridorToReachableBand) {
+  constexpr uint64_t Current = 100000;
+  auto Far =
+      branchPromotionSearchRangeForTest(Current, /*CorridorOffset=*/900000,
+                                        /*Forward=*/true);
+  EXPECT_EQ(Far.first, Current);
+  EXPECT_EQ(Far.second, Current + MaxSledDistance);
+
+  auto Near =
+      branchPromotionSearchRangeForTest(Current, /*CorridorOffset=*/120000,
+                                        /*Forward=*/true);
+  EXPECT_EQ(Near, (std::pair<uint64_t, uint64_t>{Current, 120000}));
+
+  auto Saturated = branchPromotionSearchRangeForTest(
+      std::numeric_limits<uint64_t>::max() - 8,
+      std::numeric_limits<uint64_t>::max(), /*Forward=*/true);
+  EXPECT_EQ(Saturated.second, std::numeric_limits<uint64_t>::max());
+}
+
+TEST(BranchPromotionSearchRange, ClampsBackwardCorridorToReachableBand) {
+  constexpr uint64_t Current = 1000000;
+  auto Far = branchPromotionSearchRangeForTest(Current, /*CorridorOffset=*/1000,
+                                               /*Forward=*/false);
+  EXPECT_EQ(Far.first, Current - MaxSledDistance - SetPcForwardSequenceBytes);
+  EXPECT_EQ(Far.second, Current);
+
+  auto Near = branchPromotionSearchRangeForTest(
+      Current, /*CorridorOffset=*/950000, /*Forward=*/false);
+  EXPECT_EQ(Near.first, 950000u - SetPcForwardSequenceBytes - MinInstSize);
+  EXPECT_EQ(Near.second, Current);
+
+  auto Saturated = branchPromotionSearchRangeForTest(
+      /*CurrentOffset=*/8, /*CorridorOffset=*/0, /*Forward=*/false);
+  EXPECT_EQ(Saturated.first, 0u);
+}
+
+TEST(BranchPromotionCandidateCursor, MatchesScalarDirectionalOrderAndBounds) {
+  constexpr size_t Count = 9;
+  constexpr size_t Begin = 2;
+  constexpr size_t End = 7;
+  const size_t Rejected[] = {3, 5, 99};
+  auto IsRejected = [&](size_t Index) {
+    return std::find(std::begin(Rejected), std::end(Rejected), Index) !=
+           std::end(Rejected);
+  };
+
+  llvm::SmallVector<size_t, 8> ScalarForward;
+  for (size_t Index = End; Index-- > Begin;)
+    if (!IsRejected(Index))
+      ScalarForward.push_back(Index);
+  EXPECT_EQ(promotionCandidateOrderForTest(Count, Rejected, Begin, End,
+                                           /*Forward=*/true),
+            ScalarForward);
+
+  llvm::SmallVector<size_t, 8> ScalarBackward;
+  for (size_t Index = Begin; Index != End; ++Index)
+    if (!IsRejected(Index))
+      ScalarBackward.push_back(Index);
+  EXPECT_EQ(promotionCandidateOrderForTest(Count, Rejected, Begin, End,
+                                           /*Forward=*/false),
+            ScalarBackward);
+
+  EXPECT_TRUE(
+      promotionCandidateOrderForTest(Count, Rejected, /*BeginIndex=*/Count,
+                                     /*EndIndex=*/Count + 10, /*Forward=*/true)
+          .empty());
+}
+
+TEST(BranchPromotionCandidateCursor,
+     RepeatedScanSkipsOnlyPermanentlyRejectedStarts) {
+  llvm::SmallVector<size_t, 8> Initial =
+      promotionCandidateOrderForTest(/*CandidateCount=*/6, {},
+                                     /*BeginIndex=*/1, /*EndIndex=*/5,
+                                     /*Forward=*/true);
+  EXPECT_EQ(Initial, (llvm::SmallVector<size_t, 8>{4, 3, 2, 1}));
+
+  const size_t PermanentlyRejected[] = {4, 2};
+  llvm::SmallVector<size_t, 8> Retried = promotionCandidateOrderForTest(
+      /*CandidateCount=*/6, PermanentlyRejected,
+      /*BeginIndex=*/1, /*EndIndex=*/5, /*Forward=*/true);
+  EXPECT_EQ(Retried, (llvm::SmallVector<size_t, 8>{3, 1}));
+
+  // The same persistent bits retain the opposite directional order.
+  llvm::SmallVector<size_t, 8> Backward = promotionCandidateOrderForTest(
+      /*CandidateCount=*/6, PermanentlyRejected,
+      /*BeginIndex=*/1, /*EndIndex=*/5, /*Forward=*/false);
+  EXPECT_EQ(Backward, (llvm::SmallVector<size_t, 8>{1, 3}));
+}
+
 // -- assembleSingleInst / decodeTextSection round-trip ------------------------
 
 TEST(AssembleDecode, SNopRoundTrip) {
@@ -3316,6 +4642,225 @@ TEST(RegisterLiveness, HighCardinalityFunctionUsesOneBoundedBatch) {
   EXPECT_EQ(Ctx.CurrentFunctionSgprLivenessCache.size(), 1u);
 }
 
+TEST(RegisterLiveness, PartialVccDefinitionDoesNotKillFullVcc) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  ASSERT_TRUE(S.VCCRegister.isValid());
+
+  std::vector<InternalDecodedInst> Partial = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b32 vcc_lo, s0"}));
+  ASSERT_EQ(Partial.size(), 1u);
+  ASSERT_TRUE(Partial.front().Inst.getOperand(0).isReg());
+  llvm::MCRegister VccLo(Partial.front().Inst.getOperand(0).getReg());
+  EXPECT_TRUE(instructionFullyWritesRegister(Partial.front(), S, VccLo));
+  EXPECT_FALSE(
+      instructionFullyWritesRegister(Partial.front(), S, S.VCCRegister));
+
+  std::vector<InternalDecodedInst> Full = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b64 vcc, -1"}));
+  ASSERT_EQ(Full.size(), 1u);
+  EXPECT_TRUE(instructionFullyWritesRegister(Full.front(), S, VccLo));
+  EXPECT_TRUE(instructionFullyWritesRegister(Full.front(), S, S.VCCRegister));
+
+  llvm::SmallVector<uint8_t> PartialThenHighUse =
+      assembleInstructions("s_mov_b32 vcc_lo, s0\ns_mov_b32 s1, vcc_hi", S);
+  ASSERT_FALSE(PartialThenHighUse.empty());
+  EXPECT_TRUE(
+      replacementNeedsIncomingRegister(PartialThenHighUse, S, S.VCCRegister));
+
+  llvm::SmallVector<uint8_t> FullThenHighUse =
+      assembleInstructions("s_mov_b64 vcc, -1\ns_mov_b32 s1, vcc_hi", S);
+  ASSERT_FALSE(FullThenHighUse.empty());
+  EXPECT_FALSE(
+      replacementNeedsIncomingRegister(FullThenHighUse, S, S.VCCRegister));
+}
+
+TEST(RegisterLiveness, BatchedVccNeedsRespectControlFlowAndFullDefs) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  ASSERT_TRUE(S.VCCRegister.isValid());
+
+  auto Compute = [&](llvm::ArrayRef<llvm::StringRef> Lines) {
+    std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(S, Lines);
+    EXPECT_FALSE(Decoded.empty());
+    if (Decoded.empty())
+      return std::optional<llvm::DenseSet<uint64_t>>();
+    uint64_t End = Decoded.back().Offset + Decoded.back().Size;
+    return computeIncomingRegisterNeeds(Decoded, S, /*FunctionBegin=*/0, End,
+                                        S.VCCRegister);
+  };
+
+  std::optional<llvm::DenseSet<uint64_t>> Partial =
+      Compute(llvm::ArrayRef<llvm::StringRef>(
+          {"s_mov_b32 vcc_lo, s0", "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+  ASSERT_TRUE(Partial);
+  EXPECT_TRUE(Partial->contains(0));
+
+  std::optional<llvm::DenseSet<uint64_t>> Full =
+      Compute(llvm::ArrayRef<llvm::StringRef>(
+          {"s_mov_b64 vcc, -1", "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+  ASSERT_TRUE(Full);
+  EXPECT_FALSE(Full->contains(0));
+  EXPECT_TRUE(Full->contains(MinInstSize));
+
+  std::optional<llvm::DenseSet<uint64_t>> BranchUnion = Compute(
+      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_mov_b64 vcc, -1",
+                                       "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+  ASSERT_TRUE(BranchUnion);
+  EXPECT_TRUE(BranchUnion->contains(0));
+
+  std::optional<llvm::DenseSet<uint64_t>> Opaque =
+      Compute(llvm::ArrayRef<llvm::StringRef>({"s_set_pc_i64 s[0:1]"}));
+  ASSERT_TRUE(Opaque);
+  EXPECT_TRUE(Opaque->contains(0));
+
+  std::optional<llvm::DenseSet<uint64_t>> PureLoop =
+      Compute(llvm::ArrayRef<llvm::StringRef>({"s_branch -1"}));
+  ASSERT_TRUE(PureLoop);
+  EXPECT_FALSE(PureLoop->contains(0));
+
+  std::optional<llvm::DenseSet<uint64_t>> LoopWithUnsafeExit = Compute(
+      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_branch -2",
+                                       "s_mov_b32 s1, vcc_hi", "s_endpgm"}));
+  ASSERT_TRUE(LoopWithUnsafeExit);
+  EXPECT_TRUE(LoopWithUnsafeExit->contains(0));
+  EXPECT_TRUE(LoopWithUnsafeExit->contains(MinInstSize));
+
+  expectBatchRegisterNeedsMatchesScalar(
+      S,
+      llvm::ArrayRef<llvm::StringRef>(
+          {"s_mov_b32 vcc_lo, s0", "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S.VCCRegister);
+  expectBatchRegisterNeedsMatchesScalar(
+      S,
+      llvm::ArrayRef<llvm::StringRef>(
+          {"s_mov_b64 vcc, -1", "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S.VCCRegister);
+  expectBatchRegisterNeedsMatchesScalar(
+      S,
+      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_mov_b64 vcc, -1",
+                                       "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S.VCCRegister);
+  expectBatchRegisterNeedsMatchesScalar(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_set_pc_i64 s[0:1]"}),
+      S.VCCRegister);
+  expectBatchRegisterNeedsMatchesScalar(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_branch -1"}), S.VCCRegister);
+  expectBatchRegisterNeedsMatchesScalar(
+      S,
+      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_branch -2",
+                                       "s_mov_b32 s1, vcc_hi", "s_endpgm"}),
+      S.VCCRegister);
+}
+
+TEST(RegisterLiveness, BatchProofMatchesScalarAcrossControlFlow) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  const llvm::StringRef BranchJoin[] = {"s_cbranch_scc0 1", "s_mov_b32 s30, 0",
+                                        "s_mov_b32 s0, s30", "s_endpgm"};
+  expectBatchSgprProofMatchesScalar(S, BranchJoin);
+
+  const llvm::StringRef Loop[] = {"s_mov_b32 s30, 0", "s_cbranch_scc0 -2",
+                                  "s_endpgm"};
+  expectBatchSgprProofMatchesScalar(S, Loop);
+
+  const llvm::StringRef DefBeforeOpaque[] = {"s_mov_b32 s30, 0",
+                                             "s_set_pc_i64 s[0:1]"};
+  expectBatchSgprProofMatchesScalar(S, DefBeforeOpaque);
+
+  const llvm::StringRef OpaqueBeforeDef[] = {"s_set_pc_i64 s[0:1]",
+                                             "s_mov_b32 s30, 0"};
+  expectBatchSgprProofMatchesScalar(S, OpaqueBeforeDef);
+}
+
+TEST(RegisterLiveness, NumberedSgprExtractionCoversAliasesAndTiedRmw) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::optional<llvm::SmallVector<llvm::MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*S.MRI, /*MaxSgprs=*/106);
+  ASSERT_TRUE(NumberedSgprs);
+
+  auto GetUseDef = [&](const InternalDecodedInst &DI) {
+    std::pair<llvm::BitVector, llvm::BitVector> Result{
+        llvm::BitVector(NumberedSgprs->size()),
+        llvm::BitVector(NumberedSgprs->size())};
+    getNumberedSgprUsesAndDefs(DI, S, *NumberedSgprs, Result.first,
+                               Result.second);
+    return Result;
+  };
+
+  std::vector<InternalDecodedInst> Tuple = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b64 s[0:1], s[30:31]"}));
+  ASSERT_EQ(Tuple.size(), 1u);
+  auto [TupleUses, TupleDefs] = GetUseDef(Tuple.front());
+  EXPECT_TRUE(TupleUses.test(30));
+  EXPECT_TRUE(TupleUses.test(31));
+  EXPECT_TRUE(TupleDefs.test(0));
+  EXPECT_TRUE(TupleDefs.test(1));
+
+  std::vector<InternalDecodedInst> Rmw = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_add_u32 s30, s30, 1"}));
+  ASSERT_EQ(Rmw.size(), 1u);
+  auto [RmwUses, RmwDefs] = GetUseDef(Rmw.front());
+  EXPECT_TRUE(RmwUses.test(30));
+  EXPECT_TRUE(RmwDefs.test(30));
+
+  llvm::MCRegister Low16;
+  for (unsigned I = 1; I != S.MRI->getNumRegs(); ++I) {
+    llvm::MCRegister Candidate(I);
+    if (llvm::StringRef(S.MRI->getName(Candidate)) == "SGPR30_LO16") {
+      Low16 = Candidate;
+      break;
+    }
+  }
+  ASSERT_TRUE(Low16.isValid());
+
+  std::vector<InternalDecodedInst> Half = decodeAsmSequence(
+      S, llvm::ArrayRef<llvm::StringRef>({"s_mov_b32 s0, s1"}));
+  ASSERT_EQ(Half.size(), 1u);
+  ASSERT_GE(Half.front().Inst.getNumOperands(), 2u);
+  Half.front().Inst.getOperand(1).setReg(Low16);
+  auto [HalfUses, HalfDefs] = GetUseDef(Half.front());
+  EXPECT_TRUE(HalfUses.test(30));
+  EXPECT_FALSE(HalfUses.test(1));
+  EXPECT_TRUE(HalfDefs.test(0));
+
+  Half.front().Inst.getOperand(0).setReg(Low16);
+  auto [HalfDefUses, HalfDefDefs] = GetUseDef(Half.front());
+  EXPECT_TRUE(HalfDefUses.test(30));
+  EXPECT_TRUE(HalfDefDefs.test(30));
+}
+
+TEST(RegisterLiveness, ReplacementTracksOnlyIncomingValues) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::optional<llvm::SmallVector<llvm::MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*S.MRI, /*MaxSgprs=*/106);
+  ASSERT_TRUE(NumberedSgprs);
+
+  llvm::SmallVector<uint8_t> UseBeforeDef =
+      assembleInstructions("s_mov_b32 s0, s30\ns_mov_b32 s30, 0", S);
+  ASSERT_FALSE(UseBeforeDef.empty());
+  llvm::BitVector UseBeforeDefUnsafe =
+      unsafeIncomingNumberedSgprsInReplacement(UseBeforeDef, S, *NumberedSgprs);
+  EXPECT_TRUE(UseBeforeDefUnsafe.test(30));
+
+  llvm::SmallVector<uint8_t> DefBeforeUse =
+      assembleInstructions("s_mov_b32 s30, 0\ns_mov_b32 s0, s30", S);
+  ASSERT_FALSE(DefBeforeUse.empty());
+  llvm::BitVector DefBeforeUseUnsafe =
+      unsafeIncomingNumberedSgprsInReplacement(DefBeforeUse, S, *NumberedSgprs);
+  EXPECT_FALSE(DefBeforeUseUnsafe.test(30));
+
+  llvm::SmallVector<uint8_t> Opaque =
+      assembleSingleInst("s_set_pc_i64 s[0:1]", S);
+  ASSERT_FALSE(Opaque.empty());
+  llvm::BitVector OpaqueUnsafe =
+      unsafeIncomingNumberedSgprsInReplacement(Opaque, S, *NumberedSgprs);
+  EXPECT_TRUE(OpaqueUnsafe.test(30));
+}
+
 TEST(AssembleDecode, SingleInstructionRejectsSequence) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -3634,6 +5179,123 @@ TEST(ExpandDs2Addr, RejectsCyclicExchangeDependency) {
 
   EXPECT_FALSE(expandDs2Addr(Decoded[0].Inst, Decoded[0].Mnemonic,
                              "ds_storexchg_rtn_b64", S));
+}
+
+TEST(RewriteDs2AddrOffsetsInPlace,
+     RewritesEveryNonStrideFamilyAndPreservesNonOffsetBytes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  struct Case {
+    llvm::StringLiteral Source;
+    llvm::StringLiteral Expected;
+    uint8_t Off0;
+    uint8_t Off1;
+  };
+  const Case Cases[] = {
+      {"ds_load_2addr_b32 v[0:1], v2 offset0:62 offset1:63",
+       "ds_load_2addr_b32 v[0:1], v2 offset0:248 offset1:252", 248, 252},
+      {"ds_load_2addr_b64 v[0:3], v4 offset0:30 offset1:31",
+       "ds_load_2addr_b64 v[0:3], v4 offset0:240 offset1:248", 240, 248},
+      {"ds_store_2addr_b32 v2, v0, v1 offset0:62 offset1:63",
+       "ds_store_2addr_b32 v2, v0, v1 offset0:248 offset1:252", 248, 252},
+      {"ds_store_2addr_b64 v19, v[14:15], v[20:21] "
+       "offset0:30 offset1:31",
+       "ds_store_2addr_b64 v19, v[14:15], v[20:21] "
+       "offset0:240 offset1:248",
+       240, 248},
+      {"ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 "
+       "offset0:62 offset1:63",
+       "ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 "
+       "offset0:248 offset1:252",
+       248, 252},
+      {"ds_storexchg_2addr_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
+       "offset0:30 offset1:31",
+       "ds_storexchg_2addr_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
+       "offset0:240 offset1:248",
+       240, 248},
+  };
+
+  for (const Case &C : Cases) {
+    llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(C.Source, S);
+    ASSERT_EQ(Bytes.size(), 2u * MinInstSize) << C.Source.str();
+    llvm::SmallVector<uint8_t> Original = Bytes;
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded))
+        << C.Source.str();
+    ASSERT_EQ(Decoded.size(), 1u) << C.Source.str();
+
+    EXPECT_TRUE(rewriteDs2AddrOffsetsInPlace(Bytes, Decoded[0].Inst,
+                                             Decoded[0].Mnemonic, S))
+        << C.Source.str();
+    EXPECT_EQ(Bytes[0], C.Off0) << C.Source.str();
+    EXPECT_EQ(Bytes[1], C.Off1) << C.Source.str();
+    EXPECT_TRUE(
+        std::equal(Bytes.begin() + 2, Bytes.end(), Original.begin() + 2))
+        << C.Source.str();
+
+    llvm::SmallVector<uint8_t> Expected = assembleSingleInst(C.Expected, S);
+    EXPECT_EQ(Bytes, Expected) << C.Source.str();
+  }
+}
+
+TEST(RewriteDs2AddrOffsetsInPlace,
+     RejectsUnrepresentableOffsetInEveryFamilyWithoutMutation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  for (llvm::StringRef Asm :
+       {"ds_load_2addr_b32 v[0:1], v2 offset0:63 offset1:64",
+        "ds_load_2addr_b64 v[0:3], v4 offset0:31 offset1:32",
+        "ds_store_2addr_b32 v2, v0, v1 offset0:63 offset1:64",
+        "ds_store_2addr_b64 v19, v[14:15], v[20:21] "
+        "offset0:31 offset1:32",
+        "ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 "
+        "offset0:63 offset1:64",
+        "ds_storexchg_2addr_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
+        "offset0:31 offset1:32"}) {
+    llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
+    ASSERT_EQ(Bytes.size(), 2u * MinInstSize) << Asm.str();
+    llvm::SmallVector<uint8_t> Original = Bytes;
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded))
+        << Asm.str();
+    ASSERT_EQ(Decoded.size(), 1u) << Asm.str();
+
+    EXPECT_FALSE(rewriteDs2AddrOffsetsInPlace(Bytes, Decoded[0].Inst,
+                                              Decoded[0].Mnemonic, S))
+        << Asm.str();
+    EXPECT_EQ(Bytes, Original) << Asm.str();
+  }
+}
+
+TEST(RewriteDs2AddrOffsetsInPlace, LeavesStride64FamiliesOnSplitPath) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  for (llvm::StringRef Asm :
+       {"ds_load_2addr_stride64_b32 v[0:1], v4 offset0:0 offset1:0",
+        "ds_load_2addr_stride64_b64 v[0:3], v4 offset0:0 offset1:0",
+        "ds_store_2addr_stride64_b32 v4, v0, v1 offset0:0 offset1:0",
+        "ds_store_2addr_stride64_b64 v4, v[0:1], v[2:3] "
+        "offset0:0 offset1:0",
+        "ds_storexchg_2addr_stride64_rtn_b32 v[0:1], v2, v3, v4 "
+        "offset0:0 offset1:0",
+        "ds_storexchg_2addr_stride64_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
+        "offset0:0 offset1:0"}) {
+    llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
+    ASSERT_EQ(Bytes.size(), 2u * MinInstSize) << Asm.str();
+    llvm::SmallVector<uint8_t> Original = Bytes;
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded))
+        << Asm.str();
+    ASSERT_EQ(Decoded.size(), 1u) << Asm.str();
+
+    EXPECT_FALSE(rewriteDs2AddrOffsetsInPlace(Bytes, Decoded[0].Inst,
+                                              Decoded[0].Mnemonic, S))
+        << Asm.str();
+    EXPECT_EQ(Bytes, Original) << Asm.str();
+  }
 }
 
 // -- buildKernelEntryTrampoline -----------------------------------------------

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1000,6 +1000,49 @@ TEST(CollectDirectBranchTargets,
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
+TEST(CollectDirectBranchTargets,
+     IndexesManyBoundedReturnsAndKnownCallsWithoutCartesianScan) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Prototype;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Prototype));
+  ASSERT_EQ(Prototype.size(), 2u);
+
+  constexpr size_t Count = 16384;
+  std::vector<InternalDecodedInst> Decoded;
+  Decoded.reserve(Count * 2);
+  llvm::SmallVector<uint64_t, 16> DeclaredEntries;
+  DeclaredEntries.reserve(Count);
+  llvm::SmallVector<ElfView::FunctionTextRange, 16> FunctionRanges;
+  FunctionRanges.reserve(Count);
+  for (size_t I = 0; I != Count; ++I) {
+    uint64_t CallOffset = I * 2 * MinInstSize;
+    uint64_t FunctionBegin = CallOffset + MinInstSize;
+    Decoded.push_back(Prototype[0]);
+    Decoded.back().Offset = CallOffset;
+    Decoded.push_back(Prototype[1]);
+    Decoded.back().Offset = FunctionBegin;
+    DeclaredEntries.push_back(FunctionBegin);
+    FunctionRanges.push_back({FunctionBegin, FunctionBegin + MinInstSize});
+  }
+
+  // Each call targets the following one-instruction return function. This
+  // simultaneously pins target/continuation range queries and direct-call
+  // source membership: scanning all calls for every return is quadratic.
+  uint64_t TextSize = Count * 2 * MinInstSize;
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, TextSize, DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_EQ(Info->Targets.size(), Count);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
 TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -1454,7 +1497,8 @@ TEST(CollectDirectBranchTargets, RejectsExternalAliasAtLocalFunctionEntry) {
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
-TEST(CollectDirectBranchTargets, RejectsFallthroughIntoReturnFunction) {
+TEST(CollectDirectBranchTargets,
+     RejectsUnsortedDeclaredFallthroughIntoReturnFunction) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
@@ -1470,12 +1514,13 @@ TEST(CollectDirectBranchTargets, RejectsFallthroughIntoReturnFunction) {
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
   ASSERT_EQ(Decoded.size(), 6u);
-  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[1].Offset};
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{Decoded[1].Offset, 0};
   llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
       {Decoded[1].Offset, Decoded[3].Offset}};
 
-  // The declared entry at zero reaches the local helper by fallthrough and
-  // does not define s[30:31], so the helper's return cannot be bounded.
+  // The deliberately unsorted declared entry at zero reaches the local helper
+  // by fallthrough and does not define s[30:31], so the helper's return cannot
+  // be bounded.
   std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges);

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -4727,6 +4727,40 @@ TEST(BranchIslandAllocator, CoAdvancesEqualPhysicalAliases) {
   EXPECT_TRUE(Result.Occupied.contains(MaxSledDistance));
 }
 
+TEST(BranchIslandAllocator, CarvesForwardInteriorAtReachBoundary) {
+  constexpr uint64_t From = 200000;
+  constexpr uint64_t Target = 500000;
+  std::vector<NopSled> Gateways = {
+      // The head precedes From, but the range crosses the positive reach
+      // boundary and contains a usable branch dword near its high end.
+      {100000, 330000, 100000, 0, 600000},
+      {450000, 450000 + MinInstSize, 450000, 0, 600000}};
+  BranchIslandAllocatorTestResult Result = runBranchIslandAllocatorForTest(
+      std::move(Gateways), /*OwnerOffset=*/From, /*FromOffset=*/From,
+      /*TargetOffset=*/Target, /*Backward=*/false);
+  ASSERT_TRUE(Result.Success);
+  ASSERT_EQ(Result.Islands.size(), 2u);
+  EXPECT_GT(Result.Islands[0], From);
+  EXPECT_LT(Result.Islands[0], 330000u);
+  EXPECT_EQ(Result.Islands[1], 450000u);
+}
+
+TEST(BranchIslandAllocator, CarvesBackwardInteriorAtReachBoundary) {
+  constexpr uint64_t From = 300000;
+  constexpr uint64_t Target = 0;
+  std::vector<NopSled> Gateways = {
+      {100000, 200000, 100000, 0, 400000},
+      {50000, 50000 + MinInstSize, 50000, 0, 400000}};
+  BranchIslandAllocatorTestResult Result = runBranchIslandAllocatorForTest(
+      std::move(Gateways), /*OwnerOffset=*/From, /*FromOffset=*/From,
+      /*TargetOffset=*/Target, /*Backward=*/true);
+  ASSERT_TRUE(Result.Success);
+  ASSERT_EQ(Result.Islands.size(), 2u);
+  EXPECT_GT(Result.Islands[0], 100000u);
+  EXPECT_LT(Result.Islands[0], From);
+  EXPECT_EQ(Result.Islands[1], 50000u);
+}
+
 TEST(BranchIslandAllocator, SplitsPartialAliasAtOccupiedDword) {
   llvm::DenseSet<uint64_t> Occupied = {108};
   std::vector<NopSled> Available = subtractOccupiedBranchGatewaySlotsForTest(
@@ -5889,123 +5923,6 @@ TEST(ExpandDs2Addr, RejectsCyclicExchangeDependency) {
 
   EXPECT_FALSE(expandDs2Addr(Decoded[0].Inst, Decoded[0].Mnemonic,
                              "ds_storexchg_rtn_b64", S));
-}
-
-TEST(RewriteDs2AddrOffsetsInPlace,
-     RewritesEveryNonStrideFamilyAndPreservesNonOffsetBytes) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-
-  struct Case {
-    llvm::StringLiteral Source;
-    llvm::StringLiteral Expected;
-    uint8_t Off0;
-    uint8_t Off1;
-  };
-  const Case Cases[] = {
-      {"ds_load_2addr_b32 v[0:1], v2 offset0:62 offset1:63",
-       "ds_load_2addr_b32 v[0:1], v2 offset0:248 offset1:252", 248, 252},
-      {"ds_load_2addr_b64 v[0:3], v4 offset0:30 offset1:31",
-       "ds_load_2addr_b64 v[0:3], v4 offset0:240 offset1:248", 240, 248},
-      {"ds_store_2addr_b32 v2, v0, v1 offset0:62 offset1:63",
-       "ds_store_2addr_b32 v2, v0, v1 offset0:248 offset1:252", 248, 252},
-      {"ds_store_2addr_b64 v19, v[14:15], v[20:21] "
-       "offset0:30 offset1:31",
-       "ds_store_2addr_b64 v19, v[14:15], v[20:21] "
-       "offset0:240 offset1:248",
-       240, 248},
-      {"ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 "
-       "offset0:62 offset1:63",
-       "ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 "
-       "offset0:248 offset1:252",
-       248, 252},
-      {"ds_storexchg_2addr_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
-       "offset0:30 offset1:31",
-       "ds_storexchg_2addr_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
-       "offset0:240 offset1:248",
-       240, 248},
-  };
-
-  for (const Case &C : Cases) {
-    llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(C.Source, S);
-    ASSERT_EQ(Bytes.size(), 2u * MinInstSize) << C.Source.str();
-    llvm::SmallVector<uint8_t> Original = Bytes;
-    std::vector<InternalDecodedInst> Decoded;
-    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded))
-        << C.Source.str();
-    ASSERT_EQ(Decoded.size(), 1u) << C.Source.str();
-
-    EXPECT_TRUE(rewriteDs2AddrOffsetsInPlace(Bytes, Decoded[0].Inst,
-                                             Decoded[0].Mnemonic, S))
-        << C.Source.str();
-    EXPECT_EQ(Bytes[0], C.Off0) << C.Source.str();
-    EXPECT_EQ(Bytes[1], C.Off1) << C.Source.str();
-    EXPECT_TRUE(
-        std::equal(Bytes.begin() + 2, Bytes.end(), Original.begin() + 2))
-        << C.Source.str();
-
-    llvm::SmallVector<uint8_t> Expected = assembleSingleInst(C.Expected, S);
-    EXPECT_EQ(Bytes, Expected) << C.Source.str();
-  }
-}
-
-TEST(RewriteDs2AddrOffsetsInPlace,
-     RejectsUnrepresentableOffsetInEveryFamilyWithoutMutation) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-
-  for (llvm::StringRef Asm :
-       {"ds_load_2addr_b32 v[0:1], v2 offset0:63 offset1:64",
-        "ds_load_2addr_b64 v[0:3], v4 offset0:31 offset1:32",
-        "ds_store_2addr_b32 v2, v0, v1 offset0:63 offset1:64",
-        "ds_store_2addr_b64 v19, v[14:15], v[20:21] "
-        "offset0:31 offset1:32",
-        "ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 "
-        "offset0:63 offset1:64",
-        "ds_storexchg_2addr_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
-        "offset0:31 offset1:32"}) {
-    llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
-    ASSERT_EQ(Bytes.size(), 2u * MinInstSize) << Asm.str();
-    llvm::SmallVector<uint8_t> Original = Bytes;
-    std::vector<InternalDecodedInst> Decoded;
-    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded))
-        << Asm.str();
-    ASSERT_EQ(Decoded.size(), 1u) << Asm.str();
-
-    EXPECT_FALSE(rewriteDs2AddrOffsetsInPlace(Bytes, Decoded[0].Inst,
-                                              Decoded[0].Mnemonic, S))
-        << Asm.str();
-    EXPECT_EQ(Bytes, Original) << Asm.str();
-  }
-}
-
-TEST(RewriteDs2AddrOffsetsInPlace, LeavesStride64FamiliesOnSplitPath) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-
-  for (llvm::StringRef Asm :
-       {"ds_load_2addr_stride64_b32 v[0:1], v4 offset0:0 offset1:0",
-        "ds_load_2addr_stride64_b64 v[0:3], v4 offset0:0 offset1:0",
-        "ds_store_2addr_stride64_b32 v4, v0, v1 offset0:0 offset1:0",
-        "ds_store_2addr_stride64_b64 v4, v[0:1], v[2:3] "
-        "offset0:0 offset1:0",
-        "ds_storexchg_2addr_stride64_rtn_b32 v[0:1], v2, v3, v4 "
-        "offset0:0 offset1:0",
-        "ds_storexchg_2addr_stride64_rtn_b64 v[0:3], v4, v[6:7], v[8:9] "
-        "offset0:0 offset1:0"}) {
-    llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
-    ASSERT_EQ(Bytes.size(), 2u * MinInstSize) << Asm.str();
-    llvm::SmallVector<uint8_t> Original = Bytes;
-    std::vector<InternalDecodedInst> Decoded;
-    ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded))
-        << Asm.str();
-    ASSERT_EQ(Decoded.size(), 1u) << Asm.str();
-
-    EXPECT_FALSE(rewriteDs2AddrOffsetsInPlace(Bytes, Decoded[0].Inst,
-                                              Decoded[0].Mnemonic, S))
-        << Asm.str();
-    EXPECT_EQ(Bytes, Original) << Asm.str();
-  }
 }
 
 // -- buildKernelEntryTrampoline -----------------------------------------------

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -964,6 +964,42 @@ TEST(CollectDirectBranchTargets, IgnoresSetPcWithoutTreatingItAsCall) {
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
+TEST(CollectDirectBranchTargets,
+     HandlesSparseSetPcAndFunctionRangesWithoutCartesianScan) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_set_pc_i64 s[8:9]", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Prototype;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Prototype));
+  ASSERT_EQ(Prototype.size(), 1u);
+
+  constexpr size_t Count = 16384;
+  constexpr uint64_t TextSize = 1 << 20;
+  std::vector<InternalDecodedInst> Decoded;
+  Decoded.reserve(Count);
+  llvm::SmallVector<ElfView::FunctionTextRange, 16> FunctionRanges;
+  FunctionRanges.reserve(Count);
+  for (size_t I = 0; I != Count; ++I) {
+    Decoded.push_back(Prototype[0]);
+    Decoded.back().Offset = I * MinInstSize;
+    // These validly ordered ranges do not cover any instruction. This pins
+    // the sparse return-to-range index: a full range scan for every set-PC
+    // would perform Count squared containment checks.
+    uint64_t Begin = TextSize + I * MinInstSize;
+    FunctionRanges.push_back({Begin, Begin + MinInstSize});
+  }
+
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, TextSize,
+                                 /*DeclaredEntries=*/{}, FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
 TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1784,6 +1784,26 @@ TEST(CollectDirectBranchTargets,
   EXPECT_FALSE(LeafWithLinkScratch->HasUnresolvedTargets);
   EXPECT_FALSE(LeafWithLinkScratch->HasUnboundedIndirectEntries);
 
+  // A leaf has no nested transfer that can clobber caller-saved VGPRs, so it
+  // may temporarily preserve s30 in ordinary VGPR lanes. Production device
+  // functions use this shape when those VGPRs are separately spilled around
+  // the frame; the local write/lane CFG proof remains responsible for
+  // rejecting any clobber before the readlane epilogue.
+  std::string LeafNonCsrFrame = "v_writelane_b32 v17, s30, 0\n"
+                                "v_writelane_b32 v17, s31, 1\n"
+                                "s_mov_b32 s30, 0\n"
+                                "s_mov_b32 s31, 0\n"
+                                "v_readlane_b32 s30, v17, 0\n"
+                                "v_readlane_b32 s31, v17, 1\n"
+                                "s_set_pc_i64 s[30:31]\n"
+                                "s_endpgm\n";
+  std::optional<DirectControlFlowInfo> LeafWithNonCsrLinkSave =
+      Audit(CallerFrame + LeafNonCsrFrame, {}, 0,
+            FunctionTableElfMutation::None, CallerDecoded.size());
+  ASSERT_TRUE(LeafWithNonCsrLinkSave);
+  EXPECT_FALSE(LeafWithNonCsrLinkSave->HasUnresolvedTargets);
+  EXPECT_FALSE(LeafWithNonCsrLinkSave->HasUnboundedIndirectEntries);
+
   // The same canonical leaf can be reached only by an exact materialized
   // singleton call. This is a machine-level closure, not the opaque-call ABI
   // fallback: the call target, canonical return, and continuation must be

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -244,15 +244,33 @@ expectBatchSgprProofMatchesScalar(const LLVMState &S,
       resolveNumberedSgprRegisters(*S.MRI, /*MaxSgprs=*/106);
   ASSERT_TRUE(NumberedSgprs);
   uint64_t FunctionEnd = Decoded.back().Offset + Decoded.back().Size;
-  std::optional<llvm::BitVector> Batch = unsafeIncomingNumberedSgprsInRange(
-      Decoded, S, /*FunctionBegin=*/0, FunctionEnd, /*Continuation=*/0,
-      *NumberedSgprs);
-  ASSERT_TRUE(Batch);
-  for (unsigned I = 0; I != NumberedSgprs->size(); ++I)
-    EXPECT_EQ(Batch->test(I), scalarIncomingSgprIsUnsafe(
-                                  Decoded, S, /*FunctionBegin=*/0, FunctionEnd,
-                                  /*Continuation=*/0, *NumberedSgprs, I))
-        << "s" << I;
+  llvm::SmallVector<uint64_t, 16> Continuations;
+  for (const InternalDecodedInst &DI : Decoded)
+    Continuations.push_back(DI.Offset);
+  Continuations.push_back(1);
+  BatchedSgprContinuationTestResult Batch =
+      runBatchedSgprContinuationAnalysisForTest(Decoded, S, /*FunctionBegin=*/0,
+                                                FunctionEnd, Continuations,
+                                                *NumberedSgprs);
+  EXPECT_EQ(Batch.Analyses, 1u);
+  ASSERT_EQ(Batch.Queries.size(), Continuations.size());
+  for (size_t Query = 0; Query != Decoded.size(); ++Query) {
+    std::optional<llvm::BitVector> Scalar = unsafeIncomingNumberedSgprsInRange(
+        Decoded, S, /*FunctionBegin=*/0, FunctionEnd, Continuations[Query],
+        *NumberedSgprs);
+    ASSERT_TRUE(Scalar);
+    ASSERT_TRUE(Batch.Queries[Query]);
+    EXPECT_EQ(*Batch.Queries[Query], *Scalar)
+        << "continuation 0x" << llvm::utohexstr(Continuations[Query]);
+    for (unsigned I = 0; I != NumberedSgprs->size(); ++I)
+      EXPECT_EQ(Batch.Queries[Query]->test(I),
+                scalarIncomingSgprIsUnsafe(Decoded, S, /*FunctionBegin=*/0,
+                                           FunctionEnd, Continuations[Query],
+                                           *NumberedSgprs, I))
+          << "continuation 0x" << llvm::utohexstr(Continuations[Query]) << ", s"
+          << I;
+  }
+  EXPECT_FALSE(Batch.Queries.back());
 }
 
 // Helper: decode the little-endian 32-bit dword at \p Bytes.
@@ -4772,6 +4790,104 @@ TEST(RegisterLiveness, BatchProofMatchesScalarAcrossControlFlow) {
   const llvm::StringRef OpaqueBeforeDef[] = {"s_set_pc_i64 s[0:1]",
                                              "s_mov_b32 s30, 0"};
   expectBatchSgprProofMatchesScalar(S, OpaqueBeforeDef);
+
+  const llvm::StringRef TiedAndTuple[] = {"s_add_u32 s30, s30, 1",
+                                          "s_mov_b64 s[30:31], s[0:1]",
+                                          "s_mov_b32 s2, s31", "s_endpgm"};
+  expectBatchSgprProofMatchesScalar(S, TiedAndTuple);
+
+  const llvm::StringRef InvalidBranchEdge[] = {"s_cbranch_scc0 100",
+                                               "s_endpgm"};
+  expectBatchSgprProofMatchesScalar(S, InvalidBranchEdge);
+}
+
+TEST(RegisterLiveness, BatchedSgprProofMatchesRandomizedBranchLoops) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  uint64_t State = 0x9E3779B97F4A7C15ULL;
+  auto Next = [&]() {
+    State = State * 2862933555777941757ULL + 3037000493ULL;
+    return State;
+  };
+
+  constexpr size_t InstructionCount = 10;
+  for (unsigned Trial = 0; Trial != 20; ++Trial) {
+    std::vector<std::string> Storage;
+    Storage.reserve(InstructionCount);
+    for (size_t I = 0; I + 1 < InstructionCount; ++I) {
+      unsigned Dst = Next() % 16;
+      unsigned Src = Next() % 16;
+      switch (Next() % 5) {
+      case 0:
+        Storage.push_back("s_mov_b32 s" + std::to_string(Dst) + ", s" +
+                          std::to_string(Src));
+        break;
+      case 1:
+        Storage.push_back("s_mov_b32 s" + std::to_string(Dst) + ", 0");
+        break;
+      case 2: {
+        size_t Target = Next() % InstructionCount;
+        int64_t Delta =
+            static_cast<int64_t>(Target) - static_cast<int64_t>(I) - 1;
+        Storage.push_back("s_cbranch_scc0 " + std::to_string(Delta));
+        break;
+      }
+      case 3: {
+        size_t Target = Next() % InstructionCount;
+        int64_t Delta =
+            static_cast<int64_t>(Target) - static_cast<int64_t>(I) - 1;
+        Storage.push_back("s_branch " + std::to_string(Delta));
+        break;
+      }
+      default:
+        Storage.push_back("s_add_u32 s" + std::to_string(Dst) + ", s" +
+                          std::to_string(Dst) + ", 1");
+        break;
+      }
+    }
+    Storage.push_back("s_endpgm");
+    llvm::SmallVector<llvm::StringRef, InstructionCount> Lines;
+    for (const std::string &Line : Storage)
+      Lines.push_back(Line);
+    expectBatchSgprProofMatchesScalar(S, Lines);
+  }
+}
+
+TEST(RegisterLiveness, BatchedSgprProofPreservesReplacementUnion) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeAsmSequence(
+      S,
+      llvm::ArrayRef<llvm::StringRef>({"s_cbranch_scc0 1", "s_mov_b32 s104, 0",
+                                       "s_mov_b32 s0, s103", "s_endpgm"}));
+  ASSERT_FALSE(Decoded.empty());
+  std::optional<llvm::SmallVector<llvm::MCRegister, 128>> NumberedSgprs =
+      resolveNumberedSgprRegisters(*S.MRI, /*MaxSgprs=*/106);
+  ASSERT_TRUE(NumberedSgprs);
+  uint64_t FunctionEnd = Decoded.back().Offset + Decoded.back().Size;
+  uint64_t Continuation = Decoded[1].Offset;
+  BatchedSgprContinuationTestResult Batch =
+      runBatchedSgprContinuationAnalysisForTest(Decoded, S, /*FunctionBegin=*/0,
+                                                FunctionEnd, {Continuation},
+                                                *NumberedSgprs);
+  ASSERT_EQ(Batch.Analyses, 1u);
+  ASSERT_EQ(Batch.Queries.size(), 1u);
+  ASSERT_TRUE(Batch.Queries.front());
+  std::optional<llvm::BitVector> Scalar = unsafeIncomingNumberedSgprsInRange(
+      Decoded, S, /*FunctionBegin=*/0, FunctionEnd, Continuation,
+      *NumberedSgprs);
+  ASSERT_TRUE(Scalar);
+
+  llvm::SmallVector<uint8_t> Replacement =
+      assembleInstructions("s_mov_b32 s102, 0\ns_mov_b32 s1, s101", S);
+  ASSERT_FALSE(Replacement.empty());
+  llvm::BitVector ReplacementUnsafe =
+      unsafeIncomingNumberedSgprsInReplacement(Replacement, S, *NumberedSgprs);
+  llvm::BitVector BatchedUnion = *Batch.Queries.front();
+  BatchedUnion |= ReplacementUnsafe;
+  llvm::BitVector ScalarUnion = *Scalar;
+  ScalarUnion |= ReplacementUnsafe;
+  EXPECT_EQ(BatchedUnion, ScalarUnion);
 }
 
 TEST(RegisterLiveness, NumberedSgprExtractionCoversAliasesAndTiedRmw) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1784,6 +1784,21 @@ TEST(CollectDirectBranchTargets,
   EXPECT_FALSE(LeafWithLinkScratch->HasUnresolvedTargets);
   EXPECT_FALSE(LeafWithLinkScratch->HasUnboundedIndirectEntries);
 
+  // The same canonical leaf can be reached only by an exact materialized
+  // singleton call. This is a machine-level closure, not the opaque-call ABI
+  // fallback: the call target, canonical return, and continuation must be
+  // validated together.
+  std::string ExactCaller = "s_get_pc_i64 s[0:1]\n"
+                            "s_add_nc_u64 s[0:1], s[0:1], 12\n"
+                            "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                            "s_endpgm\n";
+  std::optional<DirectControlFlowInfo> ExactCanonicalLeaf =
+      Audit(ExactCaller + LeafFrame, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/4);
+  ASSERT_TRUE(ExactCanonicalLeaf);
+  EXPECT_FALSE(ExactCanonicalLeaf->HasUnresolvedTargets);
+  EXPECT_FALSE(ExactCanonicalLeaf->HasUnboundedIndirectEntries);
+
   // Canonical compiler tail thunk: save the incoming link, materialize a
   // different STT_FUNC entry, restore the link, and jump without replacing
   // s[30:31]. The target returns directly to the thunk's original caller.
@@ -2224,6 +2239,17 @@ TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
   for (InternalDecodedInst &DI : Decoded)
     DI.Offset += 0x12EDCC;
 
+  // collectDirectBranchTargets normally sees the complete .text decode. Keep
+  // the synthetic production slice faithful to that contract by representing
+  // the resolved local target as an instruction boundary.
+  llvm::SmallVector<uint8_t> TargetBytes =
+      assembleInstructions("s_endpgm", S);
+  std::vector<InternalDecodedInst> TargetDecoded;
+  ASSERT_TRUE(decodeTextSection(TargetBytes.data(), TargetBytes.size(), S,
+                                TargetDecoded));
+  ASSERT_EQ(TargetDecoded.size(), 1u);
+  Decoded.insert(Decoded.begin(), TargetDecoded.front());
+
   // This is the exact address calculation from the production reproducer:
   // 0x1a000 + 0x12edcc + 4 - 0x12edd0 = 0x1a000.
   std::optional<DirectControlFlowInfo> Info =
@@ -2242,13 +2268,14 @@ TEST(CollectDirectBranchTargets, BoundsFiniteExternalPcMaterializedCall) {
   llvm::SmallVector<uint8_t> Bytes =
       assembleInstructions("s_get_pc_i64 s[0:1]\n"
                            "s_add_nc_u64 s[0:1], s[0:1], 0x100\n"
-                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                           "s_endpgm",
                            S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 3u);
+  ASSERT_EQ(Decoded.size(), 4u);
 
   // The exact target is outside this deliberately short .text range. The
   // external callee may return through the link pair, so the local
@@ -2260,9 +2287,8 @@ TEST(CollectDirectBranchTargets, BoundsFiniteExternalPcMaterializedCall) {
                                  /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   ASSERT_EQ(Info->Targets.size(), 1u);
-  EXPECT_TRUE(
-      Info->Targets.contains(Decoded.back().Offset + Decoded.back().Size));
-  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[3].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
@@ -2610,6 +2636,78 @@ TEST(CollectDirectBranchTargets, BoundsCanonicalSetPcReturn) {
   EXPECT_TRUE(
       Info->Targets.contains(Decoded.back().Offset + Decoded.back().Size));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     ClosesMaterializedCallExactJumpAndCanonicalReturnTogether) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 12\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                           "s_endpgm\n"
+                           "s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_endpgm\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 9u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[4].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> FunctionRanges{
+      {0, Decoded[4].Offset}, {Decoded[4].Offset, Bytes.size()}};
+
+  // No edge is independently sufficient: the materialized call defines the
+  // helper's s30 link, its exact set-PC reaches the return, and that return
+  // reaches only the call continuation. The joint finite-control-flow audit
+  // must close all three edges without treating the register call's generic
+  // indirect-branch classification as a second unbounded edge.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries, FunctionRanges,
+      /*ExternalEntries=*/{}, Bytes);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[2].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[6].Offset));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[8].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[4].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[2].Offset + Decoded[2].Size));
+  EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsFiniteCallEntryIntoAnotherCallMaterialization) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], 12\n"
+                           "s_swap_pc_i64 s[30:31], s[4:5]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 0x100\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+
+  // The first exact call targets the add in the second call's get-PC/add
+  // materialization. Both targets are finite instruction boundaries, but the
+  // first call can bypass the second call's defining get-PC. Joint closure
+  // must therefore leave the second call unresolved.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[4].Offset));
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
 TEST(CollectDirectBranchTargets, RejectsClobberedSetPcReturn) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -4125,6 +4125,181 @@ TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {
       commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Block, "unit test"));
 }
 
+TEST(SafeSgprScratchBlock, CommitCacheIsMonotoneAcrossOwnerScopes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_FALSE(Text.empty());
+
+  comgr_test::KernelDescriptorElfOptions Options;
+  Options.MetadataSgprCount = 4;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Options);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(View.textData(), View.textSize(), S, Decoded));
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+
+  std::optional<ElfView::FunctionTextRange> Function =
+      View.findFunctionTextRangeAtOffset(0);
+  ASSERT_TRUE(Function);
+  auto FunctionKey = std::make_pair(Function->Begin, Function->End);
+
+  // Overflow and a missing selected owner fail without changing any cache,
+  // counter, or externally visible kernel requirement.
+  Ctx.FunctionKernelOwner[FunctionKey] = "missing";
+  const SafeSgprScratchBlock Overflow{
+      /*Base=*/std::numeric_limits<unsigned>::max(), /*Count=*/2};
+  EXPECT_FALSE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Overflow, "unit test"));
+  const SafeSgprScratchBlock Initial{/*Base=*/4, /*Count=*/2};
+  EXPECT_FALSE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Initial, "unit test"));
+  EXPECT_EQ(Ctx.AllKernelSgprRequirement, 0u);
+  EXPECT_TRUE(Ctx.KernelSgprRequirements.empty());
+  EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 0u);
+  EXPECT_TRUE(KernelStats.empty());
+
+  // An owned commitment raises only that owner's coverage.
+  Ctx.FunctionKernelOwner[FunctionKey] = "kernel";
+  ASSERT_TRUE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Initial, "unit test"));
+  EXPECT_EQ(Ctx.AllKernelSgprRequirement, 0u);
+  EXPECT_EQ(Ctx.KernelSgprRequirements["kernel"], 8u);
+  EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 1u);
+  ASSERT_EQ(KernelStats.count("kernel"), 1u);
+  EXPECT_EQ(KernelStats["kernel"].ExtraSgprs, 4u);
+
+  // Owned coverage cannot stand in for all-kernel coverage.
+  Ctx.FunctionKernelOwner[FunctionKey] = "";
+  const SafeSgprScratchBlock Smaller{/*Base=*/0, /*Count=*/2};
+  EXPECT_TRUE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Smaller, "unit test"));
+  EXPECT_EQ(Ctx.AllKernelSgprRequirement, 4u);
+  EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 2u);
+  EXPECT_EQ(KernelStats["kernel"].ExtraSgprs, 4u);
+
+  // Equal and decreasing ownerless requirements are already represented by
+  // the monotone KernelStats update and must not rescan the descriptor table.
+  EXPECT_TRUE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Smaller, "unit test"));
+  const SafeSgprScratchBlock Smallest{/*Base=*/0, /*Count=*/1};
+  EXPECT_TRUE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Smallest, "unit test"));
+  EXPECT_EQ(Ctx.AllKernelSgprRequirement, 4u);
+  EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 2u);
+
+  // A larger global request performs exactly one new pass and raises both
+  // cached and externally visible requirements.
+  const SafeSgprScratchBlock Larger{/*Base=*/8, /*Count=*/2};
+  EXPECT_TRUE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Larger, "unit test"));
+  EXPECT_EQ(Ctx.AllKernelSgprRequirement, 12u);
+  EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 3u);
+  EXPECT_EQ(KernelStats["kernel"].ExtraSgprs, 8u);
+
+  // Global coverage is a valid lower bound for every individual owner.
+  Ctx.FunctionKernelOwner[FunctionKey] = "kernel";
+  EXPECT_TRUE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Larger, "unit test"));
+  EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 3u);
+  EXPECT_EQ(Ctx.KernelSgprRequirements["kernel"], 8u);
+
+  const SafeSgprScratchBlock Largest{/*Base=*/12, /*Count=*/2};
+  EXPECT_TRUE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Largest, "unit test"));
+  EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 4u);
+  EXPECT_EQ(Ctx.KernelSgprRequirements["kernel"], 16u);
+  EXPECT_EQ(KernelStats["kernel"].ExtraSgprs, 12u);
+}
+
+TEST(SafeSgprScratchBlock, OwnerlessCommitFailureIsAtomic) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  comgr_test::MultiKernelDescriptorElfOptions Options;
+  Options.Kernels = {
+      {"valid", 0x1000, 0x2000, /*EntryOffset=*/-0x1000,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true,
+       /*MetadataSgprCount=*/4},
+      {"malformed", 0x1100, 0x2100, /*EntryOffset=*/-0x1000,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/false,
+       /*MetadataSgprCount=*/0},
+  };
+  std::vector<uint8_t> Bytes =
+      comgr_test::makeMultiKernelDescriptorElf(Options);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Bytes.data(), Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> Decoded;
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+
+  std::optional<ElfView::FunctionTextRange> Function =
+      View.findFunctionTextRangeAtOffset(0);
+  ASSERT_TRUE(Function);
+  Ctx.FunctionKernelOwner[{Function->Begin, Function->End}] = "";
+
+  // The valid descriptor is visited before the malformed metadata entry. A
+  // one-phase implementation would leak its queued ExtraSgprs update here.
+  const SafeSgprScratchBlock Block{/*Base=*/4, /*Count=*/2};
+  EXPECT_FALSE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Block, "unit test"));
+  EXPECT_TRUE(KernelStats.empty());
+  EXPECT_EQ(Ctx.AllKernelSgprRequirement, 0u);
+  EXPECT_TRUE(Ctx.KernelSgprRequirements.empty());
+  EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 0u);
+}
+
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {
   std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64}, {100, 128, 100, 100, 128}};
   EXPECT_EQ(findNearestSled(Sleds, 0, std::numeric_limits<uint64_t>::max()),

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -588,6 +588,97 @@ TEST(FindNearestSetPcGateway, AnalyticalWidthsMatchEncodedBoundaries) {
   }
 }
 
+TEST(FindSplitVccGateway, UsesDisjointEightAndSixteenByteSleds) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x100, /*End=*/0x108, /*WritePos=*/0x100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000},
+      {/*Start=*/0x200, /*End=*/0x210, /*WritePos=*/0x200,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000,
+       /*GatewayOnly=*/true}};
+  std::optional<EncodedSplitVccGateway> Split =
+      findSplitVccGateway(Gateways, S, /*FromOffset=*/0,
+                          /*TargetOffset=*/0x81000, /*SaveSgpr=*/105);
+  ASSERT_TRUE(Split);
+  EXPECT_EQ(Split->PrimaryIndex, 0u);
+  EXPECT_EQ(Split->SecondaryIndex, 1u);
+  EXPECT_EQ(Split->PrimaryBytes.size(), 8u);
+  EXPECT_EQ(Split->SecondaryBytes.size(), 16u);
+  EXPECT_EQ(Gateways[0].WritePos, 0x100u);
+  EXPECT_EQ(Gateways[1].WritePos, 0x200u);
+
+  std::vector<InternalDecodedInst> Primary;
+  ASSERT_TRUE(decodeTextSection(Split->PrimaryBytes.data(),
+                                Split->PrimaryBytes.size(), S, Primary));
+  ASSERT_EQ(Primary.size(), 2u);
+  EXPECT_EQ(Primary[0].Mnemonic, "s_mov_b32");
+  ASSERT_GE(Primary[0].Inst.getNumOperands(), 2u);
+  ASSERT_TRUE(Primary[0].Inst.getOperand(0).isReg());
+  ASSERT_TRUE(Primary[0].Inst.getOperand(1).isReg());
+  EXPECT_STREQ(S.MRI->getName(Primary[0].Inst.getOperand(0).getReg()),
+               "SGPR105");
+  EXPECT_TRUE(S.MRI->regsOverlap(
+      llvm::MCRegister(Primary[0].Inst.getOperand(1).getReg()), S.VCCRegister));
+  EXPECT_EQ(Primary[1].Mnemonic, "s_branch");
+  EXPECT_EQ(static_cast<int16_t>(
+                readDword(Split->PrimaryBytes.data() + MinInstSize) & 0xFFFFu),
+            62);
+
+  std::vector<InternalDecodedInst> Secondary;
+  ASSERT_TRUE(decodeTextSection(Split->SecondaryBytes.data(),
+                                Split->SecondaryBytes.size(), S, Secondary));
+  ASSERT_EQ(Secondary.size(), 3u);
+  EXPECT_EQ(Secondary[0].Mnemonic, "s_get_pc_i64");
+  EXPECT_EQ(Secondary[1].Mnemonic, "s_add_nc_u64");
+  EXPECT_EQ(Secondary[2].Mnemonic, "s_set_pc_i64");
+  for (const InternalDecodedInst &DI : Secondary) {
+    ASSERT_NE(DI.Inst.getNumOperands(), 0u);
+    ASSERT_TRUE(DI.Inst.getOperand(0).isReg());
+    EXPECT_TRUE(S.MRI->regsOverlap(
+        llvm::MCRegister(DI.Inst.getOperand(0).getReg()), S.VCCRegister));
+  }
+  ASSERT_TRUE(Secondary[1].Inst.getOperand(2).isImm());
+  uint64_t Delta =
+      static_cast<uint64_t>(Secondary[1].Inst.getOperand(2).getImm());
+  EXPECT_EQ(0x200u + MinInstSize + Delta, 0x81000u);
+}
+
+TEST(FindSplitVccGateway, RejectsPhysicalOverlapWithoutMutation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x100, /*End=*/0x108, /*WritePos=*/0x100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000},
+      {/*Start=*/0x104, /*End=*/0x114, /*WritePos=*/0x104,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000,
+       /*GatewayOnly=*/true}};
+  EXPECT_FALSE(findSplitVccGateway(Gateways, S, /*FromOffset=*/0,
+                                   /*TargetOffset=*/0x81000,
+                                   /*SaveSgpr=*/105));
+  EXPECT_EQ(Gateways[0].WritePos, 0x100u);
+  EXPECT_EQ(Gateways[1].WritePos, 0x104u);
+}
+
+TEST(FindSplitVccGateway, RejectsGatewayOnlyPrimaryWithoutMutation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x100, /*End=*/0x108, /*WritePos=*/0x100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000,
+       /*GatewayOnly=*/true},
+      {/*Start=*/0x200, /*End=*/0x210, /*WritePos=*/0x200,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000}};
+  EXPECT_FALSE(findSplitVccGateway(Gateways, S, /*FromOffset=*/0,
+                                   /*TargetOffset=*/0x81000,
+                                   /*SaveSgpr=*/105));
+  EXPECT_EQ(Gateways[0].WritePos, 0x100u);
+  EXPECT_EQ(Gateways[1].WritePos, 0x200u);
+}
+
 TEST(CountReachableSetPcGatewaySlots, DistinguishesZeroFromEncodingFailure) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -1195,6 +1286,47 @@ TEST(CollectDirectBranchTargets, RejectsClobberedPcMaterializedCall) {
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.empty());
   EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(SourceTailSafety, RejectsProtectedEntriesAndOverlappingRanges) {
+  Trampoline T;
+  T.OriginalOffset = 8;
+  T.OriginalSize = 12;
+  T.HasFunctionRange = true;
+  T.FunctionStart = 0;
+  T.FunctionEnd = 32;
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> OneRange{
+      {0, 32, nullptr, nullptr}};
+  EXPECT_TRUE(sourceHasUniqueFunctionRange(T, OneRange, /*TextAddr=*/0));
+
+  DirectControlFlowInfo ControlFlow;
+  EXPECT_TRUE(isSafeSourceTailRange(T, ControlFlow,
+                                    /*HasUniqueFunctionRange=*/true,
+                                    /*Begin=*/12, /*End=*/20));
+  ControlFlow.Targets.insert(16);
+  EXPECT_FALSE(isSafeSourceTailRange(T, ControlFlow,
+                                     /*HasUniqueFunctionRange=*/true,
+                                     /*Begin=*/12, /*End=*/20));
+  ControlFlow.Targets.clear();
+  ControlFlow.HasUnboundedIndirectEntries = true;
+  EXPECT_FALSE(isSafeSourceTailRange(T, ControlFlow,
+                                     /*HasUniqueFunctionRange=*/true,
+                                     /*Begin=*/12, /*End=*/20));
+
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> AliasedRanges{
+      {0, 32, nullptr, nullptr}, {0, 32, nullptr, nullptr}};
+  // The same logical global function can appear in both .symtab and .dynsym.
+  // Equal bounds add no new interior ownership ambiguity.
+  EXPECT_TRUE(
+      sourceHasUniqueFunctionRange(T, AliasedRanges, /*TextAddr=*/0));
+
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> NestedRanges{
+      {0, 64, nullptr, nullptr}, {32, 48, nullptr, nullptr}};
+  T.FunctionEnd = 64;
+  T.OriginalOffset = 8;
+  EXPECT_TRUE(sourceHasUniqueFunctionRange(T, NestedRanges, /*TextAddr=*/0));
+  T.OriginalOffset = 36;
+  EXPECT_FALSE(sourceHasUniqueFunctionRange(T, NestedRanges, /*TextAddr=*/0));
 }
 
 TEST(CollectDirectBranchTargets, RejectsAlternateEntryIntoMaterialization) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -993,6 +993,79 @@ TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
+TEST(CollectDirectBranchTargets, BoundsFiniteExternalPcMaterializedCall) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 0x100\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+
+  // The exact target is outside this deliberately short .text range. The
+  // external callee may return through the link pair, so the local
+  // continuation remains a protected entry even though the external target
+  // contributes no local offset.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x20,
+                                 /*DeclaredEntries=*/{});
+  ASSERT_TRUE(Info);
+  ASSERT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(
+      Info->Targets.contains(Decoded.back().Offset + Decoded.back().Size));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsExternalCallContinuationIntoReturnFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_endpgm\n"
+                           "s_get_pc_i64 s[2:3]\n"
+                           "s_add_nc_u64 s[2:3], s[2:3], 0x1000\n"
+                           "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_endpgm\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -16\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 12u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{Decoded[5].Offset,
+                                                 Decoded[8].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 3> FunctionRanges{
+      {Decoded[1].Offset, Decoded[5].Offset},
+      {Decoded[5].Offset, Decoded[7].Offset},
+      {Decoded[8].Offset, Decoded[11].Offset}};
+
+  // The first call has one finite target outside this .text, and returns to
+  // the padding that falls through into the local helper. The later local
+  // call alone would appear to justify the helper's s_set_pc_i64, but the
+  // external continuation is a second link-register provenance and must keep
+  // that return unbounded.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/Bytes.size(), DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[3].Offset + Decoded[3].Size));
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
 TEST(CollectDirectBranchTargets, RejectsClobberedPcMaterializedCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -1147,9 +1220,11 @@ TEST(CollectDirectBranchTargets, BoundsCanonicalSetPcReturn) {
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
-  ASSERT_EQ(Info->Targets.size(), 2u);
+  ASSERT_EQ(Info->Targets.size(), 3u);
   EXPECT_TRUE(Info->Targets.contains(0));
   EXPECT_TRUE(Info->Targets.contains(Decoded[1].Offset));
+  EXPECT_TRUE(
+      Info->Targets.contains(Decoded.back().Offset + Decoded.back().Size));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
@@ -1431,7 +1506,9 @@ TEST(CollectDirectBranchTargets, HandlesImmediateAbsoluteTargetCall) {
       collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x220,
                                  /*TextSize=*/0x40, /*DeclaredEntries=*/{});
   ASSERT_TRUE(OutsideInfo);
-  EXPECT_TRUE(OutsideInfo->Targets.empty());
+  ASSERT_EQ(OutsideInfo->Targets.size(), 1u);
+  EXPECT_TRUE(
+      OutsideInfo->Targets.contains(Decoded[0].Offset + Decoded[0].Size));
   EXPECT_FALSE(OutsideInfo->HasUnresolvedTargets);
 
   std::optional<DirectControlFlowInfo> OverflowInfo =
@@ -1462,6 +1539,105 @@ TEST(CollectDirectBranchTargets, CollectsPcRelativeCall) {
   EXPECT_TRUE(
       Info->Targets.contains(0x200u + Decoded[0].Size + 2 * MinInstSize));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, ProtectsExternalPcRelativeCallContinuation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_call_i64 s[30:31], 2", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+
+  // The encoded target is beyond this deliberately short .text, while the
+  // instruction after the call remains inside .text. The target must not
+  // become a local protection offset, while the return continuation remains
+  // protected.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/2 * Decoded[0].Size,
+                                 /*DeclaredEntries=*/{});
+  ASSERT_TRUE(Info);
+  ASSERT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[0].Offset + Decoded[0].Size));
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsExternalPcMaterializedCallContinuationAtTextEnd) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 0x100\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                          /*TextSize=*/Bytes.size(),
+                                          /*DeclaredEntries=*/{}));
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsExternalAbsoluteCallContinuationAtTextEnd) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_swap_pc_i64 s[30:31], 0x210", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x220,
+                                          /*TextSize=*/Bytes.size(),
+                                          /*DeclaredEntries=*/{}));
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsExternalPcRelativeCallContinuationAtTextEnd) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_call_i64 s[30:31], 2", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                          /*TextSize=*/Bytes.size(),
+                                          /*DeclaredEntries=*/{}));
+}
+
+TEST(CollectDirectBranchTargets, RejectsInvalidCallContinuationArithmetic) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_swap_pc_i64 s[30:31], 0x210", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+
+  Decoded[0].Offset = 1;
+  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x220,
+                                          /*TextSize=*/0x40,
+                                          /*DeclaredEntries=*/{}));
+
+  Decoded[0].Offset = std::numeric_limits<uint64_t>::max() - 1;
+  EXPECT_FALSE(collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0,
+      /*TextSize=*/std::numeric_limits<uint64_t>::max(),
+      /*DeclaredEntries=*/{}));
 }
 
 TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1799,6 +1799,33 @@ TEST(CollectDirectBranchTargets,
   EXPECT_FALSE(ExactCanonicalLeaf->HasUnresolvedTargets);
   EXPECT_FALSE(ExactCanonicalLeaf->HasUnboundedIndirectEntries);
 
+  // Reusing the same materialized target after a call is sound when the
+  // jointly audited symbol-less leaf cannot clobber that target pair. The
+  // second call must inherit the finite target instead of becoming an opaque
+  // indirect entry.
+  std::string RepeatedCaller = "s_get_pc_i64 s[0:1]\n"
+                               "s_add_nc_u64 s[0:1], s[0:1], 16\n"
+                               "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                               "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                               "s_endpgm\n";
+  llvm::SmallVector<uint8_t> RepeatedCallerBytes =
+      assembleInstructions(RepeatedCaller, S);
+  std::vector<InternalDecodedInst> RepeatedCallerDecoded;
+  ASSERT_TRUE(decodeTextSection(RepeatedCallerBytes.data(),
+                                RepeatedCallerBytes.size(), S,
+                                RepeatedCallerDecoded));
+  ASSERT_EQ(RepeatedCallerDecoded.size(), 5u);
+  std::optional<DirectControlFlowInfo> RepeatedCanonicalLeaf =
+      Audit(RepeatedCaller + LeafFrame, {}, 0, FunctionTableElfMutation::None,
+            /*CallerEndIndex=*/RepeatedCallerDecoded.size());
+  ASSERT_TRUE(RepeatedCanonicalLeaf);
+  EXPECT_TRUE(RepeatedCanonicalLeaf->BoundedIndirectTransfers.contains(
+      RepeatedCallerDecoded[2].Offset));
+  EXPECT_TRUE(RepeatedCanonicalLeaf->BoundedIndirectTransfers.contains(
+      RepeatedCallerDecoded[3].Offset));
+  EXPECT_FALSE(RepeatedCanonicalLeaf->HasUnresolvedTargets);
+  EXPECT_FALSE(RepeatedCanonicalLeaf->HasUnboundedIndirectEntries);
+
   // A separate finite call enters the add of the exact singleton call above,
   // bypassing its defining get-PC. The canonical callee frame remains valid,
   // but the exact closure must reject this alternate materialization entry

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -2315,6 +2315,39 @@ TEST(CollectDirectBranchTargets,
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
+TEST(CollectDirectBranchTargets, RejectsOverlappingSymbolLessReturnRegions) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 5\n"
+                           "s_endpgm\n"
+                           "s_call_i64 s[30:31], 5\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_branch 2\n"
+                           "s_endpgm\n"
+                           "s_branch 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 11u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[2].Offset};
+
+  // The two distinct call entries use the same link pair but converge on one
+  // return tail. Neither provisional region owns that shared body uniquely,
+  // so the streaming overlap audit must reject both.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[10].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
 TEST(CollectDirectBranchTargets,
      RejectsWrongPairAndClobberedSymbolLessReturns) {
   LLVMState S = initLLVM(makeGfx1250Ident());

--- a/llvm/include/llvm/TargetParser/AMDGPUMCOperand.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUMCOperand.h
@@ -1,0 +1,42 @@
+//===- AMDGPUMCOperand.h - Public AMDGPU MC operand names -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Public access to the named-operand metadata generated for AMDGPU
+/// instructions. This keeps MC clients from depending on target-private
+/// TableGen headers or fixed operand positions.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TARGETPARSER_AMDGPUMCOPERAND_H
+#define LLVM_TARGETPARSER_AMDGPUMCOPERAND_H
+
+#include "llvm/Support/Compiler.h"
+
+#include <cstdint>
+
+namespace llvm::AMDGPU {
+
+enum class NamedOperand : uint8_t {
+  VAddr1,
+  SDst,
+  Src0,
+  Src1,
+  Src2,
+  Count,
+};
+
+/// Return the MC operand index associated with \p Name for \p Opcode, or -1
+/// when the instruction does not define that named operand. Concrete
+/// subtarget opcodes inherit operand names from their generated pseudo-opcode
+/// sources.
+LLVM_ABI int16_t getNamedOperandIdx(uint32_t Opcode, NamedOperand Name);
+
+} // namespace llvm::AMDGPU
+
+#endif // LLVM_TARGETPARSER_AMDGPUMCOPERAND_H

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -26,8 +26,11 @@
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/TargetParser/AMDGPUMCOperand.h"
 #include "llvm/TargetParser/AMDGPUTargetParser.h"
+#include <array>
 #include <optional>
+#include <vector>
 
 #define GET_INSTRINFO_NAMED_OPS
 #define GET_INSTRMAP_INFO
@@ -198,6 +201,69 @@ inline unsigned getHoldCntBitShift() { return 7; }
 namespace llvm {
 
 namespace AMDGPU {
+
+static int16_t getDirectNamedOperandIdx(uint32_t Opcode, NamedOperand Name) {
+  switch (Name) {
+  case NamedOperand::VAddr1:
+    return getNamedOperandIdx(Opcode, OpName::vaddr1);
+  case NamedOperand::SDst:
+    return getNamedOperandIdx(Opcode, OpName::sdst);
+  case NamedOperand::Src0:
+    return getNamedOperandIdx(Opcode, OpName::src0);
+  case NamedOperand::Src1:
+    return getNamedOperandIdx(Opcode, OpName::src1);
+  case NamedOperand::Src2:
+    return getNamedOperandIdx(Opcode, OpName::src2);
+  case NamedOperand::Count:
+    break;
+  }
+  llvm_unreachable("unknown public AMDGPU named operand");
+}
+
+int16_t getNamedOperandIdx(uint32_t Opcode, NamedOperand Name) {
+  constexpr size_t NamedOperandCount = static_cast<size_t>(NamedOperand::Count);
+  using NamedOperandIndices = std::array<int16_t, NamedOperandCount>;
+  static const std::vector<NamedOperandIndices> ResolvedIndices = [] {
+    std::vector<NamedOperandIndices> DirectIndices(INSTRUCTION_LIST_END);
+    for (NamedOperandIndices &Indices : DirectIndices)
+      Indices.fill(-1);
+    for (uint32_t Candidate = 0; Candidate < INSTRUCTION_LIST_END; ++Candidate)
+      for (size_t NameIndex = 0; NameIndex < NamedOperandCount; ++NameIndex)
+        DirectIndices[Candidate][NameIndex] = getDirectNamedOperandIdx(
+            Candidate, static_cast<NamedOperand>(NameIndex));
+
+    std::vector<NamedOperandIndices> Result = DirectIndices;
+    constexpr unsigned SubtargetCount = static_cast<unsigned>(Subtarget_14) + 1;
+    for (uint32_t Candidate = 0; Candidate < INSTRUCTION_LIST_END;
+         ++Candidate) {
+      for (unsigned SubtargetIndex = 0; SubtargetIndex < SubtargetCount;
+           ++SubtargetIndex) {
+        int32_t ConcreteOpcode =
+            getMCOpcodeGen(Candidate, static_cast<Subtarget>(SubtargetIndex));
+        if (ConcreteOpcode < 0 ||
+            static_cast<uint32_t>(ConcreteOpcode) >= INSTRUCTION_LIST_END)
+          continue;
+        for (size_t NameIndex = 0; NameIndex < NamedOperandCount; ++NameIndex) {
+          int16_t CandidateIndex = DirectIndices[Candidate][NameIndex];
+          if (CandidateIndex < 0)
+            continue;
+          int16_t &ResolvedIndex =
+              Result[static_cast<uint32_t>(ConcreteOpcode)][NameIndex];
+          if (ResolvedIndex == -1 || ResolvedIndex == CandidateIndex)
+            ResolvedIndex = CandidateIndex;
+          else
+            ResolvedIndex = -2;
+        }
+      }
+    }
+    return Result;
+  }();
+
+  if (Opcode >= ResolvedIndices.size() || Name == NamedOperand::Count)
+    return -1;
+  int16_t Index = ResolvedIndices[Opcode][static_cast<size_t>(Name)];
+  return Index >= 0 ? Index : -1;
+}
 
 /// \returns true if the target supports signed immediate offset for SMRD
 /// instructions.


### PR DESCRIPTION
## Status

**Draft integration snapshot — do not merge.**

This branch assembles the gfx1250 COMGR HotSwap component work and the
additional corpus-driven repairs needed to reach a zero-failure offline
corpus result. It is intentionally published for early design and test
review while runtime failures are still being localized.

The branch was created from frozen `amd-staging` commit
`50d16abb44335104f1f3b8ad8123d0b6aaa7f7d5`. Current `amd-staging` has
advanced to `3edd3c1a6e83d1a78e320588d496db1f3c94d892`; this 43-commit
integration stack has not yet been rebased or split into its final focused
upstream deltas.

ROCm/llvm-project#3598 remains unchanged and was used only as the functional
integration oracle.

## Scope

The stack integrates the corpus-required HotSwap scopes, including:

- bank-aware DS and scale16 WMMA lowering
- shared, relay, source-tail, and exhausted-site routing
- current-text scratch liveness and locally dead SGPR-pair selection
- bounded/indexed control-flow, call-target, and call-closure proofs
- bounded symbol-less inference and proof caches
- data-only object validation
- exact M32 scale16 lowering and local tensor-mask proof
- dense pair-only hierarchical routing
- live-VCC preservation through round-trip gateways

The final repair at `d734f1e60acd` adds owner-specific pre-promoted source
windows and VCC-preserving round-trip gateways for the large corpus case that
was not covered by the earlier in-place displacement assumptions.

## Validation completed

Exact tested head:

```text
d734f1e60acd605ccf5b5f87fd00ef3e939003b8
```

Release/assertions build on `mi300x`:

- `HotswapMCTests`: 222/222 passed
- focused HotSwap lit: 149/149 passed
- complete COMGR lit: 172 passed, 14 unsupported, 0 failed
- clean source tree and `git diff --check`

Deduplicated offline corpus on `mi300x`:

- 2,685 manifest paths
- 1,452 unique SHA-256 code objects executed
- 1,233 duplicate executions omitted while retaining alias accounting
- 1,452/1,452 unique objects passed
- 2,685/2,685 aliases report `SUCCESS`
- every execution passed first rewrite, `llvm-readobj` structural
  validation, second rewrite, and byte-for-byte idempotence
- zero success-to-failure transitions against the previous known-good run

Candidate library:

```text
sha256 9a91defe69cf86eeb69e21edcd4d3a9f4f883b6914b00ff38cba79a9145869b4
```

## Blocking runtime results

The prescribed `mi400-3` image was used:

```text
registry-sc-harbor.amd.com/hotswap/therock-hotswap-gfx1250:a20260724-base-tests-corpus
sha256:1851c0673fd13d9a7cfdbc287bf4699a7ecaad956e0e283dd79c67b79459831a
```

A fresh original-library baseline and a separate fresh candidate container
were used. The candidate attempted 13 of 34 discovered CTest trees before
hipSPARSE produced a GPU-fatal result:

- passed: hipRAND, hip kernel provider, hipBLAS, hipBLASLt provider/plugin,
  hipCUB, hipDNN, hipDNN integration, hipDNN samples, and hipFFT
- failed with the candidate after passing with the original library:
  hipBLASLt and hipSOLVER
- failed with both original and candidate libraries: MIOpen
- GPU page fault with both original and candidate libraries: hipSPARSE
  (`HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION` in `init_kernel()`)
- 21 remaining discovered suites were not run after the GPU-fatal result

The candidate MIOpen smoke filter completed 11,049 runnable tests and
reported 10 failed applicability tests. No HotSwap rewrite failure or GPU
fault was present in that MIOpen log.

## Still required before ready for review

- localize and fix the candidate-only hipBLASLt and hipSOLVER regressions
- resolve or replace the prescribed-image baseline failures for MIOpen and
  hipSPARSE without hiding them as unrelated
- rerun all 34 discovered `mi400-3` suites plus mandatory rocThrust test 64
  from fresh, healthy container state
- verify post-test GPU health and zero page faults, resets, hangs, or timeouts
- run the ASAN build and complete COMGR test suites; ASAN is intentionally
  gated until the corpus and `mi400-3` matrix pass
- rebase/reconstruct against current `amd-staging` and split or re-home
  component changes as appropriate for focused upstream review

## Review requested while draft

Early feedback is especially useful on:

- correctness of VCC save/restore ordering around round-trip gateways
- owner-specific packed source-window reservation and replay
- fail-closed behavior when safe scratch, relay, or return routes are
  exhausted
- whether the final corpus repair should remain one focused follow-up or be
  split further before the integration stack is dismantled
