### PR TITLE
[Comgr] Add explainable hotswap test subset selector

### DIFF
--- a/amd/comgr/docs/HotswapTestSelect.md
+++ b/amd/comgr/docs/HotswapTestSelect.md
@@ -1,0 +1,190 @@
+# Hotswap test selection
+
+`hotswap_test_select.py` merges calibration observations and chooses a small,
+high-value test subset. It is intended for quick corpus and A0 calibration
+runs, where executing every duplicate or redundant test is too expensive.
+
+The input is versioned JSON:
+
+```json
+{
+  "kind": "hotswap-test-observations",
+  "schema_version": 1,
+  "tests": [
+    {
+      "id": "hipblaslt/matmul/example",
+      "runtime_ms": 125,
+      "features": ["branch-rewrite", "literal-displacement"],
+      "candidate_outcome": "pass",
+      "original_outcome": "pass",
+      "novelty": 0.5,
+      "risk": 2
+    }
+  ]
+}
+```
+
+`candidate_outcome` and `original_outcome` accept `pass`, `fail`, `skip`,
+`unknown`, or `mixed`. The outcomes, `novelty`, `risk`, `sample_count`, and
+`has_candidate_only_regression` fields are optional. Test ID, runtime, and
+features are required.
+
+Merging takes the sample-weighted mean runtime, unions feature tags, retains
+the maximum risk and novelty, and marks conflicting known outcomes as `mixed`.
+It also retains `has_candidate_only_regression` when any constituent sample
+failed with the candidate and passed with the original. This separate marker
+prevents a later passing sample from hiding a previously observed regression
+when the aggregate candidate outcome becomes `mixed`. A producer that supplies
+an already aggregated `mixed` outcome should set the marker itself when it
+knows such a paired observation occurred. These rules make a merge independent
+of input order.
+
+Rewrite-manifest, audit, and semantic-check producers can use a neutral
+forward-compatible envelope:
+
+```json
+{
+  "kind": "producer-specific-kind",
+  "schema_version": 1,
+  "source": "rewrite-manifest",
+  "records": [
+    {
+      "test_id": "hipblaslt/matmul/example",
+      "runtime_ms": 125,
+      "features": ["branch-rewrite"],
+      "candidate_outcome": "pass",
+      "original_outcome": "pass",
+      "risk": 2,
+      "novelty": 0.5,
+      "provenance": ["mi400-3"]
+    }
+  ]
+}
+```
+
+Only `test_id` is required in each individual producer record. At least one
+producer must report `runtime_ms` for every test; runtime and feature
+observations may otherwise arrive from different producers. The adapter
+ignores unknown producer fields so reports can evolve, then unions their
+features and provenance:
+
+```console
+python3 amd/comgr/utils/hotswap/hotswap_test_select.py adapt \
+  --input manifest.json audit.json semcheck.json \
+  --output observations.json
+```
+
+The adapter also accepts the versioned `comgr.hotswap.inventory` schema. It
+uses `sha256:<digest>` as the test ID, so manifest, audit, and semantic-check
+records can join observations to an exact deduplicated code object without
+depending on a path alias. The inventory does not measure runtime or infer
+rewrite features. Join it with a timed producer:
+
+```console
+python3 amd/comgr/utils/hotswap/hotswap_test_select.py adapt \
+  --input inventory.json audit-observations.json \
+  --output observations.json
+```
+
+For exploratory use, `--default-runtime-ms` explicitly supplies the missing
+runtime for inventory objects that no producer timed. The adapter marks that
+provenance as `adapter-default-runtime`; it never silently treats an untimed
+object as free.
+
+Merge repeated calibration runs:
+
+```console
+python3 amd/comgr/utils/hotswap/hotswap_test_select.py merge \
+  --input run-1.json run-2.json --output observations.json
+```
+
+Every merged input must describe the same candidate build, reference build,
+target, and execution mode. Provenance is retained for auditability, but the
+version 1 schema does not infer or enforce that comparison identity. Keep
+observations from different candidate revisions in separate merges.
+
+Select a subset:
+
+```console
+python3 amd/comgr/utils/hotswap/hotswap_test_select.py select \
+  --input observations.json --runtime-budget-ms 30000 \
+  --min-novel-tests 5 --min-unknown-tests 5 --output selection.json
+```
+
+The deterministic weighted set-cover heuristic first includes every test that
+failed with the candidate and passed with the original. Those regressions may
+exceed a requested budget. It then maximizes marginal feature coverage,
+adjusted by risk, novelty, and calibration quotas. When a runtime budget is
+supplied, the greedy score is also divided by runtime (with sub-millisecond
+runtimes treated as one millisecond); without one, runtime is only a stable
+tie-break. The output includes the canonical input digest, selection reason and
+marginal coverage and provenance for every test, remaining uncovered features,
+unfilled quotas, and estimated runtime.
+
+Use repeated `--require-feature` options to cover only named features, and
+repeated `--feature-weight FEATURE=WEIGHT` options to prioritize important
+rewrite behavior. `--novelty-mode rarity` derives novelty from inverse feature
+frequency, so previously unseen tag names need no selector changes.
+`--holdout-percent` reserves a deterministic, seed-controlled subset of
+non-regression test IDs for independent validation. Known candidate-only
+regressions still override that reservation and are reported separately.
+
+The selector is a greedy heuristic, not a globally optimal set-cover solver.
+Its stable score and tie-break order make a given selection reproducible and
+explainable. Output files are written through a same-directory temporary file
+and atomically replaced. An output path that aliases an input is rejected
+before any input is read or output is opened.
+
+## PR #3646 evidence acceptance
+
+`test_hotswap_test_select_evidence.py` can consume the frozen corpus evidence
+from candidate commit `ab3cdd61c079a3e7fa7ed41d9834cc0baa256fcc`:
+
+```console
+COMGR_HOTSWAP_RESULTS_TSV=/path/to/results.tsv \
+COMGR_HOTSWAP_TRANSITIONS_TSV=/path/to/transitions-vs-5cbc-default.tsv \
+COMGR_HOTSWAP_PRIOR_FAILURES_TSV=/path/to/prior-failures-now-success.tsv \
+python3 amd/comgr/test/utils/test_hotswap_test_select_evidence.py
+```
+
+The evidence test requires these SHA-256 values before parsing the files:
+
+- `results.tsv`:
+  `ffb089ac585374ac3e9edd93cb0668ed9c6c6b21514948d94884a20f7c2176b9`
+- `transitions-vs-5cbc-default.tsv`:
+  `295c97a7bcc7b62363c5f41e9c3aa9c46741d43f2270799407b6c6cc11908c5c`
+- `prior-failures-now-success.tsv`:
+  `756066cad7ca7aea97b5d9474784f5ad4ae00bc2a1b3d381bf0592f968cfb892`
+
+The acceptance read 2,685 aliases, deduplicated them to 1,452 input hashes,
+and therefore collapsed 1,233 duplicate aliases before selection. All rows
+reported a successful first rewrite, successful second rewrite, and
+byte-identical idempotence result. The runtime p99 was 6.64 seconds. Six
+data-derived coverage dimensions were covered by two selected objects:
+
+- the repaired scale16 case covered rewrite success, idempotence, changed
+  output, the runtime tail, and a prior baseline failure;
+- one unchanged-output `kpack` object supplied the remaining unchanged-output
+  dimension.
+
+The four natural transition records are `FAILURE` to `SUCCESS`: one scale16
+case and three WMMA VGPR-MSB cases. They are improvements in the real evidence,
+not candidate-only regressions. A separate acceptance step reverses only the
+outcome orientation of those same four records and sets both budgets to zero.
+That checks that all four are still selected and marked forced when presented
+as candidate-only regressions. It does not claim that PR #3646 failed them.
+
+This evidence establishes corpus rewrite completion, deduplication identity,
+idempotence, output-change classes, measured host runtime, and old/new process
+outcomes. It does not establish GPU execution accuracy, semantic equivalence,
+or the presence of round-trip VCC preservation, owner-specific source
+windows, far gateways, materialized call closure, scratch-SGPR liveness, DS2,
+M32 scale16, or tensor-mask behavior. Those dimensions require manifest,
+audit, semantic-check, or A0 execution observations.
+
+`amd/comgr/test/Inputs/hotswap/pr3646-acceptance.json` remains a separate
+curated fixture for those risk dimensions, natural parent/child hipBLASLt and
+hipSOLVER records, and synthetic unseen holdout dimensions. It is not measured
+performance evidence. The tests rewrite every ID and feature label to verify
+that selection depends on record structure rather than memorized names. Run
+`select --help` for all controls.

--- a/amd/comgr/test/CMakeLists.txt
+++ b/amd/comgr/test/CMakeLists.txt
@@ -247,3 +247,24 @@ add_comgr_test(compile_hip_to_relocatable c)
 #add_comgr_test(compile_hip_with_libcxx_test c)
 add_comgr_test(mangled_names_hip_test c)
 #add_comgr_test(unbundle_hip_test c)
+
+add_test(
+  NAME comgr_hotswap_test_select_test
+  COMMAND "${Python3_EXECUTABLE}"
+          "${CMAKE_CURRENT_SOURCE_DIR}/utils/test_hotswap_test_select.py")
+set_tests_properties(
+  comgr_hotswap_test_select_test
+  PROPERTIES
+    ENVIRONMENT "PYTHONDONTWRITEBYTECODE=1"
+    TIMEOUT 120)
+
+add_test(
+  NAME comgr_hotswap_test_select_evidence_test
+  COMMAND "${Python3_EXECUTABLE}"
+          "${CMAKE_CURRENT_SOURCE_DIR}/utils/test_hotswap_test_select_evidence.py")
+set_tests_properties(
+  comgr_hotswap_test_select_evidence_test
+  PROPERTIES
+    ENVIRONMENT "PYTHONDONTWRITEBYTECODE=1"
+    SKIP_RETURN_CODE 77
+    TIMEOUT 120)

