### PR TITLE
[MLIR][OpenMP] Restore debug-info fixup for declare target function.

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -9179,8 +9179,9 @@ convertDeclareTargetAttr(Operation *op, mlir::omp::DeclareTargetAttr attribute,
         // a deleted block.
         ompBuilder->Builder.ClearInsertionPoint();
         ompBuilder->Builder.SetCurrentDebugLocation(llvm::DebugLoc());
-      } else if (llvm::Function *llvmFunc =
-                     moduleTranslation.lookupFunction(funcOp.getName())) {
+      } else if (llvmFunc) {
+        updateDebugInfoForDeclareTargetFunctions(llvmFunc, moduleTranslation);
+
         // Device-side declare target functions are externally visible by
         // default so they can be referenced from other device translation
         // units. That also prevents the offload LTO from internalizing and
@@ -9194,8 +9195,6 @@ convertDeclareTargetAttr(Operation *op, mlir::omp::DeclareTargetAttr attribute,
         if (!llvmFunc->isDeclaration() && llvmFunc->hasExternalLinkage() &&
             llvmFunc->getVisibility() == llvm::GlobalValue::DefaultVisibility)
           llvmFunc->setVisibility(llvm::GlobalValue::HiddenVisibility);
-      } else {
-        updateDebugInfoForDeclareTargetFunctions(llvmFunc, moduleTranslation);
       }
     }
     return success();

--- a/mlir/test/Target/LLVMIR/omptarget-decl-target-fn-debug-amdgpu.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-decl-target-fn-debug-amdgpu.mlir
@@ -23,7 +23,7 @@ module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_target_devic
 #loc3 = loc(fused<#sp>[#loc1])
 
 // CHECK: define{{.*}}@add(ptr %[[ARG:[0-9]+]]){{.*}}!dbg ![[SP:[0-9]+]] {
-// CHECK: #dbg_declare(ptr %[[ARG]], ![[A:[0-9]+]], !DIExpression()
+// CHECK: #dbg_declare(ptr %[[ARG]], ![[A:[0-9]+]], !DIExpression(DIOpArg(0, ptr), DIOpDeref(ptr)), !{{.*}})
 // CHECK: }
 // CHECK: ![[SP]] = {{.*}}!DISubprogram(name: "add"{{.*}})
 // CHECK: ![[A]] = !DILocalVariable(name: "a", arg: 1, scope: ![[SP]]{{.*}})


### PR DESCRIPTION
A recent merge of the upstream hidden-visibility change [PR](https://github.com/llvm/llvm-project/pull/207234) onto the downstream `convertDeclareTargetAttr `code chained the two into an if / else-if / else where the else-if (which re-looks-up the function with a null test) is always taken for declare target device functions. That left the trailing else, the only caller of `updateDebugInfoForDeclareTargetFunctions`, unreachable. The device functions stopped getting the DIOp expressions the AMDGPU backend needs and debug info was wrong.

This PR calls `updateDebugInfoForDeclareTargetFunctions `in the (live) branch alongside the hidden-visibility handling, and drop the dead else. Restore the CHECK in omptarget-decl-target-fn-debug-amdgpu.mlir, which had been weakened during the same merge to expect the (broken) empty !DIExpression() and un-xfailed, so it now guards the correct DIOpArg/DIOpDeref expression again.