### PR TITLE
[Comgr] Add predicate-driven hotswap reducer

### DIFF
--- a/amd/comgr/docs/HotswapReduce.md
+++ b/amd/comgr/docs/HotswapReduce.md
@@ -1,11 +1,10 @@
 # Hotswap failure reducer
 
 `utils/hotswap/hotswap_reduce.py` turns a failing hotswap corpus bundle into a
-small,
-standalone reproducer. It only accepts a transformation when a caller-provided
-interestingness command continues to return the configured exit code. The
-original inputs are never modified and the output directory is published
-atomically.
+small, standalone reproducer. It only accepts a transformation when a
+caller-provided interestingness command continues to return the configured exit
+code. The original inputs are never modified and the output directory is
+published atomically.
 
 The reducer works from the outside in:
 
@@ -14,11 +13,17 @@ The reducer works from the outside in:
    lists, followed by each retained case's `arguments` list.
 3. Optionally remove explicitly allowed, non-allocated ELF sections with
    `llvm-objcopy`.
+4. Repeat the hierarchy until a complete pass makes no change. This gives each
+   retained dimension another reduction opportunity after lower-level changes.
 
 The section pass gets section names and flags from `llvm-readobj` JSON. It does
 not parse ELF itself. Allocated sections and the default runtime-critical
 section set are always protected. Section removal is disabled unless at least
-one `--allow-remove-section` glob is provided.
+one `--allow-remove-section` glob is provided. If multiple sections have the
+same name, one allocated or protected instance protects every instance because
+`llvm-objcopy` removes sections by name. Every transformed output is parsed
+again to verify that it is still AMDGPU ELF, every requested section is gone,
+and no unrequested section disappeared.
 
 ## Interestingness command
 
@@ -33,14 +38,20 @@ placeholders are expanded for each candidate:
 
 Exit zero means interesting by default. Use `--interesting-exit-code` when the
 reproducer intentionally reports a failure with a nonzero exit. A timeout,
-launch error, or disagreement between `--predicate-runs` repetitions rejects a
-candidate. Stable outcomes are cached by the complete candidate content and
-predicate configuration; `--cache-file` makes that cache persistent.
-The resolved predicate executable and regular-file argv items are hashed into
-that identity. Repeat `--cache-dependency` for dynamically loaded libraries,
-reference data, or other file inputs, and repeat `--cache-tag` for relevant
-environment or configuration identity. A dependency that changes during a run
-aborts the reduction instead of consulting a stale cache entry.
+launch error, or exit-code disagreement between `--predicate-runs` repetitions
+rejects a candidate. Predicate output retained in the log is bounded to avoid
+unbounded memory use. Timed-out predicate process trees are terminated before
+their temporary workspace is removed.
+
+Stable outcomes are cached by the complete candidate content and predicate
+configuration; `--cache-file` makes that cache persistent. The resolved
+predicate executable and regular-file argv items are identified by path,
+content, and file mode. Repeat `--cache-dependency` for dynamically loaded
+libraries, reference data, or other file inputs, and repeat `--cache-tag` for
+relevant environment or configuration identity. A dependency that changes
+during a run aborts the reduction instead of consulting a stale cache entry.
+Predicates must be deterministic and must not rely on side effects outside
+their candidate workspace because a cache hit replaces the process execution.
 
 For example:
 
