### PR TITLE
[Comgr] Add deduplicated hotswap corpus inventory

### DIFF
--- a/amd/comgr/docs/HotswapInventory.md
+++ b/amd/comgr/docs/HotswapInventory.md
@@ -1,0 +1,110 @@
+# Hotswap corpus inventory
+
+`hotswap_inventory.py` finds AMDGPU ELF files below one or more corpus
+roots and groups exact duplicates by SHA-256. It is intended to keep the
+developer hotswap loop from rewriting identical code objects repeatedly.
+It does not decode or make claims about instruction semantics.
+
+The versioned JSON inventory is deterministic for an unchanged corpus.
+Each object group names the lexicographically first path as its
+representative and retains all duplicate paths for traceability. Non-ELF
+files, malformed ELF files, and ELF files for other machines are listed
+under `rejected`. Optional command results additionally contain measured
+runtime and command output.
+
+A frozen, newline-delimited corpus manifest can select the exact input
+set. Its paths are relative to the single corpus root:
+
+```console
+$ amd/comgr/utils/hotswap/hotswap_inventory.py extracted-corpus \
+    --manifest evidence/manifest.txt \
+    --json-output inventory.json
+```
+
+The manifest path, SHA-256, and entry count are recorded in the report.
+Duplicate, missing, absolute, root-escaping, empty, and NUL-containing
+manifest entries are errors.
+
+To inventory a corpus and produce a NUL-delimited worklist:
+
+```console
+$ amd/comgr/utils/hotswap/hotswap_inventory.py corpus \
+    --json-output inventory.json \
+    --worklist unique-code-objects.list
+```
+
+The worklist is a byte stream of absolute paths terminated by NUL bytes.
+It is safe for paths containing spaces or newlines. For example:
+
+```console
+$ xargs -0 -n1 my-hotswap-command < unique-code-objects.list
+```
+
+The tool can run a command itself without a shell. The absolute object
+path is appended to the argument vector:
+
+```console
+$ amd/comgr/utils/hotswap/hotswap_inventory.py corpus \
+    --execute build/bin/hotswap-rewrite \
+    --execute-arg=--check-idempotent \
+    --jobs 8 \
+    --timeout 120 \
+    --cache-dir .hotswap-cache \
+    --cache-dependency build/lib/libamd_comgr.so \
+    --cache-tag candidate-commit-or-container-digest \
+    --json-output results.json
+```
+
+Successful results are cached by the command identity and input content
+hash. The command identity includes the contents of the executable and
+any arguments that name regular files. Use repeatable `--cache-dependency`
+options for dynamically loaded libraries or other file inputs, and
+`--cache-tag` for relevant environment, container, or configuration
+identity. Failed and timed-out commands are not cached, so a later run
+retries them. `--jobs` controls concurrent command execution; result
+records remain in deterministic digest order. Captured standard output
+and standard error are Base64-encoded in the JSON result. Every result
+also records monotonic elapsed `runtime_ms`. Successful cache hits replay
+the original runtime so downstream selectors can estimate a future full
+run. The execution summary reports `estimated_runtime_ms` across every
+unique object and `executed_runtime_ms` for work actually performed in
+the current run.
+
+The exit status is zero when inventory and every optional command
+succeed, one when at least one optional command fails or times out, and
+two for invalid arguments or an inventory, output, or cache error. Use
+`--help` for all options.
+
+## Comparing rewrite outputs
+
+The same tool can digest the output trees produced by two implementations,
+including the #3598 oracle and a #3646 candidate:
+
+```console
+$ amd/comgr/utils/hotswap/hotswap_inventory.py \
+    evidence/pr3598/outputs evidence/pr3646/outputs \
+    --json-output output-content.json
+```
+
+Each absolute path remains associated with its content SHA-256 in the
+object groups. This makes identical output objects collapse into one
+group while changed output objects remain distinct, without encoding
+either PR, corpus location, or target semantics in the tool.
+
+## Optional #3646 corpus acceptance test
+
+`test_hotswap_inventory_acceptance.py` verifies the published 2026-07-24
+corpus invariants: 2,685 aliases, 1,452 unique content hashes, and 1,233
+duplicate executions skipped. It is skipped by CTest unless both of these
+variables are set:
+
+```console
+$ export COMGR_HOTSWAP_CORPUS_ROOT=/path/to/hotswap-corpus
+$ export COMGR_HOTSWAP_CORPUS_MANIFEST=/path/to/manifest.txt
+```
+
+The accepted frozen manifest has SHA-256
+`076ea013ba466139e76074fcbb31905a5041298e7644f6e8f590bf9353e4f5b9`.
+If the corpus or manifest changes, the acceptance test fails rather than
+silently updating its expectations. The normal hermetic test suite uses
+only small synthetic ELF fixtures.

--- a/amd/comgr/docs/HotswapInventory.md
+++ b/amd/comgr/docs/HotswapInventory.md
@@ -22,8 +22,8 @@ $ amd/comgr/utils/hotswap/hotswap_inventory.py extracted-corpus \
 ```
 
 The manifest path, SHA-256, and entry count are recorded in the report.
-Duplicate, missing, absolute, root-escaping, empty, and NUL-containing
-manifest entries are errors.
+Duplicate, missing, absolute, root-escaping (including through symlinks),
+empty, and NUL-containing manifest entries are errors.
 
 To inventory a corpus and produce a NUL-delimited worklist:
 
@@ -40,6 +40,10 @@ It is safe for paths containing spaces or newlines. For example:
 $ xargs -0 -n1 my-hotswap-command < unique-code-objects.list
 ```
 
+Place the JSON output, worklist, and cache outside the inventoried roots.
+Pre-existing files below those roots are corpus inputs; the tool refuses to
+replace an input through an alternate, hard-linked, or symlinked path.
+
 The tool can run a command itself without a shell. The absolute object
 path is appended to the argument vector:
 
