### PR TITLE
[DO NOT MERGE] Observe CI on a hotswap-only PR

### DIFF
--- a/amd/comgr/src/hotswap/README.md
+++ b/amd/comgr/src/hotswap/README.md
@@ -84,3 +84,5 @@ cmake -S amd/comgr/src/hotswap/raiser -B build-hotswap \
 ninja -C build-hotswap
 ctest --test-dir build-hotswap -L transpiler
 ```
+
+<!-- hotswap-only CI observation PR (throwaway, do not merge) -->


### PR DESCRIPTION
**Throwaway / DO NOT MERGE.** This changes only a comment in
`amd/comgr/src/hotswap/README.md` to observe how CI behaves on a
hotswap-only PR against the current `amd-staging`:

- Does the `gfx90a Test` required check run, or is it skipped?
- Does the full multi-arch pipeline (per-arch math-libs, GPU tests) run?
- Which required checks post?

Used to reconcile the reduced-CI work (#3666 / PPH #165) with existing PPH behavior. Will be closed without merging.