@@ -58,9 +69,9 @@ python3 utils/hotswap/hotswap_reduce.py \
 ```
 
 No argument is evaluated by a shell. Supplying an absolute predicate and
-absolute script path makes the recorded reproduction argv directly portable.
-Existing regular-file argv items are resolved to absolute paths before the
-first predicate run.
+absolute script path makes the recorded reproduction argv unambiguous on the
+same filesystem. Existing regular-file argv items are resolved to absolute
+paths before the first predicate run.
 
 ## PR #3646 offline differential workflow
 
@@ -99,7 +110,9 @@ oracle itself.
 ## Input and output bundle
 
 Input bundles use this versioned JSON form. Object paths and a string-valued
-`metadata` path are relative to the bundle file.
+`metadata` path are relative to the bundle file and cannot escape its directory,
+including through a symlink. Use direct `--code-object` or `--worklist` input
+when the object files intentionally live elsewhere.
 
 ```json
 {
@@ -145,14 +158,15 @@ The output contains:
 - a final reproduction argv and interesting exit code in that log
 
 The log also records original and final content digests. It intentionally
-contains no timestamps or elapsed times so identical inputs and stable
-predicates produce identical logs.
+contains no timestamps, elapsed times, or cache-hit state so identical inputs
+and stable predicates produce identical logs.
 
 ## Safety limits
 
 - Existing output directories are never overwritten.
-- Cache files cannot overwrite an input, predicate identity, dependency, or
-  live inside the atomically published output directory.
+- Cache files cannot overwrite an input (including external bundle metadata),
+  predicate identity, dependency, or live inside the atomically published
+  output directory.
 - Malformed bundles and metadata fail before a predicate runs.
 - Section pruning requires AMDGPU ELF input and available LLVM tools.
 - Protected or allocated sections cannot be opted into removal.

--- a/amd/comgr/docs/HotswapReduce.md
+++ b/amd/comgr/docs/HotswapReduce.md
@@ -1,0 +1,163 @@
+# Hotswap failure reducer
+
+`utils/hotswap/hotswap_reduce.py` turns a failing hotswap corpus bundle into a
+small,
+standalone reproducer. It only accepts a transformation when a caller-provided
+interestingness command continues to return the configured exit code. The
+original inputs are never modified and the output directory is published
+atomically.
+
+The reducer works from the outside in:
+
+1. Delta-debug the list of code objects.
+2. Delta-debug the top-level `kernels`, `cases`, and `arguments` metadata
+   lists, followed by each retained case's `arguments` list.
+3. Optionally remove explicitly allowed, non-allocated ELF sections with
+   `llvm-objcopy`.
+
+The section pass gets section names and flags from `llvm-readobj` JSON. It does
+not parse ELF itself. Allocated sections and the default runtime-critical
+section set are always protected. Section removal is disabled unless at least
+one `--allow-remove-section` glob is provided.
+
+## Interestingness command
+
+The command is an argv vector, not a shell string. Pass the executable with
+`--predicate` and repeat `--predicate-arg` for its arguments. These literal
+placeholders are expanded for each candidate:
+
+- `{bundle}`: candidate `bundle.json`
+- `{input}`: the sole candidate code object (only valid with one object)
+- `{metadata}`: candidate `metadata.json`
+- `{workspace}`: candidate directory
+
+Exit zero means interesting by default. Use `--interesting-exit-code` when the
+reproducer intentionally reports a failure with a nonzero exit. A timeout,
+launch error, or disagreement between `--predicate-runs` repetitions rejects a
+candidate. Stable outcomes are cached by the complete candidate content and
+predicate configuration; `--cache-file` makes that cache persistent.
+The resolved predicate executable and regular-file argv items are hashed into
+that identity. Repeat `--cache-dependency` for dynamically loaded libraries,
+reference data, or other file inputs, and repeat `--cache-tag` for relevant
+environment or configuration identity. A dependency that changes during a run
+aborts the reduction instead of consulting a stale cache entry.
+
+For example:
+
+```console
+python3 utils/hotswap/hotswap_reduce.py \
+  --bundle failing-bundle.json \
+  --output reduced \
+  --predicate /usr/bin/python3 \
+  --predicate-arg=/absolute/path/is_interesting.py \
+  --predicate-arg='{bundle}' \
+  --predicate-runs 3 \
+  --timeout 20 \
+  --allow-remove-section='.debug_*' \
+  --allow-remove-section='.comment'
+```
+
+No argument is evaluated by a shell. Supplying an absolute predicate and
+absolute script path makes the recorded reproduction argv directly portable.
+Existing regular-file argv items are resolved to absolute paths before the
+first predicate run.
+
+## PR #3646 offline differential workflow
+
+An A0 runtime failure is not required. The predicate can be any deterministic
+offline check, which makes the reducer useful while validating the hotswap
+implementation in PR #3646. For a discrepant hipBLASLt or hipSOLVER case,
+first put the involved code objects and launch records in a regular bundle.
+Then use one of these predicate shapes:
+
+- A wrapper rewrites the candidate with the PR #3646 build, emits its
+  structural manifest, compares it with a fixed PR #3598 reference manifest,
+  and exits with the interesting code while a difference remains.
+- A wrapper runs `hotswap-audit` over every retained object and exits with the
+  interesting code while the audit reports an invariant violation.
+- A wrapper runs `hotswap-semcheck` for the retained kernels and exits with the
+  interesting code while it returns a counterexample.
+
+For example, an offline manifest differential can be driven as:
+
+```console
+python3 utils/hotswap/hotswap_reduce.py \
+  --bundle hipblaslt-discrepancy.json \
+  --output reduced-3646-difference \
+  --predicate /absolute/path/manifest-diff-predicate \
+  --predicate-arg=/absolute/path/pr3598-reference.json \
+  --predicate-arg='{bundle}' \
+  --predicate-runs 2
+```
+
+The wrapper owns the meaning of the comparison and the selected build. The
+reducer only sees an argv vector and an exit code, so no PR-specific opcode,
+kernel name, or library test name is encoded in its reduction logic. Keep the
+reference manifest outside the candidate bundle so ddmin cannot reduce the
+oracle itself.
+
+## Input and output bundle
+
+Input bundles use this versioned JSON form. Object paths and a string-valued
+`metadata` path are relative to the bundle file.
+
+```json
+{
+  "format": "comgr-hotswap-reducer-bundle",
+  "version": 1,
+  "code_objects": [
+    {"id": "hipblaslt-case-17", "path": "objects/case 17.co"}
+  ],
+  "metadata": {
+    "kernels": [{"name": "kernel"}],
+    "cases": [{"name": "case", "arguments": [1, 2, 3]}],
+    "arguments": []
+  }
+}
+```
+
+`--code-object` can be repeated instead of providing a bundle, with optional
+metadata from `--metadata`.
+
+An inventory or test-selection pipeline can provide a NUL-delimited worklist:
+
+```console
+python3 utils/hotswap/hotswap_reduce.py \
+  --worklist unique-code-objects.list \
+  --metadata selection.json \
+  --output reduced \
+  --predicate /absolute/path/offline-predicate \
+  --predicate-arg='{bundle}'
+```
+
+Every worklist entry is treated as a path, never shell text. Absolute paths
+from the inventory utility work directly; relative paths are resolved from the
+worklist's directory. Empty, unterminated, or duplicate entries are rejected.
+A selector document can be passed directly as metadata. In addition to
+`kernels`, `cases`, and `arguments`, a top-level `selected_tests` list is
+delta-debugged generically; all unknown selector fields are preserved.
+
+The output contains:
+
+- `bundle.json`, `metadata.json`, and the retained objects under `objects/`
+- `reduction-log.json`, a versioned deterministic record of every accepted or
+  rejected transformation
+- a final reproduction argv and interesting exit code in that log
+
+The log also records original and final content digests. It intentionally
+contains no timestamps or elapsed times so identical inputs and stable
+predicates produce identical logs.
+
+## Safety limits
+
+- Existing output directories are never overwritten.
+- Cache files cannot overwrite an input, predicate identity, dependency, or
+  live inside the atomically published output directory.
+- Malformed bundles and metadata fail before a predicate runs.
+- Section pruning requires AMDGPU ELF input and available LLVM tools.
+- Protected or allocated sections cannot be opted into removal.
+- Temporary candidates are removed after interruption, timeout, or failure.
+- `llvm-reduce` is not run on linked ELF code objects; it is an IR/MIR reducer.
+  Use it before linking when a retained bundle also has LLVM IR or MIR source.
+- Persistent cache writes are atomic but are not merged across concurrent
+  reducer processes; give each concurrent process a distinct cache file.

--- a/amd/comgr/test/CMakeLists.txt
+++ b/amd/comgr/test/CMakeLists.txt
@@ -247,3 +247,13 @@ add_comgr_test(compile_hip_to_relocatable c)
 #add_comgr_test(compile_hip_with_libcxx_test c)
 add_comgr_test(mangled_names_hip_test c)
 #add_comgr_test(unbundle_hip_test c)
+
+add_test(
+  NAME comgr_hotswap_reduce_test
+  COMMAND "${Python3_EXECUTABLE}"
+          "${CMAKE_CURRENT_SOURCE_DIR}/utils/test_hotswap_reduce.py")
+set_tests_properties(
+  comgr_hotswap_reduce_test
+  PROPERTIES
+    ENVIRONMENT "PYTHONDONTWRITEBYTECODE=1"
+    TIMEOUT 120)

--- a/amd/comgr/test/utils/test_hotswap_reduce.py
+++ b/amd/comgr/test/utils/test_hotswap_reduce.py
@@ -1,0 +1,1120 @@
+#!/usr/bin/env python3
+"""Hermetic tests for utils/hotswap/hotswap_reduce.py."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import stat
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from typing import Optional, Union
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "utils" / "hotswap" / "hotswap_reduce.py"
+SPEC = importlib.util.spec_from_file_location("hotswap_reduce", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+hotswap_reduce = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = hotswap_reduce
+SPEC.loader.exec_module(hotswap_reduce)
+
+
+def write_executable(path: Path, body: str) -> Path:
+    path.write_text(
+        "#!/usr/bin/env python3\n" + textwrap.dedent(body),
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def write_bundle(
+    root: Path,
+    object_contents: list[bytes],
+    metadata: object,
+    names: Optional[list[str]] = None,
+) -> Path:
+    objects = []
+    names = names or [f"object-{index}.co" for index in range(len(object_contents))]
+    for index, (name, content) in enumerate(zip(names, object_contents)):
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        objects.append({"id": f"id-{index}", "path": name})
+    bundle = {
+        "format": hotswap_reduce.BUNDLE_FORMAT,
+        "version": hotswap_reduce.BUNDLE_VERSION,
+        "code_objects": objects,
+        "metadata": metadata,
+    }
+    path = root / "bundle.json"
+    path.write_text(json.dumps(bundle), encoding="utf-8")
+    return path
+
+
+def make_args(
+    bundle: Path,
+    output: Path,
+    predicate: Union[Path, str],
+    predicate_args: list[str],
+    **overrides: object,
+) -> argparse.Namespace:
+    values: dict[str, object] = {
+        "bundle": bundle,
+        "code_object": None,
+        "worklist": None,
+        "metadata": None,
+        "output": output,
+        "predicate": str(predicate),
+        "predicate_arg": predicate_args,
+        "interesting_exit_code": 0,
+        "predicate_runs": 1,
+        "timeout": 5.0,
+        "cache_file": None,
+        "cache_dependency": [],
+        "cache_tag": [],
+        "allow_empty_bundle": False,
+        "allow_remove_section": [],
+        "protect_section": [],
+        "readobj": "llvm-readobj",
+        "objcopy": "llvm-objcopy",
+        "tool_timeout": 5.0,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+class DdminTests(unittest.TestCase):
+    def test_finds_one_minimal_required_pair(self) -> None:
+        attempts = []
+
+        def interesting(kept: list[str], removed: list[str]) -> bool:
+            attempts.append((tuple(kept), tuple(removed)))
+            return "b" in kept and "e" in kept
+
+        result = hotswap_reduce.ddmin(list("abcdef"), interesting)
+        self.assertEqual(result, ["b", "e"])
+        self.assertTrue(attempts)
+        for index in range(len(result)):
+            candidate = result[:index] + result[index + 1 :]
+            self.assertFalse("b" in candidate and "e" in candidate)
+
+    def test_respects_minimum_size(self) -> None:
+        result = hotswap_reduce.ddmin(
+            [1, 2, 3],
+            lambda kept, removed: True,
+            minimum_size=1,
+        )
+        self.assertEqual(len(result), 1)
+
+    def test_duplicate_items_are_reduced_by_position(self) -> None:
+        result = hotswap_reduce.ddmin(
+            ["x", "x", "y"],
+            lambda kept, removed: kept.count("x") >= 1,
+        )
+        self.assertEqual(result, ["x"])
+
+
+class BundleValidationTests(unittest.TestCase):
+    def test_rejects_malformed_metadata_list(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(root, [b"object"], {"cases": {}})
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError,
+                r"metadata\.cases must be a JSON list",
+            ):
+                hotswap_reduce.load_bundle(bundle)
+
+    def test_rejects_duplicate_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            (root / "a").write_bytes(b"a")
+            (root / "b").write_bytes(b"b")
+            bundle = {
+                "format": hotswap_reduce.BUNDLE_FORMAT,
+                "version": 1,
+                "code_objects": [
+                    {"id": "same", "path": "a"},
+                    {"id": "same", "path": "b"},
+                ],
+            }
+            path = root / "bundle.json"
+            path.write_text(json.dumps(bundle), encoding="utf-8")
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "duplicate code object id"
+            ):
+                hotswap_reduce.load_bundle(path)
+
+    def test_rejects_non_finite_json(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            path = Path(name) / "bundle.json"
+            path.write_text('{"value": NaN}', encoding="utf-8")
+            with self.assertRaisesRegex(hotswap_reduce.ReducerError, "non-finite"):
+                hotswap_reduce.load_json(path)
+
+    def test_accepts_spaces_and_special_characters_in_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="reduce spaces [") as name:
+            root = Path(name)
+            bundle = write_bundle(
+                root,
+                [b"one"],
+                {},
+                names=["objects/a file [1] $x.co"],
+            )
+            candidate = hotswap_reduce.load_bundle(bundle)
+            self.assertEqual(candidate.code_objects[0].path.read_bytes(), b"one")
+            with tempfile.TemporaryDirectory() as output_name:
+                output = Path(output_name) / "candidate"
+                hotswap_reduce.materialize_candidate(candidate, output)
+                output_bundle = json.loads(
+                    (output / "bundle.json").read_text(encoding="utf-8")
+                )
+                relative = output_bundle["code_objects"][0]["path"]
+                self.assertEqual((output / relative).read_bytes(), b"one")
+
+    def test_loads_inventory_nul_worklist_and_selector_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            first = root / "object with spaces.co"
+            second = root / "object\nwith-newline.co"
+            first.write_bytes(b"first")
+            second.write_bytes(b"second")
+            worklist = root / "selected.list"
+            worklist.write_bytes(
+                os.fsencode(first.resolve())
+                + b"\0"
+                + os.fsencode(second.resolve())
+                + b"\0"
+            )
+            selection = root / "selection.json"
+            selection.write_text(
+                json.dumps(
+                    {
+                        "kind": "producer-selection",
+                        "schema_version": 1,
+                        "selected_tests": [
+                            {"id": "test-a"},
+                            {"id": "test-b"},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            candidate = hotswap_reduce.load_inputs(None, [], worklist, selection)
+            self.assertEqual(
+                [item.path for item in candidate.code_objects],
+                [first.resolve(), second.resolve()],
+            )
+            self.assertEqual(
+                candidate.metadata["selected_tests"],
+                [{"id": "test-a"}, {"id": "test-b"}],
+            )
+
+    def test_rejects_malformed_and_duplicate_nul_worklists(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            object_path = root / "object.co"
+            object_path.write_bytes(b"object")
+            worklist = root / "worklist"
+            worklist.write_bytes(os.fsencode(object_path.resolve()))
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "must end with NUL"
+            ):
+                hotswap_reduce.load_nul_worklist(worklist)
+            encoded_path = os.fsencode(object_path.resolve())
+            worklist.write_bytes(encoded_path + b"\0" + encoded_path + b"\0")
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "duplicate worklist path"
+            ):
+                hotswap_reduce.load_nul_worklist(worklist)
+
+
+class PredicateTests(unittest.TestCase):
+    def make_candidate(self, root: Path, value: bytes = b"interesting"):
+        path = root / "input.co"
+        path.write_bytes(value)
+        return hotswap_reduce.Candidate(
+            (
+                hotswap_reduce.CodeObject(
+                    "id",
+                    path.name,
+                    path,
+                    hotswap_reduce.sha256_file(path),
+                ),
+            ),
+            {},
+        )
+
+    def make_runner(
+        self,
+        root: Path,
+        script: Path,
+        arguments: list[str],
+        **overrides: object,
+    ):
+        values = {
+            "argv_template": [sys.executable, str(script)] + arguments,
+            "interesting_exit_code": 0,
+            "runs": 1,
+            "timeout": 5.0,
+            "work_root": root,
+            "cache": hotswap_reduce.PredicateCache(None),
+        }
+        values.update(overrides)
+        return hotswap_reduce.PredicateRunner(**values)
+
+    def test_cache_uses_candidate_content(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            counter = root / "count"
+            script = root / "predicate.py"
+            script.write_text(
+                textwrap.dedent(
+                    f"""
+                    import pathlib
+                    counter = pathlib.Path({str(counter)!r})
+                    count = int(counter.read_text()) if counter.exists() else 0
+                    counter.write_text(str(count + 1))
+                    raise SystemExit(0)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            runner = self.make_runner(
+                root,
+                script,
+                ["{input}"],
+            )
+            candidate = self.make_candidate(root)
+            first = runner.evaluate(candidate)
+            second = runner.evaluate(candidate)
+            self.assertTrue(first.interesting)
+            self.assertFalse(first.cached)
+            self.assertTrue(second.cached)
+            self.assertEqual(counter.read_text(encoding="utf-8"), "1")
+
+            changed = self.make_candidate(root, b"changed")
+            runner.evaluate(changed)
+            self.assertEqual(counter.read_text(encoding="utf-8"), "2")
+
+    def test_persistent_cache_survives_runner_recreation(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            counter = root / "count"
+            cache_path = root / "predicate-cache.json"
+            script = root / "predicate.py"
+            script.write_text(
+                textwrap.dedent(
+                    f"""
+                    import pathlib
+                    counter = pathlib.Path({str(counter)!r})
+                    count = int(counter.read_text()) if counter.exists() else 0
+                    counter.write_text(str(count + 1))
+                    raise SystemExit(0)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            candidate = self.make_candidate(root)
+            first = self.make_runner(
+                root,
+                script,
+                ["{input}"],
+                cache=hotswap_reduce.PredicateCache(cache_path),
+            )
+            self.assertFalse(first.evaluate(candidate).cached)
+            second = self.make_runner(
+                root,
+                script,
+                ["{input}"],
+                cache=hotswap_reduce.PredicateCache(cache_path),
+            )
+            self.assertTrue(second.evaluate(candidate).cached)
+            self.assertEqual(counter.read_text(encoding="utf-8"), "1")
+            cache = json.loads(cache_path.read_text(encoding="utf-8"))
+            self.assertEqual(cache["format"], hotswap_reduce.CACHE_FORMAT)
+            self.assertEqual(cache["version"], 1)
+
+    def test_persistent_cache_invalidates_changed_predicate_script(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            counter = root / "count"
+            cache_path = root / "predicate-cache.json"
+            script = root / "predicate.py"
+
+            def write_predicate(marker: str) -> None:
+                script.write_text(
+                    textwrap.dedent(
+                        f"""
+                        # identity: {marker}
+                        import pathlib
+                        counter = pathlib.Path({str(counter)!r})
+                        count = int(counter.read_text()) if counter.exists() else 0
+                        counter.write_text(str(count + 1))
+                        raise SystemExit(0)
+                        """
+                    ),
+                    encoding="utf-8",
+                )
+
+            candidate = self.make_candidate(root)
+            write_predicate("first")
+            first = self.make_runner(
+                root,
+                script,
+                ["{input}"],
+                cache=hotswap_reduce.PredicateCache(cache_path),
+            )
+            self.assertFalse(first.evaluate(candidate).cached)
+            write_predicate("second")
+            second = self.make_runner(
+                root,
+                script,
+                ["{input}"],
+                cache=hotswap_reduce.PredicateCache(cache_path),
+            )
+            self.assertFalse(second.evaluate(candidate).cached)
+            self.assertEqual(counter.read_text(encoding="utf-8"), "2")
+
+    def test_persistent_cache_invalidates_dependency_and_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            counter = root / "count"
+            cache_path = root / "predicate-cache.json"
+            dependency = root / "libamd_comgr.so"
+            dependency.write_bytes(b"build-one")
+            script = root / "predicate.py"
+            script.write_text(
+                textwrap.dedent(
+                    f"""
+                    import pathlib
+                    counter = pathlib.Path({str(counter)!r})
+                    count = int(counter.read_text()) if counter.exists() else 0
+                    counter.write_text(str(count + 1))
+                    raise SystemExit(0)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            candidate = self.make_candidate(root)
+
+            def make(cache_tag: str):
+                return self.make_runner(
+                    root,
+                    script,
+                    ["{input}"],
+                    cache=hotswap_reduce.PredicateCache(cache_path),
+                    cache_dependencies=[dependency],
+                    cache_tags=[cache_tag],
+                )
+
+            self.assertFalse(make("environment-one").evaluate(candidate).cached)
+            self.assertTrue(make("environment-one").evaluate(candidate).cached)
+            dependency.write_bytes(b"build-two")
+            self.assertFalse(make("environment-one").evaluate(candidate).cached)
+            self.assertFalse(make("environment-two").evaluate(candidate).cached)
+            self.assertEqual(counter.read_text(encoding="utf-8"), "3")
+
+    def test_changed_identity_during_run_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            dependency = root / "dependency"
+            dependency.write_bytes(b"one")
+            script = root / "predicate.py"
+            script.write_text("raise SystemExit(0)\n", encoding="utf-8")
+            runner = self.make_runner(
+                root,
+                script,
+                ["{input}"],
+                cache_dependencies=[dependency],
+            )
+            dependency.write_bytes(b"two")
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "identity changed"
+            ):
+                runner.evaluate(self.make_candidate(root))
+
+    def test_candidate_digest_does_not_reread_large_objects(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            candidate = self.make_candidate(root)
+            with mock.patch.object(
+                hotswap_reduce,
+                "sha256_file",
+                side_effect=AssertionError("unexpected object reread"),
+            ):
+                digest = candidate.digest()
+            self.assertRegex(digest, r"^[0-9a-f]{64}$")
+
+    def test_nonzero_exit_can_mean_interesting(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            script = root / "predicate.py"
+            script.write_text("raise SystemExit(17)\n", encoding="utf-8")
+            runner = self.make_runner(
+                root,
+                script,
+                ["{input}"],
+                interesting_exit_code=17,
+            )
+            result = runner.evaluate(self.make_candidate(root))
+            self.assertEqual(result.status, "interesting")
+            self.assertEqual(result.exit_codes, (17,))
+
+    def test_timeout_is_rejected_and_not_cached(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            script = root / "predicate.py"
+            script.write_text("import time\ntime.sleep(10)\n", encoding="utf-8")
+            runner = self.make_runner(
+                root,
+                script,
+                [],
+                timeout=0.02,
+            )
+            candidate = self.make_candidate(root)
+            first = runner.evaluate(candidate)
+            second = runner.evaluate(candidate)
+            self.assertEqual(first.status, "timeout")
+            self.assertEqual(second.status, "timeout")
+            self.assertFalse(second.cached)
+
+    def test_flaky_predicate_is_rejected_and_not_cached(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            counter = root / "count"
+            script = root / "predicate.py"
+            script.write_text(
+                textwrap.dedent(
+                    """
+                    import pathlib
+                    import sys
+                    path = pathlib.Path(sys.argv[1])
+                    count = int(path.read_text()) if path.exists() else 0
+                    path.write_text(str(count + 1))
+                    raise SystemExit(count % 2)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            runner = self.make_runner(
+                root,
+                script,
+                [str(counter)],
+                runs=2,
+            )
+            result = runner.evaluate(self.make_candidate(root))
+            self.assertEqual(result.status, "flaky")
+            self.assertFalse(result.cached)
+
+    def test_unknown_placeholder_fails_before_launch(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "unknown.*placeholder"
+            ):
+                hotswap_reduce.PredicateRunner(
+                    [sys.executable, "{unknown}"],
+                    0,
+                    1,
+                    1.0,
+                    root,
+                    hotswap_reduce.PredicateCache(None),
+                )
+
+    def test_regular_file_argv_is_resolved_before_workspace_change(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            script = root / "predicate.py"
+            script.write_text("raise SystemExit(0)\n", encoding="utf-8")
+            original_directory = Path.cwd()
+            try:
+                os.chdir(root)
+                runner = hotswap_reduce.PredicateRunner(
+                    [sys.executable, "predicate.py", "{input}"],
+                    0,
+                    1,
+                    5.0,
+                    root,
+                    hotswap_reduce.PredicateCache(None),
+                )
+            finally:
+                os.chdir(original_directory)
+            self.assertEqual(runner.argv_template[1], str(script.resolve()))
+            self.assertTrue(runner.evaluate(self.make_candidate(root)).interesting)
+
+    def test_input_placeholder_rejects_multi_object_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            one = self.make_candidate(root, b"one")
+            second_path = root / "second.co"
+            second_path.write_bytes(b"two")
+            two = hotswap_reduce.Candidate(
+                one.code_objects
+                + (
+                    hotswap_reduce.CodeObject(
+                        "second",
+                        second_path.name,
+                        second_path,
+                        hotswap_reduce.sha256_file(second_path),
+                    ),
+                ),
+                {},
+            )
+            script = root / "predicate.py"
+            script.write_text("raise SystemExit(0)\n", encoding="utf-8")
+            runner = self.make_runner(root, script, ["{input}"])
+            with self.assertRaisesRegex(hotswap_reduce.ReducerError, "exactly one"):
+                runner.evaluate(two)
+
+
+class FakeElfToolTests(unittest.TestCase):
+    def write_readobj(
+        self,
+        root: Path,
+        sections: list[tuple[str, bool]],
+        architecture: str = "amdgcn",
+    ) -> Path:
+        value = [
+            {
+                "FileSummary": {
+                    "Format": "elf64-amdgpu",
+                    "Arch": architecture,
+                },
+                "Sections": [
+                    {
+                        "Section": {
+                            "Name": {"Name": name},
+                            "Flags": {
+                                "Flags": ([{"Name": "SHF_ALLOC"}] if allocated else [])
+                            },
+                        }
+                    }
+                    for name, allocated in sections
+                ],
+            }
+        ]
+        return write_executable(
+            root / "fake readobj",
+            f"""
+            import json
+            print(json.dumps({value!r}))
+            """,
+        )
+
+    def write_objcopy(
+        self, root: Path, fail: bool = False, annotate: bool = False
+    ) -> Path:
+        return write_executable(
+            root / "fake objcopy",
+            f"""
+            import pathlib
+            import shutil
+            import sys
+            if {fail!r}:
+                print("intentional objcopy failure", file=sys.stderr)
+                raise SystemExit(4)
+            shutil.copyfile(pathlib.Path(sys.argv[-2]), pathlib.Path(sys.argv[-1]))
+            if {annotate!r}:
+                with pathlib.Path(sys.argv[-1]).open("ab") as stream:
+                    stream.write((" " + " ".join(sys.argv[1:-2])).encode())
+            """,
+        )
+
+    def test_policy_only_allows_nonallocated_unprotected_sections(self) -> None:
+        if os.name == "nt":
+            self.skipTest("executable script fixtures require a POSIX host")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            readobj = self.write_readobj(
+                root,
+                [
+                    ("", False),
+                    (".text", True),
+                    (".note", False),
+                    (".AMDGPU.config", False),
+                    (".debug_info", False),
+                    (".comment", False),
+                    (".allocated_debug", True),
+                ],
+            )
+            objcopy = self.write_objcopy(root)
+            tools = hotswap_reduce.ElfSectionTools(
+                str(readobj),
+                str(objcopy),
+                5.0,
+                ["*"],
+                [".comment"],
+                root / "artifacts",
+            )
+            tools.artifact_root.mkdir()
+            obj = root / "object.co"
+            obj.write_bytes(b"ELF")
+            self.assertEqual(tools.removable_sections(obj), [".debug_info"])
+
+    def test_missing_tool_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "could not find executable"
+            ):
+                hotswap_reduce.ElfSectionTools(
+                    str(root / "does-not-exist"),
+                    str(root / "also-missing"),
+                    1.0,
+                    ["*"],
+                    [],
+                    root,
+                )
+
+    def test_rejects_non_amdgpu_elf(self) -> None:
+        if os.name == "nt":
+            self.skipTest("executable script fixtures require a POSIX host")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            readobj = self.write_readobj(root, [(".debug_info", False)], "x86_64")
+            objcopy = self.write_objcopy(root)
+            artifacts = root / "artifacts"
+            artifacts.mkdir()
+            tools = hotswap_reduce.ElfSectionTools(
+                str(readobj),
+                str(objcopy),
+                5.0,
+                ["*"],
+                [],
+                artifacts,
+            )
+            obj = root / "object.co"
+            obj.write_bytes(b"ELF")
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "requires an AMDGPU ELF"
+            ):
+                tools.removable_sections(obj)
+
+    def test_objcopy_failure_does_not_replace_input(self) -> None:
+        if os.name == "nt":
+            self.skipTest("executable script fixtures require a POSIX host")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            readobj = self.write_readobj(root, [(".debug_info", False)])
+            objcopy = self.write_objcopy(root, fail=True)
+            artifacts = root / "artifacts"
+            artifacts.mkdir()
+            tools = hotswap_reduce.ElfSectionTools(
+                str(readobj),
+                str(objcopy),
+                5.0,
+                [".debug_*"],
+                [],
+                artifacts,
+            )
+            path = root / "object.co"
+            path.write_bytes(b"original")
+            code_object = hotswap_reduce.CodeObject(
+                "id", path.name, path, hotswap_reduce.sha256_file(path)
+            )
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "intentional objcopy failure"
+            ):
+                tools.remove_sections(code_object, [".debug_info"])
+            self.assertEqual(path.read_bytes(), b"original")
+            self.assertEqual(list(artifacts.iterdir()), [])
+
+    def test_malformed_readobj_json_is_reported(self) -> None:
+        if os.name == "nt":
+            self.skipTest("executable script fixtures require a POSIX host")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            readobj = write_executable(root / "fake readobj", "print('not json')\n")
+            objcopy = self.write_objcopy(root)
+            artifacts = root / "artifacts"
+            artifacts.mkdir()
+            tools = hotswap_reduce.ElfSectionTools(
+                str(readobj),
+                str(objcopy),
+                5.0,
+                ["*"],
+                [],
+                artifacts,
+            )
+            path = root / "object.co"
+            path.write_bytes(b"ELF")
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "malformed section JSON"
+            ):
+                tools.removable_sections(path)
+
+
+class EndToEndTests(unittest.TestCase):
+    def test_reduces_bundle_and_metadata_and_writes_reproducer(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(
+                root,
+                [b"drop", b"KEEP", b"also-drop"],
+                {
+                    "kernels": ["drop", "kernel-keep"],
+                    "cases": [
+                        {"name": "drop", "arguments": ["drop"]},
+                        {
+                            "name": "case-keep",
+                            "arguments": ["drop", "arg-keep"],
+                        },
+                    ],
+                    "arguments": ["drop", "global-keep"],
+                },
+            )
+            predicate = root / "predicate.py"
+            predicate.write_text(
+                textwrap.dedent(
+                    """
+                    import json
+                    import pathlib
+                    import sys
+                    bundle_path = pathlib.Path(sys.argv[1])
+                    value = json.loads(bundle_path.read_text())
+                    root = bundle_path.parent
+                    object_data = b"".join(
+                        (root / item["path"]).read_bytes()
+                        for item in value["code_objects"]
+                    )
+                    metadata = json.loads((root / value["metadata"]).read_text())
+                    text = json.dumps(metadata)
+                    interesting = (
+                        b"KEEP" in object_data
+                        and "kernel-keep" in text
+                        and "case-keep" in text
+                        and "arg-keep" in text
+                        and "global-keep" in text
+                    )
+                    raise SystemExit(0 if interesting else 1)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            output = root / "reduced output [x]"
+            args = make_args(
+                bundle,
+                output,
+                sys.executable,
+                [str(predicate), "{bundle}"],
+            )
+            final, log = hotswap_reduce.run_from_arguments(args)
+            self.assertEqual(
+                [item.path.read_bytes() for item in final.code_objects],
+                [b"KEEP"],
+            )
+            self.assertEqual(final.metadata["kernels"], ["kernel-keep"])
+            self.assertEqual(
+                [case["name"] for case in final.metadata["cases"]],
+                ["case-keep"],
+            )
+            self.assertEqual(final.metadata["cases"][0]["arguments"], ["arg-keep"])
+            self.assertEqual(final.metadata["arguments"], ["global-keep"])
+            self.assertEqual(log["format"], hotswap_reduce.LOG_FORMAT)
+            self.assertEqual(log["version"], 1)
+            self.assertTrue(log["transformations"])
+            self.assertTrue(any(item["accepted"] for item in log["transformations"]))
+            published_log = json.loads(
+                (output / "reduction-log.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(published_log, log)
+            self.assertEqual(published_log["reproduction"]["argv"][-1], "bundle.json")
+
+    def test_deterministic_output_and_log(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(
+                root,
+                [b"drop", b"keep"],
+                {"cases": ["drop", "keep"]},
+            )
+            predicate = root / "predicate.py"
+            predicate.write_text(
+                textwrap.dedent(
+                    """
+                    import pathlib
+                    import sys
+                    raise SystemExit(
+                        0 if b"keep" in pathlib.Path(sys.argv[1]).read_bytes()
+                        else 1
+                    )
+                    """
+                ),
+                encoding="utf-8",
+            )
+            logs = []
+            bundles = []
+            for index in range(2):
+                output = root / f"out-{index}"
+                args = make_args(
+                    bundle,
+                    output,
+                    sys.executable,
+                    [str(predicate), "{metadata}"],
+                )
+                _, log = hotswap_reduce.run_from_arguments(args)
+                logs.append(log)
+                bundles.append(
+                    (output / "bundle.json").read_bytes()
+                    + (output / "metadata.json").read_bytes()
+                )
+            self.assertEqual(logs[0], logs[1])
+            self.assertEqual(bundles[0], bundles[1])
+
+    def test_offline_reference_manifest_differential(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(
+                root,
+                [b"same-a", b"candidate-differs", b"same-b"],
+                {"cases": ["a", "discrepant-case", "b"]},
+            )
+            reference = root / "pr3598-reference.json"
+            reference.write_text(
+                json.dumps({"forbidden_sha256": "unused"}),
+                encoding="utf-8",
+            )
+            predicate = root / "offline-diff.py"
+            predicate.write_text(
+                textwrap.dedent(
+                    """
+                    import json
+                    import pathlib
+                    import sys
+                    reference = json.loads(pathlib.Path(sys.argv[1]).read_text())
+                    bundle_path = pathlib.Path(sys.argv[2])
+                    bundle = json.loads(bundle_path.read_text())
+                    root = bundle_path.parent
+                    objects = [
+                        (root / entry["path"]).read_bytes()
+                        for entry in bundle["code_objects"]
+                    ]
+                    metadata = json.loads((root / bundle["metadata"]).read_text())
+                    difference = (
+                        b"candidate-differs" in objects
+                        and "discrepant-case" in metadata.get("cases", [])
+                        and "forbidden_sha256" in reference
+                    )
+                    raise SystemExit(0 if difference else 1)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            output = root / "reduced-offline-difference"
+            args = make_args(
+                bundle,
+                output,
+                sys.executable,
+                [str(predicate), str(reference), "{bundle}"],
+                predicate_runs=2,
+            )
+            final, _ = hotswap_reduce.run_from_arguments(args)
+            self.assertEqual(
+                [item.path.read_bytes() for item in final.code_objects],
+                [b"candidate-differs"],
+            )
+            self.assertEqual(final.metadata["cases"], ["discrepant-case"])
+
+    def test_section_reduction_with_fake_llvm_tools(self) -> None:
+        if os.name == "nt":
+            self.skipTest("executable script fixtures require a POSIX host")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(root, [b"ELF"], {})
+            fixture = FakeElfToolTests()
+            readobj = fixture.write_readobj(
+                root,
+                [
+                    ("", False),
+                    (".text", True),
+                    (".debug_info", False),
+                    (".note", False),
+                ],
+            )
+            objcopy = fixture.write_objcopy(root, annotate=True)
+            predicate = root / "predicate.py"
+            predicate.write_text("raise SystemExit(0)\n", encoding="utf-8")
+            output = root / "output"
+            args = make_args(
+                bundle,
+                output,
+                sys.executable,
+                [str(predicate), "{input}"],
+                allow_remove_section=["*"],
+                readobj=str(readobj),
+                objcopy=str(objcopy),
+            )
+            final, log = hotswap_reduce.run_from_arguments(args)
+            self.assertIn(
+                b"--remove-section=.debug_info",
+                final.code_objects[0].path.read_bytes(),
+            )
+            accepted_sections = [
+                item["transformation"]["remove_sections"]
+                for item in log["transformations"]
+                if item["pass"] == "elf-sections" and item["accepted"]
+            ]
+            self.assertEqual(accepted_sections, [[".debug_info"]])
+
+    def test_unsupported_section_format_publishes_nothing(self) -> None:
+        if os.name == "nt":
+            self.skipTest("executable script fixtures require a POSIX host")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(root, [b"ELF"], {})
+            fixture = FakeElfToolTests()
+            readobj = fixture.write_readobj(
+                root, [(".debug_info", False)], architecture="x86_64"
+            )
+            objcopy = fixture.write_objcopy(root)
+            predicate = root / "predicate.py"
+            predicate.write_text("raise SystemExit(0)\n", encoding="utf-8")
+            output = root / "output"
+            args = make_args(
+                bundle,
+                output,
+                sys.executable,
+                [str(predicate), "{input}"],
+                allow_remove_section=[".debug_*"],
+                readobj=str(readobj),
+                objcopy=str(objcopy),
+            )
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "requires an AMDGPU ELF"
+            ):
+                hotswap_reduce.run_from_arguments(args)
+            self.assertFalse(output.exists())
+
+    def test_existing_output_is_never_overwritten(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(root, [b"original"], {})
+            output = root / "output"
+            output.mkdir()
+            marker = output / "marker"
+            marker.write_bytes(b"preserve")
+            args = make_args(
+                bundle,
+                output,
+                sys.executable,
+                ["-c", "raise SystemExit(0)", "{bundle}"],
+            )
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "refusing to overwrite"
+            ):
+                hotswap_reduce.run_from_arguments(args)
+            self.assertEqual(marker.read_bytes(), b"preserve")
+
+    def test_cache_cannot_overwrite_input_or_live_inside_output(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(root, [b"original"], {})
+            object_path = root / "object-0.co"
+            predicate = root / "predicate.py"
+            predicate.write_text("raise SystemExit(0)\n", encoding="utf-8")
+            output = root / "output"
+            for cache_path in (object_path, output / "cache.json", predicate):
+                args = make_args(
+                    bundle,
+                    output,
+                    sys.executable,
+                    [str(predicate), "{bundle}"],
+                    cache_file=cache_path,
+                )
+                with self.assertRaisesRegex(
+                    hotswap_reduce.ReducerError,
+                    r"refusing to overwrite|must not be inside",
+                ):
+                    hotswap_reduce.run_from_arguments(args)
+                self.assertFalse(output.exists())
+                self.assertEqual(object_path.read_bytes(), b"original")
+                self.assertEqual(
+                    predicate.read_text(encoding="utf-8"),
+                    "raise SystemExit(0)\n",
+                )
+
+    def test_interruption_publishes_nothing_and_preserves_original(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(root, [b"one", b"two"], {})
+            output = root / "output"
+            args = make_args(
+                bundle,
+                output,
+                sys.executable,
+                ["-c", "raise SystemExit(0)", "{bundle}"],
+            )
+            interesting = hotswap_reduce.PredicateResult("interesting", (0,), "", "")
+            with mock.patch.object(
+                hotswap_reduce.PredicateRunner,
+                "evaluate",
+                side_effect=[interesting, KeyboardInterrupt()],
+            ):
+                with self.assertRaises(KeyboardInterrupt):
+                    hotswap_reduce.run_from_arguments(args)
+            self.assertFalse(output.exists())
+            self.assertEqual((root / "object-0.co").read_bytes(), b"one")
+            self.assertEqual((root / "object-1.co").read_bytes(), b"two")
+
+    def test_publish_interruption_rolls_back_temporary_output(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(root, [b"original"], {})
+            candidate = hotswap_reduce.load_bundle(bundle)
+            output = root / "published"
+            real_replace = os.replace
+
+            def replace_or_interrupt(
+                source: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+                destination: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+            ) -> None:
+                if Path(os.fsdecode(destination)) == output:
+                    raise KeyboardInterrupt()
+                real_replace(source, destination)
+
+            with mock.patch.object(
+                hotswap_reduce.os,
+                "replace",
+                side_effect=replace_or_interrupt,
+            ):
+                with self.assertRaises(KeyboardInterrupt):
+                    hotswap_reduce.atomic_publish(
+                        output,
+                        candidate,
+                        {"format": "test", "version": 1},
+                    )
+            self.assertFalse(output.exists())
+            self.assertEqual((root / "object-0.co").read_bytes(), b"original")
+            temporary_outputs = list(root.glob(".published.*"))
+            self.assertEqual(temporary_outputs, [])
+
+    def test_uninteresting_original_publishes_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(root, [b"object"], {})
+            predicate = root / "predicate.py"
+            predicate.write_text("raise SystemExit(1)\n", encoding="utf-8")
+            output = root / "output"
+            args = make_args(
+                bundle,
+                output,
+                sys.executable,
+                [str(predicate), "{bundle}"],
+            )
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "original input is not"
+            ):
+                hotswap_reduce.run_from_arguments(args)
+            self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/amd/comgr/test/utils/test_hotswap_reduce.py
+++ b/amd/comgr/test/utils/test_hotswap_reduce.py
@@ -255,7 +255,15 @@ class BundleValidationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as name:
             root = Path(name)
             first = root / "object with spaces.co"
-            second = root / "object\nwith-newline.co"
+            # Windows rejects control characters in file names.  Preserve the
+            # newline-path coverage where the host permits it while still
+            # exercising NUL-delimited parsing on every platform.
+            second_name = (
+                "object;with-semicolon.co"
+                if os.name == "nt"
+                else "object\nwith-newline.co"
+            )
+            second = root / second_name
             first.write_bytes(b"first")
             second.write_bytes(b"second")
             worklist = root / "selected.list"

--- a/amd/comgr/test/utils/test_hotswap_reduce.py
+++ b/amd/comgr/test/utils/test_hotswap_reduce.py
@@ -11,6 +11,7 @@ import stat
 import sys
 import tempfile
 import textwrap
+import time
 import unittest
 from pathlib import Path
 from typing import Optional, Union
@@ -120,6 +121,21 @@ class DdminTests(unittest.TestCase):
         )
         self.assertEqual(result, ["x"])
 
+    def test_exhaustive_monotone_predicates_are_one_minimal(self) -> None:
+        for size in range(7):
+            items = list(range(size))
+            for required_bits in range(1 << size):
+                required = {item for item in items if required_bits & (1 << item)}
+                result = hotswap_reduce.ddmin(
+                    items,
+                    lambda kept, removed, required=required: required.issubset(kept),
+                )
+                self.assertEqual(set(result), required)
+                for index in range(len(result)):
+                    self.assertFalse(
+                        required.issubset(result[:index] + result[index + 1 :])
+                    )
+
 
 class BundleValidationTests(unittest.TestCase):
     def test_rejects_malformed_metadata_list(self) -> None:
@@ -152,6 +168,51 @@ class BundleValidationTests(unittest.TestCase):
             ):
                 hotswap_reduce.load_bundle(path)
 
+    def test_bundle_paths_cannot_escape_bundle_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle_root = root / "bundle"
+            bundle_root.mkdir()
+            outside = root / "outside.co"
+            outside.write_bytes(b"outside")
+            bundle = {
+                "format": hotswap_reduce.BUNDLE_FORMAT,
+                "version": 1,
+                "code_objects": [{"id": "outside", "path": "../outside.co"}],
+            }
+            bundle_path = bundle_root / "bundle.json"
+            bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+            with self.assertRaisesRegex(hotswap_reduce.ReducerError, "escapes"):
+                hotswap_reduce.load_bundle(bundle_path)
+            bundle["code_objects"][0]["path"] = str(outside)
+            bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "must be relative"
+            ):
+                hotswap_reduce.load_bundle(bundle_path)
+
+    def test_bundle_symlinks_cannot_escape_bundle_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle_root = root / "bundle"
+            bundle_root.mkdir()
+            outside = root / "outside.co"
+            outside.write_bytes(b"outside")
+            link = bundle_root / "linked.co"
+            try:
+                link.symlink_to(outside)
+            except OSError as error:
+                self.skipTest(f"symlinks unavailable: {error}")
+            bundle = {
+                "format": hotswap_reduce.BUNDLE_FORMAT,
+                "version": 1,
+                "code_objects": [{"id": "outside", "path": link.name}],
+            }
+            bundle_path = bundle_root / "bundle.json"
+            bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+            with self.assertRaisesRegex(hotswap_reduce.ReducerError, "escapes"):
+                hotswap_reduce.load_bundle(bundle_path)
+
     def test_rejects_non_finite_json(self) -> None:
         with tempfile.TemporaryDirectory() as name:
             path = Path(name) / "bundle.json"
@@ -178,6 +239,17 @@ class BundleValidationTests(unittest.TestCase):
                 )
                 relative = output_bundle["code_objects"][0]["path"]
                 self.assertEqual((output / relative).read_bytes(), b"one")
+
+    def test_materialization_rejects_changed_source_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(root, [b"original"], {})
+            candidate = hotswap_reduce.load_bundle(bundle)
+            candidate.code_objects[0].path.write_bytes(b"changed")
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "changed while materializing"
+            ):
+                hotswap_reduce.materialize_candidate(candidate, root / "candidate")
 
     def test_loads_inventory_nul_worklist_and_selector_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as name:
@@ -342,6 +414,64 @@ class PredicateTests(unittest.TestCase):
             self.assertEqual(cache["format"], hotswap_reduce.CACHE_FORMAT)
             self.assertEqual(cache["version"], 1)
 
+    def test_cached_and_uncached_results_are_equivalent(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            cache_path = root / "predicate-cache.json"
+            script = root / "predicate.py"
+            script.write_text(
+                "print('stable output')\n"
+                "print('stable error', file=__import__('sys').stderr)\n"
+                "raise SystemExit(7)\n",
+                encoding="utf-8",
+            )
+            candidate = self.make_candidate(root)
+            runner = self.make_runner(
+                root,
+                script,
+                ["{input}"],
+                interesting_exit_code=7,
+                runs=2,
+                cache=hotswap_reduce.PredicateCache(cache_path),
+            )
+            uncached = runner.evaluate(candidate)
+            cached = runner.evaluate(candidate)
+            self.assertFalse(uncached.cached)
+            self.assertTrue(cached.cached)
+            self.assertEqual(uncached.status, cached.status)
+            self.assertEqual(uncached.exit_codes, cached.exit_codes)
+            self.assertEqual(uncached.stdout, cached.stdout)
+            self.assertEqual(uncached.stderr, cached.stderr)
+            self.assertEqual(uncached.for_log(), cached.for_log())
+            self.assertNotIn("cached", cached.for_log())
+
+    def test_corrupt_matching_cache_entry_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            cache_path = root / "predicate-cache.json"
+            script = root / "predicate.py"
+            script.write_text("raise SystemExit(0)\n", encoding="utf-8")
+            candidate = self.make_candidate(root)
+            runner = self.make_runner(
+                root,
+                script,
+                ["{input}"],
+                cache=hotswap_reduce.PredicateCache(cache_path),
+            )
+            runner.evaluate(candidate)
+            cache = json.loads(cache_path.read_text(encoding="utf-8"))
+            entry = next(iter(cache["entries"].values()))
+            entry["exit_codes"] = []
+            cache_path.write_text(json.dumps(cache), encoding="utf-8")
+            recreated = self.make_runner(
+                root,
+                script,
+                ["{input}"],
+                cache=hotswap_reduce.PredicateCache(cache_path),
+            )
+            with self.assertRaisesRegex(hotswap_reduce.ReducerError, "corrupt entry"):
+                recreated.evaluate(candidate)
+
     def test_persistent_cache_invalidates_changed_predicate_script(self) -> None:
         with tempfile.TemporaryDirectory() as name:
             root = Path(name)
@@ -441,6 +571,33 @@ class PredicateTests(unittest.TestCase):
             ):
                 runner.evaluate(self.make_candidate(root))
 
+    def test_changed_identity_mode_invalidates_cached_result(self) -> None:
+        if os.name == "nt":
+            self.skipTest("POSIX executable-mode semantics")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            executable = write_executable(
+                root / "predicate",
+                """
+                raise SystemExit(0)
+                """,
+            )
+            candidate = self.make_candidate(root)
+            runner = hotswap_reduce.PredicateRunner(
+                [str(executable), "{input}"],
+                0,
+                1,
+                5.0,
+                root,
+                hotswap_reduce.PredicateCache(None),
+            )
+            self.assertFalse(runner.evaluate(candidate).cached)
+            executable.chmod(executable.stat().st_mode & ~stat.S_IXUSR)
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "identity changed"
+            ):
+                runner.evaluate(candidate)
+
     def test_candidate_digest_does_not_reread_large_objects(self) -> None:
         with tempfile.TemporaryDirectory() as name:
             root = Path(name)
@@ -514,6 +671,96 @@ class PredicateTests(unittest.TestCase):
             self.assertEqual(result.status, "flaky")
             self.assertFalse(result.cached)
 
+    def test_different_noninteresting_exit_codes_are_flaky(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            counter = root / "count"
+            script = root / "predicate.py"
+            script.write_text(
+                textwrap.dedent(
+                    """
+                    import pathlib
+                    import sys
+                    path = pathlib.Path(sys.argv[1])
+                    count = int(path.read_text()) if path.exists() else 0
+                    path.write_text(str(count + 1))
+                    raise SystemExit(1 + count % 2)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            runner = self.make_runner(root, script, [str(counter)], runs=2)
+            result = runner.evaluate(self.make_candidate(root))
+            self.assertEqual(result.status, "flaky")
+            self.assertEqual(result.exit_codes, (1, 2))
+            self.assertFalse(result.cached)
+
+    def test_timeout_terminates_predicate_descendants(self) -> None:
+        if os.name == "nt":
+            self.skipTest("POSIX process-group behavior")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            marker = root / "descendant-ran"
+            child_code = (
+                "import pathlib,time;"
+                "time.sleep(0.3);"
+                f"pathlib.Path({str(marker)!r}).write_text('leaked')"
+            )
+            script = root / "predicate.py"
+            script.write_text(
+                "import subprocess,sys,time\n"
+                f"subprocess.Popen([sys.executable, '-c', {child_code!r}])\n"
+                "time.sleep(10)\n",
+                encoding="utf-8",
+            )
+            runner = self.make_runner(root, script, [], timeout=0.05)
+            result = runner.evaluate(self.make_candidate(root))
+            self.assertEqual(result.status, "timeout")
+            time.sleep(0.5)
+            self.assertFalse(marker.exists())
+
+    def test_completed_predicate_does_not_leave_descendants(self) -> None:
+        if os.name == "nt":
+            self.skipTest("POSIX process-group behavior")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            marker = root / "descendant-ran"
+            child_code = (
+                "import pathlib,time;"
+                "time.sleep(0.3);"
+                f"pathlib.Path({str(marker)!r}).write_text('leaked')"
+            )
+            script = root / "predicate.py"
+            script.write_text(
+                "import subprocess,sys\n"
+                f"subprocess.Popen([sys.executable, '-c', {child_code!r}])\n"
+                "raise SystemExit(0)\n",
+                encoding="utf-8",
+            )
+            runner = self.make_runner(root, script, [])
+            result = runner.evaluate(self.make_candidate(root))
+            self.assertTrue(result.interesting)
+            time.sleep(0.5)
+            self.assertFalse(marker.exists())
+
+    def test_capture_is_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            script = root / "predicate.py"
+            script.write_text(
+                f"print('x' * {hotswap_reduce.CAPTURE_LIMIT * 100})\n"
+                "raise SystemExit(0)\n",
+                encoding="utf-8",
+            )
+            runner = self.make_runner(root, script, [])
+            result = runner.evaluate(self.make_candidate(root))
+            self.assertTrue(result.interesting)
+            self.assertLessEqual(
+                len(result.stdout),
+                hotswap_reduce.CAPTURE_LIMIT + len("\n<truncated>"),
+            )
+            self.assertTrue(result.stdout.endswith("\n<truncated>"))
+
     def test_unknown_placeholder_fails_before_launch(self) -> None:
         with tempfile.TemporaryDirectory() as name:
             root = Path(name)
@@ -574,6 +821,22 @@ class PredicateTests(unittest.TestCase):
             with self.assertRaisesRegex(hotswap_reduce.ReducerError, "exactly one"):
                 runner.evaluate(two)
 
+    def test_nonfinite_timeouts_are_rejected_by_argument_parser(self) -> None:
+        parser = hotswap_reduce.make_argument_parser()
+        base_arguments = [
+            "--code-object",
+            "input.co",
+            "--output",
+            "output",
+            "--predicate",
+            "predicate",
+        ]
+        for option in ("--timeout", "--tool-timeout"):
+            for value in ("nan", "inf", "-inf", "0", "-1"):
+                with mock.patch("sys.stderr"):
+                    with self.assertRaises(SystemExit):
+                        parser.parse_args(base_arguments + [option, value])
+
 
 class FakeElfToolTests(unittest.TestCase):
     def write_readobj(
@@ -582,35 +845,49 @@ class FakeElfToolTests(unittest.TestCase):
         sections: list[tuple[str, bool]],
         architecture: str = "amdgcn",
     ) -> Path:
-        value = [
-            {
-                "FileSummary": {
-                    "Format": "elf64-amdgpu",
-                    "Arch": architecture,
-                },
-                "Sections": [
-                    {
-                        "Section": {
-                            "Name": {"Name": name},
-                            "Flags": {
-                                "Flags": ([{"Name": "SHF_ALLOC"}] if allocated else [])
-                            },
-                        }
-                    }
-                    for name, allocated in sections
-                ],
-            }
-        ]
         return write_executable(
             root / "fake readobj",
             f"""
             import json
-            print(json.dumps({value!r}))
+            import pathlib
+            import sys
+            sections = {sections!r}
+            contents = pathlib.Path(sys.argv[-1]).read_bytes().decode(
+                "utf-8", errors="ignore"
+            )
+            removed = {{
+                word.split("=", 1)[1]
+                for word in contents.split()
+                if word.startswith("--remove-section=")
+            }}
+            value = [{{
+                "FileSummary": {{
+                    "Format": "elf64-amdgpu",
+                    "Arch": {architecture!r},
+                }},
+                "Sections": [
+                    {{
+                        "Section": {{
+                            "Name": {{"Name": name}},
+                            "Flags": {{
+                                "Flags": ([{{"Name": "SHF_ALLOC"}}] if allocated else [])
+                            }},
+                        }}
+                    }}
+                    for name, allocated in sections
+                    if name not in removed
+                ],
+            }}]
+            print(json.dumps(value))
             """,
         )
 
     def write_objcopy(
-        self, root: Path, fail: bool = False, annotate: bool = False
+        self,
+        root: Path,
+        fail: bool = False,
+        annotate: bool = False,
+        extra_removal: Optional[str] = None,
     ) -> Path:
         return write_executable(
             root / "fake objcopy",
@@ -625,6 +902,9 @@ class FakeElfToolTests(unittest.TestCase):
             if {annotate!r}:
                 with pathlib.Path(sys.argv[-1]).open("ab") as stream:
                     stream.write((" " + " ".join(sys.argv[1:-2])).encode())
+            if {extra_removal!r} is not None:
+                with pathlib.Path(sys.argv[-1]).open("ab") as stream:
+                    stream.write((" --remove-section=" + {extra_removal!r}).encode())
             """,
         )
 
@@ -640,6 +920,8 @@ class FakeElfToolTests(unittest.TestCase):
                     (".text", True),
                     (".note", False),
                     (".AMDGPU.config", False),
+                    (".rela.debug_info", False),
+                    (".group", False),
                     (".debug_info", False),
                     (".comment", False),
                     (".allocated_debug", True),
@@ -658,6 +940,33 @@ class FakeElfToolTests(unittest.TestCase):
             obj = root / "object.co"
             obj.write_bytes(b"ELF")
             self.assertEqual(tools.removable_sections(obj), [".debug_info"])
+
+    def test_duplicate_name_is_protected_if_any_instance_is_allocated(self) -> None:
+        if os.name == "nt":
+            self.skipTest("executable script fixtures require a POSIX host")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            readobj = self.write_readobj(
+                root,
+                [
+                    (".debug_duplicate", False),
+                    (".debug_duplicate", True),
+                    (".debug_safe", False),
+                ],
+            )
+            objcopy = self.write_objcopy(root)
+            tools = hotswap_reduce.ElfSectionTools(
+                str(readobj),
+                str(objcopy),
+                5.0,
+                [".debug_*"],
+                [],
+                root / "artifacts",
+            )
+            tools.artifact_root.mkdir()
+            obj = root / "object.co"
+            obj.write_bytes(b"ELF")
+            self.assertEqual(tools.removable_sections(obj), [".debug_safe"])
 
     def test_missing_tool_is_reported(self) -> None:
         with tempfile.TemporaryDirectory() as name:
@@ -750,6 +1059,68 @@ class FakeElfToolTests(unittest.TestCase):
                 hotswap_reduce.ReducerError, "malformed section JSON"
             ):
                 tools.removable_sections(path)
+
+    def test_objcopy_output_must_remove_requested_sections(self) -> None:
+        if os.name == "nt":
+            self.skipTest("executable script fixtures require a POSIX host")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            readobj = self.write_readobj(root, [(".debug_info", False)])
+            objcopy = self.write_objcopy(root)
+            artifacts = root / "artifacts"
+            artifacts.mkdir()
+            tools = hotswap_reduce.ElfSectionTools(
+                str(readobj),
+                str(objcopy),
+                5.0,
+                [".debug_*"],
+                [],
+                artifacts,
+            )
+            path = root / "object.co"
+            path.write_bytes(b"ELF")
+            code_object = hotswap_reduce.CodeObject(
+                "id", path.name, path, hotswap_reduce.sha256_file(path)
+            )
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "requested sections remain"
+            ):
+                tools.remove_sections(code_object, [".debug_info"])
+            self.assertEqual(list(artifacts.iterdir()), [])
+
+    def test_objcopy_output_must_preserve_unrequested_sections(self) -> None:
+        if os.name == "nt":
+            self.skipTest("executable script fixtures require a POSIX host")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            readobj = self.write_readobj(
+                root,
+                [
+                    (".debug_info", False),
+                    (".comment", False),
+                ],
+            )
+            objcopy = self.write_objcopy(root, annotate=True, extra_removal=".comment")
+            artifacts = root / "artifacts"
+            artifacts.mkdir()
+            tools = hotswap_reduce.ElfSectionTools(
+                str(readobj),
+                str(objcopy),
+                5.0,
+                [".debug_info"],
+                [],
+                artifacts,
+            )
+            path = root / "object.co"
+            path.write_bytes(b"ELF")
+            code_object = hotswap_reduce.CodeObject(
+                "id", path.name, path, hotswap_reduce.sha256_file(path)
+            )
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "unrequested sections disappeared"
+            ):
+                tools.remove_sections(code_object, [".debug_info"])
+            self.assertEqual(list(artifacts.iterdir()), [])
 
 
 class EndToEndTests(unittest.TestCase):
@@ -923,6 +1294,53 @@ class EndToEndTests(unittest.TestCase):
             )
             self.assertEqual(final.metadata["cases"], ["discrepant-case"])
 
+    def test_repeats_hierarchical_passes_to_a_fixpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(
+                root,
+                [b"A", b"B"],
+                {"arguments": ["X", "Y"]},
+            )
+            predicate = root / "nonmonotone-predicate.py"
+            predicate.write_text(
+                textwrap.dedent(
+                    """
+                    import json
+                    import pathlib
+                    import sys
+                    bundle_path = pathlib.Path(sys.argv[1])
+                    bundle = json.loads(bundle_path.read_text())
+                    root = bundle_path.parent
+                    objects = {
+                        (root / entry["path"]).read_bytes().decode()
+                        for entry in bundle["code_objects"]
+                    }
+                    metadata = json.loads((root / bundle["metadata"]).read_text())
+                    arguments = metadata["arguments"]
+                    interesting = (
+                        (objects == {"A", "B"} and arguments in (["X", "Y"], ["X"]))
+                        or (objects == {"A"} and arguments == ["X"])
+                    )
+                    raise SystemExit(0 if interesting else 1)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            output = root / "reduced"
+            args = make_args(
+                bundle,
+                output,
+                sys.executable,
+                [str(predicate), "{bundle}"],
+            )
+            final, _ = hotswap_reduce.run_from_arguments(args)
+            self.assertEqual(
+                [item.path.read_bytes() for item in final.code_objects],
+                [b"A"],
+            )
+            self.assertEqual(final.metadata["arguments"], ["X"])
+
     def test_section_reduction_with_fake_llvm_tools(self) -> None:
         if os.name == "nt":
             self.skipTest("executable script fixtures require a POSIX host")
@@ -1040,6 +1458,74 @@ class EndToEndTests(unittest.TestCase):
                     predicate.read_text(encoding="utf-8"),
                     "raise SystemExit(0)\n",
                 )
+
+    def test_cache_cannot_overwrite_external_bundle_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            external_metadata = root / "metadata.json"
+            external_metadata.write_text(
+                json.dumps(
+                    {
+                        "format": hotswap_reduce.CACHE_FORMAT,
+                        "version": hotswap_reduce.CACHE_VERSION,
+                        "entries": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            original_metadata = external_metadata.read_bytes()
+            bundle = write_bundle(root, [b"object"], external_metadata.name)
+            predicate = root / "predicate.py"
+            predicate.write_text("raise SystemExit(0)\n", encoding="utf-8")
+            args = make_args(
+                bundle,
+                root / "output",
+                sys.executable,
+                [str(predicate), "{bundle}"],
+                cache_file=external_metadata,
+            )
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "overwrite reducer input"
+            ):
+                hotswap_reduce.run_from_arguments(args)
+            self.assertEqual(external_metadata.read_bytes(), original_metadata)
+
+    def test_identity_change_during_reduction_aborts_without_output(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            bundle = write_bundle(root, [b"one", b"two"], {})
+            dependency = root / "dependency"
+            dependency.write_bytes(b"original")
+            counter = root / "counter"
+            predicate = root / "predicate.py"
+            predicate.write_text(
+                textwrap.dedent(
+                    f"""
+                    import pathlib
+                    counter = pathlib.Path({str(counter)!r})
+                    dependency = pathlib.Path({str(dependency)!r})
+                    count = int(counter.read_text()) if counter.exists() else 0
+                    counter.write_text(str(count + 1))
+                    if count == 1:
+                        dependency.write_bytes(b"changed")
+                    raise SystemExit(0)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            output = root / "output"
+            args = make_args(
+                bundle,
+                output,
+                sys.executable,
+                [str(predicate), "{bundle}"],
+                cache_dependency=[dependency],
+            )
+            with self.assertRaisesRegex(
+                hotswap_reduce.ReducerError, "identity changed"
+            ):
+                hotswap_reduce.run_from_arguments(args)
+            self.assertFalse(output.exists())
 
     def test_interruption_publishes_nothing_and_preserves_original(self) -> None:
         with tempfile.TemporaryDirectory() as name:

--- a/amd/comgr/utils/hotswap/hotswap_reduce.py
+++ b/amd/comgr/utils/hotswap/hotswap_reduce.py
@@ -1,0 +1,1461 @@
+#!/usr/bin/env python3
+"""Reduce a hotswap corpus failure while preserving an external predicate.
+
+The reducer treats the interestingness command as an argv vector. It never
+passes user input through a shell.  See ``docs/HotswapReduce.md`` for the
+bundle schema and examples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence
+
+
+BUNDLE_FORMAT = "comgr-hotswap-reducer-bundle"
+BUNDLE_VERSION = 1
+LOG_FORMAT = "comgr-hotswap-reduction-log"
+LOG_VERSION = 1
+CACHE_FORMAT = "comgr-hotswap-reduction-cache"
+CACHE_VERSION = 1
+
+KNOWN_PLACEHOLDERS = ("{bundle}", "{input}", "{metadata}", "{workspace}")
+DEFAULT_PROTECTED_SECTIONS = (
+    "",
+    ".text",
+    ".note",
+    ".note.*",
+    ".symtab",
+    ".dynsym",
+    ".strtab",
+    ".dynstr",
+    ".shstrtab",
+    ".rodata",
+    ".data",
+    ".bss",
+    ".dynamic",
+    ".AMDGPU.*",
+)
+CAPTURE_LIMIT = 4096
+
+
+class ReducerError(Exception):
+    """A user-facing, fail-safe reduction error."""
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON number {value!r} is not supported")
+
+
+def load_json(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            return json.load(stream, parse_constant=_reject_json_constant)
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        raise ReducerError(f"{path}: malformed JSON: {error}") from error
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    try:
+        text = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as error:
+        raise ReducerError(f"value is not canonical JSON: {error}") from error
+    return text.encode("ascii")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            while True:
+                chunk = stream.read(1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except OSError as error:
+        raise ReducerError(f"could not hash {path}: {error}") from error
+    return digest.hexdigest()
+
+
+def atomic_write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(canonical_json_bytes(value))
+            stream.write(b"\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, path)
+    except BaseException:
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _safe_component(value: str) -> str:
+    component = re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("._")
+    return component[:80] or "object"
+
+
+def _object_output_name(index: int, object_id: str, original_name: str) -> str:
+    return f"{index:04d}-{_safe_component(object_id)}-{_safe_component(original_name)}"
+
+
+@dataclass(frozen=True)
+class CodeObject:
+    object_id: str
+    original_name: str
+    path: Path
+    original_sha256: str
+    content_sha256: Optional[str] = None
+    removed_sections: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.content_sha256 is None:
+            object.__setattr__(self, "content_sha256", self.original_sha256)
+
+    @property
+    def digest(self) -> str:
+        return self.content_sha256 or self.original_sha256
+
+
+@dataclass(frozen=True)
+class Candidate:
+    code_objects: tuple[CodeObject, ...]
+    metadata: dict[str, Any]
+
+    def digest(self) -> str:
+        digest = hashlib.sha256()
+        digest.update(b"comgr-hotswap-reducer-candidate-v1\0")
+        for code_object in self.code_objects:
+            digest.update(canonical_json_bytes(code_object.object_id))
+            digest.update(b"\0")
+            digest.update(canonical_json_bytes(code_object.original_name))
+            digest.update(b"\0")
+            digest.update(bytes.fromhex(code_object.digest))
+        digest.update(b"\0metadata\0")
+        digest.update(canonical_json_bytes(self.metadata))
+        return digest.hexdigest()
+
+
+def _validate_metadata(metadata: Any, source: str) -> dict[str, Any]:
+    if not isinstance(metadata, dict):
+        raise ReducerError(f"{source}: metadata must be a JSON object")
+    for key in ("kernels", "cases", "arguments", "selected_tests"):
+        if key in metadata and not isinstance(metadata[key], list):
+            raise ReducerError(f"{source}: metadata.{key} must be a JSON list")
+    cases = metadata.get("cases", [])
+    for index, case in enumerate(cases):
+        if isinstance(case, dict) and "arguments" in case:
+            if not isinstance(case["arguments"], list):
+                raise ReducerError(
+                    f"{source}: metadata.cases[{index}].arguments must be a JSON list"
+                )
+    canonical_json_bytes(metadata)
+    return copy.deepcopy(metadata)
+
+
+def _resolve_input_path(path_value: Any, base: Path, description: str) -> Path:
+    if not isinstance(path_value, str) or not path_value:
+        raise ReducerError(f"{description}: path must be a non-empty string")
+    path = Path(path_value)
+    if not path.is_absolute():
+        path = base / path
+    try:
+        path = path.resolve(strict=True)
+    except OSError as error:
+        raise ReducerError(
+            f"{description}: could not resolve {path}: {error}"
+        ) from error
+    if not path.is_file():
+        raise ReducerError(f"{description}: {path} is not a regular file")
+    return path
+
+
+def load_bundle(path: Path) -> Candidate:
+    bundle_path = path.resolve()
+    value = load_json(bundle_path)
+    if not isinstance(value, dict):
+        raise ReducerError(f"{bundle_path}: bundle must be a JSON object")
+    if value.get("format") != BUNDLE_FORMAT:
+        raise ReducerError(f"{bundle_path}: format must be {BUNDLE_FORMAT!r}")
+    if value.get("version") != BUNDLE_VERSION:
+        raise ReducerError(
+            f"{bundle_path}: unsupported bundle version "
+            f"{value.get('version')!r}; expected {BUNDLE_VERSION}"
+        )
+    object_values = value.get("code_objects")
+    if not isinstance(object_values, list) or not object_values:
+        raise ReducerError(f"{bundle_path}: code_objects must be a non-empty JSON list")
+
+    code_objects: list[CodeObject] = []
+    seen_ids: set[str] = set()
+    for index, object_value in enumerate(object_values):
+        if not isinstance(object_value, dict):
+            raise ReducerError(
+                f"{bundle_path}: code_objects[{index}] must be a JSON object"
+            )
+        object_id = object_value.get("id")
+        if not isinstance(object_id, str) or not object_id:
+            raise ReducerError(
+                f"{bundle_path}: code_objects[{index}].id must be a non-empty string"
+            )
+        if object_id in seen_ids:
+            raise ReducerError(f"{bundle_path}: duplicate code object id {object_id!r}")
+        seen_ids.add(object_id)
+        object_path = _resolve_input_path(
+            object_value.get("path"),
+            bundle_path.parent,
+            f"{bundle_path}: code_objects[{index}]",
+        )
+        code_objects.append(
+            CodeObject(
+                object_id=object_id,
+                original_name=object_path.name,
+                path=object_path,
+                original_sha256=sha256_file(object_path),
+            )
+        )
+
+    metadata_value = value.get("metadata", {})
+    if isinstance(metadata_value, str):
+        metadata_path = _resolve_input_path(
+            metadata_value, bundle_path.parent, f"{bundle_path}: metadata"
+        )
+        metadata_value = load_json(metadata_path)
+        metadata_source = str(metadata_path)
+    else:
+        metadata_source = f"{bundle_path}: metadata"
+    metadata = _validate_metadata(metadata_value, metadata_source)
+    return Candidate(tuple(code_objects), metadata)
+
+
+def load_nul_worklist(path: Path) -> list[Path]:
+    """Load a NUL-delimited path list without interpreting shell syntax."""
+
+    worklist_path = path.resolve()
+    try:
+        contents = worklist_path.read_bytes()
+    except OSError as error:
+        raise ReducerError(
+            f"could not read worklist {worklist_path}: {error}"
+        ) from error
+    if not contents:
+        raise ReducerError(f"{worklist_path}: worklist is empty")
+    if not contents.endswith(b"\0"):
+        raise ReducerError(f"{worklist_path}: NUL-delimited worklist must end with NUL")
+    encoded_paths = contents[:-1].split(b"\0")
+    if any(not value for value in encoded_paths):
+        raise ReducerError(f"{worklist_path}: worklist contains an empty path")
+
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    for index, encoded_path in enumerate(encoded_paths):
+        decoded_path = os.fsdecode(encoded_path)
+        resolved_path = _resolve_input_path(
+            decoded_path,
+            worklist_path.parent,
+            f"{worklist_path}: entry #{index + 1}",
+        )
+        if resolved_path in seen:
+            raise ReducerError(
+                f"{worklist_path}: duplicate worklist path {resolved_path}"
+            )
+        seen.add(resolved_path)
+        paths.append(resolved_path)
+    return paths
+
+
+def load_inputs(
+    bundle: Optional[Path],
+    code_object_paths: Sequence[Path],
+    worklist: Optional[Path],
+    metadata_path: Optional[Path],
+) -> Candidate:
+    if bundle is not None:
+        if code_object_paths or worklist is not None or metadata_path is not None:
+            raise ReducerError(
+                "--bundle cannot be combined with --code-object, --worklist, "
+                "or --metadata"
+            )
+        return load_bundle(bundle)
+    if worklist is not None:
+        if code_object_paths:
+            raise ReducerError("--worklist cannot be combined with --code-object")
+        input_paths = load_nul_worklist(worklist)
+    else:
+        input_paths = list(code_object_paths)
+    if not input_paths:
+        raise ReducerError("one of --bundle, --code-object, or --worklist is required")
+
+    code_objects: list[CodeObject] = []
+    for index, path in enumerate(input_paths):
+        object_path = _resolve_input_path(
+            str(path), Path.cwd(), f"--code-object #{index + 1}"
+        )
+        code_objects.append(
+            CodeObject(
+                object_id=f"object-{index:04d}",
+                original_name=object_path.name,
+                path=object_path,
+                original_sha256=sha256_file(object_path),
+            )
+        )
+
+    if metadata_path is None:
+        metadata: dict[str, Any] = {}
+    else:
+        resolved_metadata = _resolve_input_path(
+            str(metadata_path), Path.cwd(), "--metadata"
+        )
+        metadata = _validate_metadata(
+            load_json(resolved_metadata), str(resolved_metadata)
+        )
+    return Candidate(tuple(code_objects), metadata)
+
+
+def materialize_candidate(candidate: Candidate, destination: Path) -> dict[str, Any]:
+    destination.mkdir(parents=True, exist_ok=True)
+    object_directory = destination / "objects"
+    object_directory.mkdir()
+    object_entries: list[dict[str, Any]] = []
+    for index, code_object in enumerate(candidate.code_objects):
+        output_name = _object_output_name(
+            index, code_object.object_id, code_object.original_name
+        )
+        relative_path = Path("objects") / output_name
+        output_path = destination / relative_path
+        shutil.copyfile(code_object.path, output_path)
+        object_entries.append(
+            {
+                "id": code_object.object_id,
+                "path": relative_path.as_posix(),
+                "sha256": code_object.digest,
+                "size": output_path.stat().st_size,
+            }
+        )
+    atomic_write_json(destination / "metadata.json", candidate.metadata)
+    bundle = {
+        "format": BUNDLE_FORMAT,
+        "version": BUNDLE_VERSION,
+        "code_objects": object_entries,
+        "metadata": "metadata.json",
+    }
+    atomic_write_json(destination / "bundle.json", bundle)
+    return bundle
+
+
+def snapshot_candidate(candidate: Candidate, destination: Path) -> Candidate:
+    """Copy original objects once so later predicate runs see immutable bytes."""
+
+    destination.mkdir(parents=True)
+    snapshots: list[CodeObject] = []
+    for index, code_object in enumerate(candidate.code_objects):
+        output_path = destination / _object_output_name(
+            index, code_object.object_id, code_object.original_name
+        )
+        shutil.copyfile(code_object.path, output_path)
+        snapshot_digest = sha256_file(output_path)
+        if snapshot_digest != code_object.original_sha256:
+            raise ReducerError(
+                f"{code_object.path}: content changed while taking the "
+                "reduction snapshot"
+            )
+        snapshots.append(
+            replace(
+                code_object,
+                path=output_path,
+                content_sha256=snapshot_digest,
+            )
+        )
+    return replace(candidate, code_objects=tuple(snapshots))
+
+
+@dataclass(frozen=True)
+class PredicateResult:
+    status: str
+    exit_codes: tuple[Optional[int], ...]
+    stdout: str
+    stderr: str
+    cached: bool = False
+
+    @property
+    def interesting(self) -> bool:
+        return self.status == "interesting"
+
+    def for_log(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "exit_codes": list(self.exit_codes),
+            "cached": self.cached,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+        }
+
+
+class PredicateCache:
+    def __init__(self, path: Optional[Path]) -> None:
+        self.path = path
+        self.values: dict[str, dict[str, Any]] = {}
+        if path is None or not path.exists():
+            return
+        value = load_json(path)
+        if (
+            not isinstance(value, dict)
+            or value.get("format") != CACHE_FORMAT
+            or value.get("version") != CACHE_VERSION
+            or not isinstance(value.get("entries"), dict)
+        ):
+            raise ReducerError(f"{path}: unsupported predicate cache format")
+        self.values = value["entries"]
+
+    def get(self, key: str) -> Optional[PredicateResult]:
+        value = self.values.get(key)
+        if not isinstance(value, dict):
+            return None
+        status = value.get("status")
+        exit_codes = value.get("exit_codes")
+        if status not in ("interesting", "uninteresting"):
+            return None
+        if not isinstance(exit_codes, list):
+            return None
+        if not all(code is None or isinstance(code, int) for code in exit_codes):
+            return None
+        stdout = value.get("stdout", "")
+        stderr = value.get("stderr", "")
+        if not isinstance(stdout, str) or not isinstance(stderr, str):
+            return None
+        return PredicateResult(
+            status,
+            tuple(exit_codes),
+            stdout,
+            stderr,
+            cached=True,
+        )
+
+    def put(self, key: str, result: PredicateResult) -> None:
+        if result.status not in ("interesting", "uninteresting"):
+            return
+        self.values[key] = {
+            "status": result.status,
+            "exit_codes": list(result.exit_codes),
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+        if self.path is not None:
+            atomic_write_json(
+                self.path,
+                {
+                    "format": CACHE_FORMAT,
+                    "version": CACHE_VERSION,
+                    "entries": self.values,
+                },
+            )
+
+
+class PredicateRunner:
+    def __init__(
+        self,
+        argv_template: Sequence[str],
+        interesting_exit_code: int,
+        runs: int,
+        timeout: float,
+        work_root: Path,
+        cache: PredicateCache,
+        cache_dependencies: Sequence[Path] = (),
+        cache_tags: Sequence[str] = (),
+    ) -> None:
+        if not argv_template:
+            raise ReducerError("the interestingness argv must not be empty")
+        if runs < 1:
+            raise ReducerError("--predicate-runs must be at least 1")
+        if timeout <= 0:
+            raise ReducerError("--timeout must be greater than zero")
+        resolved_executable = shutil.which(argv_template[0])
+        if resolved_executable is None:
+            raise ReducerError(
+                f"could not find predicate executable {argv_template[0]!r}"
+            )
+        executable_path = Path(resolved_executable).resolve()
+        if not executable_path.is_file():
+            raise ReducerError(
+                f"predicate executable is not a regular file: {executable_path}"
+            )
+        normalized_arguments: list[str] = []
+        for argument in argv_template[1:]:
+            if any(placeholder in argument for placeholder in KNOWN_PLACEHOLDERS):
+                normalized_arguments.append(argument)
+                continue
+            argument_path = Path(argument)
+            normalized_arguments.append(
+                str(argument_path.resolve()) if argument_path.is_file() else argument
+            )
+        self.argv_template = (str(executable_path),) + tuple(normalized_arguments)
+        self.interesting_exit_code = interesting_exit_code
+        self.runs = runs
+        self.timeout = timeout
+        self.work_root = work_root
+        self.cache = cache
+        self._validate_placeholders()
+        self.identity_files = self._collect_identity_files(
+            executable_path, cache_dependencies
+        )
+        if any(not tag for tag in cache_tags):
+            raise ReducerError("--cache-tag values must be non-empty")
+        self.cache_tags = tuple(cache_tags)
+        self.config_digest = hashlib.sha256(
+            canonical_json_bytes(
+                {
+                    "argv": self.argv_template,
+                    "identity_files": self.identity_files,
+                    "cache_tags": self.cache_tags,
+                    "interesting_exit_code": interesting_exit_code,
+                    "runs": runs,
+                    "timeout": timeout,
+                }
+            )
+        ).hexdigest()
+
+    def _collect_identity_files(
+        self, executable: Path, cache_dependencies: Sequence[Path]
+    ) -> tuple[dict[str, str], ...]:
+        identified_paths: list[tuple[str, Path]] = [("executable", executable)]
+        for index, argument in enumerate(self.argv_template[1:], start=1):
+            if any(placeholder in argument for placeholder in KNOWN_PLACEHOLDERS):
+                continue
+            argument_path = Path(argument)
+            if argument_path.is_file():
+                identified_paths.append((f"argv[{index}]", argument_path.resolve()))
+        for index, dependency in enumerate(cache_dependencies):
+            dependency_path = dependency.resolve()
+            if not dependency_path.is_file():
+                raise ReducerError(
+                    f"--cache-dependency is not a regular file: {dependency_path}"
+                )
+            identified_paths.append((f"dependency[{index}]", dependency_path))
+
+        identities: list[dict[str, str]] = []
+        seen_paths: set[Path] = set()
+        for role, path in identified_paths:
+            if path in seen_paths:
+                continue
+            seen_paths.add(path)
+            identities.append(
+                {
+                    "path": str(path),
+                    "role": role,
+                    "sha256": sha256_file(path),
+                }
+            )
+        return tuple(identities)
+
+    def _verify_identity_files(self) -> None:
+        for identity in self.identity_files:
+            path = Path(identity["path"])
+            if not path.is_file() or sha256_file(path) != identity["sha256"]:
+                raise ReducerError(
+                    f"predicate identity changed during reduction: {path}"
+                )
+
+    def _validate_placeholders(self) -> None:
+        for argument in self.argv_template:
+            for placeholder in re.findall(r"\{[^{}]+\}", argument):
+                if placeholder not in KNOWN_PLACEHOLDERS:
+                    raise ReducerError(
+                        f"unknown interestingness placeholder {placeholder!r}"
+                    )
+
+    def _cache_key(self, candidate_digest: str) -> str:
+        digest = hashlib.sha256()
+        digest.update(bytes.fromhex(self.config_digest))
+        digest.update(bytes.fromhex(candidate_digest))
+        return digest.hexdigest()
+
+    def _expand_argv(self, workspace: Path, candidate: Candidate) -> list[str]:
+        replacements = {
+            "{workspace}": str(workspace),
+            "{bundle}": str(workspace / "bundle.json"),
+            "{metadata}": str(workspace / "metadata.json"),
+        }
+        if len(candidate.code_objects) == 1:
+            input_name = _object_output_name(
+                0,
+                candidate.code_objects[0].object_id,
+                candidate.code_objects[0].original_name,
+            )
+            replacements["{input}"] = str(workspace / "objects" / input_name)
+        elif any("{input}" in argument for argument in self.argv_template):
+            raise ReducerError(
+                "{input} requires exactly one code object; use {bundle} "
+                "while reducing a multi-object corpus"
+            )
+        argv: list[str] = []
+        for argument in self.argv_template:
+            expanded = argument
+            for placeholder, value in replacements.items():
+                expanded = expanded.replace(placeholder, value)
+            argv.append(expanded)
+        return argv
+
+    @staticmethod
+    def _normalize_capture(value: Any, workspace: Path) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, bytes):
+            text = value.decode("utf-8", errors="replace")
+        else:
+            text = str(value)
+        text = text.replace(str(workspace), "{workspace}")
+        if len(text) > CAPTURE_LIMIT:
+            text = text[:CAPTURE_LIMIT] + "\n<truncated>"
+        return text
+
+    def evaluate(self, candidate: Candidate) -> PredicateResult:
+        self._verify_identity_files()
+        candidate_digest = candidate.digest()
+        cache_key = self._cache_key(candidate_digest)
+        cached = self.cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        exit_codes: list[Optional[int]] = []
+        outputs: list[str] = []
+        errors: list[str] = []
+        outcomes: list[bool] = []
+        for _ in range(self.runs):
+            with tempfile.TemporaryDirectory(
+                prefix="predicate-", dir=self.work_root
+            ) as temporary_name:
+                workspace = Path(temporary_name)
+                materialize_candidate(candidate, workspace)
+                argv = self._expand_argv(workspace, candidate)
+                try:
+                    completed = subprocess.run(
+                        argv,
+                        cwd=workspace,
+                        stdin=subprocess.DEVNULL,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        check=False,
+                        timeout=self.timeout,
+                    )
+                except subprocess.TimeoutExpired as error:
+                    exit_codes.append(None)
+                    outputs.append(self._normalize_capture(error.stdout, workspace))
+                    errors.append(self._normalize_capture(error.stderr, workspace))
+                    return PredicateResult(
+                        "timeout",
+                        tuple(exit_codes),
+                        "\n".join(outputs),
+                        "\n".join(errors),
+                    )
+                except OSError as error:
+                    exit_codes.append(None)
+                    errors.append(
+                        self._normalize_capture(
+                            f"could not launch predicate: {error}", workspace
+                        )
+                    )
+                    return PredicateResult(
+                        "launch-error",
+                        tuple(exit_codes),
+                        "\n".join(outputs),
+                        "\n".join(errors),
+                    )
+                exit_codes.append(completed.returncode)
+                outcomes.append(completed.returncode == self.interesting_exit_code)
+                outputs.append(self._normalize_capture(completed.stdout, workspace))
+                errors.append(self._normalize_capture(completed.stderr, workspace))
+
+        self._verify_identity_files()
+        if all(outcomes):
+            status = "interesting"
+        elif any(outcomes):
+            status = "flaky"
+        else:
+            status = "uninteresting"
+        result = PredicateResult(
+            status,
+            tuple(exit_codes),
+            "\n".join(outputs),
+            "\n".join(errors),
+        )
+        self.cache.put(cache_key, result)
+        return result
+
+    def reproduction_argv(self, candidate: Candidate) -> list[str]:
+        replacements = {
+            "{workspace}": ".",
+            "{bundle}": "bundle.json",
+            "{metadata}": "metadata.json",
+        }
+        if len(candidate.code_objects) == 1:
+            replacements["{input}"] = (
+                Path("objects")
+                / _object_output_name(
+                    0,
+                    candidate.code_objects[0].object_id,
+                    candidate.code_objects[0].original_name,
+                )
+            ).as_posix()
+        argv: list[str] = []
+        for argument in self.argv_template:
+            expanded = argument
+            for placeholder, value in replacements.items():
+                expanded = expanded.replace(placeholder, value)
+            argv.append(expanded)
+        return argv
+
+
+def ddmin(
+    items: Sequence[Any],
+    try_complement: Callable[[list[Any], list[Any]], bool],
+    minimum_size: int = 0,
+) -> list[Any]:
+    """Return a 1-minimal subsequence accepted by ``try_complement``."""
+
+    current = list(items)
+    if minimum_size < 0 or minimum_size > len(current):
+        raise ValueError("invalid minimum_size")
+    granularity = 2
+    while len(current) > minimum_size:
+        granularity = min(granularity, len(current))
+        reduced = False
+        for part in range(granularity):
+            start = part * len(current) // granularity
+            end = (part + 1) * len(current) // granularity
+            removed = current[start:end]
+            complement = current[:start] + current[end:]
+            if len(complement) < minimum_size:
+                continue
+            if try_complement(complement, removed):
+                current = complement
+                granularity = max(granularity - 1, 2)
+                reduced = True
+                break
+        if reduced:
+            continue
+        if granularity == len(current):
+            break
+        granularity = min(len(current), granularity * 2)
+    return current
+
+
+@dataclass(frozen=True)
+class SectionInfo:
+    name: str
+    allocated: bool
+
+
+class ElfSectionTools:
+    def __init__(
+        self,
+        readobj: str,
+        objcopy: str,
+        timeout: float,
+        allow_patterns: Sequence[str],
+        protect_patterns: Sequence[str],
+        artifact_root: Path,
+    ) -> None:
+        if timeout <= 0:
+            raise ReducerError("--tool-timeout must be greater than zero")
+        self.readobj = self._resolve_tool(readobj, "--readobj")
+        self.objcopy = self._resolve_tool(objcopy, "--objcopy")
+        self.timeout = timeout
+        self.allow_patterns = tuple(allow_patterns)
+        self.protect_patterns = DEFAULT_PROTECTED_SECTIONS + tuple(protect_patterns)
+        self.artifact_root = artifact_root
+        self.artifact_digests: dict[Path, str] = {}
+
+    @staticmethod
+    def _resolve_tool(tool: str, option: str) -> str:
+        resolved = shutil.which(tool)
+        if resolved is None:
+            raise ReducerError(f"{option}: could not find executable {tool!r}")
+        return resolved
+
+    def list_sections(self, path: Path) -> list[SectionInfo]:
+        argv = [
+            self.readobj,
+            "--sections",
+            "--elf-output-style=JSON",
+            str(path),
+        ]
+        try:
+            completed = subprocess.run(
+                argv,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=self.timeout,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise ReducerError(
+                f"llvm-readobj timed out while inspecting {path}"
+            ) from error
+        except OSError as error:
+            raise ReducerError(
+                f"could not launch llvm-readobj for {path}: {error}"
+            ) from error
+        if completed.returncode != 0:
+            detail = completed.stderr.decode("utf-8", errors="replace").strip()
+            raise ReducerError(
+                f"llvm-readobj could not inspect {path}: "
+                f"{detail or f'exit {completed.returncode}'}"
+            )
+        try:
+            value = json.loads(
+                completed.stdout.decode("utf-8"),
+                parse_constant=_reject_json_constant,
+            )
+            file_value = value[0]
+            summary = file_value["FileSummary"]
+            section_values = file_value["Sections"]
+        except (
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            ValueError,
+            IndexError,
+            KeyError,
+            TypeError,
+        ) as error:
+            raise ReducerError(
+                f"llvm-readobj returned malformed section JSON for {path}: {error}"
+            ) from error
+        if not isinstance(summary, dict):
+            raise ReducerError(f"llvm-readobj returned no file summary for {path}")
+        file_format = summary.get("Format")
+        architecture = summary.get("Arch")
+        if not isinstance(file_format, str) or not file_format.startswith("elf"):
+            raise ReducerError(f"{path}: section reduction only supports ELF objects")
+        if not isinstance(architecture, str) or architecture.lower() not in (
+            "amdgcn",
+            "amdgpu",
+        ):
+            raise ReducerError(
+                f"{path}: section reduction requires an AMDGPU ELF object; "
+                f"llvm-readobj reported {architecture!r}"
+            )
+        if not isinstance(section_values, list):
+            raise ReducerError(f"llvm-readobj returned no section list for {path}")
+
+        sections: list[SectionInfo] = []
+        for index, wrapped_section in enumerate(section_values):
+            try:
+                section = wrapped_section["Section"]
+                name = section["Name"]["Name"]
+                flag_values = section["Flags"]["Flags"]
+                flag_names = [flag["Name"] for flag in flag_values]
+            except (KeyError, TypeError) as error:
+                raise ReducerError(
+                    f"llvm-readobj returned malformed section #{index} for {path}"
+                ) from error
+            if not isinstance(name, str) or not all(
+                isinstance(flag, str) for flag in flag_names
+            ):
+                raise ReducerError(
+                    f"llvm-readobj returned malformed section #{index} for {path}"
+                )
+            sections.append(SectionInfo(name, "SHF_ALLOC" in flag_names))
+        return sections
+
+    def removable_sections(self, path: Path) -> list[str]:
+        removable: list[str] = []
+        for section in self.list_sections(path):
+            allowed = any(
+                fnmatch.fnmatchcase(section.name, pattern)
+                for pattern in self.allow_patterns
+            )
+            protected = section.allocated or any(
+                fnmatch.fnmatchcase(section.name, pattern)
+                for pattern in self.protect_patterns
+            )
+            if allowed and not protected:
+                removable.append(section.name)
+        return removable
+
+    def remove_sections(
+        self, code_object: CodeObject, section_names: Sequence[str]
+    ) -> CodeObject:
+        if not section_names:
+            return code_object
+        key = hashlib.sha256(
+            canonical_json_bytes(
+                {
+                    "input": code_object.digest,
+                    "remove": sorted(section_names),
+                }
+            )
+        ).hexdigest()
+        output_path = self.artifact_root / f"{key}.elf"
+        if not output_path.exists():
+            temporary_path = output_path.with_suffix(".tmp")
+            argv = [self.objcopy]
+            argv.extend(
+                f"--remove-section={section_name}"
+                for section_name in sorted(section_names)
+            )
+            argv.extend((str(code_object.path), str(temporary_path)))
+            try:
+                completed = subprocess.run(
+                    argv,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=False,
+                    timeout=self.timeout,
+                )
+            except subprocess.TimeoutExpired as error:
+                try:
+                    temporary_path.unlink()
+                except FileNotFoundError:
+                    pass
+                raise ReducerError(
+                    f"llvm-objcopy timed out while reducing {code_object.object_id!r}"
+                ) from error
+            except OSError as error:
+                try:
+                    temporary_path.unlink()
+                except FileNotFoundError:
+                    pass
+                raise ReducerError(
+                    f"could not launch llvm-objcopy for "
+                    f"{code_object.object_id!r}: {error}"
+                ) from error
+            if completed.returncode != 0 or not temporary_path.is_file():
+                try:
+                    temporary_path.unlink()
+                except FileNotFoundError:
+                    pass
+                detail = completed.stderr.decode("utf-8", errors="replace").strip()
+                raise ReducerError(
+                    f"llvm-objcopy could not reduce "
+                    f"{code_object.object_id!r}: "
+                    f"{detail or f'exit {completed.returncode}'}"
+                )
+            if temporary_path.stat().st_size == 0:
+                temporary_path.unlink()
+                raise ReducerError(
+                    f"llvm-objcopy produced an empty object for "
+                    f"{code_object.object_id!r}"
+                )
+            os.replace(temporary_path, output_path)
+            self.artifact_digests[output_path] = sha256_file(output_path)
+        output_digest = self.artifact_digests.get(output_path)
+        if output_digest is None:
+            output_digest = sha256_file(output_path)
+            self.artifact_digests[output_path] = output_digest
+        return replace(
+            code_object,
+            path=output_path,
+            content_sha256=output_digest,
+            removed_sections=tuple(sorted(section_names)),
+        )
+
+
+class Reducer:
+    def __init__(
+        self,
+        initial: Candidate,
+        runner: PredicateRunner,
+        allow_empty_bundle: bool,
+        section_tools: Optional[ElfSectionTools],
+    ) -> None:
+        self.initial = initial
+        self.current = initial
+        self.runner = runner
+        self.allow_empty_bundle = allow_empty_bundle
+        self.section_tools = section_tools
+        self.transformations: list[dict[str, Any]] = []
+
+    def _attempt(
+        self,
+        pass_name: str,
+        transformation: dict[str, Any],
+        candidate: Candidate,
+    ) -> bool:
+        candidate_digest = candidate.digest()
+        try:
+            result = self.runner.evaluate(candidate)
+        except ReducerError as error:
+            self.transformations.append(
+                {
+                    "pass": pass_name,
+                    "transformation": transformation,
+                    "candidate_digest": candidate_digest,
+                    "accepted": False,
+                    "predicate": {
+                        "status": "configuration-error",
+                        "error": str(error),
+                    },
+                }
+            )
+            return False
+        accepted = result.interesting
+        self.transformations.append(
+            {
+                "pass": pass_name,
+                "transformation": transformation,
+                "candidate_digest": candidate_digest,
+                "accepted": accepted,
+                "predicate": result.for_log(),
+            }
+        )
+        if accepted:
+            self.current = candidate
+        return accepted
+
+    def _record_tool_error(
+        self, pass_name: str, transformation: dict[str, Any], error: ReducerError
+    ) -> None:
+        self.transformations.append(
+            {
+                "pass": pass_name,
+                "transformation": transformation,
+                "candidate_digest": self.current.digest(),
+                "accepted": False,
+                "predicate": {
+                    "status": "tool-error",
+                    "error": str(error),
+                },
+            }
+        )
+
+    def reduce_bundle(self) -> None:
+        original = list(self.current.code_objects)
+
+        def try_objects(kept: list[CodeObject], removed: list[CodeObject]) -> bool:
+            candidate = replace(self.current, code_objects=tuple(kept))
+            return self._attempt(
+                "code-objects",
+                {"remove_ids": [item.object_id for item in removed]},
+                candidate,
+            )
+
+        minimum_size = 0 if self.allow_empty_bundle else 1
+        kept = ddmin(original, try_objects, minimum_size)
+        self.current = replace(self.current, code_objects=tuple(kept))
+
+    @staticmethod
+    def _set_json_path(
+        value: dict[str, Any], path: Sequence[Any], replacement: Any
+    ) -> None:
+        target: Any = value
+        for component in path[:-1]:
+            target = target[component]
+        target[path[-1]] = replacement
+
+    def _reduce_metadata_list(self, path: Sequence[Any]) -> None:
+        target: Any = self.current.metadata
+        for component in path:
+            target = target[component]
+        original = list(target)
+        path_text = ".".join(str(component) for component in path)
+
+        def try_values(kept: list[Any], removed: list[Any]) -> bool:
+            metadata = copy.deepcopy(self.current.metadata)
+            self._set_json_path(metadata, path, kept)
+            candidate = replace(self.current, metadata=metadata)
+            removed_digests = [
+                hashlib.sha256(canonical_json_bytes(item)).hexdigest()
+                for item in removed
+            ]
+            return self._attempt(
+                "metadata",
+                {
+                    "path": path_text,
+                    "remove_value_digests": removed_digests,
+                },
+                candidate,
+            )
+
+        kept = ddmin(original, try_values)
+        metadata = copy.deepcopy(self.current.metadata)
+        self._set_json_path(metadata, path, kept)
+        self.current = replace(self.current, metadata=metadata)
+
+    def reduce_metadata(self) -> None:
+        for key in ("kernels", "cases", "arguments", "selected_tests"):
+            if key in self.current.metadata and self.current.metadata[key]:
+                self._reduce_metadata_list((key,))
+        cases = self.current.metadata.get("cases", [])
+        for index, case in enumerate(cases):
+            if (
+                isinstance(case, dict)
+                and isinstance(case.get("arguments"), list)
+                and case["arguments"]
+            ):
+                self._reduce_metadata_list(("cases", index, "arguments"))
+
+    def reduce_sections(self) -> None:
+        if self.section_tools is None:
+            return
+        section_tools = self.section_tools
+        object_index = 0
+        while object_index < len(self.current.code_objects):
+            base_object = self.current.code_objects[object_index]
+            try:
+                removable = section_tools.removable_sections(base_object.path)
+            except ReducerError as error:
+                raise ReducerError(
+                    f"could not enumerate removable sections for "
+                    f"{base_object.object_id!r}: {error}"
+                ) from error
+            if not removable:
+                object_index += 1
+                continue
+
+            def try_sections(kept: list[str], removed: list[str]) -> bool:
+                removed_sections = [
+                    section for section in removable if section not in kept
+                ]
+                transformation = {
+                    "object_id": base_object.object_id,
+                    "remove_sections": sorted(removed_sections),
+                    "delta_remove_sections": sorted(removed),
+                }
+                try:
+                    reduced_object = section_tools.remove_sections(
+                        base_object, removed_sections
+                    )
+                except ReducerError as error:
+                    self._record_tool_error("elf-sections", transformation, error)
+                    return False
+                objects = list(self.current.code_objects)
+                objects[object_index] = reduced_object
+                candidate = replace(self.current, code_objects=tuple(objects))
+                return self._attempt("elf-sections", transformation, candidate)
+
+            kept = ddmin(removable, try_sections)
+            removed_sections = [section for section in removable if section not in kept]
+            if removed_sections:
+                reduced_object = section_tools.remove_sections(
+                    base_object, removed_sections
+                )
+                objects = list(self.current.code_objects)
+                objects[object_index] = reduced_object
+                self.current = replace(self.current, code_objects=tuple(objects))
+            object_index += 1
+
+    def run(self) -> Candidate:
+        initial_result = self.runner.evaluate(self.initial)
+        if not initial_result.interesting:
+            raise ReducerError(
+                "the original input is not stably interesting: "
+                f"predicate status is {initial_result.status!r}"
+            )
+        self.reduce_bundle()
+        self.reduce_metadata()
+        self.reduce_sections()
+        return self.current
+
+    def make_log(self) -> dict[str, Any]:
+        originals = [
+            {
+                "id": code_object.object_id,
+                "name": code_object.original_name,
+                "sha256": code_object.original_sha256,
+            }
+            for code_object in self.initial.code_objects
+        ]
+        return {
+            "format": LOG_FORMAT,
+            "version": LOG_VERSION,
+            "initial_digest": self.initial.digest(),
+            "final_digest": self.current.digest(),
+            "originals": originals,
+            "predicate": {
+                "argv_template": list(self.runner.argv_template),
+                "identity_files": list(self.runner.identity_files),
+                "cache_tags": list(self.runner.cache_tags),
+                "interesting_exit_code": self.runner.interesting_exit_code,
+                "runs": self.runner.runs,
+                "timeout_seconds": self.runner.timeout,
+            },
+            "section_policy": {
+                "enabled": self.section_tools is not None,
+                "allow": (
+                    list(self.section_tools.allow_patterns)
+                    if self.section_tools is not None
+                    else []
+                ),
+                "protect": (
+                    list(self.section_tools.protect_patterns)
+                    if self.section_tools is not None
+                    else []
+                ),
+                "allocated_sections_are_protected": True,
+            },
+            "transformations": self.transformations,
+            "reproduction": {
+                "working_directory": ".",
+                "argv": self.runner.reproduction_argv(self.current),
+                "interesting_exit_code": self.runner.interesting_exit_code,
+            },
+        }
+
+
+def atomic_publish(
+    output: Path, candidate: Candidate, reduction_log: dict[str, Any]
+) -> None:
+    output = output.resolve()
+    if output.exists():
+        raise ReducerError(f"refusing to overwrite existing output {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = Path(
+        tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent)
+    )
+    try:
+        materialize_candidate(candidate, temporary_path)
+        atomic_write_json(temporary_path / "reduction-log.json", reduction_log)
+        os.replace(temporary_path, output)
+    except BaseException:
+        shutil.rmtree(temporary_path, ignore_errors=True)
+        raise
+
+
+def _path_is_within(path: Path, directory: Path) -> bool:
+    try:
+        path.relative_to(directory)
+        return True
+    except ValueError:
+        return False
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def make_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--bundle", type=Path, help="Versioned input bundle JSON")
+    input_group.add_argument(
+        "--code-object",
+        type=Path,
+        action="append",
+        help="Code object input; repeat for a corpus",
+    )
+    input_group.add_argument(
+        "--worklist",
+        type=Path,
+        help="NUL-delimited code object paths from inventory or selection",
+    )
+    parser.add_argument(
+        "--metadata",
+        type=Path,
+        help="Structured launch/test metadata for --code-object or --worklist",
+    )
+    parser.add_argument(
+        "--output", type=Path, required=True, help="New output directory"
+    )
+    parser.add_argument(
+        "--predicate",
+        required=True,
+        help="Interestingness executable (no shell is used)",
+    )
+    parser.add_argument(
+        "--predicate-arg",
+        action="append",
+        default=[],
+        help=(
+            "One interestingness argv item; repeat as needed. Known "
+            "placeholders: " + ", ".join(KNOWN_PLACEHOLDERS)
+        ),
+    )
+    parser.add_argument(
+        "--interesting-exit-code",
+        type=int,
+        default=0,
+        help="Exit code meaning interesting (default: 0)",
+    )
+    parser.add_argument(
+        "--predicate-runs",
+        type=int,
+        default=1,
+        help="Repeat every uncached predicate; disagreement is flaky",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=_positive_float,
+        default=60.0,
+        help="Per-predicate timeout in seconds (default: 60)",
+    )
+    parser.add_argument(
+        "--cache-file",
+        type=Path,
+        help="Optional persistent content-addressed predicate cache",
+    )
+    parser.add_argument(
+        "--cache-dependency",
+        type=Path,
+        action="append",
+        default=[],
+        help="File whose content participates in predicate cache identity",
+    )
+    parser.add_argument(
+        "--cache-tag",
+        action="append",
+        default=[],
+        help="Environment or configuration tag for predicate cache identity",
+    )
+    parser.add_argument(
+        "--allow-empty-bundle",
+        action="store_true",
+        help="Permit reducing all code objects away",
+    )
+    parser.add_argument(
+        "--allow-remove-section",
+        action="append",
+        default=[],
+        metavar="GLOB",
+        help=("Opt in a non-allocated ELF section glob for removal; repeat as needed"),
+    )
+    parser.add_argument(
+        "--protect-section",
+        action="append",
+        default=[],
+        metavar="GLOB",
+        help="Additional protected ELF section glob; repeat as needed",
+    )
+    parser.add_argument(
+        "--readobj",
+        default="llvm-readobj",
+        help="llvm-readobj executable for section reduction",
+    )
+    parser.add_argument(
+        "--objcopy",
+        default="llvm-objcopy",
+        help="llvm-objcopy executable for section reduction",
+    )
+    parser.add_argument(
+        "--tool-timeout",
+        type=_positive_float,
+        default=30.0,
+        help="Per LLVM tool timeout in seconds (default: 30)",
+    )
+    return parser
+
+
+def run_from_arguments(args: argparse.Namespace) -> tuple[Candidate, dict[str, Any]]:
+    initial = load_inputs(
+        args.bundle,
+        args.code_object or [],
+        args.worklist,
+        args.metadata,
+    )
+    output = args.output.resolve()
+    if output.exists():
+        raise ReducerError(f"refusing to overwrite existing output {output}")
+    cache_path = args.cache_file.resolve() if args.cache_file is not None else None
+    if cache_path is not None:
+        protected_inputs = {item.path.resolve() for item in initial.code_objects}
+        for path in (args.bundle, args.metadata, args.worklist):
+            if path is not None:
+                protected_inputs.add(path.resolve())
+        protected_inputs.update(path.resolve() for path in args.cache_dependency)
+        if cache_path in protected_inputs:
+            raise ReducerError(
+                f"refusing to overwrite reducer input with cache {cache_path}"
+            )
+        if _path_is_within(cache_path, output):
+            raise ReducerError(
+                f"--cache-file must not be inside output directory {output}"
+            )
+
+    with tempfile.TemporaryDirectory(prefix="hotswap-reduce-") as temporary_name:
+        work_root = Path(temporary_name)
+        initial = snapshot_candidate(initial, work_root / "originals")
+        runner = PredicateRunner(
+            [args.predicate] + args.predicate_arg,
+            args.interesting_exit_code,
+            args.predicate_runs,
+            args.timeout,
+            work_root,
+            PredicateCache(None),
+            args.cache_dependency,
+            args.cache_tag,
+        )
+        if cache_path is not None and cache_path in {
+            Path(identity["path"]) for identity in runner.identity_files
+        }:
+            raise ReducerError(
+                f"refusing to overwrite predicate identity with cache {cache_path}"
+            )
+        runner.cache = PredicateCache(cache_path)
+        section_tools: Optional[ElfSectionTools] = None
+        if args.allow_remove_section:
+            artifact_root = work_root / "artifacts"
+            artifact_root.mkdir()
+            section_tools = ElfSectionTools(
+                args.readobj,
+                args.objcopy,
+                args.tool_timeout,
+                args.allow_remove_section,
+                args.protect_section,
+                artifact_root,
+            )
+        reducer = Reducer(
+            initial,
+            runner,
+            args.allow_empty_bundle,
+            section_tools,
+        )
+        final = reducer.run()
+        reduction_log = reducer.make_log()
+        atomic_publish(output, final, reduction_log)
+        published = load_bundle(output / "bundle.json")
+        return published, reduction_log
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = make_argument_parser()
+    args = parser.parse_args(argv)
+    try:
+        final, reduction_log = run_from_arguments(args)
+    except KeyboardInterrupt:
+        print("hotswap-reduce: interrupted; no output was published", file=sys.stderr)
+        return 130
+    except ReducerError as error:
+        print(f"hotswap-reduce: error: {error}", file=sys.stderr)
+        return 1
+    print(
+        f"wrote {args.output} with {len(final.code_objects)} code object(s); "
+        f"digest {reduction_log['final_digest']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/amd/comgr/utils/hotswap/hotswap_reduce.py
+++ b/amd/comgr/utils/hotswap/hotswap_reduce.py
@@ -57,6 +57,7 @@ DEFAULT_PROTECTED_SECTIONS = (
     ".AMDGPU.*",
 )
 CAPTURE_LIMIT = 4096
+MAX_COMPONENT_CHARS = 80
 
 
 class ReducerError(Exception):
@@ -126,7 +127,7 @@ def atomic_write_json(path: Path, value: Any) -> None:
 
 def _safe_component(value: str) -> str:
     component = re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("._")
-    return component[:80] or "object"
+    return component[:MAX_COMPONENT_CHARS] or "object"
 
 
 def _object_output_name(index: int, object_id: str, original_name: str) -> str:
@@ -495,6 +496,7 @@ class PredicateCache:
         )
 
     def put(self, key: str, result: PredicateResult) -> None:
+        # Only stable terminal outcomes are safe to replay during reduction.
         if result.status not in ("interesting", "uninteresting"):
             return
         self.values[key] = {
@@ -652,6 +654,15 @@ class PredicateRunner:
         digest.update(bytes.fromhex(candidate_digest))
         return digest.hexdigest()
 
+    def _expand_template(self, replacements: dict[str, str]) -> list[str]:
+        argv: list[str] = []
+        for argument in self.argv_template:
+            expanded = argument
+            for placeholder, value in replacements.items():
+                expanded = expanded.replace(placeholder, value)
+            argv.append(expanded)
+        return argv
+
     def _expand_argv(self, workspace: Path, candidate: Candidate) -> list[str]:
         replacements = {
             "{workspace}": str(workspace),
@@ -670,13 +681,7 @@ class PredicateRunner:
                 "{input} requires exactly one code object; use {bundle} "
                 "while reducing a multi-object corpus"
             )
-        argv: list[str] = []
-        for argument in self.argv_template:
-            expanded = argument
-            for placeholder, value in replacements.items():
-                expanded = expanded.replace(placeholder, value)
-            argv.append(expanded)
-        return argv
+        return self._expand_template(replacements)
 
     @staticmethod
     def _normalize_capture(value: Any, workspace: Path) -> str:
@@ -854,13 +859,7 @@ class PredicateRunner:
                     candidate.code_objects[0].original_name,
                 )
             ).as_posix()
-        argv: list[str] = []
-        for argument in self.argv_template:
-            expanded = argument
-            for placeholder, value in replacements.items():
-                expanded = expanded.replace(placeholder, value)
-            argv.append(expanded)
-        return argv
+        return self._expand_template(replacements)
 
 
 def ddmin(

--- a/amd/comgr/utils/hotswap/hotswap_reduce.py
+++ b/amd/comgr/utils/hotswap/hotswap_reduce.py
@@ -13,9 +13,12 @@ import copy
 import fnmatch
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
+import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -42,6 +45,11 @@ DEFAULT_PROTECTED_SECTIONS = (
     ".strtab",
     ".dynstr",
     ".shstrtab",
+    ".rel",
+    ".rel.*",
+    ".rela",
+    ".rela.*",
+    ".group",
     ".rodata",
     ".data",
     ".bss",
@@ -63,7 +71,7 @@ def load_json(path: Path) -> Any:
     try:
         with path.open("r", encoding="utf-8") as stream:
             return json.load(stream, parse_constant=_reject_json_constant)
-    except (OSError, json.JSONDecodeError, ValueError) as error:
+    except (OSError, json.JSONDecodeError, ValueError, RecursionError) as error:
         raise ReducerError(f"{path}: malformed JSON: {error}") from error
 
 
@@ -76,7 +84,7 @@ def canonical_json_bytes(value: Any) -> bytes:
             separators=(",", ":"),
             sort_keys=True,
         )
-    except (TypeError, ValueError) as error:
+    except (TypeError, ValueError, RecursionError) as error:
         raise ReducerError(f"value is not canonical JSON: {error}") from error
     return text.encode("ascii")
 
@@ -147,6 +155,7 @@ class CodeObject:
 class Candidate:
     code_objects: tuple[CodeObject, ...]
     metadata: dict[str, Any]
+    source_paths: tuple[Path, ...] = ()
 
     def digest(self) -> str:
         digest = hashlib.sha256()
@@ -179,10 +188,17 @@ def _validate_metadata(metadata: Any, source: str) -> dict[str, Any]:
     return copy.deepcopy(metadata)
 
 
-def _resolve_input_path(path_value: Any, base: Path, description: str) -> Path:
+def _resolve_input_path(
+    path_value: Any,
+    base: Path,
+    description: str,
+    require_within_base: bool = False,
+) -> Path:
     if not isinstance(path_value, str) or not path_value:
         raise ReducerError(f"{description}: path must be a non-empty string")
     path = Path(path_value)
+    if require_within_base and path.is_absolute():
+        raise ReducerError(f"{description}: bundle path must be relative")
     if not path.is_absolute():
         path = base / path
     try:
@@ -193,6 +209,8 @@ def _resolve_input_path(path_value: Any, base: Path, description: str) -> Path:
         ) from error
     if not path.is_file():
         raise ReducerError(f"{description}: {path} is not a regular file")
+    if require_within_base and not _path_is_within(path, base.resolve()):
+        raise ReducerError(f"{description}: bundle path escapes {base.resolve()}")
     return path
 
 
@@ -231,6 +249,7 @@ def load_bundle(path: Path) -> Candidate:
             object_value.get("path"),
             bundle_path.parent,
             f"{bundle_path}: code_objects[{index}]",
+            require_within_base=True,
         )
         code_objects.append(
             CodeObject(
@@ -241,17 +260,23 @@ def load_bundle(path: Path) -> Candidate:
             )
         )
 
+    source_paths = [bundle_path]
+    source_paths.extend(code_object.path for code_object in code_objects)
     metadata_value = value.get("metadata", {})
     if isinstance(metadata_value, str):
         metadata_path = _resolve_input_path(
-            metadata_value, bundle_path.parent, f"{bundle_path}: metadata"
+            metadata_value,
+            bundle_path.parent,
+            f"{bundle_path}: metadata",
+            require_within_base=True,
         )
+        source_paths.append(metadata_path)
         metadata_value = load_json(metadata_path)
         metadata_source = str(metadata_path)
     else:
         metadata_source = f"{bundle_path}: metadata"
     metadata = _validate_metadata(metadata_value, metadata_source)
-    return Candidate(tuple(code_objects), metadata)
+    return Candidate(tuple(code_objects), metadata, tuple(source_paths))
 
 
 def load_nul_worklist(path: Path) -> list[Path]:
@@ -326,16 +351,20 @@ def load_inputs(
             )
         )
 
+    source_paths = [item.path for item in code_objects]
+    if worklist is not None:
+        source_paths.append(worklist.resolve())
     if metadata_path is None:
         metadata: dict[str, Any] = {}
     else:
         resolved_metadata = _resolve_input_path(
             str(metadata_path), Path.cwd(), "--metadata"
         )
+        source_paths.append(resolved_metadata)
         metadata = _validate_metadata(
             load_json(resolved_metadata), str(resolved_metadata)
         )
-    return Candidate(tuple(code_objects), metadata)
+    return Candidate(tuple(code_objects), metadata, tuple(source_paths))
 
 
 def materialize_candidate(candidate: Candidate, destination: Path) -> dict[str, Any]:
@@ -350,6 +379,11 @@ def materialize_candidate(candidate: Candidate, destination: Path) -> dict[str, 
         relative_path = Path("objects") / output_name
         output_path = destination / relative_path
         shutil.copyfile(code_object.path, output_path)
+        copied_digest = sha256_file(output_path)
+        if copied_digest != code_object.digest:
+            raise ReducerError(
+                f"{code_object.path}: content changed while materializing candidate"
+            )
         object_entries.append(
             {
                 "id": code_object.object_id,
@@ -411,7 +445,6 @@ class PredicateResult:
         return {
             "status": self.status,
             "exit_codes": list(self.exit_codes),
-            "cached": self.cached,
             "stdout": self.stdout,
             "stderr": self.stderr,
         }
@@ -435,20 +468,24 @@ class PredicateCache:
 
     def get(self, key: str) -> Optional[PredicateResult]:
         value = self.values.get(key)
-        if not isinstance(value, dict):
+        if value is None:
             return None
+        if not isinstance(value, dict):
+            raise ReducerError(f"{self.path or 'predicate cache'}: corrupt entry {key}")
         status = value.get("status")
         exit_codes = value.get("exit_codes")
-        if status not in ("interesting", "uninteresting"):
-            return None
-        if not isinstance(exit_codes, list):
-            return None
-        if not all(code is None or isinstance(code, int) for code in exit_codes):
-            return None
+        if status not in ("interesting", "uninteresting") or not isinstance(
+            exit_codes, list
+        ):
+            raise ReducerError(f"{self.path or 'predicate cache'}: corrupt entry {key}")
+        if not exit_codes or not all(
+            isinstance(code, int) and not isinstance(code, bool) for code in exit_codes
+        ):
+            raise ReducerError(f"{self.path or 'predicate cache'}: corrupt entry {key}")
         stdout = value.get("stdout", "")
         stderr = value.get("stderr", "")
         if not isinstance(stdout, str) or not isinstance(stderr, str):
-            return None
+            raise ReducerError(f"{self.path or 'predicate cache'}: corrupt entry {key}")
         return PredicateResult(
             status,
             tuple(exit_codes),
@@ -542,7 +579,7 @@ class PredicateRunner:
 
     def _collect_identity_files(
         self, executable: Path, cache_dependencies: Sequence[Path]
-    ) -> tuple[dict[str, str], ...]:
+    ) -> tuple[dict[str, Any], ...]:
         identified_paths: list[tuple[str, Path]] = [("executable", executable)]
         for index, argument in enumerate(self.argv_template[1:], start=1):
             if any(placeholder in argument for placeholder in KNOWN_PLACEHOLDERS):
@@ -558,25 +595,45 @@ class PredicateRunner:
                 )
             identified_paths.append((f"dependency[{index}]", dependency_path))
 
-        identities: list[dict[str, str]] = []
+        identities: list[dict[str, Any]] = []
         seen_paths: set[Path] = set()
         for role, path in identified_paths:
             if path in seen_paths:
                 continue
             seen_paths.add(path)
-            identities.append(
-                {
-                    "path": str(path),
-                    "role": role,
-                    "sha256": sha256_file(path),
-                }
-            )
+            try:
+                file_mode = stat.S_IMODE(path.stat().st_mode)
+            except OSError as error:
+                raise ReducerError(
+                    f"could not inspect predicate identity {path}: {error}"
+                )
+            identity: dict[str, Any] = {
+                "path": str(path),
+                "role": role,
+                "sha256": sha256_file(path),
+                "mode": file_mode,
+            }
+            if role == "executable":
+                identity["executable"] = os.access(path, os.X_OK)
+            identities.append(identity)
         return tuple(identities)
 
     def _verify_identity_files(self) -> None:
         for identity in self.identity_files:
             path = Path(identity["path"])
-            if not path.is_file() or sha256_file(path) != identity["sha256"]:
+            try:
+                current_mode = stat.S_IMODE(path.stat().st_mode)
+            except OSError:
+                current_mode = None
+            executable_matches = identity.get("role") != "executable" or os.access(
+                path, os.X_OK
+            ) == identity.get("executable")
+            if (
+                not path.is_file()
+                or current_mode != identity.get("mode")
+                or not executable_matches
+                or sha256_file(path) != identity["sha256"]
+            ):
                 raise ReducerError(
                     f"predicate identity changed during reduction: {path}"
                 )
@@ -634,18 +691,110 @@ class PredicateRunner:
             text = text[:CAPTURE_LIMIT] + "\n<truncated>"
         return text
 
+    @staticmethod
+    def _terminate_process_tree(process: subprocess.Popen[bytes]) -> None:
+        if os.name == "nt":
+            if process.poll() is None:
+                try:
+                    subprocess.run(
+                        [
+                            "taskkill.exe",
+                            "/PID",
+                            str(process.pid),
+                            "/T",
+                            "/F",
+                        ],
+                        stdin=subprocess.DEVNULL,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        check=False,
+                        timeout=5.0,
+                    )
+                except (OSError, subprocess.TimeoutExpired):
+                    pass
+                if process.poll() is None:
+                    process.kill()
+        else:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            except PermissionError:
+                if process.poll() is None:
+                    process.kill()
+        try:
+            process.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            if process.poll() is None:
+                process.kill()
+            process.wait()
+
+    def _run_predicate(
+        self, argv: Sequence[str], workspace: Path
+    ) -> tuple[Optional[int], str, str, bool]:
+        creation_flags = (
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) if os.name == "nt" else 0
+        )
+        with tempfile.TemporaryFile() as stdout_stream:
+            with tempfile.TemporaryFile() as stderr_stream:
+                try:
+                    process = subprocess.Popen(
+                        argv,
+                        cwd=workspace,
+                        stdin=subprocess.DEVNULL,
+                        stdout=stdout_stream,
+                        stderr=stderr_stream,
+                        start_new_session=os.name != "nt",
+                        creationflags=creation_flags,
+                    )
+                except OSError as error:
+                    return (
+                        None,
+                        "",
+                        self._normalize_capture(
+                            f"could not launch predicate: {error}", workspace
+                        ),
+                        False,
+                    )
+                timed_out = False
+                try:
+                    try:
+                        return_code = process.wait(timeout=self.timeout)
+                    except subprocess.TimeoutExpired:
+                        timed_out = True
+                        return_code = None
+                finally:
+                    self._terminate_process_tree(process)
+                stdout_stream.seek(0)
+                stderr_stream.seek(0)
+                stdout = self._normalize_capture(
+                    stdout_stream.read(CAPTURE_LIMIT + 1), workspace
+                )
+                stderr = self._normalize_capture(
+                    stderr_stream.read(CAPTURE_LIMIT + 1), workspace
+                )
+                return return_code, stdout, stderr, timed_out
+
     def evaluate(self, candidate: Candidate) -> PredicateResult:
         self._verify_identity_files()
         candidate_digest = candidate.digest()
         cache_key = self._cache_key(candidate_digest)
         cached = self.cache.get(cache_key)
         if cached is not None:
+            if (
+                len(cached.exit_codes) != self.runs
+                or len(set(cached.exit_codes)) != 1
+                or cached.interesting
+                != (cached.exit_codes[0] == self.interesting_exit_code)
+            ):
+                raise ReducerError(
+                    f"{self.cache.path or 'predicate cache'}: corrupt entry {cache_key}"
+                )
             return cached
 
         exit_codes: list[Optional[int]] = []
         outputs: list[str] = []
         errors: list[str] = []
-        outcomes: list[bool] = []
         for _ in range(self.runs):
             with tempfile.TemporaryDirectory(
                 prefix="predicate-", dir=self.work_root
@@ -653,49 +802,32 @@ class PredicateRunner:
                 workspace = Path(temporary_name)
                 materialize_candidate(candidate, workspace)
                 argv = self._expand_argv(workspace, candidate)
-                try:
-                    completed = subprocess.run(
-                        argv,
-                        cwd=workspace,
-                        stdin=subprocess.DEVNULL,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                        check=False,
-                        timeout=self.timeout,
-                    )
-                except subprocess.TimeoutExpired as error:
-                    exit_codes.append(None)
-                    outputs.append(self._normalize_capture(error.stdout, workspace))
-                    errors.append(self._normalize_capture(error.stderr, workspace))
+                return_code, stdout, stderr, timed_out = self._run_predicate(
+                    argv, workspace
+                )
+                exit_codes.append(return_code)
+                outputs.append(stdout)
+                errors.append(stderr)
+                if timed_out:
                     return PredicateResult(
                         "timeout",
                         tuple(exit_codes),
                         "\n".join(outputs),
                         "\n".join(errors),
                     )
-                except OSError as error:
-                    exit_codes.append(None)
-                    errors.append(
-                        self._normalize_capture(
-                            f"could not launch predicate: {error}", workspace
-                        )
-                    )
+                if return_code is None:
                     return PredicateResult(
                         "launch-error",
                         tuple(exit_codes),
                         "\n".join(outputs),
                         "\n".join(errors),
                     )
-                exit_codes.append(completed.returncode)
-                outcomes.append(completed.returncode == self.interesting_exit_code)
-                outputs.append(self._normalize_capture(completed.stdout, workspace))
-                errors.append(self._normalize_capture(completed.stderr, workspace))
 
         self._verify_identity_files()
-        if all(outcomes):
-            status = "interesting"
-        elif any(outcomes):
+        if len(set(exit_codes)) != 1:
             status = "flaky"
+        elif exit_codes[0] == self.interesting_exit_code:
+            status = "interesting"
         else:
             status = "uninteresting"
         result = PredicateResult(
@@ -840,6 +972,7 @@ class ElfSectionTools:
             UnicodeDecodeError,
             json.JSONDecodeError,
             ValueError,
+            RecursionError,
             IndexError,
             KeyError,
             TypeError,
@@ -885,19 +1018,67 @@ class ElfSectionTools:
         return sections
 
     def removable_sections(self, path: Path) -> list[str]:
-        removable: list[str] = []
+        sections_by_name: dict[str, list[SectionInfo]] = {}
+        section_order: list[str] = []
         for section in self.list_sections(path):
+            if section.name not in sections_by_name:
+                sections_by_name[section.name] = []
+                section_order.append(section.name)
+            sections_by_name[section.name].append(section)
+
+        removable: list[str] = []
+        for section_name in section_order:
+            same_name_sections = sections_by_name[section_name]
             allowed = any(
-                fnmatch.fnmatchcase(section.name, pattern)
+                fnmatch.fnmatchcase(section_name, pattern)
                 for pattern in self.allow_patterns
             )
-            protected = section.allocated or any(
-                fnmatch.fnmatchcase(section.name, pattern)
+            protected = any(section.allocated for section in same_name_sections) or any(
+                fnmatch.fnmatchcase(section_name, pattern)
                 for pattern in self.protect_patterns
             )
             if allowed and not protected:
-                removable.append(section.name)
+                removable.append(section_name)
         return removable
+
+    def _verify_objcopy_output(
+        self,
+        input_path: Path,
+        output_path: Path,
+        requested_removals: Sequence[str],
+    ) -> None:
+        input_sections = self.list_sections(input_path)
+        output_sections = self.list_sections(output_path)
+        output_counts: dict[str, int] = {}
+        for section in output_sections:
+            output_counts[section.name] = output_counts.get(section.name, 0) + 1
+        requested = set(requested_removals)
+        retained_counts: dict[str, int] = {}
+        for section in input_sections:
+            if section.name not in requested:
+                retained_counts[section.name] = retained_counts.get(section.name, 0) + 1
+        remaining_requested = sorted(
+            name for name in requested if output_counts.get(name, 0) != 0
+        )
+        missing_retained = sorted(
+            name
+            for name, count in retained_counts.items()
+            if output_counts.get(name, 0) < count
+        )
+        if remaining_requested or missing_retained:
+            details: list[str] = []
+            if remaining_requested:
+                details.append(
+                    "requested sections remain: " + ", ".join(remaining_requested)
+                )
+            if missing_retained:
+                details.append(
+                    "unrequested sections disappeared: " + ", ".join(missing_retained)
+                )
+            raise ReducerError(
+                f"llvm-objcopy output verification failed for {input_path}: "
+                + "; ".join(details)
+            )
 
     def remove_sections(
         self, code_object: CodeObject, section_names: Sequence[str]
@@ -964,6 +1145,13 @@ class ElfSectionTools:
                     f"llvm-objcopy produced an empty object for "
                     f"{code_object.object_id!r}"
                 )
+            try:
+                self._verify_objcopy_output(
+                    code_object.path, temporary_path, section_names
+                )
+            except ReducerError:
+                temporary_path.unlink()
+                raise
             os.replace(temporary_path, output_path)
             self.artifact_digests[output_path] = sha256_file(output_path)
         output_digest = self.artifact_digests.get(output_path)
@@ -1000,22 +1188,7 @@ class Reducer:
         candidate: Candidate,
     ) -> bool:
         candidate_digest = candidate.digest()
-        try:
-            result = self.runner.evaluate(candidate)
-        except ReducerError as error:
-            self.transformations.append(
-                {
-                    "pass": pass_name,
-                    "transformation": transformation,
-                    "candidate_digest": candidate_digest,
-                    "accepted": False,
-                    "predicate": {
-                        "status": "configuration-error",
-                        "error": str(error),
-                    },
-                }
-            )
-            return False
+        result = self.runner.evaluate(candidate)
         accepted = result.interesting
         self.transformations.append(
             {
@@ -1169,9 +1342,13 @@ class Reducer:
                 "the original input is not stably interesting: "
                 f"predicate status is {initial_result.status!r}"
             )
-        self.reduce_bundle()
-        self.reduce_metadata()
-        self.reduce_sections()
+        while True:
+            previous_digest = self.current.digest()
+            self.reduce_bundle()
+            self.reduce_metadata()
+            self.reduce_sections()
+            if self.current.digest() == previous_digest:
+                break
         return self.current
 
     def make_log(self) -> dict[str, Any]:
@@ -1249,8 +1426,8 @@ def _path_is_within(path: Path, directory: Path) -> bool:
 
 def _positive_float(value: str) -> float:
     parsed = float(value)
-    if parsed <= 0:
-        raise argparse.ArgumentTypeError("must be greater than zero")
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be finite and greater than zero")
     return parsed
 
 
@@ -1380,10 +1557,7 @@ def run_from_arguments(args: argparse.Namespace) -> tuple[Candidate, dict[str, A
         raise ReducerError(f"refusing to overwrite existing output {output}")
     cache_path = args.cache_file.resolve() if args.cache_file is not None else None
     if cache_path is not None:
-        protected_inputs = {item.path.resolve() for item in initial.code_objects}
-        for path in (args.bundle, args.metadata, args.worklist):
-            if path is not None:
-                protected_inputs.add(path.resolve())
+        protected_inputs = {path.resolve() for path in initial.source_paths}
         protected_inputs.update(path.resolve() for path in args.cache_dependency)
         if cache_path in protected_inputs:
             raise ReducerError(
@@ -1449,6 +1623,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 130
     except ReducerError as error:
         print(f"hotswap-reduce: error: {error}", file=sys.stderr)
+        return 1
+    except OSError as error:
+        print(f"hotswap-reduce: filesystem error: {error}", file=sys.stderr)
         return 1
     print(
         f"wrote {args.output} with {len(final.code_objects)} code object(s); "


### PR DESCRIPTION
## Summary

Add an offline, predicate-driven reducer for hotswap failures:

- delta-debug code-object bundles, structured metadata, selector output, and
  NUL-delimited inventory worklists;
- invoke interestingness predicates as argv vectors without a shell, repeat
  uncached checks to detect flakiness, terminate timed-out process trees, and
  reject timeouts or launch failures;
- optionally remove only explicitly allowed, non-allocated AMDGPU ELF sections
  while protecting loadable and semantic sections and verifying objcopy output;
- snapshot inputs, publish results atomically, and emit deterministic,
  versioned bundles, logs, repro commands, and content-addressed caches;
- bind cache entries to predicate and dependency contents and modes,
  configuration tags, and candidate contents;
- repeat hierarchical reduction passes to a fixpoint so later metadata or
  section changes cannot leave an earlier dimension reducible.

## Real corpus acceptance

I exercised the final reducer on `mi300x` against frozen evidence from the
2,685-object #3646 corpus run:

- evidence:
  `/home/harsh/hotswap-corpus-20260725-final-staging-ab3cdd61-full2685`
- `prior-failures-now-success.tsv` SHA-256:
  `756066cad7ca7aea97b5d9474784f5ad4ae00bc2a1b3d381bf0592f968cfb892`
- `results.tsv` SHA-256:
  `ffb089ac585374ac3e9edd93cb0668ed9c6c6b21514948d94884a20f7c2176b9`
- input: 8 code objects, 659,584 bytes (four historical
  failure-to-success objects plus four successful controls)
- output: 1 code object, 47,720 bytes
- retained object SHA-256:
  `4b3086c8dd8435f2def234217060ed73d11c928fa6e97e5199ce23b1ad81a42c`
- predicate: a generic offline join of the frozen prior/current TSVs, selecting
  rows by the supplied diagnostic substring and preserving a matching input
  hash in the candidate bundle
- predicate configuration: two runs per uncached candidate, 30-second timeout,
  evidence files as explicit cache dependencies, evidence/reducer hashes as
  cache tags
- reviewed reducer SHA-256:
  `abf67d0f1f865c3b4c2b49704f24b692b4e970a3a61d4509bd0da85482b1f02e`
- result: 5 transformations (3 accepted, 2 rejected), reproduction exit 0
- initial candidate digest:
  `996c358227ffeeceb14ebe9997ca6119f7baca8e32affa481d766780f916909a`
- final candidate digest:
  `bc64dcd403cdd51b798bcbc99549584e63aa9978cc779928b88434b95ceeca1b`
- uncached wall time: 1.09 seconds; maximum RSS: 24,576 KiB

This acceptance validates deterministic corpus-membership reduction using real
failure evidence. It does not claim instruction-level reduction, runtime
semantic correctness, or GPU validation.

## Validation

- `python3 -m unittest -v amd/comgr/test/utils/test_hotswap_reduce.py`
  (54 passed)
- branch coverage: 84% (861 statements, 290 branches)
- `ruff check` and `ruff format --check`
- `mypy --ignore-missing-imports` on implementation and tests
- clean standalone Comgr CMake configure
- registered `comgr_hotswap_reduce_test` CTest (1/1 passed)
- CLI help and repository diff checks
- real 534,984-byte AMDGPU code object section reduction with
  `llvm-readobj`/`llvm-objcopy`, preserving all unrequested sections

## Limits and follow-up

- The external predicate defines interestingness; this utility does not prove
  correctness by itself.
- Linked ELF instruction rewriting is intentionally out of scope. `llvm-reduce`
  remains the appropriate earlier-stage option for IR/MIR.
- ELF section reduction is fail-closed and limited to explicitly opted-in,
  non-allocated, unprotected sections.
- Persistent cache publication is atomic, but independent concurrent writers do
  not merge entries.
- No public Comgr API is changed.
- No GPU or ASan result is claimed for this utility-only PR.

The review-hardening and Windows portability checks pass. This is ready for
review.
