### PR TITLE
[DO NOT MERGE] Validate hotswap-only reduced CI

### DIFF
--- a/amd/comgr/src/hotswap/README.md
+++ b/amd/comgr/src/hotswap/README.md
@@ -84,3 +84,5 @@ cmake -S amd/comgr/src/hotswap/raiser -B build-hotswap \
 ninja -C build-hotswap
 ctest --test-dir build-hotswap -L transpiler
 ```
+
+<!-- validation: trigger hotswap-only reduced CI (throwaway, do not merge) -->


### PR DESCRIPTION
Throwaway validation PR for the hotswap-only reduced-CI change. **Do not merge.**

Base branch (`users/lambj/hotswap-reduced-ci-testbase`) carries the reduced-CI
workflow changes; this PR touches only `amd/comgr/src/hotswap/README.md`, so the
`classify` job should report `hotswap_only=true`.

Expected behavior:
- Multi-Arch CI: only the `compiler-runtime` stage runs (Linux + Windows); math-libs
  / comm-libs / debug-tools / dctools-core / media-libs / runtime-tests, per-family
  GPU tests, artifact-structure, and python-packaging jobs are skipped.
- `hotswap_required_check_shim` posts synthesized success for the math-libs required
  context (gated on the compiler-runtime build succeeding).
- Legacy CI: build/test matrices skipped; shim posts `gfx90a Test` success.

ISSUE ID: #0000 (validation only)