--- a/amd/comgr/test/Inputs/hotswap/inventory-observations-v1.json
+++ b/amd/comgr/test/Inputs/hotswap/inventory-observations-v1.json
@@ -1,0 +1,30 @@
+{
+  "future_envelope_field": "ignored",
+  "kind": "hotswap-audit-observations",
+  "records": [
+    {
+      "candidate_outcome": "pass",
+      "features": [
+        "direct-rewrite"
+      ],
+      "future_record_field": 1,
+      "original_outcome": "pass",
+      "risk": 1,
+      "runtime_ms": 4,
+      "test_id": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    {
+      "candidate_outcome": "fail",
+      "features": [
+        "far-routing",
+        "live-state"
+      ],
+      "original_outcome": "pass",
+      "risk": 4,
+      "runtime_ms": 9,
+      "test_id": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "schema_version": 1,
+  "source": "hotswap-audit"
+}

--- a/amd/comgr/test/Inputs/hotswap/inventory-v1.json
+++ b/amd/comgr/test/Inputs/hotswap/inventory-v1.json
@@ -1,0 +1,39 @@
+{
+  "future_inventory_field": {
+    "ignored": true
+  },
+  "objects": [
+    {
+      "future_object_field": 1,
+      "paths": [
+        "/corpus/a.co",
+        "/corpus/a-copy.co"
+      ],
+      "representative": "/corpus/a.co",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 4096
+    },
+    {
+      "paths": [
+        "/corpus/b.co"
+      ],
+      "representative": "/corpus/b.co",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "size": 8192
+    }
+  ],
+  "rejected": [],
+  "roots": [
+    "/corpus"
+  ],
+  "schema": "comgr.hotswap.inventory",
+  "summary": {
+    "code_object_paths": 3,
+    "duplicate_groups": 1,
+    "duplicate_paths": 1,
+    "files_examined": 3,
+    "rejected_files": 0,
+    "unique_code_objects": 2
+  },
+  "version": 1
+}

--- a/amd/comgr/test/Inputs/hotswap/pr3646-acceptance.json
+++ b/amd/comgr/test/Inputs/hotswap/pr3646-acceptance.json
@@ -1,0 +1,126 @@
+{
+  "kind": "hotswap-test-observations",
+  "schema_version": 1,
+  "tests": [
+    {
+      "candidate_outcome": "pass",
+      "features": [
+        "m32-scale16",
+        "tensor-mask"
+      ],
+      "id": "hipblaslt/matmul/scale16",
+      "novelty": 0,
+      "original_outcome": "pass",
+      "provenance": [
+        "pr3646-curated-acceptance"
+      ],
+      "risk": 1,
+      "runtime_ms": 70
+    },
+    {
+      "candidate_outcome": "fail",
+      "features": [
+        "m32-scale16",
+        "round-trip-vcc-preservation",
+        "tensor-mask"
+      ],
+      "id": "hipblaslt/matmul/scale16/candidate-regression",
+      "novelty": 2,
+      "original_outcome": "pass",
+      "provenance": [
+        "pr3646-curated-acceptance"
+      ],
+      "risk": 5,
+      "runtime_ms": 85
+    },
+    {
+      "candidate_outcome": "pass",
+      "features": [
+        "finite-call-closure",
+        "materialized-call-closure",
+        "owner-specific-source-window"
+      ],
+      "id": "hipsolver/batched-factorization",
+      "novelty": 0,
+      "original_outcome": "pass",
+      "provenance": [
+        "pr3646-curated-acceptance"
+      ],
+      "risk": 2,
+      "runtime_ms": 45
+    },
+    {
+      "candidate_outcome": "fail",
+      "features": [
+        "ds2",
+        "owner-specific-source-window",
+        "scratch-sgpr-liveness"
+      ],
+      "id": "hipsolver/batched-factorization/candidate-regression",
+      "novelty": 2,
+      "original_outcome": "pass",
+      "provenance": [
+        "pr3646-curated-acceptance"
+      ],
+      "risk": 5,
+      "runtime_ms": 55
+    },
+    {
+      "candidate_outcome": "pass",
+      "features": [
+        "far-relay-gateway"
+      ],
+      "id": "runtime/large-code-object/far-routing",
+      "novelty": 1,
+      "original_outcome": "pass",
+      "provenance": [
+        "pr3646-curated-acceptance"
+      ],
+      "risk": 4,
+      "runtime_ms": 12
+    },
+    {
+      "candidate_outcome": "pass",
+      "features": [
+        "finite-call-closure",
+        "materialized-call-closure"
+      ],
+      "id": "runtime/large-code-object/closed-calls",
+      "novelty": 1,
+      "original_outcome": "pass",
+      "provenance": [
+        "pr3646-curated-acceptance"
+      ],
+      "risk": 4,
+      "runtime_ms": 10
+    },
+    {
+      "candidate_outcome": "unknown",
+      "features": [
+        "synthetic-holdout-unseen-control-flow"
+      ],
+      "id": "synthetic-holdout/control-flow/0",
+      "novelty": 3,
+      "original_outcome": "unknown",
+      "provenance": [
+        "pr3646-curated-acceptance"
+      ],
+      "risk": 2,
+      "runtime_ms": 2
+    },
+    {
+      "candidate_outcome": "unknown",
+      "features": [
+        "synthetic-holdout-unseen-register-state"
+      ],
+      "id": "synthetic-holdout/register-state/0",
+      "novelty": 3,
+      "original_outcome": "unknown",
+      "provenance": [
+        "pr3646-curated-acceptance"
+      ],
+      "risk": 2,
+      "runtime_ms": 2
+    }
+  ]
+}

--- a/amd/comgr/test/utils/test_hotswap_test_select.py
+++ b/amd/comgr/test/utils/test_hotswap_test_select.py
@@ -1,0 +1,1007 @@
+#!/usr/bin/env python3
+# ===- test_hotswap_test_select.py - Selector tests -----------------------===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------===#
+
+import hashlib
+import importlib.util
+import itertools
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+COMGR_DIR = Path(__file__).resolve().parents[2]
+SCRIPT = COMGR_DIR / "utils" / "hotswap" / "hotswap_test_select.py"
+INPUTS_DIR = COMGR_DIR / "test" / "Inputs" / "hotswap"
+SPEC = importlib.util.spec_from_file_location("hotswap_test_select", SCRIPT)
+selector = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(selector)
+EVIDENCE_SCRIPT = COMGR_DIR / "test" / "utils" / "test_hotswap_test_select_evidence.py"
+EVIDENCE_SPEC = importlib.util.spec_from_file_location(
+    "test_hotswap_test_select_evidence", EVIDENCE_SCRIPT
+)
+evidence = importlib.util.module_from_spec(EVIDENCE_SPEC)
+EVIDENCE_SPEC.loader.exec_module(evidence)
+
+
+def observation(*tests):
+    return {
+        "kind": selector.OBSERVATION_KIND,
+        "schema_version": selector.SCHEMA_VERSION,
+        "tests": list(tests),
+    }
+
+
+def test_record(test_id, runtime_ms, features, **overrides):
+    record = {
+        "features": features,
+        "id": test_id,
+        "runtime_ms": runtime_ms,
+    }
+    record.update(overrides)
+    return record
+
+
+class NormalizeTests(unittest.TestCase):
+    def test_empty_input(self):
+        result = selector.select_tests(observation())
+        self.assertEqual(result["selected_tests"], [])
+        self.assertEqual(result["uncovered_features"], [])
+        self.assertEqual(result["estimated_runtime_ms"], 0)
+
+    def test_rejects_missing_fields_and_unknown_fields(self):
+        with self.assertRaisesRegex(selector.SelectionError, "missing runtime_ms"):
+            selector.normalize_document(observation({"id": "broken", "features": []}))
+        with self.assertRaisesRegex(selector.SelectionError, "unknown field"):
+            selector.normalize_document(
+                observation(test_record("broken", 1, [], typo=True))
+            )
+
+    def test_rejects_malformed_values(self):
+        bad_records = [
+            test_record("", 1, []),
+            test_record("bad-runtime", -1, []),
+            test_record("bad-features", 1, "branch"),
+            test_record("bad-feature", 1, [""]),
+            test_record("bad-risk", 1, [], risk=float("inf")),
+            test_record("bad-samples", 1, [], sample_count=0),
+            test_record("bad-outcome", 1, [], candidate_outcome="crash"),
+            test_record(
+                "bad-regression-marker", 1, [], has_candidate_only_regression=1
+            ),
+        ]
+        for record in bad_records:
+            with self.subTest(record=record):
+                with self.assertRaises(selector.SelectionError):
+                    selector.normalize_document(observation(record))
+
+    def test_schema_versions_must_be_integers(self):
+        for version in (True, 1.0, "1"):
+            with self.subTest(version=version):
+                document = observation()
+                document["schema_version"] = version
+                with self.assertRaisesRegex(selector.SelectionError, "schema_version"):
+                    selector.normalize_document(document)
+
+    def test_huge_numbers_fail_cleanly_and_large_means_remain_finite(self):
+        with self.assertRaisesRegex(selector.SelectionError, "finite"):
+            selector.normalize_document(
+                observation(test_record("too-large", 10**10000, []))
+            )
+
+        result = selector.normalize_document(
+            observation(test_record("large", 1e308, [], sample_count=2))
+        )
+        self.assertTrue(math.isfinite(float(result["tests"][0]["runtime_ms"])))
+        self.assertEqual(float(result["tests"][0]["runtime_ms"]), 1e308)
+
+    def test_normalization_is_stable(self):
+        document = observation(
+            test_record("z", 2.0, ["branch", "branch", "literal"]),
+            test_record("a", 1, []),
+        )
+        first = selector.normalize_document(document)
+        second = selector.normalize_document(first)
+        self.assertEqual(first, second)
+        self.assertEqual([test["id"] for test in first["tests"]], ["a", "z"])
+        self.assertEqual(first["tests"][1]["features"], ["branch", "literal"])
+
+
+class MergeTests(unittest.TestCase):
+    def test_duplicates_merge_observations(self):
+        first = observation(
+            test_record(
+                "case",
+                10,
+                ["branch"],
+                candidate_outcome="pass",
+                original_outcome="pass",
+                novelty=1,
+                risk=2,
+                sample_count=2,
+            )
+        )
+        second = observation(
+            test_record(
+                "case",
+                40,
+                ["literal"],
+                candidate_outcome="fail",
+                original_outcome="pass",
+                novelty=3,
+                risk=1,
+            )
+        )
+        result = selector.merge_documents([first, second])
+        merged = result["tests"][0]
+        self.assertEqual(merged["features"], ["branch", "literal"])
+        self.assertEqual(merged["runtime_ms"], 20)
+        self.assertEqual(merged["sample_count"], 3)
+        self.assertEqual(merged["candidate_outcome"], "mixed")
+        self.assertEqual(merged["original_outcome"], "pass")
+        self.assertEqual(merged["novelty"], 3)
+        self.assertEqual(merged["risk"], 2)
+
+    def test_merge_is_independent_of_input_order(self):
+        first = observation(test_record("case", 11, ["a"], sample_count=2))
+        second = observation(test_record("case", 17, ["b"], sample_count=3))
+        self.assertEqual(
+            selector.merge_documents([first, second]),
+            selector.merge_documents([second, first]),
+        )
+
+    def test_merge_is_stable_across_all_input_permutations(self):
+        documents = [
+            observation(test_record("case", 1.25, ["a"], sample_count=2)),
+            observation(test_record("case", 9.5, ["b"], sample_count=3)),
+            observation(test_record("case", 4, ["c"], sample_count=5)),
+        ]
+        expected = selector.merge_documents(documents)
+        for permutation in itertools.permutations(documents):
+            with self.subTest(permutation=permutation):
+                self.assertEqual(selector.merge_documents(permutation), expected)
+
+    def test_duplicates_within_one_document_merge(self):
+        result = selector.normalize_document(
+            observation(
+                test_record("case", 2, ["a"]),
+                test_record("case", 4, ["b"]),
+            )
+        )
+        self.assertEqual(len(result["tests"]), 1)
+        self.assertEqual(result["tests"][0]["runtime_ms"], 3)
+        self.assertEqual(result["tests"][0]["sample_count"], 2)
+
+    def test_merge_preserves_an_observed_candidate_only_regression(self):
+        failed = observation(
+            test_record(
+                "flaky-regression",
+                2,
+                [],
+                candidate_outcome="fail",
+                original_outcome="pass",
+            )
+        )
+        passed = observation(
+            test_record(
+                "flaky-regression",
+                1,
+                [],
+                candidate_outcome="pass",
+                original_outcome="pass",
+            )
+        )
+        merged = selector.merge_documents([failed, passed])
+        self.assertEqual(merged["tests"][0]["candidate_outcome"], "mixed")
+        self.assertTrue(merged["tests"][0]["has_candidate_only_regression"])
+
+        selection = selector.select_tests(merged, test_count_budget=0)
+        self.assertEqual(
+            selection["known_candidate_only_regressions"], ["flaky-regression"]
+        )
+        self.assertTrue(selection["selected_tests"][0]["forced"])
+
+
+class AdapterTests(unittest.TestCase):
+    def test_adapts_inventory_and_cross_tool_observations(self):
+        with open(
+            INPUTS_DIR / "inventory-v1.json", "r", encoding="utf-8"
+        ) as inventory_file:
+            inventory = json.load(inventory_file)
+        with open(
+            INPUTS_DIR / "inventory-observations-v1.json",
+            "r",
+            encoding="utf-8",
+        ) as observations_file:
+            observations = json.load(observations_file)
+
+        result = selector.adapt_documents([inventory, observations])
+        self.assertEqual(len(result["tests"]), 2)
+        self.assertEqual(result["tests"][0]["runtime_ms"], 4)
+        self.assertEqual(result["tests"][1]["features"], ["far-routing", "live-state"])
+        self.assertEqual(
+            result["tests"][1]["provenance"],
+            ["comgr.hotswap.inventory", "hotswap-audit"],
+        )
+        selection = selector.select_tests(result, test_count_budget=1)
+        self.assertEqual(
+            selection["known_candidate_only_regressions"],
+            ["sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+        )
+        self.assertTrue(selection["selected_tests"][0]["forced"])
+        self.assertEqual(
+            selection["selected_tests"][0]["provenance"],
+            ["comgr.hotswap.inventory", "hotswap-audit"],
+        )
+
+    def test_inventory_requires_measured_or_explicit_runtime(self):
+        with open(
+            INPUTS_DIR / "inventory-v1.json", "r", encoding="utf-8"
+        ) as inventory_file:
+            inventory = json.load(inventory_file)
+        with self.assertRaisesRegex(selector.SelectionError, "no runtime_ms"):
+            selector.adapt_documents([inventory])
+
+        result = selector.adapt_documents([inventory], default_runtime_ms=10)
+        self.assertEqual([record["runtime_ms"] for record in result["tests"]], [10, 10])
+        self.assertTrue(
+            all(
+                "adapter-default-runtime" in record["provenance"]
+                for record in result["tests"]
+            )
+        )
+
+    def test_adapts_and_joins_forward_compatible_producer_records(self):
+        manifest = {
+            "kind": "vendor-rewrite-manifest",
+            "schema_version": 1,
+            "source": "rewrite-manifest",
+            "future_envelope_field": {"ignored": True},
+            "records": [
+                {
+                    "test_id": "suite/case",
+                    "runtime_ms": 12,
+                    "feature_tags": ["far-gateway"],
+                    "candidate_outcome": "fail",
+                    "original_outcome": "pass",
+                    "future_record_field": 7,
+                }
+            ],
+        }
+        audit = {
+            "kind": "vendor-audit",
+            "schema_version": 1,
+            "source": "audit",
+            "records": [
+                {
+                    "test_id": "suite/case",
+                    "features": ["scratch-live"],
+                    "risk": 3,
+                }
+            ],
+        }
+        semcheck = {
+            "kind": "vendor-semcheck",
+            "schema_version": 1,
+            "source": "semcheck",
+            "records": [
+                {
+                    "id": "suite/case",
+                    "features": ["round-trip-state"],
+                    "novelty": 2,
+                    "provenance": "solver",
+                }
+            ],
+        }
+        result = selector.adapt_documents([manifest, audit, semcheck])
+        record = result["tests"][0]
+        self.assertEqual(record["id"], "suite/case")
+        self.assertEqual(record["runtime_ms"], 12)
+        self.assertEqual(record["sample_count"], 1)
+        self.assertEqual(
+            record["features"],
+            ["far-gateway", "round-trip-state", "scratch-live"],
+        )
+        self.assertEqual(record["candidate_outcome"], "fail")
+        self.assertEqual(record["original_outcome"], "pass")
+        self.assertTrue(record["has_candidate_only_regression"])
+        self.assertEqual(record["risk"], 3)
+        self.assertEqual(record["novelty"], 2)
+        self.assertEqual(
+            record["provenance"],
+            ["audit", "rewrite-manifest", "semcheck", "solver"],
+        )
+
+    def test_adapter_averages_only_reported_runtimes(self):
+        first = {
+            "kind": "tool",
+            "schema_version": 1,
+            "records": [{"test_id": "case", "runtime_ms": 10, "sample_count": 2}],
+        }
+        second = {
+            "kind": "tool",
+            "schema_version": 1,
+            "records": [{"test_id": "case", "features": ["audit-only"]}],
+        }
+        result = selector.adapt_documents([first, second])
+        self.assertEqual(result["tests"][0]["runtime_ms"], 10)
+        self.assertEqual(result["tests"][0]["sample_count"], 2)
+
+    def test_adapter_rejects_ambiguous_or_malformed_records(self):
+        with self.assertRaisesRegex(selector.SelectionError, "schema_version"):
+            selector.adapt_documents([{"kind": "tool", "records": []}])
+        with self.assertRaisesRegex(selector.SelectionError, "conflicting"):
+            selector.adapt_documents(
+                [
+                    {
+                        "kind": "tool",
+                        "schema_version": 1,
+                        "records": [{"id": "a", "test_id": "b"}],
+                    }
+                ]
+            )
+        with self.assertRaisesRegex(selector.SelectionError, "no runtime_ms"):
+            selector.adapt_documents(
+                [
+                    {
+                        "kind": "tool",
+                        "schema_version": 1,
+                        "records": [{"test_id": "untimed"}],
+                    }
+                ]
+            )
+        with self.assertRaisesRegex(selector.SelectionError, "inventory version"):
+            selector.adapt_documents(
+                [
+                    {
+                        "schema": selector.INVENTORY_SCHEMA,
+                        "version": 2,
+                        "objects": [],
+                    }
+                ]
+            )
+        with self.assertRaisesRegex(selector.SelectionError, "invalid sha256"):
+            selector.adapt_documents(
+                [
+                    {
+                        "schema": selector.INVENTORY_SCHEMA,
+                        "version": 1,
+                        "objects": [{"sha256": "not-a-digest"}],
+                    }
+                ],
+                default_runtime_ms=1,
+            )
+        with self.assertRaisesRegex(selector.SelectionError, "conflicting features"):
+            selector.adapt_documents(
+                [
+                    {
+                        "kind": "tool",
+                        "schema_version": 1,
+                        "records": [
+                            {
+                                "test_id": "case",
+                                "features": ["a"],
+                                "feature_tags": ["b"],
+                                "runtime_ms": 1,
+                            }
+                        ],
+                    }
+                ]
+            )
+        with self.assertRaisesRegex(selector.SelectionError, "conflicting records"):
+            selector.adapt_documents(
+                [
+                    {
+                        "kind": "tool",
+                        "schema_version": 1,
+                        "records": [],
+                        "tests": [{"test_id": "ignored", "runtime_ms": 1}],
+                    }
+                ]
+            )
+        with self.assertRaisesRegex(selector.SelectionError, "schema_version"):
+            selector.adapt_documents(
+                [{"kind": "tool", "schema_version": True, "records": []}]
+            )
+        with self.assertRaisesRegex(selector.SelectionError, "inventory version"):
+            selector.adapt_documents(
+                [
+                    {
+                        "schema": selector.INVENTORY_SCHEMA,
+                        "version": True,
+                        "objects": [],
+                    }
+                ]
+            )
+
+
+class SelectionTests(unittest.TestCase):
+    def test_simple_cover_chooses_one_test(self):
+        result = selector.select_tests(
+            observation(
+                test_record("a-only", 1, ["a"]),
+                test_record("b-only", 1, ["b"]),
+                test_record("both", 2, ["a", "b"]),
+            ),
+            test_count_budget=1,
+        )
+        self.assertEqual([test["id"] for test in result["selected_tests"]], ["both"])
+        self.assertEqual(result["selected_tests"][0]["marginal_features"], ["a", "b"])
+        self.assertEqual(result["uncovered_features"], [])
+
+    def test_runtime_budget_prefers_coverage_per_millisecond(self):
+        result = selector.select_tests(
+            observation(
+                test_record("slow", 100, ["a", "b"]),
+                test_record("cheap-a", 5, ["a"]),
+                test_record("cheap-b", 5, ["b"]),
+            ),
+            runtime_budget_ms=10,
+        )
+        self.assertEqual(
+            [test["id"] for test in result["selected_tests"]],
+            ["cheap-a", "cheap-b"],
+        )
+        self.assertEqual(result["estimated_runtime_ms"], 10)
+
+    def test_count_budget_reports_uncovered_features(self):
+        result = selector.select_tests(
+            observation(
+                test_record("a", 1, ["a"]),
+                test_record("b", 1, ["b"]),
+            ),
+            test_count_budget=1,
+        )
+        self.assertEqual(len(result["selected_tests"]), 1)
+        self.assertEqual(result["uncovered_features"], ["b"])
+
+    def test_regressions_are_forced_past_budgets(self):
+        result = selector.select_tests(
+            observation(
+                test_record(
+                    "regression-a",
+                    8,
+                    ["a"],
+                    candidate_outcome="fail",
+                    original_outcome="pass",
+                ),
+                test_record(
+                    "regression-b",
+                    8,
+                    ["b"],
+                    candidate_outcome="fail",
+                    original_outcome="pass",
+                ),
+                test_record("other", 1, ["c"]),
+            ),
+            runtime_budget_ms=5,
+            test_count_budget=1,
+        )
+        self.assertEqual(
+            [test["id"] for test in result["selected_tests"]],
+            ["regression-a", "regression-b"],
+        )
+        self.assertTrue(all(test["forced"] for test in result["selected_tests"]))
+        self.assertTrue(result["budget_exceeded_by_forced_regressions"])
+        self.assertEqual(result["uncovered_features"], ["c"])
+
+    def test_mixed_outcome_is_not_a_forced_regression(self):
+        result = selector.select_tests(
+            observation(
+                test_record(
+                    "mixed",
+                    1,
+                    [],
+                    candidate_outcome="mixed",
+                    original_outcome="pass",
+                )
+            ),
+            test_count_budget=0,
+        )
+        self.assertEqual(result["selected_tests"], [])
+        self.assertEqual(result["known_candidate_only_regressions"], [])
+
+    def test_ties_use_runtime_then_identifier(self):
+        result = selector.select_tests(
+            observation(
+                test_record("z", 1, ["a"]),
+                test_record("b", 1, ["a"]),
+                test_record("a-slow", 2, ["a"]),
+            ),
+            test_count_budget=1,
+        )
+        self.assertEqual(result["selected_tests"][0]["id"], "b")
+
+    def test_feature_weights_affect_selection(self):
+        result = selector.select_tests(
+            observation(
+                test_record("ab", 1, ["a", "b"]),
+                test_record("critical", 1, ["critical"]),
+            ),
+            feature_weights={"critical": 10},
+            test_count_budget=1,
+        )
+        self.assertEqual(result["selected_tests"][0]["id"], "critical")
+
+    def test_novelty_breaks_equal_coverage(self):
+        result = selector.select_tests(
+            observation(
+                test_record("familiar", 1, ["a"], novelty=0),
+                test_record("novel", 1, ["a"], novelty=4),
+            ),
+            test_count_budget=1,
+        )
+        self.assertEqual(result["selected_tests"][0]["id"], "novel")
+
+    def test_rarity_novelty_mode_is_label_agnostic(self):
+        result = selector.select_tests(
+            observation(
+                test_record("common", 1, ["shared"]),
+                test_record("rare", 1, ["shared", "never-seen-before"]),
+            ),
+            requested_features=["shared"],
+            novelty_mode="rarity",
+            test_count_budget=1,
+        )
+        self.assertEqual(result["selected_tests"][0]["id"], "rare")
+        self.assertGreater(result["selected_tests"][0]["effective_novelty"], 0)
+
+    def test_novel_and_unknown_quotas_select_calibration_cases(self):
+        result = selector.select_tests(
+            observation(
+                test_record(
+                    "known",
+                    1,
+                    ["a"],
+                    candidate_outcome="pass",
+                    original_outcome="pass",
+                ),
+                test_record(
+                    "novel",
+                    1,
+                    [],
+                    novelty=2,
+                    candidate_outcome="pass",
+                    original_outcome="pass",
+                ),
+                test_record("unknown", 1, []),
+            ),
+            min_novel_tests=1,
+            min_unknown_tests=1,
+        )
+        self.assertEqual(
+            [test["id"] for test in result["selected_tests"]],
+            ["novel", "known", "unknown"],
+        )
+        self.assertEqual(
+            result["unfilled_quotas"], {"novel_tests": 0, "unknown_tests": 0}
+        )
+
+    def test_impossible_quotas_are_reported(self):
+        result = selector.select_tests(
+            observation(
+                test_record(
+                    "known",
+                    1,
+                    [],
+                    candidate_outcome="pass",
+                    original_outcome="pass",
+                )
+            ),
+            min_novel_tests=1,
+            min_unknown_tests=1,
+        )
+        self.assertEqual(
+            result["unfilled_quotas"], {"novel_tests": 1, "unknown_tests": 1}
+        )
+
+    def test_requested_missing_feature_is_reported(self):
+        result = selector.select_tests(
+            observation(test_record("case", 1, ["present"])),
+            requested_features=["absent"],
+        )
+        self.assertEqual(result["selected_tests"], [])
+        self.assertEqual(result["uncovered_features"], ["absent"])
+
+    def test_invalid_selection_options_are_rejected(self):
+        document = observation()
+        invalid_options = [
+            {"test_count_budget": -1},
+            {"min_novel_tests": -1},
+            {"min_unknown_tests": -1},
+            {"feature_weights": {"": 1}},
+            {"requested_features": [1]},
+            {"holdout_percent": 101},
+            {"holdout_seed": 7},
+            {"novelty_mode": "memorize-names"},
+            {"risk_weight": float("nan")},
+            {"runtime_budget_ms": float("inf")},
+        ]
+        for options in invalid_options:
+            with self.subTest(options=options):
+                with self.assertRaises(selector.SelectionError):
+                    selector.select_tests(document, **options)
+
+    def test_score_and_selected_runtime_overflow_fail_cleanly(self):
+        irrelevant_risk = selector.select_tests(
+            observation(
+                test_record("irrelevant", 1, [], risk=1e308),
+                test_record("covers-a", 1, ["a"]),
+            ),
+            risk_weight=1e308,
+        )
+        self.assertEqual(
+            [record["id"] for record in irrelevant_risk["selected_tests"]],
+            ["covers-a"],
+        )
+
+        with self.assertRaisesRegex(selector.SelectionError, "risk score"):
+            selector.select_tests(
+                observation(test_record("large-risk", 1, ["a"], risk=1e308)),
+                risk_weight=1e308,
+            )
+
+        regressions = observation(
+            *[
+                test_record(
+                    "regression-%d" % index,
+                    1e308,
+                    [],
+                    candidate_outcome="fail",
+                    original_outcome="pass",
+                )
+                for index in range(2)
+            ]
+        )
+        with self.assertRaisesRegex(selector.SelectionError, "selected runtime"):
+            selector.select_tests(regressions)
+
+    def test_zero_runtime_test_fits_zero_runtime_budget(self):
+        result = selector.select_tests(
+            observation(test_record("free", 0, ["covered"])),
+            runtime_budget_ms=0,
+        )
+        self.assertEqual(
+            [record["id"] for record in result["selected_tests"]], ["free"]
+        )
+        self.assertEqual(result["estimated_runtime_ms"], 0)
+
+    def test_holdout_is_deterministic_and_keeps_regressions(self):
+        result = selector.select_tests(
+            observation(
+                test_record("reserved", 1, ["held"]),
+                test_record(
+                    "regression",
+                    2,
+                    ["forced"],
+                    candidate_outcome="fail",
+                    original_outcome="pass",
+                ),
+            ),
+            holdout_percent=100,
+            holdout_seed="acceptance",
+        )
+        self.assertEqual(
+            [test["id"] for test in result["selected_tests"]], ["regression"]
+        )
+        self.assertEqual(result["holdout"]["reserved_tests"], ["reserved"])
+        self.assertEqual(result["holdout"]["regression_overrides"], ["regression"])
+        repeated = selector.select_tests(
+            observation(
+                test_record("reserved", 1, ["held"]),
+                test_record(
+                    "regression",
+                    2,
+                    ["forced"],
+                    candidate_outcome="fail",
+                    original_outcome="pass",
+                ),
+            ),
+            holdout_percent=100,
+            holdout_seed="acceptance",
+        )
+        self.assertEqual(result, repeated)
+
+    def test_holdout_seed_changes_generic_partition(self):
+        document = observation(
+            *[test_record("case-%02d" % index, 1, ["shared"]) for index in range(40)]
+        )
+        first = selector.select_tests(
+            document, holdout_percent=50, holdout_seed="first"
+        )
+        second = selector.select_tests(
+            document, holdout_percent=50, holdout_seed="second"
+        )
+        self.assertNotEqual(
+            first["holdout"]["reserved_tests"],
+            second["holdout"]["reserved_tests"],
+        )
+
+    def test_digest_ignores_input_format_and_order(self):
+        first = observation(
+            test_record("b", 2, ["y"]),
+            test_record("a", 1, ["x"]),
+        )
+        second = observation(
+            test_record("a", 1.0, ["x"]),
+            test_record("b", 2.0, ["y"]),
+        )
+        self.assertEqual(
+            selector.select_tests(first)["input_digest"],
+            selector.select_tests(second)["input_digest"],
+        )
+
+
+class CommandLineTests(unittest.TestCase):
+    def setUp(self):
+        self.script = str(SCRIPT)
+
+    def run_cli(self, *arguments):
+        return subprocess.run(
+            [sys.executable, self.script] + list(arguments),
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def test_unknown_flag_is_rejected(self):
+        result = self.run_cli("select", "--input", "not-read.json", "--unknown-flag")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unrecognized arguments", result.stderr)
+
+    def test_select_cli_emits_stable_json(self):
+        with tempfile.TemporaryDirectory() as directory:
+            input_path = os.path.join(directory, "input.json")
+            with open(input_path, "w", encoding="utf-8") as output:
+                json.dump(observation(test_record("case", 1, ["branch"])), output)
+            first = self.run_cli("select", "--input", input_path)
+            second = self.run_cli("select", "--input", input_path)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(first.stdout, second.stdout)
+        self.assertEqual(json.loads(first.stdout)["kind"], selector.SELECTION_KIND)
+
+    def test_output_cannot_alias_input(self):
+        with tempfile.TemporaryDirectory() as directory:
+            input_path = os.path.join(directory, "input.json")
+            original = "not valid JSON"
+            with open(input_path, "w", encoding="utf-8") as output:
+                output.write(original)
+            alias_path = os.path.join(directory, ".", "input.json")
+            result = self.run_cli(
+                "select",
+                "--input",
+                input_path,
+                "--output",
+                alias_path,
+            )
+            with open(input_path, "r", encoding="utf-8") as input_file:
+                after = input_file.read()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refusing to overwrite input", result.stderr)
+        self.assertEqual(after, original)
+
+    def test_output_cannot_alias_input_through_hardlink(self):
+        with tempfile.TemporaryDirectory() as directory:
+            input_path = os.path.join(directory, "input.json")
+            alias_path = os.path.join(directory, "hardlink.json")
+            with open(input_path, "w", encoding="utf-8") as output:
+                json.dump(observation(test_record("case", 1, [])), output)
+            try:
+                os.link(input_path, alias_path)
+            except OSError as error:
+                self.skipTest("hard links unavailable: %s" % error)
+            result = self.run_cli(
+                "select",
+                "--input",
+                input_path,
+                "--output",
+                alias_path,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refusing to overwrite input", result.stderr)
+
+    def test_unicode_paths_and_identifiers_round_trip(self):
+        with tempfile.TemporaryDirectory() as directory:
+            input_path = os.path.join(
+                directory, "observations-\N{GREEK SMALL LETTER PI}.json"
+            )
+            output_path = os.path.join(directory, "selection-\N{SNOWMAN}.json")
+            with open(input_path, "w", encoding="utf-8") as output:
+                json.dump(
+                    observation(
+                        test_record(
+                            "suite/\N{GREEK SMALL LETTER DELTA}",
+                            1,
+                            ["feature-\N{SNOWMAN}"],
+                        )
+                    ),
+                    output,
+                )
+            result = self.run_cli(
+                "select", "--input", input_path, "--output", output_path
+            )
+            with open(output_path, "r", encoding="utf-8") as output:
+                selected = json.load(output)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            selected["selected_tests"][0]["id"],
+            "suite/\N{GREEK SMALL LETTER DELTA}",
+        )
+
+    def test_invalid_utf8_and_huge_json_number_report_clean_errors(self):
+        with tempfile.TemporaryDirectory() as directory:
+            invalid_utf8 = os.path.join(directory, "invalid-utf8.json")
+            with open(invalid_utf8, "wb") as output:
+                output.write(b"\xff")
+            utf8_result = self.run_cli("select", "--input", invalid_utf8)
+
+            huge_number = os.path.join(directory, "huge-number.json")
+            with open(huge_number, "w", encoding="utf-8") as output:
+                output.write(
+                    '{"kind":"hotswap-test-observations","schema_version":1,'
+                    '"tests":[{"id":"case","features":[],"runtime_ms":'
+                    + "1"
+                    + "0" * 5000
+                    + "}]}"
+                )
+            number_result = self.run_cli("select", "--input", huge_number)
+
+        self.assertNotEqual(utf8_result.returncode, 0)
+        self.assertIn("cannot parse JSON", utf8_result.stderr)
+        self.assertNotIn("Traceback", utf8_result.stderr)
+
+        # Python 3.11+ rejects the integer while parsing; older supported
+        # interpreters parse it and the selector's finite-range check rejects it.
+        self.assertNotEqual(number_result.returncode, 0)
+        self.assertTrue(
+            "cannot parse JSON" in number_result.stderr
+            or "finite non-negative" in number_result.stderr
+        )
+        self.assertNotIn("Traceback", number_result.stderr)
+
+    def test_atomic_write_rolls_back_and_removes_temporary_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = os.path.join(directory, "selection.json")
+            with open(output_path, "w", encoding="utf-8") as output:
+                output.write("original")
+            with mock.patch.object(
+                selector.os, "replace", side_effect=OSError("injected")
+            ):
+                with self.assertRaisesRegex(selector.SelectionError, "injected"):
+                    selector._write_json(output_path, {"schema_version": 1})
+            with open(output_path, "r", encoding="utf-8") as output:
+                after = output.read()
+            temporary_files = [
+                name
+                for name in os.listdir(directory)
+                if name.startswith(".hotswap-test-select-")
+            ]
+        self.assertEqual(after, "original")
+        self.assertEqual(temporary_files, [])
+
+    def test_merge_cli_writes_output(self):
+        with tempfile.TemporaryDirectory() as directory:
+            first_path = os.path.join(directory, "first.json")
+            second_path = os.path.join(directory, "second.json")
+            output_path = os.path.join(directory, "merged.json")
+            for path, feature in ((first_path, "a"), (second_path, "b")):
+                with open(path, "w", encoding="utf-8") as output:
+                    json.dump(observation(test_record("case", 1, [feature])), output)
+            result = self.run_cli(
+                "merge",
+                "--input",
+                first_path,
+                second_path,
+                "--output",
+                output_path,
+            )
+            with open(output_path, "r", encoding="utf-8") as merged_file:
+                merged = json.load(merged_file)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(merged["tests"][0]["features"], ["a", "b"])
+
+    def test_adapt_cli_accepts_generic_producer_envelope(self):
+        with tempfile.TemporaryDirectory() as directory:
+            input_path = os.path.join(directory, "producer.json")
+            with open(input_path, "w", encoding="utf-8") as output:
+                json.dump(
+                    {
+                        "kind": "future-audit",
+                        "schema_version": 1,
+                        "records": [
+                            {
+                                "test_id": "case",
+                                "runtime_ms": 1,
+                                "features": ["future-feature"],
+                            }
+                        ],
+                    },
+                    output,
+                )
+            result = self.run_cli("adapt", "--input", input_path)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["tests"][0]["id"], "case")
+
+
+class Pr3646AcceptanceTests(unittest.TestCase):
+    def setUp(self):
+        fixture_path = INPUTS_DIR / "pr3646-acceptance.json"
+        with open(fixture_path, "r", encoding="utf-8") as fixture_file:
+            self.fixture = json.load(fixture_file)
+        self.risk_dimensions = [
+            "ds2",
+            "far-relay-gateway",
+            "finite-call-closure",
+            "m32-scale16",
+            "materialized-call-closure",
+            "owner-specific-source-window",
+            "round-trip-vcc-preservation",
+            "scratch-sgpr-liveness",
+            "tensor-mask",
+        ]
+
+    def test_curated_acceptance_covers_risk_and_regressions(self):
+        result = selector.select_tests(
+            self.fixture,
+            requested_features=self.risk_dimensions,
+            test_count_budget=4,
+            novelty_mode="combined",
+        )
+        self.assertEqual(result["uncovered_features"], [])
+        self.assertEqual(len(result["selected_tests"]), 4)
+        self.assertEqual(len(result["known_candidate_only_regressions"]), 2)
+        self.assertTrue(result["selected_tests"][0]["forced"])
+        self.assertTrue(result["selected_tests"][1]["forced"])
+
+    def test_acceptance_result_depends_on_structure_not_labels(self):
+        renamed = json.loads(json.dumps(self.fixture))
+        feature_map = {}
+        for index, record in enumerate(renamed["tests"]):
+            record["id"] = "renamed/test-%02d" % index
+            renamed_features = []
+            for feature in record["features"]:
+                if feature not in feature_map:
+                    feature_map[feature] = "opaque-feature-%02d" % len(feature_map)
+                renamed_features.append(feature_map[feature])
+            record["features"] = renamed_features
+        result = selector.select_tests(
+            renamed,
+            requested_features=[
+                feature_map[feature] for feature in self.risk_dimensions
+            ],
+            test_count_budget=4,
+            novelty_mode="combined",
+        )
+        self.assertEqual(result["uncovered_features"], [])
+        self.assertEqual(len(result["selected_tests"]), 4)
+        self.assertEqual(sum(test["forced"] for test in result["selected_tests"]), 2)
+
+
+class EvidenceValidationTests(unittest.TestCase):
+    def test_frozen_evidence_hash_is_enforced(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "evidence.tsv")
+            with open(path, "wb") as output:
+                output.write(b"frozen evidence\n")
+            expected = hashlib.sha256(b"frozen evidence\n").hexdigest()
+            self.assertEqual(
+                evidence.require_sha256(path, expected, "fixture"), expected
+            )
+            with self.assertRaisesRegex(ValueError, "expected"):
+                evidence.require_sha256(path, "0" * 64, "fixture")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/amd/comgr/test/utils/test_hotswap_test_select_evidence.py
+++ b/amd/comgr/test/utils/test_hotswap_test_select_evidence.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+# ===- test_hotswap_test_select_evidence.py - Evidence acceptance -----------===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------===#
+
+"""Optional selector acceptance test using the frozen PR #3646 evidence."""
+
+import csv
+import hashlib
+import importlib.util
+import json
+import math
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+EXPECTED_ALIASES = 2685
+EXPECTED_UNIQUE = 1452
+EXPECTED_PRIOR_FAILURES = 4
+EXPECTED_P99_RUNTIME_SECONDS = 6.64
+EXPECTED_SHA256 = {
+    "prior failures": "756066cad7ca7aea97b5d9474784f5ad4ae00bc2a1b3d381bf0592f968cfb892",
+    "results": "ffb089ac585374ac3e9edd93cb0668ed9c6c6b21514948d94884a20f7c2176b9",
+    "transitions": "295c97a7bcc7b62363c5f41e9c3aa9c46741d43f2270799407b6c6cc11908c5c",
+}
+COMGR_DIR = Path(__file__).resolve().parents[2]
+SCRIPT = COMGR_DIR / "utils" / "hotswap" / "hotswap_test_select.py"
+SPEC = importlib.util.spec_from_file_location("hotswap_test_select", SCRIPT)
+SELECTOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(SELECTOR)
+
+
+def require_sha256(path, expected, label):
+    digest = hashlib.sha256()
+    with open(path, "rb") as input_file:
+        while True:
+            block = input_file.read(1024 * 1024)
+            if not block:
+                break
+            digest.update(block)
+    actual = digest.hexdigest()
+    if actual != expected:
+        raise ValueError(
+            "{} SHA-256 is {}, expected {}".format(label, actual, expected)
+        )
+    return actual
+
+
+def fail(message):
+    print("FAIL: " + message, file=sys.stderr)
+    return 1
+
+
+def read_tsv(path):
+    with open(path, "r", encoding="utf-8", newline="") as input_file:
+        return list(csv.DictReader(input_file, delimiter="\t"))
+
+
+def load_evidence(results_path, transitions_path, prior_failures_path):
+    require_sha256(results_path, EXPECTED_SHA256["results"], "results")
+    require_sha256(transitions_path, EXPECTED_SHA256["transitions"], "transitions")
+    require_sha256(
+        prior_failures_path, EXPECTED_SHA256["prior failures"], "prior failures"
+    )
+
+    results = read_tsv(results_path)
+    prior_failures = read_tsv(prior_failures_path)
+    with open(transitions_path, "r", encoding="utf-8", newline="") as input_file:
+        transitions = [
+            tuple(line.rstrip("\n").split("\t"))
+            for line in input_file
+            if line.rstrip("\n")
+        ]
+
+    if len(results) != EXPECTED_ALIASES:
+        raise ValueError(
+            "results contain {} aliases, expected {}".format(
+                len(results), EXPECTED_ALIASES
+            )
+        )
+    if len(transitions) != EXPECTED_ALIASES:
+        raise ValueError(
+            "transitions contain {} aliases, expected {}".format(
+                len(transitions), EXPECTED_ALIASES
+            )
+        )
+    if any(len(transition) != 3 for transition in transitions):
+        raise ValueError("transition rows must have three columns")
+    transition_by_path = {
+        path: (original, candidate) for path, original, candidate in transitions
+    }
+    if len(transition_by_path) != EXPECTED_ALIASES:
+        raise ValueError("transition paths must be unique")
+
+    required_result_fields = (
+        "first_seconds",
+        "first_result",
+        "input_sha256",
+        "output_sha256",
+        "pass2_cmp_rc",
+        "pass2_result",
+        "relative_path",
+        "result",
+    )
+    if any(field not in results[0] for field in required_result_fields):
+        raise ValueError("results are missing required columns")
+    if any(
+        row["first_result"] != "SUCCESS"
+        or row["pass2_result"] != "SUCCESS"
+        or row["pass2_cmp_rc"] != "0"
+        or row["result"] != "SUCCESS"
+        for row in results
+    ):
+        raise ValueError("results contain a failed rewrite or idempotence check")
+
+    prior_paths = {row["relative_path"] for row in prior_failures}
+    if len(prior_paths) != EXPECTED_PRIOR_FAILURES:
+        raise ValueError(
+            "prior failures contain {} paths, expected {}".format(
+                len(prior_paths), EXPECTED_PRIOR_FAILURES
+            )
+        )
+    result_paths = {row["relative_path"] for row in results}
+    if set(transition_by_path) != result_paths:
+        raise ValueError("transition and result path sets differ")
+    if not prior_paths <= result_paths:
+        raise ValueError("a prior-failure path is missing from results")
+    if any(transition_by_path[path] != ("FAILURE", "SUCCESS") for path in prior_paths):
+        raise ValueError("prior failures do not have FAILURE-to-SUCCESS transitions")
+    if (
+        sum(
+            transition == ("FAILURE", "SUCCESS")
+            for transition in transition_by_path.values()
+        )
+        != EXPECTED_PRIOR_FAILURES
+    ):
+        raise ValueError("unexpected number of FAILURE-to-SUCCESS transitions")
+    if (
+        sum(
+            transition == ("SUCCESS", "SUCCESS")
+            for transition in transition_by_path.values()
+        )
+        != EXPECTED_ALIASES - EXPECTED_PRIOR_FAILURES
+    ):
+        raise ValueError("unexpected non-success transition")
+
+    rows_by_digest = defaultdict(list)
+    for row in results:
+        rows_by_digest[row["input_sha256"]].append(row)
+    if len(rows_by_digest) != EXPECTED_UNIQUE:
+        raise ValueError(
+            "results contain {} unique objects, expected {}".format(
+                len(rows_by_digest), EXPECTED_UNIQUE
+            )
+        )
+
+    runtimes = sorted(
+        max(float(row["first_seconds"]) for row in rows)
+        for rows in rows_by_digest.values()
+    )
+    p99_runtime = runtimes[math.ceil(0.99 * len(runtimes)) - 1]
+    tests = []
+    prior_test_ids = []
+    for digest in sorted(rows_by_digest):
+        rows = rows_by_digest[digest]
+        aliases = sorted(row["relative_path"] for row in rows)
+        prior_aliases = sorted(set(aliases) & prior_paths)
+        test_id = prior_aliases[0] if prior_aliases else aliases[0]
+        runtime_seconds = max(float(row["first_seconds"]) for row in rows)
+        features = ["idempotent-rewrite", "rewrite-success"]
+        if any(row["input_sha256"] != row["output_sha256"] for row in rows):
+            features.append("output-changed")
+        else:
+            features.append("output-unchanged")
+        if runtime_seconds >= p99_runtime:
+            features.append("runtime-tail")
+        if prior_aliases:
+            features.append("prior-baseline-failure")
+            prior_test_ids.append(test_id)
+        tests.append(
+            {
+                "candidate_outcome": "pass",
+                "features": features,
+                "id": test_id,
+                "novelty": 1 if runtime_seconds >= p99_runtime else 0,
+                "original_outcome": "fail" if prior_aliases else "pass",
+                "provenance": [
+                    "pr3646-results",
+                    "pr3646-transitions",
+                ],
+                "risk": 4 if prior_aliases else 0,
+                "runtime_ms": runtime_seconds * 1000,
+            }
+        )
+
+    document = {
+        "kind": SELECTOR.OBSERVATION_KIND,
+        "schema_version": SELECTOR.SCHEMA_VERSION,
+        "tests": tests,
+    }
+    return document, sorted(prior_test_ids), p99_runtime
+
+
+def main():
+    results_path = os.environ.get("COMGR_HOTSWAP_RESULTS_TSV")
+    transitions_path = os.environ.get("COMGR_HOTSWAP_TRANSITIONS_TSV")
+    prior_failures_path = os.environ.get("COMGR_HOTSWAP_PRIOR_FAILURES_TSV")
+    if not results_path or not transitions_path or not prior_failures_path:
+        print(
+            "SKIP: set COMGR_HOTSWAP_RESULTS_TSV, "
+            "COMGR_HOTSWAP_TRANSITIONS_TSV, and "
+            "COMGR_HOTSWAP_PRIOR_FAILURES_TSV",
+            file=sys.stderr,
+        )
+        return 77
+
+    try:
+        document, prior_test_ids, p99_runtime = load_evidence(
+            results_path, transitions_path, prior_failures_path
+        )
+        requested_features = [
+            "idempotent-rewrite",
+            "output-changed",
+            "output-unchanged",
+            "prior-baseline-failure",
+            "rewrite-success",
+            "runtime-tail",
+        ]
+        actual = SELECTOR.select_tests(
+            document,
+            requested_features=requested_features,
+            test_count_budget=6,
+            novelty_mode="combined",
+        )
+        if actual["uncovered_features"]:
+            return fail(
+                "real-evidence selection left features uncovered: {}".format(
+                    actual["uncovered_features"]
+                )
+            )
+        if actual["known_candidate_only_regressions"]:
+            return fail(
+                "real evidence incorrectly classified repaired baseline failures "
+                "as candidate-only regressions"
+            )
+        if len(actual["selected_tests"]) != 2:
+            return fail(
+                "real-evidence selection chose {} objects, expected 2".format(
+                    len(actual["selected_tests"])
+                )
+            )
+        if not math.isclose(
+            p99_runtime, EXPECTED_P99_RUNTIME_SECONDS, rel_tol=0, abs_tol=0.005
+        ):
+            return fail(
+                "runtime p99 is {:.9g} seconds, expected {:.2f}".format(
+                    p99_runtime, EXPECTED_P99_RUNTIME_SECONDS
+                )
+            )
+
+        candidate_regression_document = json.loads(json.dumps(document))
+        records_by_id = {
+            record["id"]: record for record in candidate_regression_document["tests"]
+        }
+        for test_id in prior_test_ids:
+            records_by_id[test_id]["candidate_outcome"] = "fail"
+            records_by_id[test_id]["original_outcome"] = "pass"
+        forced = SELECTOR.select_tests(
+            candidate_regression_document,
+            runtime_budget_ms=0,
+            test_count_budget=0,
+        )
+        if forced["known_candidate_only_regressions"] != prior_test_ids:
+            return fail("candidate-only orientation did not retain all four cases")
+        if [record["id"] for record in forced["selected_tests"]] != prior_test_ids:
+            return fail("forced selection did not contain exactly the four cases")
+        if not all(record["forced"] for record in forced["selected_tests"]):
+            return fail("a candidate-only regression was not marked forced")
+        if not forced["budget_exceeded_by_forced_regressions"]:
+            return fail("forced regressions did not report their budget override")
+    except (OSError, UnicodeError, ValueError, SELECTOR.SelectionError) as error:
+        return fail(str(error))
+
+    summary = {
+        "aliases": EXPECTED_ALIASES,
+        "duplicate_aliases_collapsed": EXPECTED_ALIASES - EXPECTED_UNIQUE,
+        "evidence_sha256": EXPECTED_SHA256,
+        "forced_retention_cases": prior_test_ids,
+        "p99_runtime_seconds": p99_runtime,
+        "real_evidence_selected": [
+            {
+                "id": record["id"],
+                "marginal_features": record["marginal_features"],
+            }
+            for record in actual["selected_tests"]
+        ],
+        "unique_code_objects": EXPECTED_UNIQUE,
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/amd/comgr/utils/hotswap/hotswap_test_select.py
+++ b/amd/comgr/utils/hotswap/hotswap_test_select.py
@@ -1,0 +1,1082 @@
+#!/usr/bin/env python3
+# ===- hotswap_test_select.py - Select hotswap calibration tests -----------===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------===#
+
+"""Merge hotswap observations and select a small, high-value test subset.
+
+The selector is deliberately deterministic and dependency-free. It uses a
+weighted greedy set-cover heuristic, always retaining known candidate-only
+regressions. Its JSON output records why each test was selected.
+"""
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import sys
+import tempfile
+from collections import defaultdict
+
+
+SCHEMA_VERSION = 1
+OBSERVATION_KIND = "hotswap-test-observations"
+SELECTION_KIND = "hotswap-test-selection"
+INVENTORY_SCHEMA = "comgr.hotswap.inventory"
+INVENTORY_VERSION = 1
+OUTCOMES = frozenset(("pass", "fail", "skip", "unknown", "mixed"))
+DOCUMENT_FIELDS = frozenset(("kind", "schema_version", "tests"))
+TEST_FIELDS = frozenset(
+    (
+        "candidate_outcome",
+        "features",
+        "has_candidate_only_regression",
+        "id",
+        "novelty",
+        "original_outcome",
+        "provenance",
+        "risk",
+        "runtime_ms",
+        "sample_count",
+    )
+)
+
+
+class SelectionError(ValueError):
+    """An invalid observation or selection option."""
+
+
+def _is_number(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _validate_weight(value, name):
+    if not _is_number(value):
+        raise SelectionError("%s must be a finite non-negative number" % name)
+    try:
+        normalized = float(value)
+    except OverflowError as error:
+        raise SelectionError(
+            "%s must be a finite non-negative number" % name
+        ) from error
+    if not math.isfinite(normalized) or normalized < 0:
+        raise SelectionError("%s must be a finite non-negative number" % name)
+    return normalized
+
+
+def _canonical_number(value):
+    try:
+        normalized = float(value)
+    except OverflowError as error:
+        raise SelectionError("computed numeric result must be finite") from error
+    if not math.isfinite(normalized):
+        raise SelectionError("computed numeric result must be finite")
+    if normalized.is_integer():
+        return int(normalized)
+    return normalized
+
+
+def _finite_sum(values, name):
+    try:
+        result = math.fsum(values)
+    except (OverflowError, ValueError) as error:
+        raise SelectionError("%s exceeds the finite numeric range" % name) from error
+    if not math.isfinite(result):
+        raise SelectionError("%s exceeds the finite numeric range" % name)
+    return result
+
+
+def _finite_product(left, right, name):
+    result = float(left) * float(right)
+    if not math.isfinite(result):
+        raise SelectionError("%s exceeds the finite numeric range" % name)
+    return result
+
+
+def _weighted_runtime(records):
+    sample_count = sum(record["sample_count"] for record in records)
+    weighted_samples = sorted(
+        float(record["runtime_ms"]) * (record["sample_count"] / sample_count)
+        for record in records
+    )
+    runtime_ms = _finite_sum(
+        weighted_samples,
+        "weighted runtime",
+    )
+    return runtime_ms, sample_count
+
+
+def _normalize_outcome(value, field, test_id):
+    if value is None:
+        return "unknown"
+    if not isinstance(value, str) or value not in OUTCOMES:
+        raise SelectionError(
+            "test %r field %s must be one of %s"
+            % (test_id, field, ", ".join(sorted(OUTCOMES)))
+        )
+    return value
+
+
+def _normalize_test(record, index):
+    if not isinstance(record, dict):
+        raise SelectionError("test record %d must be an object" % index)
+    unknown_fields = sorted(set(record) - TEST_FIELDS)
+    if unknown_fields:
+        raise SelectionError(
+            "test record %d has unknown field(s): %s"
+            % (index, ", ".join(unknown_fields))
+        )
+
+    test_id = record.get("id")
+    if not isinstance(test_id, str) or not test_id:
+        raise SelectionError("test record %d has a missing or empty id" % index)
+
+    if "runtime_ms" not in record:
+        raise SelectionError("test %r is missing runtime_ms" % test_id)
+    runtime_ms = _validate_weight(record["runtime_ms"], "test %r runtime_ms" % test_id)
+
+    features = record.get("features")
+    if not isinstance(features, list):
+        raise SelectionError("test %r features must be an array" % test_id)
+    for feature in features:
+        if not isinstance(feature, str) or not feature:
+            raise SelectionError(
+                "test %r features must contain non-empty strings" % test_id
+            )
+
+    sample_count = record.get("sample_count", 1)
+    if (
+        not isinstance(sample_count, int)
+        or isinstance(sample_count, bool)
+        or sample_count < 1
+    ):
+        raise SelectionError(
+            "test %r sample_count must be a positive integer" % test_id
+        )
+
+    provenance = record.get("provenance", [])
+    if not isinstance(provenance, list):
+        raise SelectionError("test %r provenance must be an array" % test_id)
+    for source in provenance:
+        if not isinstance(source, str) or not source:
+            raise SelectionError(
+                "test %r provenance must contain non-empty strings" % test_id
+            )
+
+    candidate_outcome = _normalize_outcome(
+        record.get("candidate_outcome"), "candidate_outcome", test_id
+    )
+    original_outcome = _normalize_outcome(
+        record.get("original_outcome"), "original_outcome", test_id
+    )
+    has_candidate_only_regression = record.get("has_candidate_only_regression", False)
+    if not isinstance(has_candidate_only_regression, bool):
+        raise SelectionError(
+            "test %r has_candidate_only_regression must be a boolean" % test_id
+        )
+    has_candidate_only_regression = has_candidate_only_regression or (
+        candidate_outcome == "fail" and original_outcome == "pass"
+    )
+
+    return {
+        "candidate_outcome": candidate_outcome,
+        "features": sorted(set(features)),
+        "has_candidate_only_regression": has_candidate_only_regression,
+        "id": test_id,
+        "novelty": _canonical_number(
+            _validate_weight(record.get("novelty", 0), "test %r novelty" % test_id)
+        ),
+        "original_outcome": original_outcome,
+        "provenance": sorted(set(provenance)),
+        "risk": _canonical_number(
+            _validate_weight(record.get("risk", 0), "test %r risk" % test_id)
+        ),
+        "runtime_ms": _canonical_number(runtime_ms),
+        "sample_count": sample_count,
+    }
+
+
+def normalize_document(document):
+    """Validate and canonicalize one observation document."""
+    if not isinstance(document, dict):
+        raise SelectionError("observation document must be an object")
+    unknown_fields = sorted(set(document) - DOCUMENT_FIELDS)
+    if unknown_fields:
+        raise SelectionError(
+            "observation document has unknown field(s): %s" % ", ".join(unknown_fields)
+        )
+    schema_version = document.get("schema_version")
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != SCHEMA_VERSION
+    ):
+        raise SelectionError("schema_version must be %d" % SCHEMA_VERSION)
+    kind = document.get("kind", OBSERVATION_KIND)
+    if kind != OBSERVATION_KIND:
+        raise SelectionError("kind must be %r" % OBSERVATION_KIND)
+    tests = document.get("tests")
+    if not isinstance(tests, list):
+        raise SelectionError("tests must be an array")
+    return merge_documents(
+        [
+            {
+                "kind": OBSERVATION_KIND,
+                "schema_version": SCHEMA_VERSION,
+                "tests": [
+                    _normalize_test(record, index) for index, record in enumerate(tests)
+                ],
+            }
+        ],
+        already_normalized=True,
+    )
+
+
+def _merge_outcomes(outcomes):
+    meaningful = set(outcomes) - set(("unknown",))
+    if not meaningful:
+        return "unknown"
+    if len(meaningful) == 1:
+        return next(iter(meaningful))
+    return "mixed"
+
+
+def merge_documents(documents, already_normalized=False):
+    """Merge observation documents with deterministic, order-independent rules."""
+    records_by_id = defaultdict(list)
+    for document in documents:
+        normalized = document if already_normalized else normalize_document(document)
+        for record in normalized["tests"]:
+            records_by_id[record["id"]].append(record)
+
+    merged_tests = []
+    for test_id in sorted(records_by_id):
+        records = records_by_id[test_id]
+        runtime_ms, sample_count = _weighted_runtime(records)
+        features = sorted(
+            set(feature for record in records for feature in record["features"])
+        )
+        merged_tests.append(
+            {
+                "candidate_outcome": _merge_outcomes(
+                    record["candidate_outcome"] for record in records
+                ),
+                "features": features,
+                "has_candidate_only_regression": any(
+                    record["has_candidate_only_regression"] for record in records
+                ),
+                "id": test_id,
+                "novelty": max(record["novelty"] for record in records),
+                "original_outcome": _merge_outcomes(
+                    record["original_outcome"] for record in records
+                ),
+                "provenance": sorted(
+                    set(source for record in records for source in record["provenance"])
+                ),
+                "risk": max(record["risk"] for record in records),
+                "runtime_ms": _canonical_number(runtime_ms),
+                "sample_count": sample_count,
+            }
+        )
+    return {
+        "kind": OBSERVATION_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "tests": merged_tests,
+    }
+
+
+def _normalize_raw_record(record, index, source):
+    if not isinstance(record, dict):
+        raise SelectionError("producer record %d must be an object" % index)
+    test_id = record.get("test_id", record.get("id"))
+    if "test_id" in record and "id" in record and record["test_id"] != record["id"]:
+        raise SelectionError(
+            "producer record %d has conflicting test_id and id" % index
+        )
+    if (
+        "features" in record
+        and "feature_tags" in record
+        and record["features"] != record["feature_tags"]
+    ):
+        raise SelectionError(
+            "producer record %d has conflicting features and feature_tags" % index
+        )
+
+    provenance = record.get("provenance", [])
+    if isinstance(provenance, str):
+        provenance = [provenance]
+    elif not isinstance(provenance, list):
+        raise SelectionError(
+            "producer record %d provenance must be a string or array" % index
+        )
+    if source not in provenance:
+        provenance = list(provenance) + [source]
+
+    translated = {
+        "candidate_outcome": record.get("candidate_outcome"),
+        "features": record.get("features", record.get("feature_tags", [])),
+        "has_candidate_only_regression": record.get(
+            "has_candidate_only_regression", False
+        ),
+        "id": test_id,
+        "novelty": record.get("novelty", 0),
+        "original_outcome": record.get("original_outcome"),
+        "provenance": provenance,
+        "risk": record.get("risk", 0),
+        "runtime_ms": record.get("runtime_ms", 0),
+        "sample_count": record.get("sample_count", 1),
+    }
+    return _normalize_test(translated, index), "runtime_ms" in record
+
+
+def _adapt_inventory(document):
+    version = document.get("version")
+    if (
+        not isinstance(version, int)
+        or isinstance(version, bool)
+        or version != INVENTORY_VERSION
+    ):
+        raise SelectionError("inventory version must be %d" % INVENTORY_VERSION)
+    objects = document.get("objects")
+    if not isinstance(objects, list):
+        raise SelectionError("inventory objects must be an array")
+
+    records = []
+    for index, item in enumerate(objects):
+        if not isinstance(item, dict):
+            raise SelectionError("inventory object %d must be an object" % index)
+        digest = item.get("sha256")
+        if (
+            not isinstance(digest, str)
+            or len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+        ):
+            raise SelectionError("inventory object %d has an invalid sha256" % index)
+        records.append(
+            _normalize_raw_record(
+                {
+                    "test_id": "sha256:" + digest,
+                    "provenance": [INVENTORY_SCHEMA],
+                },
+                index,
+                INVENTORY_SCHEMA,
+            )
+        )
+    return records
+
+
+def adapt_documents(documents, default_runtime_ms=None):
+    """Adapt forward-compatible producer reports to canonical observations."""
+    if default_runtime_ms is not None:
+        default_runtime_ms = _validate_weight(default_runtime_ms, "default runtime")
+    adapted_records = []
+    for document_index, document in enumerate(documents):
+        if not isinstance(document, dict):
+            raise SelectionError("producer document must be an object")
+        if document.get("schema") == INVENTORY_SCHEMA:
+            adapted_records.extend(_adapt_inventory(document))
+            continue
+        if document.get("kind") == OBSERVATION_KIND:
+            normalized = normalize_document(document)
+            adapted_records.extend((record, True) for record in normalized["tests"])
+            continue
+        schema_version = document.get("schema_version")
+        if (
+            not isinstance(schema_version, int)
+            or isinstance(schema_version, bool)
+            or schema_version != SCHEMA_VERSION
+        ):
+            raise SelectionError("producer schema_version must be %d" % SCHEMA_VERSION)
+        source = document.get("source", document.get("kind"))
+        if not isinstance(source, str) or not source:
+            source = "input-%d" % document_index
+        if (
+            "records" in document
+            and "tests" in document
+            and document["records"] != document["tests"]
+        ):
+            raise SelectionError(
+                "producer document has conflicting records and tests arrays"
+            )
+        records = document.get("records", document.get("tests"))
+        if not isinstance(records, list):
+            raise SelectionError("producer records must be an array")
+        adapted_records.extend(
+            _normalize_raw_record(record, index, source)
+            for index, record in enumerate(records)
+        )
+
+    records_by_id = defaultdict(list)
+    for record, has_runtime in adapted_records:
+        records_by_id[record["id"]].append((record, has_runtime))
+
+    merged = []
+    for test_id in sorted(records_by_id):
+        entries = records_by_id[test_id]
+        records = [entry[0] for entry in entries]
+        timed_records = [entry[0] for entry in entries if entry[1]]
+        if timed_records:
+            runtime_ms, sample_count = _weighted_runtime(timed_records)
+        else:
+            if default_runtime_ms is None:
+                raise SelectionError(
+                    "test %r has no runtime_ms in any producer report" % test_id
+                )
+            sample_count = 1
+            runtime_ms = default_runtime_ms
+            for record in records:
+                if "adapter-default-runtime" not in record["provenance"]:
+                    record["provenance"].append("adapter-default-runtime")
+        merged.append(
+            {
+                "candidate_outcome": _merge_outcomes(
+                    record["candidate_outcome"] for record in records
+                ),
+                "features": sorted(
+                    set(feature for record in records for feature in record["features"])
+                ),
+                "has_candidate_only_regression": any(
+                    record["has_candidate_only_regression"] for record in records
+                ),
+                "id": test_id,
+                "novelty": max(record["novelty"] for record in records),
+                "original_outcome": _merge_outcomes(
+                    record["original_outcome"] for record in records
+                ),
+                "provenance": sorted(
+                    set(source for record in records for source in record["provenance"])
+                ),
+                "risk": max(record["risk"] for record in records),
+                "runtime_ms": _canonical_number(runtime_ms),
+                "sample_count": sample_count,
+            }
+        )
+    return {
+        "kind": OBSERVATION_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "tests": merged,
+    }
+
+
+def observation_digest(document):
+    try:
+        canonical = json.dumps(
+            document,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("ascii")
+    except (TypeError, ValueError) as error:
+        raise SelectionError("cannot compute digest for observation JSON") from error
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def _is_regression(record):
+    return record["has_candidate_only_regression"]
+
+
+def _has_unknown_outcome(record):
+    return (
+        record["candidate_outcome"] == "unknown"
+        or record["original_outcome"] == "unknown"
+    )
+
+
+def _is_holdout(test_id, percent, seed):
+    if percent <= 0:
+        return False
+    key = (seed + "\0" + test_id).encode("utf-8")
+    bucket = int.from_bytes(hashlib.sha256(key).digest()[:8], "big")
+    return bucket < percent * (1 << 64) / 100.0
+
+
+def _effective_novelties(records, mode):
+    feature_counts = defaultdict(int)
+    for record in records:
+        for feature in record["features"]:
+            feature_counts[feature] += 1
+    novelties = {}
+    for record in records:
+        rarity = _finite_sum(
+            (1.0 / feature_counts[feature] for feature in record["features"]),
+            "effective novelty",
+        )
+        reported = float(record["novelty"])
+        if mode == "reported":
+            effective = reported
+        elif mode == "rarity":
+            effective = rarity
+        else:
+            effective = _finite_sum((reported, rarity), "effective novelty")
+        novelties[record["id"]] = effective
+    return novelties
+
+
+def _fits_budget(
+    record, selected_count, runtime_ms, test_count_budget, runtime_budget_ms
+):
+    if test_count_budget is not None and selected_count + 1 > test_count_budget:
+        return False
+    if runtime_budget_ms is not None and (
+        runtime_ms > runtime_budget_ms
+        or record["runtime_ms"] > runtime_budget_ms - runtime_ms
+    ):
+        return False
+    return True
+
+
+def _candidate_value(
+    record,
+    effective_novelty,
+    uncovered,
+    novel_needed,
+    unknown_needed,
+    feature_weights,
+    risk_weight,
+    novelty_weight,
+    unknown_weight,
+):
+    marginal = sorted(set(record["features"]) & uncovered)
+    coverage_value = _finite_sum(
+        (feature_weights.get(feature, 1.0) for feature in marginal),
+        "feature coverage score",
+    )
+    quota_value = 0.0
+    if novel_needed and effective_novelty > 0:
+        quota_value = _finite_sum(
+            (
+                quota_value,
+                _finite_product(
+                    novelty_weight, effective_novelty, "novelty quota score"
+                ),
+            ),
+            "quota score",
+        )
+    if unknown_needed and _has_unknown_outcome(record):
+        quota_value = _finite_sum((quota_value, unknown_weight), "quota score")
+    if coverage_value == 0 and quota_value == 0:
+        return 0.0, coverage_value, marginal
+
+    risk_multiplier = _finite_sum(
+        (
+            1.0,
+            _finite_product(risk_weight, record["risk"], "risk score"),
+        ),
+        "risk multiplier",
+    )
+    weighted_values = []
+    if coverage_value > 0:
+        coverage_multiplier = _finite_sum(
+            (
+                risk_multiplier,
+                _finite_product(
+                    novelty_weight, effective_novelty, "novelty coverage score"
+                ),
+            ),
+            "coverage multiplier",
+        )
+        weighted_values.append(
+            _finite_product(
+                coverage_value, coverage_multiplier, "weighted coverage score"
+            )
+        )
+    if quota_value > 0:
+        weighted_values.append(
+            _finite_product(quota_value, risk_multiplier, "weighted quota score"),
+        )
+    value = _finite_sum(weighted_values, "selection score")
+    return value, coverage_value, marginal
+
+
+def select_tests(
+    document,
+    requested_features=None,
+    feature_weights=None,
+    runtime_budget_ms=None,
+    test_count_budget=None,
+    min_novel_tests=0,
+    min_unknown_tests=0,
+    risk_weight=1.0,
+    novelty_weight=1.0,
+    unknown_weight=1.0,
+    novelty_mode="reported",
+    holdout_percent=0.0,
+    holdout_seed="hotswap-test-select-v1",
+):
+    """Return a versioned, explainable selection document."""
+    observations = normalize_document(document)
+    feature_weights = dict(feature_weights or {})
+    requested_features = list(requested_features or [])
+
+    if runtime_budget_ms is not None:
+        runtime_budget_ms = _validate_weight(runtime_budget_ms, "runtime budget")
+    if test_count_budget is not None and (
+        not isinstance(test_count_budget, int)
+        or isinstance(test_count_budget, bool)
+        or test_count_budget < 0
+    ):
+        raise SelectionError("test-count budget must be a non-negative integer")
+    for name, count in (
+        ("min novel tests", min_novel_tests),
+        ("min unknown tests", min_unknown_tests),
+    ):
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise SelectionError("%s must be a non-negative integer" % name)
+    risk_weight = _validate_weight(risk_weight, "risk weight")
+    novelty_weight = _validate_weight(novelty_weight, "novelty weight")
+    unknown_weight = _validate_weight(unknown_weight, "unknown weight")
+    if novelty_mode not in ("reported", "rarity", "combined"):
+        raise SelectionError("novelty mode must be reported, rarity, or combined")
+    holdout_percent = _validate_weight(holdout_percent, "holdout percent")
+    if holdout_percent > 100:
+        raise SelectionError("holdout percent must not exceed 100")
+    if not isinstance(holdout_seed, str):
+        raise SelectionError("holdout seed must be a string")
+
+    normalized_weights = {}
+    for feature, weight in feature_weights.items():
+        if not isinstance(feature, str) or not feature:
+            raise SelectionError("feature-weight names must be non-empty strings")
+        normalized_weights[feature] = _validate_weight(
+            weight, "feature weight %r" % feature
+        )
+
+    all_records = observations["tests"]
+    regression_ids = sorted(
+        record["id"] for record in all_records if _is_regression(record)
+    )
+    holdout_ids = sorted(
+        record["id"]
+        for record in all_records
+        if _is_holdout(record["id"], holdout_percent, holdout_seed)
+    )
+    regression_id_set = set(regression_ids)
+    holdout_id_set = set(holdout_ids)
+    eligible_records = [
+        record
+        for record in all_records
+        if record["id"] not in holdout_id_set or record["id"] in regression_id_set
+    ]
+    effective_novelties = _effective_novelties(eligible_records, novelty_mode)
+
+    all_features = sorted(
+        set(feature for record in eligible_records for feature in record["features"])
+    )
+    for feature in requested_features:
+        if not isinstance(feature, str) or not feature:
+            raise SelectionError("requested features must be non-empty strings")
+    targets = sorted(set(requested_features)) if requested_features else all_features
+
+    records_by_id = {record["id"]: record for record in all_records}
+
+    selected = []
+    selected_ids = set()
+    covered = set()
+    runtime_ms = 0.0
+    novel_count = 0
+    unknown_count = 0
+
+    def add_selection(record, forced, score, marginal):
+        nonlocal novel_count, runtime_ms, unknown_count
+        effective_novelty = effective_novelties[record["id"]]
+        reasons = []
+        if forced:
+            reasons.append("candidate-only-regression")
+        reasons.extend("covers:" + feature for feature in marginal)
+        if effective_novelty > 0 and novel_count < min_novel_tests:
+            reasons.append("novel-case")
+        if _has_unknown_outcome(record) and unknown_count < min_unknown_tests:
+            reasons.append("unknown-outcome")
+
+        runtime_ms = _finite_sum(
+            (runtime_ms, float(record["runtime_ms"])), "selected runtime"
+        )
+        covered.update(marginal)
+        if effective_novelty > 0:
+            novel_count += 1
+        if _has_unknown_outcome(record):
+            unknown_count += 1
+        selected_ids.add(record["id"])
+        selected.append(
+            {
+                "cumulative_runtime_ms": _canonical_number(runtime_ms),
+                "effective_novelty": _canonical_number(effective_novelty),
+                "forced": forced,
+                "id": record["id"],
+                "marginal_features": marginal,
+                "provenance": record["provenance"],
+                "reasons": reasons,
+                "runtime_ms": record["runtime_ms"],
+                "selection_score": _canonical_number(score),
+            }
+        )
+
+    for test_id in regression_ids:
+        record = records_by_id[test_id]
+        marginal = sorted(set(record["features"]) & (set(targets) - covered))
+        add_selection(record, True, 0.0, marginal)
+
+    while True:
+        uncovered = set(targets) - covered
+        novel_needed = novel_count < min_novel_tests
+        unknown_needed = unknown_count < min_unknown_tests
+        if not uncovered and not novel_needed and not unknown_needed:
+            break
+
+        candidates = []
+        for record in eligible_records:
+            if record["id"] in selected_ids:
+                continue
+            if not _fits_budget(
+                record,
+                len(selected),
+                runtime_ms,
+                test_count_budget,
+                runtime_budget_ms,
+            ):
+                continue
+            value, coverage_value, marginal = _candidate_value(
+                record,
+                effective_novelties[record["id"]],
+                uncovered,
+                novel_needed,
+                unknown_needed,
+                normalized_weights,
+                risk_weight,
+                novelty_weight,
+                unknown_weight,
+            )
+            if value <= 0:
+                continue
+            divisor = (
+                max(float(record["runtime_ms"]), 1.0)
+                if runtime_budget_ms is not None
+                else 1.0
+            )
+            candidates.append(
+                (
+                    -(value / divisor),
+                    -value,
+                    -coverage_value,
+                    float(record["runtime_ms"]),
+                    record["id"],
+                    record,
+                    marginal,
+                )
+            )
+        if not candidates:
+            break
+        candidates.sort()
+        best = candidates[0]
+        add_selection(best[5], False, -best[1], best[6])
+
+    uncovered = sorted(set(targets) - covered)
+    estimated_runtime = _canonical_number(runtime_ms)
+    forced_runtime_exceeded = False
+    if runtime_budget_ms is not None:
+        remaining_runtime = runtime_budget_ms
+        for test_id in regression_ids:
+            forced_runtime = float(records_by_id[test_id]["runtime_ms"])
+            if forced_runtime > remaining_runtime:
+                forced_runtime_exceeded = True
+                break
+            remaining_runtime -= forced_runtime
+    forced_exceeded = (
+        test_count_budget is not None and len(regression_ids) > test_count_budget
+    ) or forced_runtime_exceeded
+    return {
+        "budget": {
+            "runtime_ms": (
+                None
+                if runtime_budget_ms is None
+                else _canonical_number(runtime_budget_ms)
+            ),
+            "test_count": test_count_budget,
+        },
+        "budget_exceeded_by_forced_regressions": forced_exceeded,
+        "estimated_runtime_ms": estimated_runtime,
+        "input_digest": observation_digest(observations),
+        "kind": SELECTION_KIND,
+        "known_candidate_only_regressions": regression_ids,
+        "holdout": {
+            "percent": _canonical_number(holdout_percent),
+            "regression_overrides": sorted(holdout_id_set & regression_id_set),
+            "reserved_tests": sorted(holdout_id_set - regression_id_set),
+            "seed": holdout_seed,
+        },
+        "novelty_mode": novelty_mode,
+        "requested_features": targets,
+        "schema_version": SCHEMA_VERSION,
+        "selection_policy": {
+            "feature_weights": {
+                feature: _canonical_number(weight)
+                for feature, weight in sorted(normalized_weights.items())
+            },
+            "min_novel_tests": min_novel_tests,
+            "min_unknown_tests": min_unknown_tests,
+            "novelty_weight": _canonical_number(novelty_weight),
+            "risk_weight": _canonical_number(risk_weight),
+            "unknown_weight": _canonical_number(unknown_weight),
+        },
+        "selected_tests": selected,
+        "uncovered_features": uncovered,
+        "unfilled_quotas": {
+            "novel_tests": max(0, min_novel_tests - novel_count),
+            "unknown_tests": max(0, min_unknown_tests - unknown_count),
+        },
+    }
+
+
+def _read_json(path):
+    try:
+        if path == "-":
+            return json.load(sys.stdin)
+        with open(path, "r", encoding="utf-8") as input_file:
+            return json.load(input_file)
+    except (UnicodeError, ValueError) as error:
+        raise SelectionError("cannot parse JSON from %r: %s" % (path, error)) from error
+
+
+def _normalized_path(path):
+    return os.path.normcase(os.path.realpath(os.path.abspath(path)))
+
+
+def _protect_inputs(output_path, input_paths):
+    if output_path == "-":
+        return
+    normalized_output = _normalized_path(output_path)
+    for input_path in input_paths:
+        if input_path == "-":
+            continue
+        normalized_input = _normalized_path(input_path)
+        aliases_input = normalized_output == normalized_input
+        if not aliases_input:
+            try:
+                aliases_input = os.path.samefile(output_path, input_path)
+            except OSError:
+                aliases_input = False
+        if aliases_input:
+            raise SelectionError("refusing to overwrite input %r" % input_path)
+
+
+def _write_json(path, document):
+    try:
+        text = (
+            json.dumps(
+                document,
+                allow_nan=False,
+                ensure_ascii=True,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    except (TypeError, ValueError) as error:
+        raise SelectionError("cannot serialize selection JSON: %s" % error) from error
+    if path == "-":
+        sys.stdout.write(text)
+        return
+    destination = os.path.abspath(path)
+    directory = os.path.dirname(destination)
+    if not os.path.isdir(directory):
+        raise SelectionError("output directory does not exist: %r" % directory)
+    temporary_path = None
+    try:
+        descriptor, temporary_path = tempfile.mkstemp(
+            prefix=".hotswap-test-select-", dir=directory
+        )
+        with os.fdopen(descriptor, "wb") as output_file:
+            output_file.write(text.encode("ascii"))
+            output_file.flush()
+            os.fsync(output_file.fileno())
+        os.replace(temporary_path, destination)
+        temporary_path = None
+    except OSError as error:
+        raise SelectionError("cannot write %r: %s" % (destination, error)) from error
+    finally:
+        if temporary_path is not None:
+            try:
+                os.unlink(temporary_path)
+            except OSError:
+                pass
+
+
+def _parse_feature_weights(values):
+    weights = {}
+    for value in values:
+        if "=" not in value:
+            raise SelectionError(
+                "feature weights must use FEATURE=WEIGHT syntax: %r" % value
+            )
+        feature, raw_weight = value.split("=", 1)
+        if not feature:
+            raise SelectionError("feature-weight names must be non-empty")
+        try:
+            weight = float(raw_weight)
+        except ValueError as error:
+            raise SelectionError(
+                "feature weight %r is not a number" % raw_weight
+            ) from error
+        weights[feature] = _validate_weight(weight, "feature weight %r" % feature)
+    return weights
+
+
+def _create_parser():
+    parser = argparse.ArgumentParser(
+        description=(
+            "merge hotswap calibration observations or greedily select a "
+            "small, explainable test subset"
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    adapt_parser = subparsers.add_parser(
+        "adapt", help="normalize producer reports into observation JSON"
+    )
+    adapt_parser.add_argument(
+        "--input", nargs="+", required=True, help="producer report JSON file(s)"
+    )
+    adapt_parser.add_argument(
+        "--output", default="-", help="output JSON file (default: stdout)"
+    )
+    adapt_parser.add_argument(
+        "--default-runtime-ms",
+        type=float,
+        help=(
+            "explicit runtime for records not timed by any producer "
+            "(required for a standalone inventory)"
+        ),
+    )
+
+    merge_parser = subparsers.add_parser(
+        "merge", help="merge one or more observation JSON files"
+    )
+    merge_parser.add_argument(
+        "--input", nargs="+", required=True, help="observation JSON file(s)"
+    )
+    merge_parser.add_argument(
+        "--output", default="-", help="output JSON file (default: stdout)"
+    )
+
+    select_parser = subparsers.add_parser(
+        "select", help="select tests from an observation JSON file"
+    )
+    select_parser.add_argument("--input", required=True, help="observation JSON")
+    select_parser.add_argument(
+        "--output", default="-", help="output JSON file (default: stdout)"
+    )
+    select_parser.add_argument(
+        "--runtime-budget-ms", type=float, help="optional total runtime budget"
+    )
+    select_parser.add_argument(
+        "--test-count-budget", type=int, help="optional test-count budget"
+    )
+    select_parser.add_argument(
+        "--require-feature",
+        action="append",
+        default=[],
+        help="feature to cover; repeat as needed (default: cover all)",
+    )
+    select_parser.add_argument(
+        "--feature-weight",
+        action="append",
+        default=[],
+        metavar="FEATURE=WEIGHT",
+        help="coverage weight; repeat as needed",
+    )
+    select_parser.add_argument(
+        "--min-novel-tests",
+        type=int,
+        default=0,
+        help="minimum selected tests with nonzero novelty",
+    )
+    select_parser.add_argument(
+        "--min-unknown-tests",
+        type=int,
+        default=0,
+        help="minimum selected tests with an unknown calibration outcome",
+    )
+    select_parser.add_argument(
+        "--risk-weight", type=float, default=1.0, help="per-test risk multiplier"
+    )
+    select_parser.add_argument(
+        "--novelty-weight",
+        type=float,
+        default=1.0,
+        help="novel-case quota weight",
+    )
+    select_parser.add_argument(
+        "--unknown-weight",
+        type=float,
+        default=1.0,
+        help="unknown-outcome quota weight",
+    )
+    select_parser.add_argument(
+        "--novelty-mode",
+        choices=("reported", "rarity", "combined"),
+        default="reported",
+        help="use reported novelty, feature rarity, or both",
+    )
+    select_parser.add_argument(
+        "--holdout-percent",
+        type=float,
+        default=0.0,
+        help="deterministically reserve this percentage of non-regressions",
+    )
+    select_parser.add_argument(
+        "--holdout-seed",
+        default="hotswap-test-select-v1",
+        help="stable seed for deterministic holdout partitioning",
+    )
+    return parser
+
+
+def main(argv=None):
+    parser = _create_parser()
+    arguments = parser.parse_args(argv)
+    try:
+        input_paths = (
+            arguments.input if isinstance(arguments.input, list) else [arguments.input]
+        )
+        _protect_inputs(arguments.output, input_paths)
+        if arguments.command in ("adapt", "merge"):
+            if arguments.input.count("-") > 1:
+                raise SelectionError("standard input may only be read once")
+            documents = [_read_json(path) for path in arguments.input]
+            if arguments.command == "adapt":
+                result = adapt_documents(
+                    documents,
+                    default_runtime_ms=arguments.default_runtime_ms,
+                )
+            else:
+                result = merge_documents(documents)
+        else:
+            result = select_tests(
+                _read_json(arguments.input),
+                requested_features=arguments.require_feature,
+                feature_weights=_parse_feature_weights(arguments.feature_weight),
+                runtime_budget_ms=arguments.runtime_budget_ms,
+                test_count_budget=arguments.test_count_budget,
+                min_novel_tests=arguments.min_novel_tests,
+                min_unknown_tests=arguments.min_unknown_tests,
+                risk_weight=arguments.risk_weight,
+                novelty_weight=arguments.novelty_weight,
+                unknown_weight=arguments.unknown_weight,
+                novelty_mode=arguments.novelty_mode,
+                holdout_percent=arguments.holdout_percent,
+                holdout_seed=arguments.holdout_seed,
+            )
+        _write_json(arguments.output, result)
+    except (OSError, json.JSONDecodeError, SelectionError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add a dependency-free developer utility for selecting a small, explainable
subset of hotswap corpus or A0 calibration tests.

The utility:

- adapts and merges versioned manifest, audit, semantic-check, and
  `comgr.hotswap.inventory` JSON;
- applies deterministic weighted greedy set cover under runtime and test-count
  budgets;
- retains every observed candidate-only regression, including when later
  samples make the aggregate outcome `mixed`;
- supports risk and feature weights, novel/unknown quotas, feature-rarity
  novelty, and deterministic seeded holdouts;
- emits stable versioned JSON with an input digest, marginal coverage,
  selection reasons, uncovered features, budget state, and producer
  provenance;
- rejects ambiguous schema aliases and non-finite numeric results;
- rejects output paths that alias inputs and writes output with same-directory
  atomic replacement.

This is a developer utility only. It adds no COMGR public API or native
hotswap behavior.

## PR #3646 evidence acceptance

The optional evidence test was run against the frozen corpus artifacts on
`mi300x` for candidate source commit
`ab3cdd61c079a3e7fa7ed41d9834cc0baa256fcc`.

The test now verifies the artifact hashes before parsing:

- `results.tsv` SHA-256:
  `ffb089ac585374ac3e9edd93cb0668ed9c6c6b21514948d94884a20f7c2176b9`
- `transitions-vs-5cbc-default.tsv` SHA-256:
  `295c97a7bcc7b62363c5f41e9c3aa9c46741d43f2270799407b6c6cc11908c5c`
- `prior-failures-now-success.tsv` SHA-256:
  `756066cad7ca7aea97b5d9474784f5ad4ae00bc2a1b3d381bf0592f968cfb892`

Results:

- 2,685 aliases collapsed to 1,452 input hashes, removing 1,233 duplicate
  aliases from selector candidates;
- every first rewrite, second rewrite, and byte-idempotence result succeeded;
- runtime p99 was 6.64 seconds;
- exactly two selected objects covered all six evidence-derived dimensions:
  rewrite success, idempotence, changed output, unchanged output, a prior
  baseline failure, and the runtime tail.

The four natural transition records are baseline `FAILURE` to candidate
`SUCCESS`, not candidate-only failures. A separate zero-budget acceptance step
reverses only their outcome orientation and verifies that those exact four
records are all retained and marked forced when represented as candidate-only
regressions.

## Review fixes

The senior-review pass found and fixed:

- repeated-run merging could turn a known `fail`/`pass` regression into
  `mixed`/`pass` and then drop it from forced selection;
- huge but JSON-valid numbers could raise an uncaught `OverflowError`, while
  finite inputs could overflow aggregation or scoring and emit `Infinity`;
- the frozen-evidence acceptance documented hashes but did not enforce them;
- generic producer aliases such as `features`/`feature_tags` or
  `records`/`tests` could conflict silently;
- the selection output promised provenance but did not retain it;
- the evidence description overstated duplicate execution behavior rather
  than describing the duplicate aliases collapsed before selection.

Regression coverage includes strict schema-version types, very large values,
zero runtimes, merge permutations, hard-link aliases, Unicode paths and IDs,
invalid UTF-8, atomic-write rollback, and evidence-hash tampering.

## Validation

- Based directly on `amd-staging`
  `d4450799dba192da73bd12d739e8a58dc610630d`.
- `python3 amd/comgr/test/utils/test_hotswap_test_select.py`
  - 46 tests passed.
- 1,000 deterministic randomized selector invariant cases
  - passed.
- `python3 amd/comgr/test/utils/test_hotswap_test_select_evidence.py` with the
  three frozen evidence paths on `mi300x`
  - passed.
- Fresh Release CMake configure with `BUILD_TESTING=ON`
  - passed.
- CTest
  - `comgr_hotswap_test_select_test` passed;
  - evidence test skips with return code 77 when evidence variables are absent.
- Python 3.8 grammar parse for all three Python files
  - passed.
- Ruff format check and lint
  - passed.
- JSON fixture validation and `git diff --check`
  - passed.

## Limitations

- The selector is an explainable greedy heuristic; it does not claim global
  set-cover optimality.
- All merged observations must describe the same candidate/reference builds,
  target, and execution mode. Schema version 1 retains provenance but does not
  enforce comparison identity.
- The corpus evidence establishes rewrite completion, content deduplication,
  idempotence, output-change classes, host runtime, and process outcomes. It
  does not establish GPU execution accuracy or semantic equivalence.
- The evidence does not identify round-trip VCC preservation, owner-specific
  source windows, far gateways, materialized call closure, scratch-SGPR
  liveness, DS2, M32 scale16, or tensor-mask behavior. Those require
  manifest/audit/semantic-check tags or A0 execution observations.
- The checked-in PR #3646 risk fixture is curated and label-rewritten in tests;
  it is deliberately separate from measured evidence.
- No GPU or ASAN run was performed for this Python-only utility. There are no
  GPU, native-code, public-API, or ASAN changes in this PR.

Required GitHub checks restarted for commit
`bf2a064fab65b2da23dbccbacbf1d014081f52d7`; the PR remains draft until they
pass.