@@ -55,20 +59,23 @@ $ amd/comgr/utils/hotswap/hotswap_inventory.py corpus \
     --json-output results.json
 ```
 
-Successful results are cached by the command identity and input content
-hash. The command identity includes the contents of the executable and
-any arguments that name regular files. Use repeatable `--cache-dependency`
-options for dynamically loaded libraries or other file inputs, and
-`--cache-tag` for relevant environment, container, or configuration
-identity. Failed and timed-out commands are not cached, so a later run
-retries them. `--jobs` controls concurrent command execution; result
-records remain in deterministic digest order. Captured standard output
-and standard error are Base64-encoded in the JSON result. Every result
-also records monotonic elapsed `runtime_ms`. Successful cache hits replay
-the original runtime so downstream selectors can estimate a future full
-run. The execution summary reports `estimated_runtime_ms` across every
-unique object and `executed_runtime_ms` for work actually performed in
-the current run.
+Successful results are cached by the command identity, input content hash,
+and representative path. Including the path preserves command behavior
+when two corpus locations contain identical bytes. The command identity
+includes the timeout, the contents of the executable, and any arguments
+that name regular files. Use repeatable `--cache-dependency` options for
+dynamically loaded libraries or other file inputs, and `--cache-tag` for
+relevant environment, container, or configuration identity. Failed and
+timed-out commands are not cached, so a later run retries them. `--jobs`
+controls concurrent command execution; result records remain in
+deterministic digest order. Captured standard output and standard error are
+Base64-encoded in the JSON result. Every result also records monotonic
+elapsed `runtime_ms`. Successful cache hits replay the original runtime so
+downstream selectors can estimate a future full run. The execution summary
+reports `estimated_runtime_ms` across every unique object and
+`executed_runtime_ms` for work actually performed in the current run.
+On POSIX systems, a timeout terminates the command's process group so
+descendants that inherited output pipes cannot leave the inventory blocked.
 
 The exit status is zero when inventory and every optional command
 succeed, one when at least one optional command fails or times out, and

--- a/amd/comgr/test/CMakeLists.txt
+++ b/amd/comgr/test/CMakeLists.txt
@@ -247,3 +247,16 @@ add_comgr_test(compile_hip_to_relocatable c)
 #add_comgr_test(compile_hip_with_libcxx_test c)
 add_comgr_test(mangled_names_hip_test c)
 #add_comgr_test(unbundle_hip_test c)
+
+add_test(
+  NAME comgr_hotswap_inventory
+  COMMAND "${Python3_EXECUTABLE}"
+          "${CMAKE_CURRENT_SOURCE_DIR}/utils/test_hotswap_inventory.py")
+
+add_test(
+  NAME comgr_hotswap_inventory_acceptance
+  COMMAND "${Python3_EXECUTABLE}"
+          "${CMAKE_CURRENT_SOURCE_DIR}/utils/test_hotswap_inventory_acceptance.py")
+set_tests_properties(
+  comgr_hotswap_inventory_acceptance
+  PROPERTIES SKIP_RETURN_CODE 77)

--- a/amd/comgr/test/utils/test_hotswap_inventory.py
+++ b/amd/comgr/test/utils/test_hotswap_inventory.py
@@ -346,14 +346,16 @@ class HotswapInventoryTest(unittest.TestCase):
         self.write("second", duplicate_contents)
         dangerous = self.write("$(touch PWNED)", make_elf(b"unique"))
         log = self.root / "command-log"
-        command = self.make_command("""
+        command = self.make_command(
+            """
             import json
             import os
             import sys
             with open(os.environ["INVENTORY_LOG"], "a", encoding="utf-8") as f:
                 f.write(json.dumps(sys.argv[-1]) + "\\n")
             print("processed")
-            """)
+            """
+        )
         environment = os.environ.copy()
         environment["INVENTORY_LOG"] = str(log)
 
@@ -384,11 +386,13 @@ class HotswapInventoryTest(unittest.TestCase):
 
     def test_command_failure_is_recorded_and_returns_one(self):
         self.write("object", make_elf())
-        command = self.make_command("""
+        command = self.make_command(
+            """
             import sys
             print("bad", file=sys.stderr)
             sys.exit(7)
-            """)
+            """
+        )
 
         completed = self.run_cli(
             self.root, "--execute", command[0], "--execute-arg", command[2]
@@ -408,10 +412,12 @@ class HotswapInventoryTest(unittest.TestCase):
     def test_parallel_jobs_preserve_deterministic_result_order(self):
         for index in range(5):
             self.write("object-{}".format(index), make_elf(str(index).encode("ascii")))
-        command = self.make_command("""
+        command = self.make_command(
+            """
             import sys
             print(sys.argv[-1])
-            """)
+            """
+        )
 
         completed = self.run_cli(
             self.root,
@@ -439,10 +445,12 @@ class HotswapInventoryTest(unittest.TestCase):
 
     def test_timeout_is_recorded_and_returns_one(self):
         self.write("object", make_elf())
-        command = self.make_command("""
+        command = self.make_command(
+            """
             import time
             time.sleep(10)
-            """)
+            """
+        )
 
         completed = self.run_cli(
             self.root,
@@ -463,7 +471,8 @@ class HotswapInventoryTest(unittest.TestCase):
     @unittest.skipUnless(os.name == "posix", "requires POSIX process groups")
     def test_timeout_terminates_descendants_holding_output_pipes(self):
         self.write("object", make_elf())
-        command = self.make_command("""
+        command = self.make_command(
+            """
             import subprocess
             import sys
             subprocess.Popen([
@@ -471,7 +480,8 @@ class HotswapInventoryTest(unittest.TestCase):
                 "-c",
                 "import time; time.sleep(10)",
             ])
-            """)
+            """
+        )
 
         start_time = time.monotonic()
         completed = self.run_cli(
@@ -494,13 +504,15 @@ class HotswapInventoryTest(unittest.TestCase):
         code_object = self.write("object", make_elf(b"first"))
         counter = self.root / "counter"
         cache = self.root / "cache"
-        command = self.make_command("""
+        command = self.make_command(
+            """
             import os
             from pathlib import Path
             counter = Path(os.environ["INVENTORY_COUNTER"])
             value = int(counter.read_text()) if counter.exists() else 0
             counter.write_text(str(value + 1))
-            """)
+            """
+        )
         environment = os.environ.copy()
         environment["INVENTORY_COUNTER"] = str(counter)
         arguments = [
@@ -664,7 +676,8 @@ class HotswapInventoryTest(unittest.TestCase):
         self.write("object", make_elf())
         counter = self.root / "counter"
         cache = self.root / "cache"
-        command = self.make_command("""
+        command = self.make_command(
+            """
             import os
             import sys
             from pathlib import Path
@@ -672,7 +685,8 @@ class HotswapInventoryTest(unittest.TestCase):
             value = int(counter.read_text()) if counter.exists() else 0
             counter.write_text(str(value + 1))
             sys.exit(1)
-            """)
+            """
+        )
         environment = os.environ.copy()
         environment["INVENTORY_COUNTER"] = str(counter)
         arguments = [

--- a/amd/comgr/test/utils/test_hotswap_inventory.py
+++ b/amd/comgr/test/utils/test_hotswap_inventory.py
@@ -1,0 +1,712 @@
+#!/usr/bin/env python3
+"""Hermetic tests for utils/hotswap/hotswap_inventory.py."""
+
+import base64
+import hashlib
+import importlib.util
+import json
+import os
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+SCRIPT = (Path(__file__).resolve().parents[2] / "utils" / "hotswap" /
+          "hotswap_inventory.py")
+SPEC = importlib.util.spec_from_file_location("hotswap_inventory", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+INVENTORY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(INVENTORY)
+
+
+def make_elf(payload=b"", machine=INVENTORY.EM_AMDGPU, elf_class=2,
+             endian="<", ident_version=1, elf_version=1):
+    """Build the smallest header accepted by the inventory classifier."""
+    header_size = 52 if elf_class == 1 else 64
+    header = bytearray(header_size)
+    header[:4] = INVENTORY.ELF_MAGIC
+    header[4] = elf_class
+    header[5] = 1 if endian == "<" else 2
+    header[6] = ident_version
+    struct.pack_into(endian + "HHI", header, 16, 3, machine, elf_version)
+    header_size_offset = 40 if elf_class == 1 else 52
+    struct.pack_into(endian + "H", header, header_size_offset, header_size)
+    return bytes(header) + payload
+
+
+class HotswapInventoryTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write(self, relative_path, contents):
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(contents)
+        return path
+
+    def run_cli(self, *arguments, env=None, cwd=None):
+        command = [sys.executable, str(SCRIPT)] + [
+            str(argument) for argument in arguments
+        ]
+        return subprocess.run(
+            command,
+            cwd=str(cwd or self.root),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False)
+
+    def parse_report(self, completed):
+        return json.loads(completed.stdout.decode("ascii"))
+
+    def make_command(self, body):
+        script = self.write("command.py", textwrap.dedent(body).encode())
+        return [sys.executable, "--execute-arg", script]
+
+    def test_empty_corpus(self):
+        report = INVENTORY.build_inventory([str(self.root)])
+        self.assertEqual(report["schema"], INVENTORY.SCHEMA)
+        self.assertEqual(report["version"], 2)
+        self.assertEqual(report["objects"], [])
+        self.assertEqual(report["rejected"], [])
+        self.assertEqual(
+            report["summary"],
+            {
+                "files_examined": 0,
+                "code_object_paths": 0,
+                "unique_code_objects": 0,
+                "duplicate_paths": 0,
+                "duplicate_groups": 0,
+                "rejected_files": 0,
+            })
+
+    def test_recurses_and_deduplicates_by_content_not_suffix(self):
+        contents = make_elf(b"same")
+        first = self.write("z/object.hsaco", contents)
+        second = self.write("a/no-suffix", contents)
+        unique = self.write("nested/deeper/object.txt", make_elf(b"unique"))
+        self.write("nested/not-an-elf.hsaco", b"plain text")
+
+        report = INVENTORY.build_inventory([str(self.root)])
+
+        self.assertEqual(report["summary"]["files_examined"], 4)
+        self.assertEqual(report["summary"]["code_object_paths"], 3)
+        self.assertEqual(report["summary"]["unique_code_objects"], 2)
+        self.assertEqual(report["summary"]["duplicate_paths"], 1)
+        self.assertEqual(report["summary"]["duplicate_groups"], 1)
+        groups = {item["sha256"]: item for item in report["objects"]}
+        duplicate = groups[hashlib.sha256(contents).hexdigest()]
+        expected_paths = sorted(
+            [str(first), str(second)], key=os.fsencode)
+        self.assertEqual(duplicate["paths"], expected_paths)
+        self.assertEqual(duplicate["representative"], expected_paths[0])
+        self.assertIn(str(unique), [
+            item["representative"] for item in report["objects"]
+        ])
+
+    def test_rejects_non_elf_other_machine_and_malformed_elf(self):
+        plain = self.write("plain", b"not elf")
+        host = self.write("host", make_elf(machine=62))
+        truncated = self.write("truncated", INVENTORY.ELF_MAGIC + b"\x02")
+        invalid_size = bytearray(make_elf())
+        struct.pack_into("<H", invalid_size, 52, 0)
+        invalid = self.write("invalid-size", invalid_size)
+
+        report = INVENTORY.build_inventory([str(self.root)])
+        reasons = {item["path"]: item["reason"]
+                   for item in report["rejected"]}
+
+        self.assertEqual(reasons[str(plain)], "not-elf")
+        self.assertEqual(reasons[str(host)], "non-amdgpu-elf")
+        self.assertEqual(reasons[str(truncated)], "truncated-elf-ident")
+        self.assertEqual(reasons[str(invalid)], "invalid-elf-header-size")
+
+    def test_accepts_32_bit_and_big_endian_headers(self):
+        little32 = self.write(
+            "little32", make_elf(b"32", elf_class=1, endian="<"))
+        big64 = self.write(
+            "big64", make_elf(b"64", elf_class=2, endian=">"))
+
+        report = INVENTORY.build_inventory([str(self.root)])
+
+        self.assertEqual(report["summary"]["unique_code_objects"], 2)
+        self.assertEqual(
+            {item["representative"] for item in report["objects"]},
+            {str(little32), str(big64)})
+
+    def test_repeated_and_overlapping_roots_do_not_repeat_paths(self):
+        code_object = self.write("nested/object", make_elf())
+        report = INVENTORY.build_inventory([
+            str(self.root),
+            str(self.root),
+            str(code_object.parent),
+            str(code_object),
+        ])
+        self.assertEqual(report["summary"]["files_examined"], 1)
+        self.assertEqual(report["summary"]["code_object_paths"], 1)
+
+    def test_multiple_output_roots_are_grouped_by_content_digest(self):
+        shared = make_elf(b"shared output")
+        oracle_shared = self.write("oracle/output/shared", shared)
+        candidate_shared = self.write("candidate/output/shared", shared)
+        oracle_changed = self.write(
+            "oracle/output/changed", make_elf(b"oracle"))
+        candidate_changed = self.write(
+            "candidate/output/changed", make_elf(b"candidate"))
+
+        report = INVENTORY.build_inventory([
+            str(self.root / "candidate" / "output"),
+            str(self.root / "oracle" / "output"),
+        ])
+
+        groups = {item["sha256"]: item for item in report["objects"]}
+        shared_group = groups[hashlib.sha256(shared).hexdigest()]
+        self.assertEqual(
+            shared_group["paths"],
+            sorted([str(oracle_shared), str(candidate_shared)],
+                   key=os.fsencode))
+        self.assertEqual(
+            {item["representative"] for item in report["objects"]
+             if len(item["paths"]) == 1},
+            {str(oracle_changed), str(candidate_changed)})
+
+    def test_manifest_selects_exact_files_and_records_its_digest(self):
+        first = self.write("corpus/first", make_elf(b"first"))
+        second = self.write("corpus/nested/second", make_elf(b"second"))
+        self.write("corpus/unlisted", make_elf(b"unlisted"))
+        manifest_contents = b"nested/second\nfirst\n"
+        manifest = self.write("manifest.txt", manifest_contents)
+
+        report = INVENTORY.build_inventory(
+            [str(self.root / "corpus")], str(manifest))
+
+        self.assertEqual(report["summary"]["files_examined"], 2)
+        self.assertEqual(report["summary"]["unique_code_objects"], 2)
+        self.assertEqual(
+            {item["representative"] for item in report["objects"]},
+            {str(first), str(second)})
+        self.assertEqual(
+            report["manifest"],
+            {
+                "path": str(manifest),
+                "sha256": hashlib.sha256(manifest_contents).hexdigest(),
+                "entries": 2,
+            })
+
+    def test_manifest_errors_are_specific(self):
+        corpus = self.root / "corpus"
+        corpus.mkdir()
+        self.write("corpus/object", make_elf())
+        cases = {
+            "empty": b"object\n\n",
+            "duplicate": b"object\nobject\n",
+            "absolute": os.fsencode(str(corpus / "object")) + b"\n",
+            "escape": b"../manifest.txt\n",
+            "missing": b"missing\n",
+            "nul": b"object\0suffix\n",
+        }
+        for name, contents in cases.items():
+            with self.subTest(name=name):
+                manifest = self.write(
+                    "manifests/{}.txt".format(name), contents)
+                completed = self.run_cli(
+                    corpus, "--manifest", manifest)
+                self.assertEqual(completed.returncode, 2)
+                self.assertIn(b"manifest", completed.stderr)
+
+    def test_manifest_requires_one_root(self):
+        first_root = self.root / "first-root"
+        second_root = self.root / "second-root"
+        first_root.mkdir()
+        second_root.mkdir()
+        manifest = self.write("manifest.txt", b"object\n")
+        completed = self.run_cli(
+            first_root, second_root, "--manifest", manifest)
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn(b"exactly one corpus root", completed.stderr)
+
+    @unittest.skipIf(
+        os.name == "nt" or not hasattr(os, "symlink"),
+        "symlink creation may require Windows developer mode")
+    def test_file_symlink_is_duplicate_and_directory_symlink_is_not_followed(
+            self):
+        target = self.write("real/object", make_elf())
+        file_link = self.root / "file-link"
+        file_link.symlink_to(target)
+        directory_link = self.root / "directory-link"
+        directory_link.symlink_to(target.parent, target_is_directory=True)
+
+        report = INVENTORY.build_inventory([str(self.root)])
+
+        self.assertEqual(report["summary"]["files_examined"], 2)
+        self.assertEqual(report["summary"]["code_object_paths"], 2)
+        self.assertEqual(report["summary"]["unique_code_objects"], 1)
+        self.assertEqual(
+            report["objects"][0]["paths"],
+            sorted([str(target), str(file_link)], key=os.fsencode))
+
+    @unittest.skipIf(
+        os.name == "nt" or not hasattr(os, "symlink"),
+        "symlink creation may require Windows developer mode")
+    def test_explicit_directory_symlink_root_is_traversed(self):
+        target = self.write("real/object", make_elf())
+        link = self.root / "root-link"
+        link.symlink_to(target.parent, target_is_directory=True)
+
+        report = INVENTORY.build_inventory([str(link)])
+
+        self.assertEqual(report["summary"]["code_object_paths"], 1)
+        self.assertEqual(
+            report["objects"][0]["representative"],
+            str(link / target.name))
+
+    @unittest.skipIf(
+        os.name == "nt" or not hasattr(os, "symlink"),
+        "symlink creation may require Windows developer mode")
+    def test_broken_symlink_fails_loudly(self):
+        (self.root / "broken").symlink_to(self.root / "missing")
+        completed = self.run_cli(self.root)
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn(b"broken symlink", completed.stderr)
+        self.assertEqual(completed.stdout, b"")
+
+    def test_json_is_byte_for_byte_deterministic(self):
+        self.write("z", make_elf(b"z"))
+        self.write("a", make_elf(b"a"))
+        first = self.run_cli(self.root)
+        second = self.run_cli(self.root)
+        self.assertEqual(first.returncode, 0)
+        self.assertEqual(first.stdout, second.stdout)
+        self.assertTrue(first.stdout.endswith(b"\n"))
+
+    def test_worklist_is_nul_safe_and_uses_representatives(self):
+        first = self.write("space name\nline", make_elf(b"one"))
+        self.write("duplicate", first.read_bytes())
+        second = self.write("literal;$(touch PWNED)", make_elf(b"two"))
+        worklist = self.root / "worklist"
+
+        completed = self.run_cli(self.root, "--worklist", worklist)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        paths = worklist.read_bytes().split(b"\0")
+        self.assertEqual(paths[-1], b"")
+        report = self.parse_report(completed)
+        expected = [
+            os.fsencode(item["representative"])
+            for item in report["objects"]
+        ]
+        self.assertEqual(paths[:-1], expected)
+        self.assertIn(os.fsencode(second), paths)
+        self.assertFalse((self.root / "PWNED").exists())
+
+    def test_command_runs_once_per_unique_object_without_a_shell(self):
+        duplicate_contents = make_elf(b"duplicate")
+        self.write("first", duplicate_contents)
+        self.write("second", duplicate_contents)
+        dangerous = self.write("$(touch PWNED)", make_elf(b"unique"))
+        log = self.root / "command-log"
+        command = self.make_command(
+            """
+            import json
+            import os
+            import sys
+            with open(os.environ["INVENTORY_LOG"], "a", encoding="utf-8") as f:
+                f.write(json.dumps(sys.argv[-1]) + "\\n")
+            print("processed")
+            """)
+        environment = os.environ.copy()
+        environment["INVENTORY_LOG"] = str(log)
+
+        completed = self.run_cli(
+            self.root,
+            "--execute", command[0],
+            "--execute-arg", command[2],
+            env=environment)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        report = self.parse_report(completed)
+        self.assertEqual(report["execution"]["summary"]["total"], 2)
+        self.assertEqual(report["execution"]["summary"]["passed"], 2)
+        logged_paths = [json.loads(line)
+                        for line in log.read_text().splitlines()]
+        self.assertEqual(
+            logged_paths,
+            [item["representative"] for item in report["objects"]])
+        self.assertIn(str(dangerous), logged_paths)
+        self.assertFalse((self.root / "PWNED").exists())
+        for result in report["execution"]["results"]:
+            self.assertEqual(
+                base64.b64decode(result["stdout_base64"]), b"processed\n")
+
+    def test_command_failure_is_recorded_and_returns_one(self):
+        self.write("object", make_elf())
+        command = self.make_command(
+            """
+            import sys
+            print("bad", file=sys.stderr)
+            sys.exit(7)
+            """)
+
+        completed = self.run_cli(
+            self.root,
+            "--execute", command[0],
+            "--execute-arg", command[2])
+
+        self.assertEqual(completed.returncode, 1)
+        result = self.parse_report(completed)["execution"]["results"][0]
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["returncode"], 7)
+        self.assertIsInstance(result["runtime_ms"], int)
+        self.assertGreaterEqual(result["runtime_ms"], 0)
+        self.assertEqual(
+            base64.b64decode(result["stderr_base64"]), b"bad\n")
+
+    def test_parallel_jobs_preserve_deterministic_result_order(self):
+        for index in range(5):
+            self.write(
+                "object-{}".format(index),
+                make_elf(str(index).encode("ascii")))
+        command = self.make_command(
+            """
+            import sys
+            print(sys.argv[-1])
+            """)
+
+        completed = self.run_cli(
+            self.root,
+            "--execute", command[0],
+            "--execute-arg", command[2],
+            "--jobs", "3")
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        report = self.parse_report(completed)
+        execution = report["execution"]
+        self.assertEqual(execution["jobs"], 3)
+        self.assertEqual(
+            [result["path"] for result in execution["results"]],
+            [item["representative"] for item in report["objects"]])
+        for result in execution["results"]:
+            self.assertEqual(
+                base64.b64decode(result["stdout_base64"]).decode().strip(),
+                result["path"])
+
+    def test_timeout_is_recorded_and_returns_one(self):
+        self.write("object", make_elf())
+        command = self.make_command(
+            """
+            import time
+            time.sleep(10)
+            """)
+
+        completed = self.run_cli(
+            self.root,
+            "--execute", command[0],
+            "--execute-arg", command[2],
+            "--timeout", "0.05")
+
+        self.assertEqual(completed.returncode, 1)
+        result = self.parse_report(completed)["execution"]["results"][0]
+        self.assertEqual(result["status"], "timed-out")
+        self.assertIsNone(result["returncode"])
+        self.assertGreaterEqual(result["runtime_ms"], 40)
+
+    def test_success_cache_hits_and_input_changes_invalidate(self):
+        code_object = self.write("object", make_elf(b"first"))
+        counter = self.root / "counter"
+        cache = self.root / "cache"
+        command = self.make_command(
+            """
+            import os
+            from pathlib import Path
+            counter = Path(os.environ["INVENTORY_COUNTER"])
+            value = int(counter.read_text()) if counter.exists() else 0
+            counter.write_text(str(value + 1))
+            """)
+        environment = os.environ.copy()
+        environment["INVENTORY_COUNTER"] = str(counter)
+        arguments = [
+            self.root,
+            "--execute", command[0],
+            "--execute-arg", command[2],
+            "--cache-dir", cache,
+        ]
+
+        first = self.run_cli(*arguments, env=environment)
+        second = self.run_cli(*arguments, env=environment)
+        code_object.write_bytes(make_elf(b"changed"))
+        third = self.run_cli(*arguments, env=environment)
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertEqual(third.returncode, 0, third.stderr)
+        self.assertEqual(counter.read_text(), "2")
+        self.assertEqual(
+            self.parse_report(first)["execution"]["summary"]["cache_hits"], 0)
+        self.assertEqual(
+            self.parse_report(second)["execution"]["summary"]["cache_hits"], 1)
+        self.assertEqual(
+            self.parse_report(third)["execution"]["summary"]["cache_hits"], 0)
+        first_execution = self.parse_report(first)["execution"]
+        second_execution = self.parse_report(second)["execution"]
+        self.assertEqual(
+            first_execution["results"][0]["runtime_ms"],
+            second_execution["results"][0]["runtime_ms"])
+        self.assertEqual(
+            second_execution["summary"]["estimated_runtime_ms"],
+            second_execution["results"][0]["runtime_ms"])
+        self.assertEqual(
+            second_execution["summary"]["executed_runtime_ms"], 0)
+
+    def test_failed_command_is_not_cached(self):
+        self.write("object", make_elf())
+        counter = self.root / "counter"
+        cache = self.root / "cache"
+        command = self.make_command(
+            """
+            import os
+            import sys
+            from pathlib import Path
+            counter = Path(os.environ["INVENTORY_COUNTER"])
+            value = int(counter.read_text()) if counter.exists() else 0
+            counter.write_text(str(value + 1))
+            sys.exit(1)
+            """)
+        environment = os.environ.copy()
+        environment["INVENTORY_COUNTER"] = str(counter)
+        arguments = [
+            self.root,
+            "--execute", command[0],
+            "--execute-arg", command[2],
+            "--cache-dir", cache,
+        ]
+
+        first = self.run_cli(*arguments, env=environment)
+        second = self.run_cli(*arguments, env=environment)
+
+        self.assertEqual(first.returncode, 1)
+        self.assertEqual(second.returncode, 1)
+        self.assertEqual(counter.read_text(), "2")
+
+    def test_corrupt_cache_fails_loudly(self):
+        self.write("object", make_elf())
+        cache = self.root / "cache"
+        command = self.make_command("print('ok')\n")
+        arguments = [
+            self.root,
+            "--execute", command[0],
+            "--execute-arg", command[2],
+            "--cache-dir", cache,
+        ]
+        first = self.run_cli(*arguments)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        cache_entries = list(cache.rglob("*.json"))
+        self.assertEqual(len(cache_entries), 1)
+        cache_entries[0].write_text("{not json")
+
+        second = self.run_cli(*arguments)
+
+        self.assertEqual(second.returncode, 2)
+        self.assertIn(b"cannot read cache entry", second.stderr)
+        self.assertEqual(second.stdout, b"")
+
+    def test_non_object_cache_entry_fails_loudly(self):
+        self.write("object", make_elf())
+        cache = self.root / "cache"
+        command = self.make_command("print('ok')\n")
+        arguments = [
+            self.root,
+            "--execute", command[0],
+            "--execute-arg", command[2],
+            "--cache-dir", cache,
+        ]
+        first = self.run_cli(*arguments)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        cache_entry = next(cache.rglob("*.json"))
+        cache_entry.write_text("[]")
+
+        second = self.run_cli(*arguments)
+
+        self.assertEqual(second.returncode, 2)
+        self.assertIn(b"is not a JSON object", second.stderr)
+
+    def test_stale_cache_version_is_rejected(self):
+        self.write("object", make_elf())
+        cache = self.root / "cache"
+        command = self.make_command("print('ok')\n")
+        arguments = [
+            self.root,
+            "--execute", command[0],
+            "--execute-arg", command[2],
+            "--cache-dir", cache,
+        ]
+        first = self.run_cli(*arguments)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        cache_entry = next(cache.rglob("*.json"))
+        entry = json.loads(cache_entry.read_text())
+        self.assertEqual(entry["version"], INVENTORY.CACHE_VERSION)
+        entry["version"] = INVENTORY.CACHE_VERSION - 1
+        cache_entry.write_text(json.dumps(entry))
+
+        second = self.run_cli(*arguments)
+
+        self.assertEqual(second.returncode, 2)
+        self.assertIn(b"invalid version", second.stderr)
+
+    def test_cache_runtime_requires_nonnegative_integer(self):
+        self.write("object", make_elf())
+        cache = self.root / "cache"
+        command = self.make_command("print('ok')\n")
+        arguments = [
+            self.root,
+            "--execute", command[0],
+            "--execute-arg", command[2],
+            "--cache-dir", cache,
+        ]
+        first = self.run_cli(*arguments)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        cache_entry = next(cache.rglob("*.json"))
+        entry = json.loads(cache_entry.read_text())
+        for invalid_runtime in (-1, 1.5, True, None):
+            with self.subTest(invalid_runtime=invalid_runtime):
+                entry["runtime_ms"] = invalid_runtime
+                cache_entry.write_text(json.dumps(entry))
+                completed = self.run_cli(*arguments)
+                self.assertEqual(completed.returncode, 2)
+                self.assertIn(b"invalid runtime_ms", completed.stderr)
+
+    def test_command_file_content_change_invalidates_cache_identity(self):
+        self.write("object", make_elf())
+        cache = self.root / "cache"
+        command_script = self.write("worker.py", b"print('first')\n")
+        arguments = [
+            self.root,
+            "--execute", sys.executable,
+            "--execute-arg", command_script,
+            "--cache-dir", cache,
+        ]
+
+        first = self.run_cli(*arguments)
+        command_script.write_bytes(b"print('second')\n")
+        second = self.run_cli(*arguments)
+
+        first_execution = self.parse_report(first)["execution"]
+        second_execution = self.parse_report(second)["execution"]
+        self.assertNotEqual(
+            first_execution["command_key"], second_execution["command_key"])
+        self.assertEqual(second_execution["summary"]["cache_hits"], 0)
+        self.assertEqual(
+            base64.b64decode(
+                second_execution["results"][0]["stdout_base64"]),
+            b"second\n")
+
+    def test_cache_dependency_and_tag_change_command_identity(self):
+        self.write("object", make_elf())
+        dependency = self.write("libcandidate.so", b"version one")
+        command = self.make_command("print('ok')\n")
+
+        def run(tag):
+            return self.run_cli(
+                self.root,
+                "--execute", command[0],
+                "--execute-arg", command[2],
+                "--cache-dependency", dependency,
+                "--cache-tag", tag)
+
+        first = self.parse_report(run("configuration-one"))["execution"]
+        dependency.write_bytes(b"version two")
+        second = self.parse_report(run("configuration-one"))["execution"]
+        third = self.parse_report(run("configuration-two"))["execution"]
+
+        self.assertNotEqual(first["command_key"], second["command_key"])
+        self.assertNotEqual(second["command_key"], third["command_key"])
+        self.assertEqual(
+            second["cache_dependencies"], [str(dependency)])
+        self.assertEqual(third["cache_tags"], ["configuration-two"])
+
+    def test_unknown_flag_and_invalid_option_relationships_are_rejected(self):
+        for arguments in (
+                [self.root, "--unknown"],
+                [self.root, "--execute-arg", "x"],
+                [self.root, "--cache-dir", "cache"],
+                [self.root, "--cache-dependency", "dependency"],
+                [self.root, "--cache-tag", "tag"],
+                [self.root, "--timeout", "0"],
+                [self.root, "--timeout", "1"],
+                [self.root, "--jobs", "0"],
+                [self.root, "--jobs", "2"],
+                [self.root, "--worklist", "-"]):
+            with self.subTest(arguments=arguments):
+                completed = self.run_cli(*arguments)
+                self.assertEqual(completed.returncode, 2)
+                self.assertIn(b"error:", completed.stderr)
+
+    def test_missing_root_and_missing_output_directory_fail_loudly(self):
+        missing = self.run_cli(self.root / "missing")
+        self.assertEqual(missing.returncode, 2)
+        self.assertIn(b"does not exist", missing.stderr)
+
+        output = self.run_cli(
+            self.root, "--json-output", self.root / "missing" / "report.json")
+        self.assertEqual(output.returncode, 2)
+        self.assertIn(b"output directory does not exist", output.stderr)
+
+    def test_same_json_and_worklist_path_is_rejected(self):
+        output = self.root / "output"
+        completed = self.run_cli(
+            self.root, "--json-output", output, "--worklist", output)
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn(b"must be different", completed.stderr)
+
+    def test_output_cannot_overwrite_input_or_manifest(self):
+        code_object = self.write("corpus/object", make_elf())
+        manifest = self.write("manifest.txt", b"object\n")
+        for arguments in (
+                [self.root / "corpus", "--json-output", code_object],
+                [self.root / "corpus", "--worklist", code_object],
+                [
+                    self.root / "corpus",
+                    "--manifest", manifest,
+                    "--json-output", manifest,
+                ]):
+            with self.subTest(arguments=arguments):
+                completed = self.run_cli(*arguments)
+                self.assertEqual(completed.returncode, 2)
+                self.assertIn(
+                    b"refusing to overwrite inventory input",
+                    completed.stderr)
+                self.assertEqual(code_object.read_bytes(), make_elf())
+
+    def test_help_documents_execution_and_worklist(self):
+        completed = self.run_cli("--help")
+        self.assertEqual(completed.returncode, 0)
+        self.assertIn(b"--worklist", completed.stdout)
+        self.assertIn(b"--manifest", completed.stdout)
+        self.assertIn(b"--execute", completed.stdout)
+        self.assertIn(b"--cache-dir", completed.stdout)
+        self.assertIn(b"--cache-dependency", completed.stdout)
+        self.assertIn(b"--cache-tag", completed.stdout)
+        self.assertIn(b"--jobs", completed.stdout)
+
+    def test_rejects_non_regular_explicit_root(self):
+        if not hasattr(os, "mkfifo"):
+            self.skipTest("FIFOs unavailable")
+        fifo = self.root / "fifo"
+        os.mkfifo(fifo)
+        mode = fifo.stat().st_mode
+        self.assertTrue(stat.S_ISFIFO(mode))
+        completed = self.run_cli(fifo)
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn(b"not a regular file or directory", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/amd/comgr/test/utils/test_hotswap_inventory.py
+++ b/amd/comgr/test/utils/test_hotswap_inventory.py
@@ -12,20 +12,28 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 import unittest
 from pathlib import Path
 
 
-SCRIPT = (Path(__file__).resolve().parents[2] / "utils" / "hotswap" /
-          "hotswap_inventory.py")
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / "utils" / "hotswap" / "hotswap_inventory.py"
+)
 SPEC = importlib.util.spec_from_file_location("hotswap_inventory", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 INVENTORY = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(INVENTORY)
 
 
-def make_elf(payload=b"", machine=INVENTORY.EM_AMDGPU, elf_class=2,
-             endian="<", ident_version=1, elf_version=1):
+def make_elf(
+    payload=b"",
+    machine=INVENTORY.EM_AMDGPU,
+    elf_class=2,
+    endian="<",
+    ident_version=1,
+    elf_version=1,
+):
     """Build the smallest header accepted by the inventory classifier."""
     header_size = 52 if elf_class == 1 else 64
     header = bytearray(header_size)
@@ -63,7 +71,8 @@ class HotswapInventoryTest(unittest.TestCase):
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            check=False)
+            check=False,
+        )
 
     def parse_report(self, completed):
         return json.loads(completed.stdout.decode("ascii"))
@@ -87,7 +96,8 @@ class HotswapInventoryTest(unittest.TestCase):
                 "duplicate_paths": 0,
                 "duplicate_groups": 0,
                 "rejected_files": 0,
-            })
+            },
+        )
 
     def test_recurses_and_deduplicates_by_content_not_suffix(self):
         contents = make_elf(b"same")
@@ -105,13 +115,12 @@ class HotswapInventoryTest(unittest.TestCase):
         self.assertEqual(report["summary"]["duplicate_groups"], 1)
         groups = {item["sha256"]: item for item in report["objects"]}
         duplicate = groups[hashlib.sha256(contents).hexdigest()]
-        expected_paths = sorted(
-            [str(first), str(second)], key=os.fsencode)
+        expected_paths = sorted([str(first), str(second)], key=os.fsencode)
         self.assertEqual(duplicate["paths"], expected_paths)
         self.assertEqual(duplicate["representative"], expected_paths[0])
-        self.assertIn(str(unique), [
-            item["representative"] for item in report["objects"]
-        ])
+        self.assertIn(
+            str(unique), [item["representative"] for item in report["objects"]]
+        )
 
     def test_rejects_non_elf_other_machine_and_malformed_elf(self):
         plain = self.write("plain", b"not elf")
@@ -122,8 +131,7 @@ class HotswapInventoryTest(unittest.TestCase):
         invalid = self.write("invalid-size", invalid_size)
 
         report = INVENTORY.build_inventory([str(self.root)])
-        reasons = {item["path"]: item["reason"]
-                   for item in report["rejected"]}
+        reasons = {item["path"]: item["reason"] for item in report["rejected"]}
 
         self.assertEqual(reasons[str(plain)], "not-elf")
         self.assertEqual(reasons[str(host)], "non-amdgpu-elf")
@@ -131,26 +139,27 @@ class HotswapInventoryTest(unittest.TestCase):
         self.assertEqual(reasons[str(invalid)], "invalid-elf-header-size")
 
     def test_accepts_32_bit_and_big_endian_headers(self):
-        little32 = self.write(
-            "little32", make_elf(b"32", elf_class=1, endian="<"))
-        big64 = self.write(
-            "big64", make_elf(b"64", elf_class=2, endian=">"))
+        little32 = self.write("little32", make_elf(b"32", elf_class=1, endian="<"))
+        big64 = self.write("big64", make_elf(b"64", elf_class=2, endian=">"))
 
         report = INVENTORY.build_inventory([str(self.root)])
 
         self.assertEqual(report["summary"]["unique_code_objects"], 2)
         self.assertEqual(
             {item["representative"] for item in report["objects"]},
-            {str(little32), str(big64)})
+            {str(little32), str(big64)},
+        )
 
     def test_repeated_and_overlapping_roots_do_not_repeat_paths(self):
         code_object = self.write("nested/object", make_elf())
-        report = INVENTORY.build_inventory([
-            str(self.root),
-            str(self.root),
-            str(code_object.parent),
-            str(code_object),
-        ])
+        report = INVENTORY.build_inventory(
+            [
+                str(self.root),
+                str(self.root),
+                str(code_object.parent),
+                str(code_object),
+            ]
+        )
         self.assertEqual(report["summary"]["files_examined"], 1)
         self.assertEqual(report["summary"]["code_object_paths"], 1)
 
@@ -158,26 +167,32 @@ class HotswapInventoryTest(unittest.TestCase):
         shared = make_elf(b"shared output")
         oracle_shared = self.write("oracle/output/shared", shared)
         candidate_shared = self.write("candidate/output/shared", shared)
-        oracle_changed = self.write(
-            "oracle/output/changed", make_elf(b"oracle"))
+        oracle_changed = self.write("oracle/output/changed", make_elf(b"oracle"))
         candidate_changed = self.write(
-            "candidate/output/changed", make_elf(b"candidate"))
+            "candidate/output/changed", make_elf(b"candidate")
+        )
 
-        report = INVENTORY.build_inventory([
-            str(self.root / "candidate" / "output"),
-            str(self.root / "oracle" / "output"),
-        ])
+        report = INVENTORY.build_inventory(
+            [
+                str(self.root / "candidate" / "output"),
+                str(self.root / "oracle" / "output"),
+            ]
+        )
 
         groups = {item["sha256"]: item for item in report["objects"]}
         shared_group = groups[hashlib.sha256(shared).hexdigest()]
         self.assertEqual(
             shared_group["paths"],
-            sorted([str(oracle_shared), str(candidate_shared)],
-                   key=os.fsencode))
+            sorted([str(oracle_shared), str(candidate_shared)], key=os.fsencode),
+        )
         self.assertEqual(
-            {item["representative"] for item in report["objects"]
-             if len(item["paths"]) == 1},
-            {str(oracle_changed), str(candidate_changed)})
+            {
+                item["representative"]
+                for item in report["objects"]
+                if len(item["paths"]) == 1
+            },
+            {str(oracle_changed), str(candidate_changed)},
+        )
 
     def test_manifest_selects_exact_files_and_records_its_digest(self):
         first = self.write("corpus/first", make_elf(b"first"))
@@ -186,21 +201,22 @@ class HotswapInventoryTest(unittest.TestCase):
         manifest_contents = b"nested/second\nfirst\n"
         manifest = self.write("manifest.txt", manifest_contents)
 
-        report = INVENTORY.build_inventory(
-            [str(self.root / "corpus")], str(manifest))
+        report = INVENTORY.build_inventory([str(self.root / "corpus")], str(manifest))
 
         self.assertEqual(report["summary"]["files_examined"], 2)
         self.assertEqual(report["summary"]["unique_code_objects"], 2)
         self.assertEqual(
             {item["representative"] for item in report["objects"]},
-            {str(first), str(second)})
+            {str(first), str(second)},
+        )
         self.assertEqual(
             report["manifest"],
             {
                 "path": str(manifest),
                 "sha256": hashlib.sha256(manifest_contents).hexdigest(),
                 "entries": 2,
-            })
+            },
+        )
 
     def test_manifest_errors_are_specific(self):
         corpus = self.root / "corpus"
@@ -216,10 +232,10 @@ class HotswapInventoryTest(unittest.TestCase):
         }
         for name, contents in cases.items():
             with self.subTest(name=name):
-                manifest = self.write(
-                    "manifests/{}.txt".format(name), contents)
-                completed = self.run_cli(
-                    corpus, "--manifest", manifest)
+                # Prefix the case name because names such as "nul.txt" address a
+                # reserved device instead of a regular file on Windows.
+                manifest = self.write("manifests/case-{}.txt".format(name), contents)
+                completed = self.run_cli(corpus, "--manifest", manifest)
                 self.assertEqual(completed.returncode, 2)
                 self.assertIn(b"manifest", completed.stderr)
 
@@ -229,16 +245,31 @@ class HotswapInventoryTest(unittest.TestCase):
         first_root.mkdir()
         second_root.mkdir()
         manifest = self.write("manifest.txt", b"object\n")
-        completed = self.run_cli(
-            first_root, second_root, "--manifest", manifest)
+        completed = self.run_cli(first_root, second_root, "--manifest", manifest)
         self.assertEqual(completed.returncode, 2)
         self.assertIn(b"exactly one corpus root", completed.stderr)
 
     @unittest.skipIf(
         os.name == "nt" or not hasattr(os, "symlink"),
-        "symlink creation may require Windows developer mode")
-    def test_file_symlink_is_duplicate_and_directory_symlink_is_not_followed(
-            self):
+        "symlink creation may require Windows developer mode",
+    )
+    def test_manifest_rejects_symlink_escape(self):
+        corpus = self.root / "corpus"
+        corpus.mkdir()
+        outside = self.write("outside/object", make_elf())
+        (corpus / "outside-link").symlink_to(outside)
+        manifest = self.write("manifest.txt", b"outside-link\n")
+
+        completed = self.run_cli(corpus, "--manifest", manifest)
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn(b"escapes its corpus root through a symlink", completed.stderr)
+
+    @unittest.skipIf(
+        os.name == "nt" or not hasattr(os, "symlink"),
+        "symlink creation may require Windows developer mode",
+    )
+    def test_file_symlink_is_duplicate_and_directory_symlink_is_not_followed(self):
         target = self.write("real/object", make_elf())
         file_link = self.root / "file-link"
         file_link.symlink_to(target)
@@ -252,11 +283,13 @@ class HotswapInventoryTest(unittest.TestCase):
         self.assertEqual(report["summary"]["unique_code_objects"], 1)
         self.assertEqual(
             report["objects"][0]["paths"],
-            sorted([str(target), str(file_link)], key=os.fsencode))
+            sorted([str(target), str(file_link)], key=os.fsencode),
+        )
 
     @unittest.skipIf(
         os.name == "nt" or not hasattr(os, "symlink"),
-        "symlink creation may require Windows developer mode")
+        "symlink creation may require Windows developer mode",
+    )
     def test_explicit_directory_symlink_root_is_traversed(self):
         target = self.write("real/object", make_elf())
         link = self.root / "root-link"
@@ -266,12 +299,13 @@ class HotswapInventoryTest(unittest.TestCase):
 
         self.assertEqual(report["summary"]["code_object_paths"], 1)
         self.assertEqual(
-            report["objects"][0]["representative"],
-            str(link / target.name))
+            report["objects"][0]["representative"], str(link / target.name)
+        )
 
     @unittest.skipIf(
         os.name == "nt" or not hasattr(os, "symlink"),
-        "symlink creation may require Windows developer mode")
+        "symlink creation may require Windows developer mode",
+    )
     def test_broken_symlink_fails_loudly(self):
         (self.root / "broken").symlink_to(self.root / "missing")
         completed = self.run_cli(self.root)
@@ -289,7 +323,8 @@ class HotswapInventoryTest(unittest.TestCase):
         self.assertTrue(first.stdout.endswith(b"\n"))
 
     def test_worklist_is_nul_safe_and_uses_representatives(self):
-        first = self.write("space name\nline", make_elf(b"one"))
+        unusual_name = "space name\nline" if os.name != "nt" else "space name & line"
+        first = self.write(unusual_name, make_elf(b"one"))
         self.write("duplicate", first.read_bytes())
         second = self.write("literal;$(touch PWNED)", make_elf(b"two"))
         worklist = self.root / "worklist"
@@ -300,10 +335,7 @@ class HotswapInventoryTest(unittest.TestCase):
         paths = worklist.read_bytes().split(b"\0")
         self.assertEqual(paths[-1], b"")
         report = self.parse_report(completed)
-        expected = [
-            os.fsencode(item["representative"])
-            for item in report["objects"]
-        ]
+        expected = [os.fsencode(item["representative"]) for item in report["objects"]]
         self.assertEqual(paths[:-1], expected)
         self.assertIn(os.fsencode(second), paths)
         self.assertFalse((self.root / "PWNED").exists())
@@ -314,8 +346,7 @@ class HotswapInventoryTest(unittest.TestCase):
         self.write("second", duplicate_contents)
         dangerous = self.write("$(touch PWNED)", make_elf(b"unique"))
         log = self.root / "command-log"
-        command = self.make_command(
-            """
+        command = self.make_command("""
             import json
             import os
             import sys
@@ -328,38 +359,40 @@ class HotswapInventoryTest(unittest.TestCase):
 
         completed = self.run_cli(
             self.root,
-            "--execute", command[0],
-            "--execute-arg", command[2],
-            env=environment)
+            "--execute",
+            command[0],
+            "--execute-arg",
+            command[2],
+            env=environment,
+        )
 
         self.assertEqual(completed.returncode, 0, completed.stderr)
         report = self.parse_report(completed)
         self.assertEqual(report["execution"]["summary"]["total"], 2)
         self.assertEqual(report["execution"]["summary"]["passed"], 2)
-        logged_paths = [json.loads(line)
-                        for line in log.read_text().splitlines()]
+        logged_paths = [json.loads(line) for line in log.read_text().splitlines()]
         self.assertEqual(
-            logged_paths,
-            [item["representative"] for item in report["objects"]])
+            logged_paths, [item["representative"] for item in report["objects"]]
+        )
         self.assertIn(str(dangerous), logged_paths)
         self.assertFalse((self.root / "PWNED").exists())
         for result in report["execution"]["results"]:
             self.assertEqual(
-                base64.b64decode(result["stdout_base64"]), b"processed\n")
+                base64.b64decode(result["stdout_base64"]),
+                b"processed" + os.linesep.encode(),
+            )
 
     def test_command_failure_is_recorded_and_returns_one(self):
         self.write("object", make_elf())
-        command = self.make_command(
-            """
+        command = self.make_command("""
             import sys
             print("bad", file=sys.stderr)
             sys.exit(7)
             """)
 
         completed = self.run_cli(
-            self.root,
-            "--execute", command[0],
-            "--execute-arg", command[2])
+            self.root, "--execute", command[0], "--execute-arg", command[2]
+        )
 
         self.assertEqual(completed.returncode, 1)
         result = self.parse_report(completed)["execution"]["results"][0]
@@ -368,24 +401,27 @@ class HotswapInventoryTest(unittest.TestCase):
         self.assertIsInstance(result["runtime_ms"], int)
         self.assertGreaterEqual(result["runtime_ms"], 0)
         self.assertEqual(
-            base64.b64decode(result["stderr_base64"]), b"bad\n")
+            base64.b64decode(result["stderr_base64"]),
+            b"bad" + os.linesep.encode(),
+        )
 
     def test_parallel_jobs_preserve_deterministic_result_order(self):
         for index in range(5):
-            self.write(
-                "object-{}".format(index),
-                make_elf(str(index).encode("ascii")))
-        command = self.make_command(
-            """
+            self.write("object-{}".format(index), make_elf(str(index).encode("ascii")))
+        command = self.make_command("""
             import sys
             print(sys.argv[-1])
             """)
 
         completed = self.run_cli(
             self.root,
-            "--execute", command[0],
-            "--execute-arg", command[2],
-            "--jobs", "3")
+            "--execute",
+            command[0],
+            "--execute-arg",
+            command[2],
+            "--jobs",
+            "3",
+        )
 
         self.assertEqual(completed.returncode, 0, completed.stderr)
         report = self.parse_report(completed)
@@ -393,25 +429,30 @@ class HotswapInventoryTest(unittest.TestCase):
         self.assertEqual(execution["jobs"], 3)
         self.assertEqual(
             [result["path"] for result in execution["results"]],
-            [item["representative"] for item in report["objects"]])
+            [item["representative"] for item in report["objects"]],
+        )
         for result in execution["results"]:
             self.assertEqual(
                 base64.b64decode(result["stdout_base64"]).decode().strip(),
-                result["path"])
+                result["path"],
+            )
 
     def test_timeout_is_recorded_and_returns_one(self):
         self.write("object", make_elf())
-        command = self.make_command(
-            """
+        command = self.make_command("""
             import time
             time.sleep(10)
             """)
 
         completed = self.run_cli(
             self.root,
-            "--execute", command[0],
-            "--execute-arg", command[2],
-            "--timeout", "0.05")
+            "--execute",
+            command[0],
+            "--execute-arg",
+            command[2],
+            "--timeout",
+            "0.05",
+        )
 
         self.assertEqual(completed.returncode, 1)
         result = self.parse_report(completed)["execution"]["results"][0]
@@ -419,12 +460,41 @@ class HotswapInventoryTest(unittest.TestCase):
         self.assertIsNone(result["returncode"])
         self.assertGreaterEqual(result["runtime_ms"], 40)
 
+    @unittest.skipUnless(os.name == "posix", "requires POSIX process groups")
+    def test_timeout_terminates_descendants_holding_output_pipes(self):
+        self.write("object", make_elf())
+        command = self.make_command("""
+            import subprocess
+            import sys
+            subprocess.Popen([
+                sys.executable,
+                "-c",
+                "import time; time.sleep(10)",
+            ])
+            """)
+
+        start_time = time.monotonic()
+        completed = self.run_cli(
+            self.root,
+            "--execute",
+            command[0],
+            "--execute-arg",
+            command[2],
+            "--timeout",
+            "0.05",
+        )
+        elapsed = time.monotonic() - start_time
+
+        self.assertEqual(completed.returncode, 1)
+        result = self.parse_report(completed)["execution"]["results"][0]
+        self.assertEqual(result["status"], "timed-out")
+        self.assertLess(elapsed, 2.0)
+
     def test_success_cache_hits_and_input_changes_invalidate(self):
         code_object = self.write("object", make_elf(b"first"))
         counter = self.root / "counter"
         cache = self.root / "cache"
-        command = self.make_command(
-            """
+        command = self.make_command("""
             import os
             from pathlib import Path
             counter = Path(os.environ["INVENTORY_COUNTER"])
@@ -435,9 +505,12 @@ class HotswapInventoryTest(unittest.TestCase):
         environment["INVENTORY_COUNTER"] = str(counter)
         arguments = [
             self.root,
-            "--execute", command[0],
-            "--execute-arg", command[2],
-            "--cache-dir", cache,
+            "--execute",
+            command[0],
+            "--execute-arg",
+            command[2],
+            "--cache-dir",
+            cache,
         ]
 
         first = self.run_cli(*arguments, env=environment)
@@ -450,28 +523,148 @@ class HotswapInventoryTest(unittest.TestCase):
         self.assertEqual(third.returncode, 0, third.stderr)
         self.assertEqual(counter.read_text(), "2")
         self.assertEqual(
-            self.parse_report(first)["execution"]["summary"]["cache_hits"], 0)
+            self.parse_report(first)["execution"]["summary"]["cache_hits"], 0
+        )
         self.assertEqual(
-            self.parse_report(second)["execution"]["summary"]["cache_hits"], 1)
+            self.parse_report(second)["execution"]["summary"]["cache_hits"], 1
+        )
         self.assertEqual(
-            self.parse_report(third)["execution"]["summary"]["cache_hits"], 0)
+            self.parse_report(third)["execution"]["summary"]["cache_hits"], 0
+        )
         first_execution = self.parse_report(first)["execution"]
         second_execution = self.parse_report(second)["execution"]
         self.assertEqual(
             first_execution["results"][0]["runtime_ms"],
-            second_execution["results"][0]["runtime_ms"])
+            second_execution["results"][0]["runtime_ms"],
+        )
+        uncached_result = dict(first_execution["results"][0])
+        cached_result = dict(second_execution["results"][0])
+        uncached_result.pop("cached")
+        cached_result.pop("cached")
+        self.assertEqual(uncached_result, cached_result)
         self.assertEqual(
             second_execution["summary"]["estimated_runtime_ms"],
-            second_execution["results"][0]["runtime_ms"])
+            second_execution["results"][0]["runtime_ms"],
+        )
+        self.assertEqual(second_execution["summary"]["executed_runtime_ms"], 0)
+
+    def test_cache_key_includes_representative_path(self):
+        contents = make_elf(b"same bytes")
+        first_object = self.write("first/object", contents)
+        second_object = self.write("second/object", contents)
+        cache = self.root / "cache"
+        command = self.write("worker.py", b"import sys\nprint(sys.argv[-1])\n")
+
+        def run(corpus_root):
+            return self.run_cli(
+                corpus_root,
+                "--execute",
+                sys.executable,
+                "--execute-arg",
+                command,
+                "--cache-dir",
+                cache,
+            )
+
+        first = run(first_object.parent)
+        second = run(second_object.parent)
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        second_result = self.parse_report(second)["execution"]["results"][0]
+        self.assertFalse(second_result["cached"])
         self.assertEqual(
-            second_execution["summary"]["executed_runtime_ms"], 0)
+            base64.b64decode(second_result["stdout_base64"]),
+            os.fsencode(second_object) + os.linesep.encode(),
+        )
+
+    def test_cache_key_includes_timeout(self):
+        corpus = self.root / "corpus"
+        self.write("corpus/object", make_elf())
+        cache = self.root / "cache"
+        command = self.write("worker.py", b"import time\ntime.sleep(0.1)\n")
+        base_arguments = [
+            corpus,
+            "--execute",
+            sys.executable,
+            "--execute-arg",
+            command,
+            "--cache-dir",
+            cache,
+        ]
+
+        first = self.run_cli(*base_arguments)
+        second = self.run_cli(*base_arguments, "--timeout", "0.01")
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 1)
+        second_result = self.parse_report(second)["execution"]["results"][0]
+        self.assertFalse(second_result["cached"])
+        self.assertEqual(second_result["status"], "timed-out")
+
+    def test_concurrent_cache_writers_leave_a_valid_entry(self):
+        corpus = self.root / "corpus"
+        self.write("corpus/object", make_elf())
+        cache = self.root / "cache"
+        command = self.write(
+            "worker.py", b"import time\ntime.sleep(0.1)\nprint('complete')\n"
+        )
+        arguments = [
+            sys.executable,
+            str(SCRIPT),
+            str(corpus),
+            "--execute",
+            sys.executable,
+            "--execute-arg",
+            str(command),
+            "--cache-dir",
+            str(cache),
+        ]
+
+        first = subprocess.Popen(
+            arguments,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        second = subprocess.Popen(
+            arguments,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        first_output, first_error = first.communicate(timeout=30)
+        second_output, second_error = second.communicate(timeout=30)
+
+        self.assertEqual(first.returncode, 0, first_error)
+        self.assertEqual(second.returncode, 0, second_error)
+        self.assertEqual(json.loads(first_output)["execution"]["summary"]["total"], 1)
+        self.assertEqual(json.loads(second_output)["execution"]["summary"]["total"], 1)
+        cache_entries = list(cache.rglob("*.json"))
+        self.assertEqual(len(cache_entries), 1)
+        cache_entry = json.loads(cache_entries[0].read_text(encoding="ascii"))
+        self.assertEqual(cache_entry["schema"], INVENTORY.CACHE_SCHEMA)
+        self.assertEqual(cache_entry["version"], INVENTORY.CACHE_VERSION)
+
+        cached = self.run_cli(
+            corpus,
+            "--execute",
+            sys.executable,
+            "--execute-arg",
+            command,
+            "--cache-dir",
+            cache,
+        )
+        self.assertEqual(cached.returncode, 0, cached.stderr)
+        self.assertEqual(
+            self.parse_report(cached)["execution"]["summary"]["cache_hits"], 1
+        )
 
     def test_failed_command_is_not_cached(self):
         self.write("object", make_elf())
         counter = self.root / "counter"
         cache = self.root / "cache"
-        command = self.make_command(
-            """
+        command = self.make_command("""
             import os
             import sys
             from pathlib import Path
@@ -484,9 +677,12 @@ class HotswapInventoryTest(unittest.TestCase):
         environment["INVENTORY_COUNTER"] = str(counter)
         arguments = [
             self.root,
-            "--execute", command[0],
-            "--execute-arg", command[2],
-            "--cache-dir", cache,
+            "--execute",
+            command[0],
+            "--execute-arg",
+            command[2],
+            "--cache-dir",
+            cache,
         ]
 
         first = self.run_cli(*arguments, env=environment)
@@ -502,9 +698,12 @@ class HotswapInventoryTest(unittest.TestCase):
         command = self.make_command("print('ok')\n")
         arguments = [
             self.root,
-            "--execute", command[0],
-            "--execute-arg", command[2],
-            "--cache-dir", cache,
+            "--execute",
+            command[0],
+            "--execute-arg",
+            command[2],
+            "--cache-dir",
+            cache,
         ]
         first = self.run_cli(*arguments)
         self.assertEqual(first.returncode, 0, first.stderr)
@@ -524,9 +723,12 @@ class HotswapInventoryTest(unittest.TestCase):
         command = self.make_command("print('ok')\n")
         arguments = [
             self.root,
-            "--execute", command[0],
-            "--execute-arg", command[2],
-            "--cache-dir", cache,
+            "--execute",
+            command[0],
+            "--execute-arg",
+            command[2],
+            "--cache-dir",
+            cache,
         ]
         first = self.run_cli(*arguments)
         self.assertEqual(first.returncode, 0, first.stderr)
@@ -544,9 +746,12 @@ class HotswapInventoryTest(unittest.TestCase):
         command = self.make_command("print('ok')\n")
         arguments = [
             self.root,
-            "--execute", command[0],
-            "--execute-arg", command[2],
-            "--cache-dir", cache,
+            "--execute",
+            command[0],
+            "--execute-arg",
+            command[2],
+            "--cache-dir",
+            cache,
         ]
         first = self.run_cli(*arguments)
         self.assertEqual(first.returncode, 0, first.stderr)
@@ -567,9 +772,12 @@ class HotswapInventoryTest(unittest.TestCase):
         command = self.make_command("print('ok')\n")
         arguments = [
             self.root,
-            "--execute", command[0],
-            "--execute-arg", command[2],
-            "--cache-dir", cache,
+            "--execute",
+            command[0],
+            "--execute-arg",
+            command[2],
+            "--cache-dir",
+            cache,
         ]
         first = self.run_cli(*arguments)
         self.assertEqual(first.returncode, 0, first.stderr)
@@ -589,9 +797,12 @@ class HotswapInventoryTest(unittest.TestCase):
         command_script = self.write("worker.py", b"print('first')\n")
         arguments = [
             self.root,
-            "--execute", sys.executable,
-            "--execute-arg", command_script,
-            "--cache-dir", cache,
+            "--execute",
+            sys.executable,
+            "--execute-arg",
+            command_script,
+            "--cache-dir",
+            cache,
         ]
 
         first = self.run_cli(*arguments)
@@ -601,12 +812,13 @@ class HotswapInventoryTest(unittest.TestCase):
         first_execution = self.parse_report(first)["execution"]
         second_execution = self.parse_report(second)["execution"]
         self.assertNotEqual(
-            first_execution["command_key"], second_execution["command_key"])
+            first_execution["command_key"], second_execution["command_key"]
+        )
         self.assertEqual(second_execution["summary"]["cache_hits"], 0)
         self.assertEqual(
-            base64.b64decode(
-                second_execution["results"][0]["stdout_base64"]),
-            b"second\n")
+            base64.b64decode(second_execution["results"][0]["stdout_base64"]),
+            b"second" + os.linesep.encode(),
+        )
 
     def test_cache_dependency_and_tag_change_command_identity(self):
         self.write("object", make_elf())
@@ -616,10 +828,15 @@ class HotswapInventoryTest(unittest.TestCase):
         def run(tag):
             return self.run_cli(
                 self.root,
-                "--execute", command[0],
-                "--execute-arg", command[2],
-                "--cache-dependency", dependency,
-                "--cache-tag", tag)
+                "--execute",
+                command[0],
+                "--execute-arg",
+                command[2],
+                "--cache-dependency",
+                dependency,
+                "--cache-tag",
+                tag,
+            )
 
         first = self.parse_report(run("configuration-one"))["execution"]
         dependency.write_bytes(b"version two")
@@ -628,22 +845,24 @@ class HotswapInventoryTest(unittest.TestCase):
 
         self.assertNotEqual(first["command_key"], second["command_key"])
         self.assertNotEqual(second["command_key"], third["command_key"])
-        self.assertEqual(
-            second["cache_dependencies"], [str(dependency)])
+        self.assertEqual(second["cache_dependencies"], [str(dependency)])
         self.assertEqual(third["cache_tags"], ["configuration-two"])
 
     def test_unknown_flag_and_invalid_option_relationships_are_rejected(self):
         for arguments in (
-                [self.root, "--unknown"],
-                [self.root, "--execute-arg", "x"],
-                [self.root, "--cache-dir", "cache"],
-                [self.root, "--cache-dependency", "dependency"],
-                [self.root, "--cache-tag", "tag"],
-                [self.root, "--timeout", "0"],
-                [self.root, "--timeout", "1"],
-                [self.root, "--jobs", "0"],
-                [self.root, "--jobs", "2"],
-                [self.root, "--worklist", "-"]):
+            [self.root, "--unknown"],
+            [self.root, "--execute-arg", "x"],
+            [self.root, "--cache-dir", "cache"],
+            [self.root, "--cache-dependency", "dependency"],
+            [self.root, "--cache-tag", "tag"],
+            [self.root, "--timeout", "0"],
+            [self.root, "--execute", sys.executable, "--timeout", "nan"],
+            [self.root, "--execute", sys.executable, "--timeout", "inf"],
+            [self.root, "--timeout", "1"],
+            [self.root, "--jobs", "0"],
+            [self.root, "--jobs", "2"],
+            [self.root, "--worklist", "-"],
+        ):
             with self.subTest(arguments=arguments):
                 completed = self.run_cli(*arguments)
                 self.assertEqual(completed.returncode, 2)
@@ -655,34 +874,76 @@ class HotswapInventoryTest(unittest.TestCase):
         self.assertIn(b"does not exist", missing.stderr)
 
         output = self.run_cli(
-            self.root, "--json-output", self.root / "missing" / "report.json")
+            self.root, "--json-output", self.root / "missing" / "report.json"
+        )
         self.assertEqual(output.returncode, 2)
         self.assertIn(b"output directory does not exist", output.stderr)
 
     def test_same_json_and_worklist_path_is_rejected(self):
         output = self.root / "output"
         completed = self.run_cli(
-            self.root, "--json-output", output, "--worklist", output)
+            self.root, "--json-output", output, "--worklist", output
+        )
         self.assertEqual(completed.returncode, 2)
         self.assertIn(b"must be different", completed.stderr)
+
+    @unittest.skipIf(
+        os.name == "nt" or not hasattr(os, "symlink"),
+        "symlink creation may require Windows developer mode",
+    )
+    def test_aliased_json_and_worklist_paths_are_rejected(self):
+        output_directory = self.root / "output"
+        output_directory.mkdir()
+        output_alias = self.root / "output-alias"
+        output_alias.symlink_to(output_directory, target_is_directory=True)
+
+        completed = self.run_cli(
+            self.root / "empty",
+            "--json-output",
+            output_directory / "result",
+            "--worklist",
+            output_alias / "result",
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn(b"must be different", completed.stderr)
+
+    @unittest.skipIf(
+        os.name == "nt" or not hasattr(os, "symlink"),
+        "symlink creation may require Windows developer mode",
+    )
+    def test_output_cannot_overwrite_input_through_directory_symlink(self):
+        corpus = self.root / "corpus"
+        code_object = self.write("corpus/object", make_elf())
+        corpus_alias = self.root / "corpus-alias"
+        corpus_alias.symlink_to(corpus, target_is_directory=True)
+
+        completed = self.run_cli(corpus, "--json-output", corpus_alias / "object")
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn(b"refusing to overwrite inventory input", completed.stderr)
+        self.assertEqual(code_object.read_bytes(), make_elf())
 
     def test_output_cannot_overwrite_input_or_manifest(self):
         code_object = self.write("corpus/object", make_elf())
         manifest = self.write("manifest.txt", b"object\n")
         for arguments in (
-                [self.root / "corpus", "--json-output", code_object],
-                [self.root / "corpus", "--worklist", code_object],
-                [
-                    self.root / "corpus",
-                    "--manifest", manifest,
-                    "--json-output", manifest,
-                ]):
+            [self.root / "corpus", "--json-output", code_object],
+            [self.root / "corpus", "--worklist", code_object],
+            [
+                self.root / "corpus",
+                "--manifest",
+                manifest,
+                "--json-output",
+                manifest,
+            ],
+        ):
             with self.subTest(arguments=arguments):
                 completed = self.run_cli(*arguments)
                 self.assertEqual(completed.returncode, 2)
                 self.assertIn(
-                    b"refusing to overwrite inventory input",
-                    completed.stderr)
+                    b"refusing to overwrite inventory input", completed.stderr
+                )
                 self.assertEqual(code_object.read_bytes(), make_elf())
 
     def test_help_documents_execution_and_worklist(self):

--- a/amd/comgr/test/utils/test_hotswap_inventory_acceptance.py
+++ b/amd/comgr/test/utils/test_hotswap_inventory_acceptance.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Optional end-to-end acceptance test for the frozen #3646 corpus."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+EXPECTED_MANIFEST_SHA256 = (
+    "076ea013ba466139e76074fcbb31905a5041298e7644f6e8f590bf9353e4f5b9")
+EXPECTED_ALIASES = 2685
+EXPECTED_UNIQUE = 1452
+EXPECTED_DUPLICATES = 1233
+SCRIPT = (Path(__file__).resolve().parents[2] / "utils" / "hotswap" /
+          "hotswap_inventory.py")
+
+
+def main():
+    corpus_root = os.environ.get("COMGR_HOTSWAP_CORPUS_ROOT")
+    manifest = os.environ.get("COMGR_HOTSWAP_CORPUS_MANIFEST")
+    if not corpus_root or not manifest:
+        print(
+            "SKIP: set COMGR_HOTSWAP_CORPUS_ROOT and "
+            "COMGR_HOTSWAP_CORPUS_MANIFEST to run the #3646 corpus "
+            "acceptance test",
+            file=sys.stderr)
+        return 77
+
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        report_path = Path(temporary_directory) / "inventory.json"
+        worklist_path = Path(temporary_directory) / "unique.nul"
+        command = [
+            sys.executable,
+            str(SCRIPT),
+            corpus_root,
+            "--manifest",
+            manifest,
+            "--json-output",
+            str(report_path),
+            "--worklist",
+            str(worklist_path),
+        ]
+        completed = subprocess.run(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False)
+        if completed.returncode != 0:
+            sys.stderr.buffer.write(completed.stderr)
+            return 1
+
+        try:
+            report = json.loads(report_path.read_text(encoding="ascii"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as error:
+            print("cannot read inventory report: {}".format(error),
+                  file=sys.stderr)
+            return 1
+
+        if (report.get("schema") != "comgr.hotswap.inventory" or
+                report.get("version") != 2):
+            print("inventory report has an unexpected schema or version",
+                  file=sys.stderr)
+            return 1
+        expected_summary = {
+            "files_examined": EXPECTED_ALIASES,
+            "code_object_paths": EXPECTED_ALIASES,
+            "unique_code_objects": EXPECTED_UNIQUE,
+            "duplicate_paths": EXPECTED_DUPLICATES,
+            "rejected_files": 0,
+        }
+        for key, expected in expected_summary.items():
+            actual = report.get("summary", {}).get(key)
+            if actual != expected:
+                print(
+                    "corpus invariant changed: {} is {}, expected {}".format(
+                        key, actual, expected),
+                    file=sys.stderr)
+                return 1
+        if report.get("manifest", {}).get(
+                "sha256") != EXPECTED_MANIFEST_SHA256:
+            print(
+                "corpus manifest hash changed: got {}, expected {}".format(
+                    report.get("manifest", {}).get("sha256"),
+                    EXPECTED_MANIFEST_SHA256),
+                file=sys.stderr)
+            return 1
+        if report.get("rejected") != []:
+            print("manifest contains rejected inputs", file=sys.stderr)
+            return 1
+
+        try:
+            worklist_entries = worklist_path.read_bytes().split(b"\0")
+        except OSError as error:
+            print("cannot read unique worklist: {}".format(error),
+                  file=sys.stderr)
+            return 1
+        if not worklist_entries or worklist_entries[-1] != b"":
+            print("unique worklist is not NUL terminated", file=sys.stderr)
+            return 1
+        if len(worklist_entries) - 1 != EXPECTED_UNIQUE:
+            print(
+                "unique worklist has {} entries, expected {}".format(
+                    len(worklist_entries) - 1, EXPECTED_UNIQUE),
+                file=sys.stderr)
+            return 1
+
+    print(
+        "PASS: #3646 corpus has {} aliases, {} unique objects, and {} "
+        "duplicates".format(
+            EXPECTED_ALIASES, EXPECTED_UNIQUE, EXPECTED_DUPLICATES))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/amd/comgr/test/utils/test_hotswap_inventory_acceptance.py
+++ b/amd/comgr/test/utils/test_hotswap_inventory_acceptance.py
@@ -10,12 +10,14 @@ from pathlib import Path
 
 
 EXPECTED_MANIFEST_SHA256 = (
-    "076ea013ba466139e76074fcbb31905a5041298e7644f6e8f590bf9353e4f5b9")
+    "076ea013ba466139e76074fcbb31905a5041298e7644f6e8f590bf9353e4f5b9"
+)
 EXPECTED_ALIASES = 2685
 EXPECTED_UNIQUE = 1452
 EXPECTED_DUPLICATES = 1233
-SCRIPT = (Path(__file__).resolve().parents[2] / "utils" / "hotswap" /
-          "hotswap_inventory.py")
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / "utils" / "hotswap" / "hotswap_inventory.py"
+)
 
 
 def main():
@@ -26,7 +28,8 @@ def main():
             "SKIP: set COMGR_HOTSWAP_CORPUS_ROOT and "
             "COMGR_HOTSWAP_CORPUS_MANIFEST to run the #3646 corpus "
             "acceptance test",
-            file=sys.stderr)
+            file=sys.stderr,
+        )
         return 77
 
     with tempfile.TemporaryDirectory() as temporary_directory:
@@ -48,7 +51,8 @@ def main():
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            check=False)
+            check=False,
+        )
         if completed.returncode != 0:
             sys.stderr.buffer.write(completed.stderr)
             return 1
@@ -56,14 +60,16 @@ def main():
         try:
             report = json.loads(report_path.read_text(encoding="ascii"))
         except (OSError, UnicodeError, json.JSONDecodeError) as error:
-            print("cannot read inventory report: {}".format(error),
-                  file=sys.stderr)
+            print("cannot read inventory report: {}".format(error), file=sys.stderr)
             return 1
 
-        if (report.get("schema") != "comgr.hotswap.inventory" or
-                report.get("version") != 2):
-            print("inventory report has an unexpected schema or version",
-                  file=sys.stderr)
+        if (
+            report.get("schema") != "comgr.hotswap.inventory"
+            or report.get("version") != 2
+        ):
+            print(
+                "inventory report has an unexpected schema or version", file=sys.stderr
+            )
             return 1
         expected_summary = {
             "files_examined": EXPECTED_ALIASES,
@@ -77,16 +83,18 @@ def main():
             if actual != expected:
                 print(
                     "corpus invariant changed: {} is {}, expected {}".format(
-                        key, actual, expected),
-                    file=sys.stderr)
+                        key, actual, expected
+                    ),
+                    file=sys.stderr,
+                )
                 return 1
-        if report.get("manifest", {}).get(
-                "sha256") != EXPECTED_MANIFEST_SHA256:
+        if report.get("manifest", {}).get("sha256") != EXPECTED_MANIFEST_SHA256:
             print(
                 "corpus manifest hash changed: got {}, expected {}".format(
-                    report.get("manifest", {}).get("sha256"),
-                    EXPECTED_MANIFEST_SHA256),
-                file=sys.stderr)
+                    report.get("manifest", {}).get("sha256"), EXPECTED_MANIFEST_SHA256
+                ),
+                file=sys.stderr,
+            )
             return 1
         if report.get("rejected") != []:
             print("manifest contains rejected inputs", file=sys.stderr)
@@ -95,8 +103,7 @@ def main():
         try:
             worklist_entries = worklist_path.read_bytes().split(b"\0")
         except OSError as error:
-            print("cannot read unique worklist: {}".format(error),
-                  file=sys.stderr)
+            print("cannot read unique worklist: {}".format(error), file=sys.stderr)
             return 1
         if not worklist_entries or worklist_entries[-1] != b"":
             print("unique worklist is not NUL terminated", file=sys.stderr)
@@ -104,14 +111,16 @@ def main():
         if len(worklist_entries) - 1 != EXPECTED_UNIQUE:
             print(
                 "unique worklist has {} entries, expected {}".format(
-                    len(worklist_entries) - 1, EXPECTED_UNIQUE),
-                file=sys.stderr)
+                    len(worklist_entries) - 1, EXPECTED_UNIQUE
+                ),
+                file=sys.stderr,
+            )
             return 1
 
     print(
         "PASS: #3646 corpus has {} aliases, {} unique objects, and {} "
-        "duplicates".format(
-            EXPECTED_ALIASES, EXPECTED_UNIQUE, EXPECTED_DUPLICATES))
+        "duplicates".format(EXPECTED_ALIASES, EXPECTED_UNIQUE, EXPECTED_DUPLICATES)
+    )
     return 0
 
 

--- a/amd/comgr/utils/hotswap/hotswap_inventory.py
+++ b/amd/comgr/utils/hotswap/hotswap_inventory.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+"""Inventory and run a command once per unique AMDGPU code object."""
+
+import argparse
+import base64
+import concurrent.futures
+import functools
+import hashlib
+import json
+import os
+import shutil
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+
+SCHEMA = "comgr.hotswap.inventory"
+SCHEMA_VERSION = 2
+CACHE_SCHEMA = "comgr.hotswap.inventory.cache"
+CACHE_VERSION = 2
+EM_AMDGPU = 224
+ELF_MAGIC = b"\x7fELF"
+HASH_BLOCK_SIZE = 1024 * 1024
+
+
+class InventoryError(Exception):
+    """An input, filesystem, or cache error that should stop the run."""
+
+
+def path_sort_key(path):
+    """Sort paths by their filesystem byte representation."""
+    return os.fsencode(path)
+
+
+def normalized_path(path):
+    """Return a deterministic absolute spelling without resolving symlinks."""
+    return os.path.normpath(os.path.abspath(path))
+
+
+def discover_files(roots):
+    """Return sorted, distinct regular-file paths below roots.
+
+    File symlinks are included. Directory symlinks found while walking a
+    directory are not followed, which avoids cycles. An explicitly named
+    symlink to a directory is traversed because the user selected that root.
+    """
+    discovered = set()
+
+    def visit_directory(directory):
+        try:
+            with os.scandir(directory) as entries:
+                sorted_entries = sorted(entries, key=lambda entry:
+                                        os.fsencode(entry.name))
+        except OSError as error:
+            raise InventoryError("cannot read directory '{}': {}".format(
+                directory, error)) from error
+
+        for entry in sorted_entries:
+            entry_path = normalized_path(entry.path)
+            try:
+                if entry.is_dir(follow_symlinks=False):
+                    visit_directory(entry_path)
+                elif entry.is_file(follow_symlinks=True):
+                    discovered.add(entry_path)
+                elif entry.is_symlink() and not os.path.exists(entry_path):
+                    raise InventoryError(
+                        "broken symlink in corpus: '{}'".format(entry_path))
+            except OSError as error:
+                raise InventoryError("cannot inspect '{}': {}".format(
+                    entry_path, error)) from error
+
+    if not roots:
+        raise InventoryError("at least one corpus root is required")
+
+    for root in sorted({normalized_path(root) for root in roots},
+                       key=path_sort_key):
+        if not os.path.lexists(root):
+            raise InventoryError("corpus root does not exist: '{}'".format(
+                root))
+        try:
+            if os.path.isdir(root):
+                visit_directory(root)
+            elif os.path.isfile(root):
+                discovered.add(root)
+            else:
+                raise InventoryError(
+                    "corpus root is not a regular file or directory: "
+                    "'{}'".format(root))
+        except OSError as error:
+            raise InventoryError("cannot inspect corpus root '{}': {}".format(
+                root, error)) from error
+
+    return sorted(discovered, key=path_sort_key)
+
+
+def read_manifest(root, manifest_path):
+    """Read a newline-delimited list of paths relative to one corpus root."""
+    normalized_root = normalized_path(root)
+    if not os.path.isdir(normalized_root):
+        raise InventoryError(
+            "manifest root is not a directory: '{}'".format(normalized_root))
+    normalized_manifest = normalized_path(manifest_path)
+    try:
+        with open(normalized_manifest, "rb") as stream:
+            contents = stream.read()
+    except OSError as error:
+        raise InventoryError("cannot read manifest '{}': {}".format(
+            normalized_manifest, error)) from error
+
+    if b"\0" in contents:
+        raise InventoryError(
+            "manifest contains a NUL byte: '{}'".format(normalized_manifest))
+    raw_entries = contents.split(b"\n")
+    if raw_entries and raw_entries[-1] == b"":
+        raw_entries.pop()
+
+    paths = []
+    seen = set()
+    for line_number, raw_entry in enumerate(raw_entries, start=1):
+        if raw_entry.endswith(b"\r"):
+            raw_entry = raw_entry[:-1]
+        if not raw_entry:
+            raise InventoryError(
+                "manifest '{}' has an empty path at line {}".format(
+                    normalized_manifest, line_number))
+        relative = os.fsdecode(raw_entry)
+        if os.path.isabs(relative):
+            raise InventoryError(
+                "manifest '{}' has an absolute path at line {}".format(
+                    normalized_manifest, line_number))
+        path = normalized_path(os.path.join(normalized_root, relative))
+        try:
+            common = os.path.commonpath([normalized_root, path])
+        except ValueError as error:
+            raise InventoryError(
+                "manifest '{}' has an invalid path at line {}".format(
+                    normalized_manifest, line_number)) from error
+        if common != normalized_root:
+            raise InventoryError(
+                "manifest '{}' escapes its corpus root at line {}".format(
+                    normalized_manifest, line_number))
+        if path in seen:
+            raise InventoryError(
+                "manifest '{}' repeats path '{}'".format(
+                    normalized_manifest, relative))
+        seen.add(path)
+        if not os.path.isfile(path):
+            raise InventoryError(
+                "manifest path is not a regular file: '{}'".format(path))
+        paths.append(path)
+
+    return (
+        sorted(paths, key=path_sort_key),
+        {
+            "path": normalized_manifest,
+            "sha256": hashlib.sha256(contents).hexdigest(),
+            "entries": len(paths),
+        },
+    )
+
+
+def classify_header(header):
+    """Return None for an AMDGPU ELF header or a rejection reason."""
+    if len(header) < len(ELF_MAGIC) or header[:4] != ELF_MAGIC:
+        return "not-elf"
+    if len(header) < 16:
+        return "truncated-elf-ident"
+
+    elf_class = header[4]
+    elf_data = header[5]
+    ident_version = header[6]
+    if elf_class not in (1, 2):
+        return "unsupported-elf-class"
+    if elf_data not in (1, 2):
+        return "unsupported-elf-endianness"
+    if ident_version != 1:
+        return "unsupported-elf-ident-version"
+
+    header_size = 52 if elf_class == 1 else 64
+    if len(header) < header_size:
+        return "truncated-elf-header"
+
+    endian = "<" if elf_data == 1 else ">"
+    _elf_type, machine, version = struct.unpack_from(
+        endian + "HHI", header, 16)
+    if version != 1:
+        return "unsupported-elf-version"
+    if machine != EM_AMDGPU:
+        return "non-amdgpu-elf"
+
+    header_size_offset = 40 if elf_class == 1 else 52
+    declared_header_size = struct.unpack_from(
+        endian + "H", header, header_size_offset)[0]
+    if declared_header_size != header_size:
+        return "invalid-elf-header-size"
+    return None
+
+
+def inspect_file(path):
+    """Classify and hash one file while detecting concurrent modification."""
+    try:
+        with open(path, "rb") as stream:
+            initial_stat = os.fstat(stream.fileno())
+            if not stat.S_ISREG(initial_stat.st_mode):
+                raise InventoryError(
+                    "corpus path is not a regular file: '{}'".format(path))
+            header = stream.read(64)
+            rejection = classify_header(header)
+            if rejection is not None:
+                final_stat = os.fstat(stream.fileno())
+                ensure_unchanged(path, initial_stat, final_stat)
+                return None, rejection
+
+            digest = hashlib.sha256()
+            stream.seek(0)
+            while True:
+                block = stream.read(HASH_BLOCK_SIZE)
+                if not block:
+                    break
+                digest.update(block)
+            final_stat = os.fstat(stream.fileno())
+            ensure_unchanged(path, initial_stat, final_stat)
+            return {
+                "path": path,
+                "sha256": digest.hexdigest(),
+                "size": initial_stat.st_size,
+            }, None
+    except InventoryError:
+        raise
+    except OSError as error:
+        raise InventoryError("cannot read '{}': {}".format(path, error)) \
+            from error
+
+
+def ensure_unchanged(path, initial_stat, final_stat):
+    """Reject a file that changed while it was being inspected."""
+    initial_identity = (
+        initial_stat.st_dev,
+        initial_stat.st_ino,
+        initial_stat.st_size,
+        initial_stat.st_mtime_ns,
+    )
+    final_identity = (
+        final_stat.st_dev,
+        final_stat.st_ino,
+        final_stat.st_size,
+        final_stat.st_mtime_ns,
+    )
+    if initial_identity != final_identity:
+        raise InventoryError(
+            "corpus file changed while being read: '{}'".format(path))
+
+
+def build_inventory(roots, manifest_path=None):
+    """Build the deterministic JSON-compatible inventory."""
+    manifest = None
+    if manifest_path is None:
+        files = discover_files(roots)
+    else:
+        if len(roots) != 1:
+            raise InventoryError(
+                "a manifest requires exactly one corpus root")
+        files, manifest = read_manifest(roots[0], manifest_path)
+    by_digest = {}
+    rejected = []
+
+    for path in files:
+        item, reason = inspect_file(path)
+        if item is None:
+            rejected.append({"path": path, "reason": reason})
+            continue
+        digest = item["sha256"]
+        if digest not in by_digest:
+            by_digest[digest] = {
+                "sha256": digest,
+                "size": item["size"],
+                "paths": [],
+            }
+        by_digest[digest]["paths"].append(path)
+
+    objects = []
+    for digest in sorted(by_digest):
+        item = by_digest[digest]
+        paths = sorted(item["paths"], key=path_sort_key)
+        objects.append({
+            "sha256": digest,
+            "size": item["size"],
+            "representative": paths[0],
+            "paths": paths,
+        })
+
+    code_object_paths = sum(len(item["paths"]) for item in objects)
+    duplicate_groups = sum(1 for item in objects
+                           if len(item["paths"]) > 1)
+    inventory = {
+        "schema": SCHEMA,
+        "version": SCHEMA_VERSION,
+        "roots": sorted({normalized_path(root) for root in roots},
+                        key=path_sort_key),
+        "summary": {
+            "files_examined": len(files),
+            "code_object_paths": code_object_paths,
+            "unique_code_objects": len(objects),
+            "duplicate_paths": code_object_paths - len(objects),
+            "duplicate_groups": duplicate_groups,
+            "rejected_files": len(rejected),
+        },
+        "objects": objects,
+        "rejected": sorted(rejected,
+                           key=lambda item: path_sort_key(item["path"])),
+    }
+    if manifest is not None:
+        inventory["manifest"] = manifest
+    return inventory
+
+
+def json_bytes(value):
+    """Serialize JSON canonically."""
+    return (json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True) +
+            "\n").encode("ascii")
+
+
+def atomic_write(path, contents):
+    """Atomically replace path with contents."""
+    destination = normalized_path(path)
+    directory = os.path.dirname(destination)
+    if not os.path.isdir(directory):
+        raise InventoryError(
+            "output directory does not exist: '{}'".format(directory))
+    temporary_path = None
+    try:
+        descriptor, temporary_path = tempfile.mkstemp(
+            prefix=".hotswap-inventory-", dir=directory)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(contents)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, destination)
+        temporary_path = None
+    except OSError as error:
+        raise InventoryError("cannot write '{}': {}".format(
+            destination, error)) from error
+    finally:
+        if temporary_path is not None:
+            try:
+                os.unlink(temporary_path)
+            except OSError:
+                pass
+
+
+def write_worklist(path, objects):
+    """Write representative paths as a NUL-delimited byte stream."""
+    contents = b"".join(
+        os.fsencode(item["representative"]) + b"\0" for item in objects)
+    atomic_write(path, contents)
+
+
+def protect_inventory_inputs(inventory, output_paths):
+    """Refuse to overwrite an input code object or the selected manifest."""
+    protected = set()
+    for item in inventory["objects"]:
+        protected.update(item["paths"])
+    protected.update(item["path"] for item in inventory["rejected"])
+    if "manifest" in inventory:
+        protected.add(inventory["manifest"]["path"])
+    for output_path in output_paths:
+        if output_path is None or output_path == "-":
+            continue
+        normalized_output = normalized_path(output_path)
+        if normalized_output in protected:
+            raise InventoryError(
+                "refusing to overwrite inventory input '{}'".format(
+                    normalized_output))
+
+
+def resolve_program(program):
+    """Resolve a command executable before computing its cache identity."""
+    if os.path.dirname(program):
+        resolved = normalized_path(program)
+        if not os.path.isfile(resolved):
+            raise InventoryError(
+                "command executable does not exist: '{}'".format(program))
+        if not os.access(resolved, os.X_OK):
+            raise InventoryError(
+                "command executable is not executable: '{}'".format(program))
+        return resolved
+    resolved = shutil.which(program)
+    if resolved is None:
+        raise InventoryError(
+            "command executable was not found on PATH: '{}'".format(program))
+    return normalized_path(resolved)
+
+
+def hash_regular_file(path):
+    """Hash a regular file used as part of command identity."""
+    digest = hashlib.sha256()
+    try:
+        with open(path, "rb") as stream:
+            while True:
+                block = stream.read(HASH_BLOCK_SIZE)
+                if not block:
+                    break
+                digest.update(block)
+    except OSError as error:
+        raise InventoryError("cannot hash command file '{}': {}".format(
+            path, error)) from error
+    return digest.hexdigest()
+
+
+def command_identity(argv, dependencies, tags):
+    """Return a content-sensitive key for an executable and file arguments."""
+    files = []
+    for index, argument in enumerate(argv):
+        candidate = normalized_path(argument)
+        if os.path.isfile(candidate):
+            files.append({
+                "kind": "argv",
+                "index": index,
+                "path": candidate,
+                "sha256": hash_regular_file(candidate),
+            })
+    normalized_dependencies = []
+    for dependency in dependencies:
+        path = normalized_path(dependency)
+        if not os.path.isfile(path):
+            raise InventoryError(
+                "cache dependency is not a regular file: '{}'".format(path))
+        normalized_dependencies.append(path)
+    for path in sorted(set(normalized_dependencies), key=path_sort_key):
+        files.append({
+            "kind": "dependency",
+            "path": path,
+            "sha256": hash_regular_file(path),
+        })
+    identity = {"argv": argv, "files": files, "tags": tags}
+    return hashlib.sha256(json_bytes(identity)).hexdigest()
+
+
+def read_cache_entry(path, command_key, digest):
+    """Read and validate one successful cached result."""
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "rb") as stream:
+            entry = json.load(stream)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise InventoryError("cannot read cache entry '{}': {}".format(
+            path, error)) from error
+
+    if not isinstance(entry, dict):
+        raise InventoryError(
+            "cache entry '{}' is not a JSON object".format(path))
+    expected = {
+        "schema": CACHE_SCHEMA,
+        "version": CACHE_VERSION,
+        "command_key": command_key,
+        "sha256": digest,
+    }
+    for key, value in expected.items():
+        if entry.get(key) != value:
+            raise InventoryError(
+                "cache entry '{}' has invalid {}".format(path, key))
+    if entry.get("returncode") != 0:
+        raise InventoryError(
+            "cache entry '{}' is not a successful result".format(path))
+    runtime_ms = entry.get("runtime_ms")
+    if (isinstance(runtime_ms, bool) or not isinstance(runtime_ms, int) or
+            runtime_ms < 0):
+        raise InventoryError(
+            "cache entry '{}' has invalid runtime_ms".format(path))
+    for key in ("stdout_base64", "stderr_base64"):
+        value = entry.get(key)
+        if not isinstance(value, str):
+            raise InventoryError(
+                "cache entry '{}' has invalid {}".format(path, key))
+        try:
+            base64.b64decode(value.encode("ascii"), validate=True)
+        except (ValueError, UnicodeError) as error:
+            raise InventoryError(
+                "cache entry '{}' has invalid {}".format(path, key)) \
+                from error
+    return entry
+
+
+def elapsed_runtime_ms(start_time):
+    """Convert monotonic elapsed time to a nonnegative integer."""
+    return int(round(max(0.0, time.monotonic() - start_time) * 1000))
+
+
+def run_one_command(item, argv_prefix, command_key, timeout,
+                    normalized_cache):
+    """Run or load the result for one unique content digest."""
+    representative = item["representative"]
+    digest = item["sha256"]
+    argv = argv_prefix + [representative]
+    cache_path = None
+    cached = None
+    if normalized_cache is not None:
+        cache_path = os.path.join(
+            normalized_cache, command_key, digest + ".json")
+        cached = read_cache_entry(cache_path, command_key, digest)
+    if cached is not None:
+        return {
+            "sha256": digest,
+            "path": representative,
+            "argv": argv,
+            "status": "passed",
+            "cached": True,
+            "returncode": 0,
+            "runtime_ms": cached["runtime_ms"],
+            "stdout_base64": cached["stdout_base64"],
+            "stderr_base64": cached["stderr_base64"],
+        }
+
+    start_time = time.monotonic()
+    try:
+        completed = subprocess.run(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+            shell=False)
+        result = {
+            "sha256": digest,
+            "path": representative,
+            "argv": argv,
+            "status": ("passed" if completed.returncode == 0
+                       else "failed"),
+            "cached": False,
+            "returncode": completed.returncode,
+            "runtime_ms": elapsed_runtime_ms(start_time),
+            "stdout_base64": base64.b64encode(
+                completed.stdout).decode("ascii"),
+            "stderr_base64": base64.b64encode(
+                completed.stderr).decode("ascii"),
+        }
+    except subprocess.TimeoutExpired as error:
+        stdout = error.stdout if error.stdout is not None else b""
+        stderr = error.stderr if error.stderr is not None else b""
+        result = {
+            "sha256": digest,
+            "path": representative,
+            "argv": argv,
+            "status": "timed-out",
+            "cached": False,
+            "returncode": None,
+            "runtime_ms": elapsed_runtime_ms(start_time),
+            "stdout_base64": base64.b64encode(stdout).decode("ascii"),
+            "stderr_base64": base64.b64encode(stderr).decode("ascii"),
+        }
+    except OSError as error:
+        result = {
+            "sha256": digest,
+            "path": representative,
+            "argv": argv,
+            "status": "launch-error",
+            "cached": False,
+            "returncode": None,
+            "runtime_ms": elapsed_runtime_ms(start_time),
+            "error": str(error),
+            "stdout_base64": "",
+            "stderr_base64": "",
+        }
+
+    if cache_path is not None and result["status"] == "passed":
+        cache_entry = {
+            "schema": CACHE_SCHEMA,
+            "version": CACHE_VERSION,
+            "command_key": command_key,
+            "sha256": digest,
+            "returncode": 0,
+            "runtime_ms": result["runtime_ms"],
+            "stdout_base64": result["stdout_base64"],
+            "stderr_base64": result["stderr_base64"],
+        }
+        atomic_write(cache_path, json_bytes(cache_entry))
+    return result
+
+
+def run_command(inventory, program, arguments, timeout, cache_dir, jobs,
+                cache_dependencies, cache_tags):
+    """Run argv plus each unique representative, without invoking a shell."""
+    resolved_program = resolve_program(program)
+    argv_prefix = [resolved_program] + arguments
+    command_key = command_identity(
+        argv_prefix, cache_dependencies, cache_tags)
+
+    normalized_cache = None
+    if cache_dir is not None:
+        normalized_cache = normalized_path(cache_dir)
+        try:
+            os.makedirs(os.path.join(normalized_cache, command_key),
+                        exist_ok=True)
+        except OSError as error:
+            raise InventoryError("cannot create cache directory '{}': {}"
+                                 .format(normalized_cache, error)) from error
+
+    run_one = functools.partial(
+        run_one_command,
+        argv_prefix=argv_prefix,
+        command_key=command_key,
+        timeout=timeout,
+        normalized_cache=normalized_cache)
+    if jobs == 1:
+        results = [run_one(item) for item in inventory["objects"]]
+    else:
+        with concurrent.futures.ThreadPoolExecutor(
+                max_workers=jobs) as executor:
+            results = list(executor.map(run_one, inventory["objects"]))
+
+    return {
+        "command": argv_prefix,
+        "command_key": command_key,
+        "cache_dependencies": sorted(
+            {normalized_path(path) for path in cache_dependencies},
+            key=path_sort_key),
+        "cache_tags": cache_tags,
+        "timeout_seconds": timeout,
+        "jobs": jobs,
+        "results": results,
+        "summary": {
+            "total": len(results),
+            "passed": sum(1 for result in results
+                          if result["status"] == "passed"),
+            "failed": sum(1 for result in results
+                          if result["status"] != "passed"),
+            "cache_hits": sum(1 for result in results if result["cached"]),
+            "estimated_runtime_ms": sum(
+                result["runtime_ms"] for result in results),
+            "executed_runtime_ms": sum(
+                result["runtime_ms"] for result in results
+                if not result["cached"]),
+        },
+    }
+
+
+def create_argument_parser():
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inventory AMDGPU ELF code objects, deduplicate them by SHA-256, "
+            "and optionally run one command per unique object."))
+    parser.add_argument(
+        "roots", metavar="ROOT", nargs="+",
+        help="file or directory to inventory recursively")
+    parser.add_argument(
+        "--json-output", metavar="PATH", default="-",
+        help="write the JSON report to PATH (default: standard output)")
+    parser.add_argument(
+        "--worklist", metavar="PATH",
+        help="write unique representative paths as NUL-delimited bytes")
+    parser.add_argument(
+        "--manifest", metavar="PATH",
+        help=("inventory only newline-delimited paths from PATH, relative to "
+              "one corpus root"))
+    parser.add_argument(
+        "--execute", metavar="PROGRAM",
+        help="run PROGRAM once per unique object; the path is appended")
+    parser.add_argument(
+        "--execute-arg", metavar="ARG", action="append", default=[],
+        help=("pass ARG before the object path; repeat as needed (use "
+              "--execute-arg=--flag for arguments beginning with '-')"))
+    parser.add_argument(
+        "--timeout", metavar="SECONDS", type=float,
+        help="terminate each command after this many seconds")
+    parser.add_argument(
+        "--cache-dir", metavar="PATH",
+        help="reuse successful results by command and input content hash")
+    parser.add_argument(
+        "--cache-dependency", metavar="PATH", action="append", default=[],
+        help="hash PATH into the command cache key; repeat as needed")
+    parser.add_argument(
+        "--cache-tag", metavar="TEXT", action="append", default=[],
+        help="include TEXT in the command cache key; repeat as needed")
+    parser.add_argument(
+        "--jobs", metavar="COUNT", type=int, default=1,
+        help="run up to COUNT commands concurrently (default: 1)")
+    return parser
+
+
+def validate_arguments(parser, arguments):
+    """Validate relationships not expressible with argparse declarations."""
+    if arguments.timeout is not None and arguments.timeout <= 0:
+        parser.error("--timeout must be greater than zero")
+    if arguments.jobs <= 0:
+        parser.error("--jobs must be greater than zero")
+    if arguments.execute is None:
+        if arguments.execute_arg:
+            parser.error("--execute-arg requires --execute")
+        if arguments.timeout is not None:
+            parser.error("--timeout requires --execute")
+        if arguments.cache_dir is not None:
+            parser.error("--cache-dir requires --execute")
+        if arguments.cache_dependency:
+            parser.error("--cache-dependency requires --execute")
+        if arguments.cache_tag:
+            parser.error("--cache-tag requires --execute")
+        if arguments.jobs != 1:
+            parser.error("--jobs requires --execute")
+    if arguments.worklist == "-":
+        parser.error("--worklist requires a file path, not standard output")
+    if arguments.manifest is not None and len(arguments.roots) != 1:
+        parser.error("--manifest requires exactly one corpus root")
+    if (arguments.worklist is not None and
+            arguments.json_output != "-" and
+            normalized_path(arguments.worklist) ==
+            normalized_path(arguments.json_output)):
+        parser.error("--worklist and --json-output must be different files")
+
+
+def main(argv=None):
+    """Command-line entry point."""
+    parser = create_argument_parser()
+    arguments = parser.parse_args(argv)
+    validate_arguments(parser, arguments)
+
+    try:
+        inventory = build_inventory(arguments.roots, arguments.manifest)
+        protect_inventory_inputs(
+            inventory, [arguments.worklist, arguments.json_output])
+        if arguments.worklist is not None:
+            write_worklist(arguments.worklist, inventory["objects"])
+
+        command_failed = False
+        if arguments.execute is not None:
+            execution = run_command(
+                inventory,
+                arguments.execute,
+                arguments.execute_arg,
+                arguments.timeout,
+                arguments.cache_dir,
+                arguments.jobs,
+                arguments.cache_dependency,
+                arguments.cache_tag)
+            inventory["execution"] = execution
+            command_failed = execution["summary"]["failed"] != 0
+
+        report = json_bytes(inventory)
+        if arguments.json_output == "-":
+            sys.stdout.buffer.write(report)
+            sys.stdout.buffer.flush()
+        else:
+            atomic_write(arguments.json_output, report)
+        return 1 if command_failed else 0
+    except (InventoryError, OSError) as error:
+        print("hotswap-inventory: error: {}".format(error), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/amd/comgr/utils/hotswap/hotswap_inventory.py
+++ b/amd/comgr/utils/hotswap/hotswap_inventory.py
@@ -7,8 +7,10 @@ import concurrent.futures
 import functools
 import hashlib
 import json
+import math
 import os
 import shutil
+import signal
 import stat
 import struct
 import subprocess
@@ -20,7 +22,7 @@ import time
 SCHEMA = "comgr.hotswap.inventory"
 SCHEMA_VERSION = 2
 CACHE_SCHEMA = "comgr.hotswap.inventory.cache"
-CACHE_VERSION = 2
+CACHE_VERSION = 3
 EM_AMDGPU = 224
 ELF_MAGIC = b"\x7fELF"
 HASH_BLOCK_SIZE = 1024 * 1024
@@ -40,6 +42,18 @@ def normalized_path(path):
     return os.path.normpath(os.path.abspath(path))
 
 
+def paths_alias(first, second):
+    """Return whether two path spellings identify the same location."""
+    first_path = normalized_path(first)
+    second_path = normalized_path(second)
+    try:
+        return os.path.samefile(first_path, second_path)
+    except (OSError, ValueError):
+        first_resolved = os.path.normcase(os.path.realpath(first_path))
+        second_resolved = os.path.normcase(os.path.realpath(second_path))
+        return first_resolved == second_resolved
+
+
 def discover_files(roots):
     """Return sorted, distinct regular-file paths below roots.
 
@@ -52,11 +66,13 @@ def discover_files(roots):
     def visit_directory(directory):
         try:
             with os.scandir(directory) as entries:
-                sorted_entries = sorted(entries, key=lambda entry:
-                                        os.fsencode(entry.name))
+                sorted_entries = sorted(
+                    entries, key=lambda entry: os.fsencode(entry.name)
+                )
         except OSError as error:
-            raise InventoryError("cannot read directory '{}': {}".format(
-                directory, error)) from error
+            raise InventoryError(
+                "cannot read directory '{}': {}".format(directory, error)
+            ) from error
 
         for entry in sorted_entries:
             entry_path = normalized_path(entry.path)
@@ -67,19 +83,19 @@ def discover_files(roots):
                     discovered.add(entry_path)
                 elif entry.is_symlink() and not os.path.exists(entry_path):
                     raise InventoryError(
-                        "broken symlink in corpus: '{}'".format(entry_path))
+                        "broken symlink in corpus: '{}'".format(entry_path)
+                    )
             except OSError as error:
-                raise InventoryError("cannot inspect '{}': {}".format(
-                    entry_path, error)) from error
+                raise InventoryError(
+                    "cannot inspect '{}': {}".format(entry_path, error)
+                ) from error
 
     if not roots:
         raise InventoryError("at least one corpus root is required")
 
-    for root in sorted({normalized_path(root) for root in roots},
-                       key=path_sort_key):
+    for root in sorted({normalized_path(root) for root in roots}, key=path_sort_key):
         if not os.path.lexists(root):
-            raise InventoryError("corpus root does not exist: '{}'".format(
-                root))
+            raise InventoryError("corpus root does not exist: '{}'".format(root))
         try:
             if os.path.isdir(root):
                 visit_directory(root)
@@ -87,11 +103,12 @@ def discover_files(roots):
                 discovered.add(root)
             else:
                 raise InventoryError(
-                    "corpus root is not a regular file or directory: "
-                    "'{}'".format(root))
+                    "corpus root is not a regular file or directory: '{}'".format(root)
+                )
         except OSError as error:
-            raise InventoryError("cannot inspect corpus root '{}': {}".format(
-                root, error)) from error
+            raise InventoryError(
+                "cannot inspect corpus root '{}': {}".format(root, error)
+            ) from error
 
     return sorted(discovered, key=path_sort_key)
 
@@ -101,18 +118,22 @@ def read_manifest(root, manifest_path):
     normalized_root = normalized_path(root)
     if not os.path.isdir(normalized_root):
         raise InventoryError(
-            "manifest root is not a directory: '{}'".format(normalized_root))
+            "manifest root is not a directory: '{}'".format(normalized_root)
+        )
+    resolved_root = os.path.realpath(normalized_root)
     normalized_manifest = normalized_path(manifest_path)
     try:
         with open(normalized_manifest, "rb") as stream:
             contents = stream.read()
     except OSError as error:
-        raise InventoryError("cannot read manifest '{}': {}".format(
-            normalized_manifest, error)) from error
+        raise InventoryError(
+            "cannot read manifest '{}': {}".format(normalized_manifest, error)
+        ) from error
 
     if b"\0" in contents:
         raise InventoryError(
-            "manifest contains a NUL byte: '{}'".format(normalized_manifest))
+            "manifest contains a NUL byte: '{}'".format(normalized_manifest)
+        )
     raw_entries = contents.split(b"\n")
     if raw_entries and raw_entries[-1] == b"":
         raw_entries.pop()
@@ -125,31 +146,54 @@ def read_manifest(root, manifest_path):
         if not raw_entry:
             raise InventoryError(
                 "manifest '{}' has an empty path at line {}".format(
-                    normalized_manifest, line_number))
+                    normalized_manifest, line_number
+                )
+            )
         relative = os.fsdecode(raw_entry)
         if os.path.isabs(relative):
             raise InventoryError(
                 "manifest '{}' has an absolute path at line {}".format(
-                    normalized_manifest, line_number))
+                    normalized_manifest, line_number
+                )
+            )
         path = normalized_path(os.path.join(normalized_root, relative))
         try:
             common = os.path.commonpath([normalized_root, path])
         except ValueError as error:
             raise InventoryError(
                 "manifest '{}' has an invalid path at line {}".format(
-                    normalized_manifest, line_number)) from error
-        if common != normalized_root:
+                    normalized_manifest, line_number
+                )
+            ) from error
+        if os.path.normcase(common) != os.path.normcase(normalized_root):
             raise InventoryError(
                 "manifest '{}' escapes its corpus root at line {}".format(
-                    normalized_manifest, line_number))
+                    normalized_manifest, line_number
+                )
+            )
+        resolved_path = os.path.realpath(path)
+        try:
+            resolved_common = os.path.commonpath([resolved_root, resolved_path])
+        except ValueError as error:
+            raise InventoryError(
+                "manifest '{}' has an invalid path at line {}".format(
+                    normalized_manifest, line_number
+                )
+            ) from error
+        if os.path.normcase(resolved_common) != os.path.normcase(resolved_root):
+            raise InventoryError(
+                "manifest '{}' escapes its corpus root through a symlink at "
+                "line {}".format(normalized_manifest, line_number)
+            )
         if path in seen:
             raise InventoryError(
-                "manifest '{}' repeats path '{}'".format(
-                    normalized_manifest, relative))
+                "manifest '{}' repeats path '{}'".format(normalized_manifest, relative)
+            )
         seen.add(path)
         if not os.path.isfile(path):
             raise InventoryError(
-                "manifest path is not a regular file: '{}'".format(path))
+                "manifest path is not a regular file: '{}'".format(path)
+            )
         paths.append(path)
 
     return (
@@ -184,16 +228,16 @@ def classify_header(header):
         return "truncated-elf-header"
 
     endian = "<" if elf_data == 1 else ">"
-    _elf_type, machine, version = struct.unpack_from(
-        endian + "HHI", header, 16)
+    _elf_type, machine, version = struct.unpack_from(endian + "HHI", header, 16)
     if version != 1:
         return "unsupported-elf-version"
     if machine != EM_AMDGPU:
         return "non-amdgpu-elf"
 
     header_size_offset = 40 if elf_class == 1 else 52
-    declared_header_size = struct.unpack_from(
-        endian + "H", header, header_size_offset)[0]
+    declared_header_size = struct.unpack_from(endian + "H", header, header_size_offset)[
+        0
+    ]
     if declared_header_size != header_size:
         return "invalid-elf-header-size"
     return None
@@ -206,7 +250,8 @@ def inspect_file(path):
             initial_stat = os.fstat(stream.fileno())
             if not stat.S_ISREG(initial_stat.st_mode):
                 raise InventoryError(
-                    "corpus path is not a regular file: '{}'".format(path))
+                    "corpus path is not a regular file: '{}'".format(path)
+                )
             header = stream.read(64)
             rejection = classify_header(header)
             if rejection is not None:
@@ -231,8 +276,7 @@ def inspect_file(path):
     except InventoryError:
         raise
     except OSError as error:
-        raise InventoryError("cannot read '{}': {}".format(path, error)) \
-            from error
+        raise InventoryError("cannot read '{}': {}".format(path, error)) from error
 
 
 def ensure_unchanged(path, initial_stat, final_stat):
@@ -242,16 +286,17 @@ def ensure_unchanged(path, initial_stat, final_stat):
         initial_stat.st_ino,
         initial_stat.st_size,
         initial_stat.st_mtime_ns,
+        initial_stat.st_ctime_ns,
     )
     final_identity = (
         final_stat.st_dev,
         final_stat.st_ino,
         final_stat.st_size,
         final_stat.st_mtime_ns,
+        final_stat.st_ctime_ns,
     )
     if initial_identity != final_identity:
-        raise InventoryError(
-            "corpus file changed while being read: '{}'".format(path))
+        raise InventoryError("corpus file changed while being read: '{}'".format(path))
 
 
 def build_inventory(roots, manifest_path=None):
@@ -261,8 +306,7 @@ def build_inventory(roots, manifest_path=None):
         files = discover_files(roots)
     else:
         if len(roots) != 1:
-            raise InventoryError(
-                "a manifest requires exactly one corpus root")
+            raise InventoryError("a manifest requires exactly one corpus root")
         files, manifest = read_manifest(roots[0], manifest_path)
     by_digest = {}
     rejected = []
@@ -285,21 +329,21 @@ def build_inventory(roots, manifest_path=None):
     for digest in sorted(by_digest):
         item = by_digest[digest]
         paths = sorted(item["paths"], key=path_sort_key)
-        objects.append({
-            "sha256": digest,
-            "size": item["size"],
-            "representative": paths[0],
-            "paths": paths,
-        })
+        objects.append(
+            {
+                "sha256": digest,
+                "size": item["size"],
+                "representative": paths[0],
+                "paths": paths,
+            }
+        )
 
     code_object_paths = sum(len(item["paths"]) for item in objects)
-    duplicate_groups = sum(1 for item in objects
-                           if len(item["paths"]) > 1)
+    duplicate_groups = sum(1 for item in objects if len(item["paths"]) > 1)
     inventory = {
         "schema": SCHEMA,
         "version": SCHEMA_VERSION,
-        "roots": sorted({normalized_path(root) for root in roots},
-                        key=path_sort_key),
+        "roots": sorted({normalized_path(root) for root in roots}, key=path_sort_key),
         "summary": {
             "files_examined": len(files),
             "code_object_paths": code_object_paths,
@@ -309,8 +353,7 @@ def build_inventory(roots, manifest_path=None):
             "rejected_files": len(rejected),
         },
         "objects": objects,
-        "rejected": sorted(rejected,
-                           key=lambda item: path_sort_key(item["path"])),
+        "rejected": sorted(rejected, key=lambda item: path_sort_key(item["path"])),
     }
     if manifest is not None:
         inventory["manifest"] = manifest
@@ -319,8 +362,9 @@ def build_inventory(roots, manifest_path=None):
 
 def json_bytes(value):
     """Serialize JSON canonically."""
-    return (json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True) +
-            "\n").encode("ascii")
+    return (
+        json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True) + "\n"
+    ).encode("ascii")
 
 
 def atomic_write(path, contents):
@@ -328,12 +372,12 @@ def atomic_write(path, contents):
     destination = normalized_path(path)
     directory = os.path.dirname(destination)
     if not os.path.isdir(directory):
-        raise InventoryError(
-            "output directory does not exist: '{}'".format(directory))
+        raise InventoryError("output directory does not exist: '{}'".format(directory))
     temporary_path = None
     try:
         descriptor, temporary_path = tempfile.mkstemp(
-            prefix=".hotswap-inventory-", dir=directory)
+            prefix=".hotswap-inventory-", dir=directory
+        )
         with os.fdopen(descriptor, "wb") as stream:
             stream.write(contents)
             stream.flush()
@@ -341,8 +385,9 @@ def atomic_write(path, contents):
         os.replace(temporary_path, destination)
         temporary_path = None
     except OSError as error:
-        raise InventoryError("cannot write '{}': {}".format(
-            destination, error)) from error
+        raise InventoryError(
+            "cannot write '{}': {}".format(destination, error)
+        ) from error
     finally:
         if temporary_path is not None:
             try:
@@ -353,8 +398,7 @@ def atomic_write(path, contents):
 
 def write_worklist(path, objects):
     """Write representative paths as a NUL-delimited byte stream."""
-    contents = b"".join(
-        os.fsencode(item["representative"]) + b"\0" for item in objects)
+    contents = b"".join(os.fsencode(item["representative"]) + b"\0" for item in objects)
     atomic_write(path, contents)
 
 
@@ -370,10 +414,13 @@ def protect_inventory_inputs(inventory, output_paths):
         if output_path is None or output_path == "-":
             continue
         normalized_output = normalized_path(output_path)
-        if normalized_output in protected:
-            raise InventoryError(
-                "refusing to overwrite inventory input '{}'".format(
-                    normalized_output))
+        for protected_path in protected:
+            if paths_alias(normalized_output, protected_path):
+                raise InventoryError(
+                    "refusing to overwrite inventory input '{}'".format(
+                        normalized_output
+                    )
+                )
 
 
 def resolve_program(program):
@@ -382,15 +429,18 @@ def resolve_program(program):
         resolved = normalized_path(program)
         if not os.path.isfile(resolved):
             raise InventoryError(
-                "command executable does not exist: '{}'".format(program))
+                "command executable does not exist: '{}'".format(program)
+            )
         if not os.access(resolved, os.X_OK):
             raise InventoryError(
-                "command executable is not executable: '{}'".format(program))
+                "command executable is not executable: '{}'".format(program)
+            )
         return resolved
     resolved = shutil.which(program)
     if resolved is None:
         raise InventoryError(
-            "command executable was not found on PATH: '{}'".format(program))
+            "command executable was not found on PATH: '{}'".format(program)
+        )
     return normalized_path(resolved)
 
 
@@ -405,41 +455,52 @@ def hash_regular_file(path):
                     break
                 digest.update(block)
     except OSError as error:
-        raise InventoryError("cannot hash command file '{}': {}".format(
-            path, error)) from error
+        raise InventoryError(
+            "cannot hash command file '{}': {}".format(path, error)
+        ) from error
     return digest.hexdigest()
 
 
-def command_identity(argv, dependencies, tags):
+def command_identity(argv, dependencies, tags, timeout):
     """Return a content-sensitive key for an executable and file arguments."""
     files = []
     for index, argument in enumerate(argv):
         candidate = normalized_path(argument)
         if os.path.isfile(candidate):
-            files.append({
-                "kind": "argv",
-                "index": index,
-                "path": candidate,
-                "sha256": hash_regular_file(candidate),
-            })
+            files.append(
+                {
+                    "kind": "argv",
+                    "index": index,
+                    "path": candidate,
+                    "sha256": hash_regular_file(candidate),
+                }
+            )
     normalized_dependencies = []
     for dependency in dependencies:
         path = normalized_path(dependency)
         if not os.path.isfile(path):
             raise InventoryError(
-                "cache dependency is not a regular file: '{}'".format(path))
+                "cache dependency is not a regular file: '{}'".format(path)
+            )
         normalized_dependencies.append(path)
     for path in sorted(set(normalized_dependencies), key=path_sort_key):
-        files.append({
-            "kind": "dependency",
-            "path": path,
-            "sha256": hash_regular_file(path),
-        })
-    identity = {"argv": argv, "files": files, "tags": tags}
+        files.append(
+            {
+                "kind": "dependency",
+                "path": path,
+                "sha256": hash_regular_file(path),
+            }
+        )
+    identity = {
+        "argv": argv,
+        "files": files,
+        "tags": tags,
+        "timeout_seconds": timeout,
+    }
     return hashlib.sha256(json_bytes(identity)).hexdigest()
 
 
-def read_cache_entry(path, command_key, digest):
+def read_cache_entry(path, command_key, digest, representative):
     """Read and validate one successful cached result."""
     if not os.path.exists(path):
         return None
@@ -447,41 +508,41 @@ def read_cache_entry(path, command_key, digest):
         with open(path, "rb") as stream:
             entry = json.load(stream)
     except (OSError, UnicodeError, json.JSONDecodeError) as error:
-        raise InventoryError("cannot read cache entry '{}': {}".format(
-            path, error)) from error
+        raise InventoryError(
+            "cannot read cache entry '{}': {}".format(path, error)
+        ) from error
 
     if not isinstance(entry, dict):
-        raise InventoryError(
-            "cache entry '{}' is not a JSON object".format(path))
+        raise InventoryError("cache entry '{}' is not a JSON object".format(path))
     expected = {
         "schema": CACHE_SCHEMA,
         "version": CACHE_VERSION,
         "command_key": command_key,
         "sha256": digest,
+        "path": representative,
     }
     for key, value in expected.items():
         if entry.get(key) != value:
-            raise InventoryError(
-                "cache entry '{}' has invalid {}".format(path, key))
+            raise InventoryError("cache entry '{}' has invalid {}".format(path, key))
     if entry.get("returncode") != 0:
-        raise InventoryError(
-            "cache entry '{}' is not a successful result".format(path))
+        raise InventoryError("cache entry '{}' is not a successful result".format(path))
     runtime_ms = entry.get("runtime_ms")
-    if (isinstance(runtime_ms, bool) or not isinstance(runtime_ms, int) or
-            runtime_ms < 0):
-        raise InventoryError(
-            "cache entry '{}' has invalid runtime_ms".format(path))
+    if (
+        isinstance(runtime_ms, bool)
+        or not isinstance(runtime_ms, int)
+        or runtime_ms < 0
+    ):
+        raise InventoryError("cache entry '{}' has invalid runtime_ms".format(path))
     for key in ("stdout_base64", "stderr_base64"):
         value = entry.get(key)
         if not isinstance(value, str):
-            raise InventoryError(
-                "cache entry '{}' has invalid {}".format(path, key))
+            raise InventoryError("cache entry '{}' has invalid {}".format(path, key))
         try:
             base64.b64decode(value.encode("ascii"), validate=True)
         except (ValueError, UnicodeError) as error:
             raise InventoryError(
-                "cache entry '{}' has invalid {}".format(path, key)) \
-                from error
+                "cache entry '{}' has invalid {}".format(path, key)
+            ) from error
     return entry
 
 
@@ -490,8 +551,36 @@ def elapsed_runtime_ms(start_time):
     return int(round(max(0.0, time.monotonic() - start_time) * 1000))
 
 
-def run_one_command(item, argv_prefix, command_key, timeout,
-                    normalized_cache):
+def execute_command(argv, timeout):
+    """Run argv and terminate its POSIX process group after a timeout."""
+    popen_arguments = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+    }
+    if os.name == "posix":
+        popen_arguments["start_new_session"] = True
+    process = subprocess.Popen(argv, **popen_arguments)
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as error:
+        if os.name == "posix":
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        else:
+            process.kill()
+        stdout, stderr = process.communicate()
+        raise subprocess.TimeoutExpired(
+            error.cmd, error.timeout, output=stdout, stderr=stderr
+        ) from error
+    return subprocess.CompletedProcess(
+        argv, process.returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def run_one_command(item, argv_prefix, command_key, timeout, normalized_cache):
     """Run or load the result for one unique content digest."""
     representative = item["representative"]
     digest = item["sha256"]
@@ -499,9 +588,13 @@ def run_one_command(item, argv_prefix, command_key, timeout,
     cache_path = None
     cached = None
     if normalized_cache is not None:
+        cache_entry_key = hashlib.sha256(
+            json_bytes({"path": representative, "sha256": digest})
+        ).hexdigest()
         cache_path = os.path.join(
-            normalized_cache, command_key, digest + ".json")
-        cached = read_cache_entry(cache_path, command_key, digest)
+            normalized_cache, command_key, cache_entry_key + ".json"
+        )
+        cached = read_cache_entry(cache_path, command_key, digest, representative)
     if cached is not None:
         return {
             "sha256": digest,
@@ -517,27 +610,17 @@ def run_one_command(item, argv_prefix, command_key, timeout,
 
     start_time = time.monotonic()
     try:
-        completed = subprocess.run(
-            argv,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=timeout,
-            check=False,
-            shell=False)
+        completed = execute_command(argv, timeout)
         result = {
             "sha256": digest,
             "path": representative,
             "argv": argv,
-            "status": ("passed" if completed.returncode == 0
-                       else "failed"),
+            "status": ("passed" if completed.returncode == 0 else "failed"),
             "cached": False,
             "returncode": completed.returncode,
             "runtime_ms": elapsed_runtime_ms(start_time),
-            "stdout_base64": base64.b64encode(
-                completed.stdout).decode("ascii"),
-            "stderr_base64": base64.b64encode(
-                completed.stderr).decode("ascii"),
+            "stdout_base64": base64.b64encode(completed.stdout).decode("ascii"),
+            "stderr_base64": base64.b64encode(completed.stderr).decode("ascii"),
         }
     except subprocess.TimeoutExpired as error:
         stdout = error.stdout if error.stdout is not None else b""
@@ -573,6 +656,7 @@ def run_one_command(item, argv_prefix, command_key, timeout,
             "version": CACHE_VERSION,
             "command_key": command_key,
             "sha256": digest,
+            "path": representative,
             "returncode": 0,
             "runtime_ms": result["runtime_ms"],
             "stdout_base64": result["stdout_base64"],
@@ -582,59 +666,63 @@ def run_one_command(item, argv_prefix, command_key, timeout,
     return result
 
 
-def run_command(inventory, program, arguments, timeout, cache_dir, jobs,
-                cache_dependencies, cache_tags):
+def run_command(
+    inventory,
+    program,
+    arguments,
+    timeout,
+    cache_dir,
+    jobs,
+    cache_dependencies,
+    cache_tags,
+):
     """Run argv plus each unique representative, without invoking a shell."""
     resolved_program = resolve_program(program)
     argv_prefix = [resolved_program] + arguments
-    command_key = command_identity(
-        argv_prefix, cache_dependencies, cache_tags)
+    command_key = command_identity(argv_prefix, cache_dependencies, cache_tags, timeout)
 
     normalized_cache = None
     if cache_dir is not None:
         normalized_cache = normalized_path(cache_dir)
         try:
-            os.makedirs(os.path.join(normalized_cache, command_key),
-                        exist_ok=True)
+            os.makedirs(os.path.join(normalized_cache, command_key), exist_ok=True)
         except OSError as error:
-            raise InventoryError("cannot create cache directory '{}': {}"
-                                 .format(normalized_cache, error)) from error
+            raise InventoryError(
+                "cannot create cache directory '{}': {}".format(normalized_cache, error)
+            ) from error
 
     run_one = functools.partial(
         run_one_command,
         argv_prefix=argv_prefix,
         command_key=command_key,
         timeout=timeout,
-        normalized_cache=normalized_cache)
+        normalized_cache=normalized_cache,
+    )
     if jobs == 1:
         results = [run_one(item) for item in inventory["objects"]]
     else:
-        with concurrent.futures.ThreadPoolExecutor(
-                max_workers=jobs) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
             results = list(executor.map(run_one, inventory["objects"]))
 
     return {
         "command": argv_prefix,
         "command_key": command_key,
         "cache_dependencies": sorted(
-            {normalized_path(path) for path in cache_dependencies},
-            key=path_sort_key),
+            {normalized_path(path) for path in cache_dependencies}, key=path_sort_key
+        ),
         "cache_tags": cache_tags,
         "timeout_seconds": timeout,
         "jobs": jobs,
         "results": results,
         "summary": {
             "total": len(results),
-            "passed": sum(1 for result in results
-                          if result["status"] == "passed"),
-            "failed": sum(1 for result in results
-                          if result["status"] != "passed"),
+            "passed": sum(1 for result in results if result["status"] == "passed"),
+            "failed": sum(1 for result in results if result["status"] != "passed"),
             "cache_hits": sum(1 for result in results if result["cached"]),
-            "estimated_runtime_ms": sum(
-                result["runtime_ms"] for result in results),
+            "estimated_runtime_ms": sum(result["runtime_ms"] for result in results),
             "executed_runtime_ms": sum(
-                result["runtime_ms"] for result in results
-                if not result["cached"]),
+                result["runtime_ms"] for result in results if not result["cached"]
+            ),
         },
     }
 
@@ -644,48 +732,89 @@ def create_argument_parser():
     parser = argparse.ArgumentParser(
         description=(
             "Inventory AMDGPU ELF code objects, deduplicate them by SHA-256, "
-            "and optionally run one command per unique object."))
+            "and optionally run one command per unique object."
+        )
+    )
     parser.add_argument(
-        "roots", metavar="ROOT", nargs="+",
-        help="file or directory to inventory recursively")
+        "roots",
+        metavar="ROOT",
+        nargs="+",
+        help="file or directory to inventory recursively",
+    )
     parser.add_argument(
-        "--json-output", metavar="PATH", default="-",
-        help="write the JSON report to PATH (default: standard output)")
+        "--json-output",
+        metavar="PATH",
+        default="-",
+        help="write the JSON report to PATH (default: standard output)",
+    )
     parser.add_argument(
-        "--worklist", metavar="PATH",
-        help="write unique representative paths as NUL-delimited bytes")
+        "--worklist",
+        metavar="PATH",
+        help="write unique representative paths as NUL-delimited bytes",
+    )
     parser.add_argument(
-        "--manifest", metavar="PATH",
-        help=("inventory only newline-delimited paths from PATH, relative to "
-              "one corpus root"))
+        "--manifest",
+        metavar="PATH",
+        help=(
+            "inventory only newline-delimited paths from PATH, relative to "
+            "one corpus root"
+        ),
+    )
     parser.add_argument(
-        "--execute", metavar="PROGRAM",
-        help="run PROGRAM once per unique object; the path is appended")
+        "--execute",
+        metavar="PROGRAM",
+        help="run PROGRAM once per unique object; the path is appended",
+    )
     parser.add_argument(
-        "--execute-arg", metavar="ARG", action="append", default=[],
-        help=("pass ARG before the object path; repeat as needed (use "
-              "--execute-arg=--flag for arguments beginning with '-')"))
+        "--execute-arg",
+        metavar="ARG",
+        action="append",
+        default=[],
+        help=(
+            "pass ARG before the object path; repeat as needed (use "
+            "--execute-arg=--flag for arguments beginning with '-')"
+        ),
+    )
     parser.add_argument(
-        "--timeout", metavar="SECONDS", type=float,
-        help="terminate each command after this many seconds")
+        "--timeout",
+        metavar="SECONDS",
+        type=float,
+        help="terminate each command after this many seconds",
+    )
     parser.add_argument(
-        "--cache-dir", metavar="PATH",
-        help="reuse successful results by command and input content hash")
+        "--cache-dir",
+        metavar="PATH",
+        help="reuse successful results by command and input content hash",
+    )
     parser.add_argument(
-        "--cache-dependency", metavar="PATH", action="append", default=[],
-        help="hash PATH into the command cache key; repeat as needed")
+        "--cache-dependency",
+        metavar="PATH",
+        action="append",
+        default=[],
+        help="hash PATH into the command cache key; repeat as needed",
+    )
     parser.add_argument(
-        "--cache-tag", metavar="TEXT", action="append", default=[],
-        help="include TEXT in the command cache key; repeat as needed")
+        "--cache-tag",
+        metavar="TEXT",
+        action="append",
+        default=[],
+        help="include TEXT in the command cache key; repeat as needed",
+    )
     parser.add_argument(
-        "--jobs", metavar="COUNT", type=int, default=1,
-        help="run up to COUNT commands concurrently (default: 1)")
+        "--jobs",
+        metavar="COUNT",
+        type=int,
+        default=1,
+        help="run up to COUNT commands concurrently (default: 1)",
+    )
     return parser
 
 
 def validate_arguments(parser, arguments):
     """Validate relationships not expressible with argparse declarations."""
-    if arguments.timeout is not None and arguments.timeout <= 0:
+    if arguments.timeout is not None and (
+        not math.isfinite(arguments.timeout) or arguments.timeout <= 0
+    ):
         parser.error("--timeout must be greater than zero")
     if arguments.jobs <= 0:
         parser.error("--jobs must be greater than zero")
@@ -706,10 +835,11 @@ def validate_arguments(parser, arguments):
         parser.error("--worklist requires a file path, not standard output")
     if arguments.manifest is not None and len(arguments.roots) != 1:
         parser.error("--manifest requires exactly one corpus root")
-    if (arguments.worklist is not None and
-            arguments.json_output != "-" and
-            normalized_path(arguments.worklist) ==
-            normalized_path(arguments.json_output)):
+    if (
+        arguments.worklist is not None
+        and arguments.json_output != "-"
+        and paths_alias(arguments.worklist, arguments.json_output)
+    ):
         parser.error("--worklist and --json-output must be different files")
 
 
@@ -721,8 +851,7 @@ def main(argv=None):
 
     try:
         inventory = build_inventory(arguments.roots, arguments.manifest)
-        protect_inventory_inputs(
-            inventory, [arguments.worklist, arguments.json_output])
+        protect_inventory_inputs(inventory, [arguments.worklist, arguments.json_output])
         if arguments.worklist is not None:
             write_worklist(arguments.worklist, inventory["objects"])
 
@@ -736,7 +865,8 @@ def main(argv=None):
                 arguments.cache_dir,
                 arguments.jobs,
                 arguments.cache_dependency,
-                arguments.cache_tag)
+                arguments.cache_tag,
+            )
             inventory["execution"] = execution
             command_failed = execution["summary"]["failed"] != 0
 


### PR DESCRIPTION
This adds a fast, deterministic hotswap corpus inventory so exact duplicate
code objects are rewritten only once while every alias remains traceable.

## What it does

- Recursively identifies AMDGPU ELF inputs from their headers rather than
  filename suffixes.
- Groups exact duplicates by SHA-256 and chooses a deterministic canonical
  representative.
- Emits versioned JSON and a NUL-delimited unique worklist.
- Optionally executes an argv-safe command over unique representatives, with
  parallel jobs, per-object `runtime_ms`, timeouts, explicit result records,
  and no shell interpolation.
- Caches successful results by input content, representative path, and command
  identity. The command identity includes the timeout, executable,
  regular-file arguments, explicit dynamic-library dependencies, and caller
  tags. Cache schema v3 stores and replays runtime estimates for the budgeted
  test selector.
- Supports frozen newline-delimited manifests and multiple output roots for
  later content-digest comparison.
- Rejects manifest symlink escapes and refuses aliased JSON/worklist paths or
  output paths that would overwrite corpus inputs.
- On POSIX, terminates the command process group after a timeout so descendants
  cannot keep captured output pipes open indefinitely.

This is developer tooling only. It does not change the COMGR public API,
hotswap rewrite policy, instruction decoding, or GPU behavior.

## Tests

Based on `ROCm/llvm-project:amd-staging` at
`d4450799dba192da73bd12d739e8a58dc610630d`.

- `python3 amd/comgr/test/utils/test_hotswap_inventory.py`
  - PASS: 39/39 hermetic unit/integration tests.
- Standalone COMGR CMake configure
  - PASS using the existing release LLVM/Clang/LLD/AMDDeviceLibs packages.
  - API consistency check: COMGR 3.5, 72 declared/exported APIs.
- `ctest --test-dir /tmp/hotswap-inventory-cmake -R '^comgr_hotswap_inventory$' --output-on-failure`
  - PASS: `comgr_hotswap_inventory`.
- Optional external acceptance CTest
  - SKIP as designed without corpus environment variables.
- Project formatter using the CI-pinned Darker 1.7.2 / Black 23.12.1:
  `darker --check --diff -r d4450799...HEAD`
  - PASS on the implementation and both tests.
- `ruff check` on the implementation and both tests
  - PASS.
- `python3 -m py_compile` on the implementation and both tests
  - PASS.
- `git diff --check`
  - PASS.

The tests cover cache path and timeout identity, concurrent cache writers,
symlink-root containment, aliased output paths, timeout process-group cleanup,
deterministic cached/uncached results, Windows-safe paths and native child
line endings, invalid timeout values, and the original inventory/execution
behavior.

### External #3646 corpus acceptance

The #3646 corpus is acceptance data, not embedded core logic. The default
suite remains hermetic and synthetic. The optional CTest runs only when
`COMGR_HOTSWAP_CORPUS_ROOT` and `COMGR_HOTSWAP_CORPUS_MANIFEST` are set.
All #3646-specific counts and the frozen manifest hash are confined to that
acceptance test.

The opt-in end-to-end acceptance test passed against the fully extracted
2026-07-24 corpus in 2.26 seconds with 23,904 KiB maximum RSS:

- Archive SHA-256:
  `6fdfb5c5c6dbc8ebfad2d4fafb106e16586ad0b77942e79efa1416cb322e5aa3`
- Manifest SHA-256:
  `076ea013ba466139e76074fcbb31905a5041298e7644f6e8f590bf9353e4f5b9`
- 2,685 code-object aliases
- 1,452 SHA-256-unique objects
- 1,233 duplicate executions skipped

A separate recursive scan without the manifest also passed in 2.03 seconds
with 23,432 KiB maximum RSS. It reported 2,693 files examined, 2,685 AMDGPU ELF
paths, 1,452 unique objects, 1,233 duplicate paths in 1,231 duplicate groups,
and eight rejected non-ELF metadata files.

## Scope and limitations

- No public API or ABI change.
- No native code change; no GPU or MI400 execution is required for this tool.
- ASAN was not run because this PR is Python-only and the project-specific
  validation order defers ASAN until corpus and MI400 rewrite tests pass.
- ELF admission validates the ELF identification/header and AMDGPU machine
  value; it does not duplicate LLVM's full section, note, or code-object
  validation.
- Newline-delimited input manifests cannot represent a path containing a
  newline. Generated worklists are NUL-delimited and do support such paths on
  filesystems that permit them.
- Directory symlinks discovered during recursion are not followed, preventing
  cycles. Explicit directory-symlink roots and file symlinks are supported.
- Captured command output is kept in memory and Base64-encoded in JSON, so
  callers should avoid commands with unbounded output.
- `estimated_runtime_ms` is the sum of per-object runtimes, not parallel
  wall-clock time. Environment- or library-dependent commands should name
  those inputs with `--cache-dependency`/`--cache-tag`.
