### PR TITLE
[Clang][Sema] Deduce element count from `__vector_size__(N * sizeof(T))`

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -263,6 +263,42 @@ getDeducedNTTParameterFromExpr(TemplateDeductionInfo &Info, Expr *E) {
   return getDeducedNTTParameterFromExpr(E, Info.getDeducedDepth());
 }
 
+/// If the size expression of a dependent vector type is written in the
+/// idiomatic form 'N * sizeof(ElementType)', in either operand order, return
+/// the declaration of the non-type template parameter 'N'. Otherwise, return
+/// null. This lets a generic '__vector_size__' vector take part in template
+/// argument deduction the way an 'ext_vector_type' vector already does.
+static NonTypeOrVarTemplateParmDecl
+getDeducedVectorSizeParm(const Expr *SizeExpr, QualType ElementType,
+                         const ASTContext &Context, unsigned Depth) {
+  const auto *Mul = dyn_cast<BinaryOperator>(SizeExpr->IgnoreParenImpCasts());
+  if (!Mul || Mul->getOpcode() != BO_Mul)
+    return nullptr;
+
+  const Expr *LHS = Mul->getLHS()->IgnoreParenImpCasts();
+  const Expr *RHS = Mul->getRHS()->IgnoreParenImpCasts();
+
+  auto IsSizeOfElement = [&](const Expr *E) {
+    const auto *U = dyn_cast<UnaryExprOrTypeTraitExpr>(E);
+    return U && U->getKind() == UETT_SizeOf && U->isArgumentType() &&
+           Context.hasSameType(U->getArgumentType(), ElementType);
+  };
+
+  if (IsSizeOfElement(RHS))
+    return getDeducedNTTParameterFromExpr(LHS, Depth);
+  if (IsSizeOfElement(LHS))
+    return getDeducedNTTParameterFromExpr(RHS, Depth);
+
+  return nullptr;
+}
+
+static NonTypeOrVarTemplateParmDecl
+getDeducedVectorSizeParm(TemplateDeductionInfo &Info, Expr *SizeExpr,
+                         QualType ElementType, const ASTContext &Context) {
+  return getDeducedVectorSizeParm(SizeExpr, ElementType, Context,
+                                  Info.getDeducedDepth());
+}
+
 /// Determine whether two declaration pointers refer to the same
 /// declaration.
 static bool isSameDeclaration(Decl *X, Decl *Y) {
@@ -2259,6 +2295,9 @@ static TemplateDeductionResult DeduceTemplateArgumentsByTypeMatch(
         // Perform deduction on the vector size, if we can.
         NonTypeOrVarTemplateParmDecl NTTP =
             getDeducedNTTParameterFromExpr(Info, VP->getSizeExpr());
+        if (!NTTP)
+          NTTP = getDeducedVectorSizeParm(Info, VP->getSizeExpr(),
+                                          VP->getElementType(), S.Context);
         if (!NTTP)
           return TemplateDeductionResult::Success;
 
@@ -6895,6 +6934,10 @@ MarkUsedTemplateParameters(ASTContext &Ctx, QualType T,
                                Depth, Used);
     MarkUsedTemplateParameters(Ctx, VecType->getSizeExpr(), OnlyDeduced, Depth,
                                Used);
+
+    if (const NonTypeOrVarTemplateParmDecl NTTP = getDeducedVectorSizeParm(
+            VecType->getSizeExpr(), VecType->getElementType(), Ctx, Depth))
+      Used[NTTP.getIndex()] = true;
     break;
   }
   case Type::DependentSizedExtVector: {

--- a/clang/test/SemaTemplate/deduce-vector-size-idiom.cpp
+++ b/clang/test/SemaTemplate/deduce-vector-size-idiom.cpp
@@ -1,0 +1,228 @@
+// RUN: %clang_cc1 -std=c++17 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -std=c++17 -fsyntax-only -verify %s
+
+template <class A, class B> struct is_same {
+  static constexpr bool value = false;
+};
+template <class A> struct is_same<A, A> {
+  static constexpr bool value = true;
+};
+
+template <class T> T make();
+template <int N> struct tag {};
+
+template <class T, int N>
+using gen = T __attribute__((__vector_size__(N * sizeof(T))));
+template <class T, int N>
+using ext = T __attribute__((ext_vector_type(N)));
+
+namespace both_deduced {
+template <class V> struct traits {
+  static constexpr int size = 0;
+  using scalar = void;
+};
+template <class T, int N>
+struct traits<T __attribute__((__vector_size__(N * sizeof(T))))> {
+  static constexpr int size = N;
+  using scalar = T;
+};
+
+static_assert(traits<gen<float, 4>>::size == 4);
+static_assert(is_same<traits<gen<float, 4>>::scalar, float>::value);
+static_assert(traits<gen<double, 2>>::size == 2);
+
+static_assert(traits<gen<char, 16>>::size == 16);
+static_assert(is_same<traits<gen<char, 16>>::scalar, char>::value);
+
+static_assert(traits<float>::size == 0);
+static_assert(traits<ext<float, 4>>::size == 0);
+}
+
+namespace spelling {
+template <class V> struct reversed {
+  static constexpr int size = 0;
+};
+template <class T, int N>
+struct reversed<T __attribute__((__vector_size__(sizeof(T) * N)))> {
+  static constexpr int size = N;
+};
+static_assert(reversed<gen<int, 2>>::size == 2);
+static_assert(reversed<gen<double, 4>>::size == 4);
+
+template <class V> struct parenthesized {
+  static constexpr int size = 0;
+};
+template <class T, int N>
+struct parenthesized<T __attribute__((__vector_size__((N * sizeof(T)))))> {
+  static constexpr int size = N;
+};
+static_assert(parenthesized<gen<int, 4>>::size == 4);
+}
+
+namespace fixed_element {
+template <class V> struct traits {
+  static constexpr int size = 0;
+};
+template <int N>
+struct traits<int __attribute__((__vector_size__(N * sizeof(int))))> {
+  static constexpr int size = N;
+};
+static_assert(traits<gen<int, 4>>::size == 4);
+static_assert(traits<gen<int, 16>>::size == 16);
+static_assert(traits<gen<float, 4>>::size == 0);
+}
+
+namespace unsigned_parameter {
+template <class V> struct traits {
+  static constexpr unsigned size = 0;
+};
+template <class T, unsigned N>
+struct traits<T __attribute__((__vector_size__(N * sizeof(T))))> {
+  static constexpr unsigned size = N;
+};
+static_assert(traits<gen<int, 4>>::size == 4u);
+}
+
+namespace via_alias {
+template <class T, int Rank>
+using native_vector = T __attribute__((__vector_size__(Rank * sizeof(T))));
+
+template <class V> struct traits {
+  static constexpr int size = 0;
+  using scalar = void;
+};
+template <class T, int Rank>
+struct traits<native_vector<T, Rank>> {
+  static constexpr int size = Rank;
+  using scalar = T;
+};
+
+static_assert(traits<native_vector<float, 4>>::size == 4);
+static_assert(traits<gen<double, 8>>::size == 8);
+static_assert(is_same<traits<gen<double, 8>>::scalar, double>::value);
+static_assert(traits<float>::size == 0);
+}
+
+namespace variable_template {
+template <class V> constexpr int size = 0;
+template <class T, int N>
+constexpr int size<T __attribute__((__vector_size__(N * sizeof(T))))> = N;
+
+static_assert(size<gen<float, 4>> == 4);
+static_assert(size<gen<char, 16>> == 16);
+static_assert(size<float> == 0);
+}
+
+namespace coexistence {
+struct ExtKind {};
+struct GenKind {};
+
+template <class V> struct notation {
+  static constexpr int size = 0;
+  using kind = void;
+};
+template <class T, int N>
+struct notation<T __attribute__((ext_vector_type(N)))> {
+  static constexpr int size = N;
+  using kind = ExtKind;
+};
+template <class T, int N>
+struct notation<T __attribute__((__vector_size__(N * sizeof(T))))> {
+  static constexpr int size = N;
+  using kind = GenKind;
+};
+
+static_assert(notation<ext<float, 4>>::size == 4);
+static_assert(is_same<notation<ext<float, 4>>::kind, ExtKind>::value);
+static_assert(notation<gen<float, 4>>::size == 4);
+static_assert(is_same<notation<gen<float, 4>>::kind, GenKind>::value);
+static_assert(notation<float>::size == 0);
+}
+
+namespace function_templates {
+template <class T, int N> tag<N> by_value(gen<T, N>);
+static_assert(
+    is_same<decltype(by_value(make<gen<float, 4>>())), tag<4>>::value);
+static_assert(is_same<decltype(by_value(make<gen<char, 8>>())), tag<8>>::value);
+
+template <int N> tag<N> fixed_element(gen<float, N>);
+static_assert(
+    is_same<decltype(fixed_element(make<gen<float, 8>>())), tag<8>>::value);
+
+template <class T, int N>
+tag<N> reversed(T __attribute__((__vector_size__(sizeof(T) * N))));
+static_assert(is_same<decltype(reversed(make<gen<int, 4>>())), tag<4>>::value);
+
+template <class T, int N> tag<N> by_ref(const gen<T, N> &);
+static_assert(is_same<decltype(by_ref(make<gen<float, 4>>())), tag<4>>::value);
+
+template <class T, int N> tag<N> by_ptr(gen<T, N> *);
+static_assert(
+    is_same<decltype(by_ptr(make<gen<float, 4> *>())), tag<4>>::value);
+
+template <class T, int N> tag<N> ext_vec(ext<T, N>);
+static_assert(is_same<decltype(ext_vec(make<ext<float, 4>>())), tag<4>>::value);
+}
+
+namespace not_the_idiom {
+template <class V> struct traits {
+  static constexpr int size = 0;
+};
+
+// expected-note@+2{{non-deducible template parameter 'N'}}
+// expected-error@+2{{contains a template parameter that cannot be deduced}}
+template <class T, int N>
+struct traits<T __attribute__((__vector_size__(N * 4)))> {
+  static constexpr int size = N;
+};
+
+// expected-note@+2{{non-deducible template parameter 'N'}}
+// expected-error@+2{{contains a template parameter that cannot be deduced}}
+template <class T, int N>
+struct traits<T __attribute__((__vector_size__(N * sizeof(int))))> {
+  static constexpr int size = N;
+};
+
+// expected-note@+2{{non-deducible template parameter 'N'}}
+// expected-error@+2{{contains a template parameter that cannot be deduced}}
+template <class T, int N>
+struct traits<T __attribute__((__vector_size__(N + sizeof(T))))> {
+  static constexpr int size = N;
+};
+
+// expected-note@+2{{non-deducible template parameter 'N'}}
+// expected-error@+2{{contains a template parameter that cannot be deduced}}
+template <class T, int N>
+struct traits<T __attribute__((__vector_size__(2 * N * sizeof(T))))> {
+  static constexpr int size = N;
+};
+
+static_assert(traits<gen<float, 4>>::size == 0);
+static_assert(traits<gen<int, 4>>::size == 0);
+static_assert(traits<gen<float, 8>>::size == 0);
+}
+
+namespace bare_size {
+template <class V> struct traits {
+  static constexpr int size = 0;
+};
+template <class T, int Bytes>
+struct traits<T __attribute__((__vector_size__(Bytes)))> {
+  static constexpr int size = Bytes;
+};
+static_assert(traits<gen<char, 16>>::size == 16);
+static_assert(traits<gen<float, 4>>::size == 0);
+}
+
+namespace no_deducible_size {
+template <class V> struct traits {
+  static constexpr bool matched = false;
+};
+template <class T>
+struct traits<T __attribute__((__vector_size__(sizeof(T) * sizeof(T))))> {
+  static constexpr bool matched = true;
+};
+static_assert(traits<gen<float, 4>>::matched);
+static_assert(!traits<gen<double, 2>>::matched);
+}


### PR DESCRIPTION
Upstream #176033 ("[AMDGPU][NFC] Change AMDGPU builtins to use ExtVector") switched AMDGPU builtins from `_Vector` to `_ExtVector`. It was reverted two days later in a43f0d9785fa(#1118) and has not been re-landed. The AMDGPU builtins therefore still produce generic `__attribute__((__vector_size__(...)))` vectors. 

Any library that wants to write type traits over the vectors these builtins return therefore has to write them over generic vectors, and it cannot recover the element count of one. This patch fixes it. A vector's byte size is by definition `numElements * sizeof(elementType)`. When the size expression is exactly `N * sizeof(ElementType)` and the `sizeof` operand is the vector's own element type then we get `N` as the element count. 