### PR TITLE
ci: reduced CI for hotswap-only PRs (compiler-runtime only)

### DIFF
--- a/.github/workflows/classify_hotswap.yml
+++ b/.github/workflows/classify_hotswap.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   classify:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     outputs:
       hotswap_only: ${{ steps.detect.outputs.hotswap_only }}
     steps:
@@ -47,11 +48,14 @@ jobs:
             exit 0
           fi
 
+          # Fall back to full CI on any API error: an empty/failed fetch yields
+          # hotswap_only=false, and the job still exits 0 so the build jobs that
+          # depend on `classify` are not skipped.
           files="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
-            --jq '.[].filename')"
+            --jq '.[].filename' 2>/dev/null || true)"
 
           if [[ -z "${files}" ]]; then
-            echo "No changed files reported; hotswap_only=false"
+            echo "No changed files reported (or fetch failed); hotswap_only=false"
             echo "hotswap_only=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi

--- a/.github/workflows/classify_hotswap.yml
+++ b/.github/workflows/classify_hotswap.yml
@@ -1,0 +1,80 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Classify whether a PR is "hotswap-only".
+#
+# A PR is hotswap-only iff it has at least one changed file and EVERY changed
+# file matches the hotswap allowlist below. When true, callers run only the
+# generic `compiler-runtime` build stage (which builds comgr and runs the COMGR
+# lit + ctest suites, exercising the hotswap tests) and skip the per-arch stages,
+# GPU test fan-out, and packaging.
+#
+# Conservative by design: any path outside the allowlist (including
+# amd/comgr/CMakeLists.txt, amd/comgr/test-lit/CMakeLists.txt, shared headers,
+# .github/**, etc.) flips the result to false -> full CI. Non-pull_request events
+# are always false.
+
+name: Classify Hotswap
+
+on:
+  workflow_call:
+    outputs:
+      hotswap_only:
+        description: "'true' if every changed PR file is in the hotswap allowlist, else 'false'."
+        value: ${{ jobs.classify.outputs.hotswap_only }}
+
+permissions:
+  contents: read
+
+jobs:
+  classify:
+    runs-on: ubuntu-24.04
+    outputs:
+      hotswap_only: ${{ steps.detect.outputs.hotswap_only }}
+    steps:
+      - name: Detect hotswap-only change set
+        id: detect
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" != "pull_request" || -z "${PR_NUMBER}" ]]; then
+            echo "Not a pull_request event; hotswap_only=false"
+            echo "hotswap_only=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          files="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename')"
+
+          if [[ -z "${files}" ]]; then
+            echo "No changed files reported; hotswap_only=false"
+            echo "hotswap_only=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "${files}"
+
+          hotswap_only=true
+          while IFS= read -r f; do
+            [[ -z "${f}" ]] && continue
+            case "${f}" in
+              amd/comgr/src/hotswap/*) ;;
+              amd/comgr/test-lit/hotswap/*) ;;
+              amd/comgr/test-unit/hotswap/*) ;;
+              amd/comgr/test-lit/comgr-sources/hotswap*) ;;
+              amd/comgr/utils/*hotswap*) ;;
+              *)
+                echo "Non-hotswap path forces full CI: ${f}"
+                hotswap_only=false
+                break
+                ;;
+            esac
+          done <<< "${files}"
+
+          echo "hotswap_only=${hotswap_only}"
+          echo "hotswap_only=${hotswap_only}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -42,6 +42,10 @@ on:
         type: string
         default: ""
         description: "Comma-separated build stages to skip (artifacts already copied by the orchestrator)"
+      compiler_runtime_only:
+        type: string
+        default: "false"
+        description: "'true' -> build only the generic compiler-runtime stage (hotswap-only PRs); skip all downstream per-arch/tool stages."
       release_type:
         description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
@@ -78,7 +82,7 @@ jobs:
   # ==========================================================================
   runtime-tests:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'runtime-tests') }}
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'runtime-tests') && inputs.compiler_runtime_only != 'true' }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
@@ -100,7 +104,7 @@ jobs:
   math-libs:
     needs: compiler-runtime
     #if: ${{ false }} #Temporary disable
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'math-libs') }}
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'math-libs') && inputs.compiler_runtime_only != 'true' }}
     strategy:
       # `fail-fast: false` lets all families complete even if one fails.
       # This is useful for CI (to see all failures at once), but for releases
@@ -131,7 +135,7 @@ jobs:
   # ==========================================================================
   comm-libs:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'comm-libs') }}
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'comm-libs') && inputs.compiler_runtime_only != 'true' }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
@@ -153,7 +157,7 @@ jobs:
   # ==========================================================================
   debug-tools:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'debug-tools') }}
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'debug-tools') && inputs.compiler_runtime_only != 'true' }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
@@ -174,7 +178,7 @@ jobs:
   # ==========================================================================
   dctools-core:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'dctools-core') }}
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'dctools-core') && inputs.compiler_runtime_only != 'true' }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
@@ -221,7 +225,7 @@ jobs:
   # ==========================================================================
   media-libs:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'media-libs') }}
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'media-libs') && inputs.compiler_runtime_only != 'true' }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:

--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -38,6 +38,10 @@ on:
         type: string
         default: ""
         description: "Comma-separated build stages to skip (artifacts already copied by the orchestrator)"
+      compiler_runtime_only:
+        type: string
+        default: "false"
+        description: "'true' -> build only the generic compiler-runtime stage (hotswap-only PRs); skip all downstream per-arch/tool stages."
       rocm_package_version:
         type: string
       release_type:
@@ -76,7 +80,7 @@ jobs:
   # ==========================================================================
   runtime-tests:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'runtime-tests') }}
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'runtime-tests') && inputs.compiler_runtime_only != 'true' }}
     uses: ./.github/workflows/multi_arch_build_windows_artifacts.yml
     secrets: inherit
     with:
@@ -97,7 +101,7 @@ jobs:
   # ==========================================================================
   math-libs:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'math-libs') }}
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'math-libs') && inputs.compiler_runtime_only != 'true' }}
     strategy:
       # `fail-fast: false` lets all families complete even if one fails.
       # This is useful for CI (to see all failures at once), but for releases

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -24,6 +24,10 @@ on:
         description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
         default: ci
+      compiler_runtime_only:
+        type: string
+        default: "false"
+        description: "'true' -> hotswap-only PR: build only the compiler-runtime stage; skip per-arch stages, artifact/GPU tests, and packaging."
 
 permissions:
   contents: read
@@ -78,6 +82,7 @@ jobs:
       build_variant_suffix: ${{ fromJSON(inputs.build_config).build_variant_suffix }}
       expect_failure: ${{ fromJSON(inputs.build_config).expect_failure }}
       prebuilt_stages: ${{ fromJSON(inputs.build_config).prebuilt_stages }}
+      compiler_runtime_only: ${{ inputs.compiler_runtime_only }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
       test_type: ${{ inputs.test_type }}
@@ -89,7 +94,7 @@ jobs:
     needs: [build_multi_arch_stages]
     name: Validate Artifact Structure
     # If we are expecting a build failure, do not run tests to save machine capacity.
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false && inputs.compiler_runtime_only != 'true' }}
     uses: ./.github/workflows/test_artifacts_structure.yml
     with:
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
@@ -100,7 +105,7 @@ jobs:
     needs: [copy_prebuilt_stages, build_multi_arch_stages]
     name: Test ${{ matrix.family_info.amdgpu_family }}
     # If we are expecting a build failure, do not run tests to save machine capacity.
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false && inputs.compiler_runtime_only != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +125,7 @@ jobs:
   build_python_packages:
     needs: [build_multi_arch_stages]
     name: Build Python Packages
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false && inputs.compiler_runtime_only != 'true' }}
     uses: ./.github/workflows/build_portable_linux_python_packages.yml
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -24,6 +24,10 @@ on:
         description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
         default: ci
+      compiler_runtime_only:
+        type: string
+        default: "false"
+        description: "'true' -> hotswap-only PR: build only the compiler-runtime stage; skip per-arch stages, artifact/GPU tests, and packaging."
 
 permissions:
   contents: read
@@ -83,6 +87,7 @@ jobs:
       build_variant_suffix: ${{ fromJSON(inputs.build_config).build_variant_suffix }}
       expect_failure: ${{ fromJSON(inputs.build_config).expect_failure }}
       prebuilt_stages: ${{ fromJSON(inputs.build_config).prebuilt_stages }}
+      compiler_runtime_only: ${{ inputs.compiler_runtime_only }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
       test_type: ${{inputs.test_type }}
@@ -94,7 +99,7 @@ jobs:
     needs: [build_multi_arch_stages]
     name: Validate Artifact Structure
     # If we are expecting a build failure, do not run tests to save machine capacity.
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false && inputs.compiler_runtime_only != 'true' }}
     uses: ./.github/workflows/test_artifacts_structure.yml
     with:
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
@@ -107,6 +112,7 @@ jobs:
     # If we are expecting a build failure, do not run tests to save machine capacity.
     if: >-
       ${{ !cancelled() && fromJSON(inputs.build_config).expect_failure == false &&
+      inputs.compiler_runtime_only != 'true' &&
       (needs.copy_prebuilt_stages.result == 'success' ||
       needs.copy_prebuilt_stages.result == 'skipped') &&
       needs.build_multi_arch_stages.result == 'success' }}
@@ -129,7 +135,7 @@ jobs:
   build_python_packages:
     needs: [build_multi_arch_stages]
     name: Build Python Packages
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false && inputs.compiler_runtime_only != 'true' }}
     uses: ./.github/workflows/build_windows_python_packages.yml
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -82,9 +82,13 @@ jobs:
     with:
       build_variant: "release"
 
+  # Classify hotswap-only PRs so we can run just the compiler-runtime stage.
+  classify:
+    uses: ./.github/workflows/classify_hotswap.yml
+
   linux_build_and_test:
     name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}
-    needs: setup
+    needs: [setup, classify]
     if: >-
       ${{
         needs.setup.outputs.linux_build_config != '' &&
@@ -97,13 +101,14 @@ jobs:
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
+      compiler_runtime_only: ${{ needs.classify.outputs.hotswap_only }}
     permissions:
       contents: read
       id-token: write
 
   windows_build_and_test:
     name: Windows::${{ fromJSON(needs.setup.outputs.windows_build_config || '{}').build_variant_label || 'skip' }}
-    needs: setup
+    needs: [setup, classify]
     if: >-
       ${{
         needs.setup.outputs.windows_build_config != '' &&
@@ -116,9 +121,35 @@ jobs:
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: 'smoke'
+      compiler_runtime_only: ${{ needs.classify.outputs.hotswap_only }}
     permissions:
       contents: read
       id-token: write
+
+  # On hotswap-only PRs the per-arch math-libs stage is skipped, so its required
+  # status check never posts and would block merge. Synthesize a success status
+  # for that exact context. Keep CONTEXT in lockstep with the amd-staging ruleset
+  # required_status_checks entry (ROCm/llvm-project ruleset 9057712).
+  hotswap_required_check_shim:
+    name: Hotswap Required Check Shim
+    needs: [classify, linux_build_and_test]
+    if: ${{ !cancelled() && needs.classify.outputs.hotswap_only == 'true' && needs.linux_build_and_test.result == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      statuses: write
+    steps:
+      - name: Post synthesized success for skipped math-libs required check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          CONTEXT: "Linux::release / Build Multi-Arch Stages / math-libs (gfx94X-dcgpu, gfx942, linux-gfx942-1gpu-ccs-csp-ossci-rocm, false) / Stage - Math Libs (gfx94X-dcgpu)"
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${REPO}/statuses/${SHA}" \
+            -f state=success \
+            -f context="${CONTEXT}" \
+            -f description="Skipped: hotswap-only PR (compiler-runtime build ran comgr/hotswap tests)"
 
   ci_summary:
     name: CI Summary


### PR DESCRIPTION
## Summary

Run a reduced CI pipeline for PRs that touch **only** the comgr hotswap subtree. Such a PR builds just the generic `compiler-runtime` stage on Linux + Windows — which builds comgr and runs the COMGR lit + ctest suites (so the hotswap lit/unit tests execute) — and skips the per-arch `math-libs`/`comm-libs`/`debug-tools`/`dctools-core`/`media-libs` stages, per-family GPU tests, artifact-structure validation, and python packaging.

Any change outside the hotswap allowlist (including `amd/comgr/CMakeLists.txt`, shared headers, or `.github/**`) falls back to full CI. Non-`pull_request` events always run full CI.

## Allowlist (hotswap-only)

```
amd/comgr/src/hotswap/**
amd/comgr/test-lit/hotswap/**
amd/comgr/test-unit/hotswap/**
amd/comgr/test-lit/comgr-sources/hotswap*
amd/comgr/utils/*hotswap*
```

## Changes

- **`classify_hotswap.yml`** (new reusable): reads the PR's changed files and outputs `hotswap_only`.
- **`compiler_runtime_only`** input threaded through `multi_arch_ci_linux.yml`, `multi_arch_ci_windows.yml`, `multi_arch_build_portable_linux.yml`, `multi_arch_build_windows.yml`; gates every non-`compiler-runtime` stage and the downstream test/validate/package jobs.
- **`rockci_multi_arch_amd_staging.yml`**: adds the `classify` job, passes the flag to the Linux/Windows builds, and posts a synthesized success for the required Linux `math-libs` status **only when the `compiler-runtime` build succeeds**, so the intentionally-skipped required check does not block merge (a failed compiler-runtime build leaves it unposted → PR blocked, as intended).

## Validation

Verified on a throwaway base+head pair: a README-only change under `amd/comgr/src/hotswap/` produced `hotswap_only=true`, ran only `compiler-runtime` on both platforms, and skipped `math-libs` + per-family tests. A change also touching `amd/comgr/CMakeLists.txt` falls back to full CI.

## Note

The `gfx90a Test` required check is produced by the PSDB trigger tooling, not GitHub Actions; skipping it for hotswap-only PRs is handled by a companion change to that tooling.
