### PR TITLE
[Comgr][hotswap] Add an on-disk cache for transpiled code objects

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -598,8 +598,11 @@ target_link_libraries(amd_comgr
 #
 # The rewriter (byte-level rewrite path) backs the always-on
 # amd_comgr_hotswap_rewrite API, so it is linked unconditionally. The raiser
-# (IR transpiler path) is opt-in behind COMGR_ENABLE_HOTSWAP_TRANSPILE.
+# (IR transpiler path) is opt-in behind COMGR_ENABLE_HOTSWAP_TRANSPILE. The
+# translation cache is LLVM-only and linked unconditionally so its objects are
+# available to any transpile entry point.
 target_link_libraries(amd_comgr PRIVATE hotswap::rewriter)
+target_link_libraries(amd_comgr PRIVATE hotswap::translation_cache)
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   target_link_libraries(amd_comgr PRIVATE hotswap::raiser)
 endif()

--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -1,7 +1,9 @@
-# Hotswap subproject coordinator. Both hotswap paths are built as OBJECT
-# libraries whose TUs land directly in amd_comgr.so:
-#   hotswap::rewriter  byte-level rewrite path (linked unconditionally)
-#   hotswap::raiser    IR transpiler path (opt-in, COMGR_ENABLE_HOTSWAP_TRANSPILE)
+# Hotswap subproject coordinator. Each hotswap path is built as an OBJECT
+# library whose TUs land directly in amd_comgr.so:
+#   hotswap::rewriter          byte-level rewrite path (linked unconditionally)
+#   hotswap::raiser            IR transpiler path (opt-in, COMGR_ENABLE_HOTSWAP_TRANSPILE)
+#   hotswap::translation_cache on-disk cache for transpiled code objects
 # Shared, path-agnostic headers live in common/ (header-only, no target).
 add_subdirectory(rewriter)
 add_subdirectory(raiser)
+add_subdirectory(cache)

--- a/amd/comgr/src/hotswap/cache/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/cache/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.20)
+project(hotswap-translation-cache LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# --- LLVM ---------------------------------------------------------------------
+if(NOT TARGET LLVMSupport)
+  find_package(LLVM REQUIRED CONFIG)
+endif()
+if(NOT COMMAND llvm_update_compile_flags)
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+  include(AddLLVM)
+endif()
+
+include_directories(${LLVM_INCLUDE_DIRS})
+link_directories(${LLVM_LIBRARY_DIRS})
+add_definitions(${LLVM_DEFINITIONS})
+
+# --- Library ------------------------------------------------------------------
+# OBJECT library so its translation units land directly in amd_comgr.so when
+# `target_link_libraries(amd_comgr PRIVATE hotswap::translation_cache)` runs
+# in the parent CMakeLists.txt. Depends only on LLVM: the transpile pipeline
+# result type (pipeline.h) and the AMDGPU kernel-name query
+# (code-object-utils) are the module's only cross-file surface, and both are
+# LLVM-only, so the cache carries no comgr metadata-layer coupling.
+add_library(hotswap-translation-cache OBJECT
+  translation-cache.cpp
+  code-object-utils.cpp
+)
+
+if(NOT TARGET hotswap::translation_cache)
+  add_library(hotswap::translation_cache ALIAS hotswap-translation-cache)
+endif()
+
+# Match LLVM's compile flags (no-rtti, no-exceptions); mixing RTTI-on TUs with
+# RTTI-off LLVM libs produces undefined-reference errors for `typeinfo`
+# symbols on any class with a virtual method.
+llvm_update_compile_flags(hotswap-translation-cache)
+
+set_target_properties(hotswap-translation-cache
+  PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Public include root (src/) so consumers can
+# `#include "hotswap/cache/translation-cache.h"`.
+target_include_directories(hotswap-translation-cache PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_link_libraries(hotswap-translation-cache
+  PUBLIC
+    LLVMBinaryFormat
+    LLVMCore
+    LLVMObject
+    LLVMSupport
+    LLVMTargetParser
+)

--- a/amd/comgr/src/hotswap/cache/code-object-utils.cpp
+++ b/amd/comgr/src/hotswap/cache/code-object-utils.cpp
@@ -1,0 +1,94 @@
+//===- code-object-utils.cpp - AMDGPU code-object metadata --------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "code-object-utils.h"
+
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/Object/ELF.h"
+#include "llvm/Support/Error.h"
+
+namespace COMGR::hotswap {
+namespace {
+
+// Look up `Key` in `Map`. Returns null when the key is absent.
+// `MapDocNode::find(StringRef)` allocates the lookup key on `Map`'s owning
+// document, so callers need only pass the literal string.
+llvm::msgpack::DocNode *findInMap(llvm::msgpack::MapDocNode &Map,
+                                  llvm::StringRef Key) {
+  auto It = Map.find(Key);
+  return (It == Map.end()) ? nullptr : &It->second;
+}
+
+// Iterate the `amdhsa.kernels` array of a parsed AMDGPU MsgPack document and
+// invoke `CB` on each kernel map node. Silently skips non-map children.
+template <class Fn>
+void forEachKernelNode(llvm::msgpack::Document &Doc, Fn &&CB) {
+  llvm::msgpack::DocNode &Root = Doc.getRoot();
+  if (!Root.isMap())
+    return;
+  llvm::msgpack::DocNode *Kernels = findInMap(Root.getMap(), "amdhsa.kernels");
+  if (!Kernels || !Kernels->isArray())
+    return;
+  for (auto &K : Kernels->getArray()) {
+    if (!K.isMap())
+      continue;
+    CB(K.getMap());
+  }
+}
+
+} // namespace
+
+llvm::Expected<llvm::SmallVector<std::string>>
+listKernelNames(llvm::MemoryBufferRef ElfData) {
+  using namespace llvm;
+
+  Expected<object::ELF64LEFile> ElfOrErr =
+      object::ELF64LEFile::create(ElfData.getBuffer());
+  if (!ElfOrErr)
+    return ElfOrErr.takeError();
+  const object::ELF64LEFile &Elf = *ElfOrErr;
+
+  Expected<ArrayRef<object::ELF64LE::Shdr>> SectionsOrErr = Elf.sections();
+  if (!SectionsOrErr)
+    return SectionsOrErr.takeError();
+
+  SmallVector<std::string> Names;
+  bool FoundNote = false;
+  for (const object::ELF64LE::Shdr &Sec : *SectionsOrErr) {
+    if (Sec.sh_type != ELF::SHT_NOTE)
+      continue;
+    Error Err = Error::success();
+    for (const object::ELF64LE::Note &Note : Elf.notes(Sec, Err)) {
+      if (Note.getType() != ELF::NT_AMDGPU_METADATA ||
+          Note.getName() != "AMDGPU")
+        continue;
+      ArrayRef<uint8_t> Desc = Note.getDesc(Sec.sh_addralign);
+      msgpack::Document Doc;
+      if (!Doc.readFromBlob(
+              StringRef(reinterpret_cast<const char *>(Desc.data()),
+                        Desc.size()),
+              /*Multi=*/false))
+        return createStringError(
+            "listKernelNames: failed to parse AMDGPU metadata note");
+      forEachKernelNode(Doc, [&](msgpack::MapDocNode &KMap) {
+        if (msgpack::DocNode *Name = findInMap(KMap, ".name"))
+          Names.push_back(Name->toString());
+      });
+      FoundNote = true;
+    }
+    if (Err)
+      return std::move(Err);
+  }
+
+  if (!FoundNote)
+    return createStringError("listKernelNames: no AMDGPU metadata note");
+  return Names;
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/cache/code-object-utils.h
+++ b/amd/comgr/src/hotswap/cache/code-object-utils.h
@@ -1,0 +1,34 @@
+//===- code-object-utils.h - AMDGPU code-object metadata ----------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The single code-object metadata query the translation cache needs: the
+// list of kernel names declared in an ELF's AMDGPU MsgPack notes. Depends
+// only on LLVM (ELF object + MsgPack) so the cache module has no comgr
+// metadata-layer coupling.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_CODE_OBJECT_UTILS_H
+#define HOTSWAP_TRANSPILER_CODE_OBJECT_UTILS_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBufferRef.h"
+
+#include <string>
+
+namespace COMGR::hotswap {
+
+/// List the kernel names declared in the AMDGPU MsgPack notes embedded in
+/// `ElfData`. Returns an error when no AMDGPU metadata note is present.
+llvm::Expected<llvm::SmallVector<std::string>>
+listKernelNames(llvm::MemoryBufferRef ElfData);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/cache/pipeline.h
+++ b/amd/comgr/src/hotswap/cache/pipeline.h
@@ -1,0 +1,73 @@
+//===- pipeline.h - Transpile pipeline result -----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// PipelineResult is the transpile pipeline's output: the lowered HSACO plus
+// the attribution fields the translation cache persists and restores. Only
+// the result type is declared here -- the pipeline itself is not part of the
+// translation-cache module.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_PIPELINE_H
+#define HOTSWAP_TRANSPILER_PIPELINE_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/MemoryBufferRef.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace COMGR::hotswap {
+
+struct PipelineTimings {
+  double totalSeconds = 0.0;
+  double listKernelsSeconds = 0.0;
+  double extractTextSeconds = 0.0;
+  double createTempDirSeconds = 0.0;
+  double raiseSeconds = 0.0;
+  double writeIrSeconds = 0.0;
+  double optSeconds = 0.0;
+  double llcSeconds = 0.0;
+  double linkSeconds = 0.0;
+  double readHsacoSeconds = 0.0;
+  double collectMetadataSeconds = 0.0;
+};
+
+struct PipelineResult {
+  std::unique_ptr<llvm::MemoryBuffer> Hsaco;
+  PipelineTimings Timings;
+  std::string FailMnemonic;
+  std::string FailKernel;
+  std::string FailReason;
+  std::string FailFormat;
+  std::string FailDetail;
+  uint64_t FailOffset = 0;
+  // Successful raises can still carry proof-relevant attribution. Today this
+  // records C5 predicate-chain sites accepted under a projection-specific
+  // proof (for example single-source-wave MODREP with no active replica
+  // lanes); loader proof logs surface these fields on `hotswap_result`.
+  int C5SuppressedCount = 0;
+  std::string C5SuppressionReason;
+  bool UsesScratchPrivateSegment = false;
+  uint32_t SourcePrivateSegmentFixedSize = 0;
+  bool TargetEnablePrivateSegment = false;
+  uint32_t TargetPrivateSegmentFixedSize = 0;
+  int LiftedCount = 0;
+  int TotalCount = 0;
+  // ScaledModuloReplicationProjection requirement for the (single) transpiled
+  // kernel: the factor (W_t/W_s) the launch runtime must scale the block's x
+  // extent by. 1 means no scaling.
+  unsigned ScaledDispatchFactor = 1;
+  bool Success = false;
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/cache/translation-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/translation-cache.cpp
@@ -1,0 +1,827 @@
+#include "translation-cache.h"
+
+#include "code-object-utils.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/SHA256.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <chrono>
+#include <dlfcn.h>
+#include <string>
+#include <sys/stat.h>
+
+#define DEBUG_TYPE "translation-cache"
+
+namespace COMGR::hotswap {
+namespace {
+
+using TimingClock = std::chrono::steady_clock;
+
+double secondsBetween(TimingClock::time_point start,
+                      TimingClock::time_point end) {
+  return std::chrono::duration<double>(end - start).count();
+}
+
+TimingClock::time_point timingStart(bool CollectTimings) {
+  return CollectTimings ? TimingClock::now() : TimingClock::time_point{};
+}
+
+double timingElapsed(bool CollectTimings, TimingClock::time_point start) {
+  return CollectTimings ? secondsBetween(start, TimingClock::now()) : 0.0;
+}
+
+constexpr int kCacheSchemaVersion = 4;
+
+struct FileIdentity {
+  std::string path;
+  bool present = false;
+  uint64_t size = 0;
+  int64_t mtimeSec = 0;
+  int64_t mtimeNsec = 0;
+  std::string sha256;
+};
+
+struct KeyData {
+  std::string key;
+  std::string sourceSha256;
+  std::string rulesSha256;
+  std::string buildIdentity;
+  std::string deviceLibrariesIdentity;
+  std::string elfMachineHex;
+  std::string elfFlagsHex;
+  std::vector<std::string> kernelNames;
+};
+
+std::string hexU32(uint32_t value) {
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  os << "0x" << llvm::format_hex_no_prefix(value, 0);
+  return os.str();
+}
+
+struct ElfHeaderFields {
+  uint16_t machine = 0;
+  uint32_t flags = 0;
+};
+
+llvm::Expected<ElfHeaderFields>
+readElfHeaderFields(llvm::MemoryBufferRef buffer) {
+  auto objOrErr = llvm::object::ObjectFile::createELFObjectFile(buffer);
+  if (!objOrErr)
+    return objOrErr.takeError();
+  const auto *elf =
+      llvm::dyn_cast<llvm::object::ELFObjectFileBase>(objOrErr->get());
+  if (!elf)
+    return llvm::createStringError(
+        "source code object is not a 64-bit little-endian ELF");
+  return ElfHeaderFields{elf->getEMachine(), elf->getPlatformFlags()};
+}
+
+llvm::Expected<std::string> hashFile(llvm::StringRef path) {
+  auto buffer = llvm::MemoryBuffer::getFile(path);
+  if (!buffer)
+    return llvm::errorCodeToError(buffer.getError());
+  return sha256Hex((*buffer)->getMemBufferRef());
+}
+
+llvm::Expected<FileIdentity> statIdentity(llvm::StringRef path) {
+  FileIdentity id;
+  id.path = path.str();
+  struct stat st;
+  if (::stat(id.path.c_str(), &st) != 0)
+    return id;
+  id.present = true;
+  id.size = static_cast<uint64_t>(st.st_size);
+#if defined(__linux__)
+  id.mtimeSec = static_cast<int64_t>(st.st_mtim.tv_sec);
+  id.mtimeNsec = static_cast<int64_t>(st.st_mtim.tv_nsec);
+#else
+  id.mtimeSec = static_cast<int64_t>(st.st_mtime);
+  id.mtimeNsec = 0;
+#endif
+  llvm::Expected<std::string> hash = hashFile(id.path);
+  if (!hash)
+    return llvm::createStringError(id.path + ": " +
+                                   llvm::toString(hash.takeError()));
+  id.sha256 = std::move(*hash);
+  return id;
+}
+
+std::string identityString(const FileIdentity &id) {
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  os << id.path << "|present=" << (id.present ? "1" : "0")
+     << "|size=" << id.size << "|mtime=" << id.mtimeSec << "." << id.mtimeNsec
+     << "|sha256=" << id.sha256;
+  return os.str();
+}
+
+std::string loadedImageIdentity() {
+  static const std::string identity = [] {
+    std::string out;
+    llvm::raw_string_ostream os(out);
+    os << "llvm=" << LLVM_VERSION_STRING;
+    Dl_info info;
+    if (::dladdr(reinterpret_cast<void *>(&loadedImageIdentity), &info) &&
+        info.dli_fname) {
+      if (auto id = statIdentity(info.dli_fname))
+        os << "|image=" << identityString(*id);
+      else
+        os << "|image=<error=" << llvm::toString(id.takeError()) << ">";
+    } else {
+      os << "|image=<dladdr-unavailable>";
+    }
+    return os.str();
+  }();
+  return identity;
+}
+
+void appendKeyField(std::string &material, llvm::StringRef name,
+                    llvm::StringRef value) {
+  material.append(name.data(), name.size());
+  material.push_back('\0');
+  material += std::to_string(value.size());
+  material.push_back(':');
+  if (!value.empty())
+    material.append(value.data(), value.size());
+  material.push_back('\0');
+}
+
+void appendKeyField(std::string &material, llvm::StringRef name, bool value) {
+  appendKeyField(material, name, llvm::StringRef(value ? "true" : "false"));
+}
+
+void appendKeyField(std::string &material, llvm::StringRef name, int value) {
+  appendKeyField(material, name, std::to_string(value));
+}
+
+llvm::Expected<KeyData> buildKeyData(const TranslationCacheRequest &request,
+                                     bool CollectTimings,
+                                     TranslationCacheKeyBuildTimings &Timings) {
+  KeyData data;
+  if (request.SourceObject.getBufferSize() == 0)
+    return llvm::createStringError("empty source code object");
+  if (request.SourceGfx.empty() || request.TargetGfx.empty())
+    return llvm::createStringError("missing source or target gfx");
+
+  auto sourceHashStart = timingStart(CollectTimings);
+  data.sourceSha256 = sha256Hex(request.SourceObject);
+  Timings.sourceHashSeconds = timingElapsed(CollectTimings, sourceHashStart);
+
+  auto elfHeaderStart = timingStart(CollectTimings);
+  llvm::Expected<ElfHeaderFields> elfHeader =
+      readElfHeaderFields(request.SourceObject);
+  Timings.elfHeaderSeconds = timingElapsed(CollectTimings, elfHeaderStart);
+  if (!elfHeader)
+    return elfHeader.takeError();
+  data.elfMachineHex = hexU32(elfHeader->machine);
+  data.elfFlagsHex = hexU32(elfHeader->flags);
+
+  if (!request.HotswapRulesPath.empty()) {
+    auto rulesHashStart = timingStart(CollectTimings);
+    llvm::Expected<std::string> rulesHash = hashFile(request.HotswapRulesPath);
+    Timings.rulesHashSeconds = timingElapsed(CollectTimings, rulesHashStart);
+    if (!rulesHash)
+      return llvm::createStringError(
+          "failed to hash HSA_HOTSWAP_RULES '" + request.HotswapRulesPath +
+          "': " + llvm::toString(rulesHash.takeError()));
+    data.rulesSha256 = std::move(*rulesHash);
+  }
+
+  auto loadedImageIdentityStart = timingStart(CollectTimings);
+  data.buildIdentity = loadedImageIdentity();
+  Timings.loadedImageIdentitySeconds =
+      timingElapsed(CollectTimings, loadedImageIdentityStart);
+  data.deviceLibrariesIdentity = request.DeviceLibrariesIdentity;
+  if (!request.KernelName.empty()) {
+    data.kernelNames.push_back(request.KernelName);
+  } else {
+    auto kernelNamesStart = timingStart(CollectTimings);
+    llvm::Expected<llvm::SmallVector<std::string>> NamesOrErr =
+        listKernelNames(request.SourceObject);
+    Timings.kernelNamesSeconds =
+        timingElapsed(CollectTimings, kernelNamesStart);
+    if (!NamesOrErr)
+      return llvm::createStringError(
+          "failed to list kernels for translation cache key: " +
+          llvm::toString(NamesOrErr.takeError()));
+    data.kernelNames.assign(NamesOrErr->begin(), NamesOrErr->end());
+    if (data.kernelNames.empty())
+      return llvm::createStringError(
+          "source code object has no kernel metadata entries");
+  }
+
+  auto materialBuildStart = timingStart(CollectTimings);
+  std::string material;
+  appendKeyField(material, "schema", std::to_string(kCacheSchemaVersion));
+  appendKeyField(material, "source_sha256", data.sourceSha256);
+  appendKeyField(material, "source_gfx", request.SourceGfx);
+  appendKeyField(material, "target_gfx", request.TargetGfx);
+  appendKeyField(material, "source_isa", request.SourceIsa);
+  appendKeyField(material, "target_isa", request.TargetIsa);
+  appendKeyField(material, "code_isa", request.CodeIsa);
+  appendKeyField(material, "elf_machine", data.elfMachineHex);
+  appendKeyField(material, "elf_flags", data.elfFlagsHex);
+  appendKeyField(material, "orig_mach", request.OrigMach);
+  appendKeyField(material, "opt_level", static_cast<int>(request.OptLevel));
+  appendKeyField(material, "rules_path", request.HotswapRulesPath);
+  appendKeyField(material, "rules_sha256", data.rulesSha256);
+  appendKeyField(material, "strict", request.StrictMode);
+  appendKeyField(material, "enable_writelane_rewrite",
+                 request.EnableWritelaneRewrite);
+  appendKeyField(material, "enable_wave_native", request.EnableWaveNative);
+  appendKeyField(material, "force_scaled_modrep", request.ForceScaledModrep);
+  appendKeyField(material, "assume_hip_global_offset_zero",
+                 request.AssumeHipGlobalOffsetZero);
+  if (!request.KernelName.empty())
+    appendKeyField(material, "kernel_name", request.KernelName);
+  appendKeyField(material, "hotswap_build_identity", data.buildIdentity);
+  appendKeyField(material, "device_libraries_identity",
+                 data.deviceLibrariesIdentity);
+  Timings.materialBuildSeconds =
+      timingElapsed(CollectTimings, materialBuildStart);
+  auto keyHashStart = timingStart(CollectTimings);
+  data.key = sha256Hex(llvm::MemoryBufferRef(material, ""));
+  Timings.keyHashSeconds = timingElapsed(CollectTimings, keyHashStart);
+  return data;
+}
+
+std::string cacheRoot(const TranslationCacheRequest &request) {
+  return request.CacheDirectory;
+}
+
+bool cacheDisabledByPolicy(const TranslationCacheRequest &request) {
+  return request.CacheDisabled || cacheRoot(request).empty();
+}
+
+std::string cacheSubdir(const TranslationCacheRequest &request,
+                        llvm::StringRef key) {
+  llvm::SmallString<256> path(cacheRoot(request));
+  llvm::sys::path::append(path, key.substr(0, 2));
+  return std::string(path);
+}
+
+std::string cacheObjectPath(const TranslationCacheRequest &request,
+                            llvm::StringRef key) {
+  llvm::SmallString<256> path(cacheSubdir(request, key));
+  llvm::sys::path::append(path, llvm::Twine(key) + ".Hsaco");
+  return std::string(path);
+}
+
+std::string cacheMetadataPath(const TranslationCacheRequest &request,
+                              llvm::StringRef key) {
+  llvm::SmallString<256> path(cacheSubdir(request, key));
+  llvm::sys::path::append(path, llvm::Twine(key) + ".json");
+  return std::string(path);
+}
+
+bool exists(llvm::StringRef path) { return llvm::sys::fs::exists(path); }
+
+std::string jsonToString(llvm::json::Value value) {
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  value.print(os);
+  os << "\n";
+  return os.str();
+}
+
+llvm::Error writeFileAtomic(llvm::StringRef path, llvm::StringRef contents) {
+  return llvm::writeToOutput(path, [&](llvm::raw_ostream &os) {
+    os << contents;
+    return llvm::Error::success();
+  });
+}
+
+llvm::Error writeFileAtomic(llvm::StringRef path,
+                            llvm::ArrayRef<uint8_t> data) {
+  return writeFileAtomic(
+      path, llvm::StringRef(reinterpret_cast<const char *>(data.data()),
+                            data.size()));
+}
+
+llvm::Expected<std::string> requireString(const llvm::json::Object &obj,
+                                          llvm::StringRef field) {
+  auto value = obj.getString(field);
+  if (!value)
+    return llvm::createStringError("metadata field '" + field +
+                                   "' missing or not a string");
+  return value->str();
+}
+
+llvm::Expected<int64_t> requireInt(const llvm::json::Object &obj,
+                                   llvm::StringRef field) {
+  auto value = obj.getInteger(field);
+  if (!value)
+    return llvm::createStringError("metadata field '" + field +
+                                   "' missing or not an integer");
+  return *value;
+}
+
+llvm::Expected<bool> requireBool(const llvm::json::Object &obj,
+                                 llvm::StringRef field) {
+  auto value = obj.getBoolean(field);
+  if (!value)
+    return llvm::createStringError("metadata field '" + field +
+                                   "' missing or not a boolean");
+  return *value;
+}
+
+llvm::Error requireEqualString(const llvm::json::Object &obj,
+                               llvm::StringRef field,
+                               llvm::StringRef expected) {
+  auto value = requireString(obj, field);
+  if (!value)
+    return value.takeError();
+  if (*value != expected)
+    return llvm::createStringError("metadata field '" + field + "' mismatch");
+  return llvm::Error::success();
+}
+
+llvm::Error validateKernelNameField(const llvm::json::Object &obj,
+                                    llvm::StringRef expected) {
+  const llvm::json::Value *rawValue = obj.get("kernel_name");
+  if (!rawValue) {
+    if (expected.empty())
+      return llvm::Error::success();
+    return llvm::createStringError("metadata field 'kernel_name' missing");
+  }
+  auto value = rawValue->getAsString();
+  if (!value)
+    return llvm::createStringError(
+        "metadata field 'kernel_name' is not a string");
+  if (*value != expected)
+    return llvm::createStringError("metadata field 'kernel_name' mismatch");
+  return llvm::Error::success();
+}
+
+llvm::Error requireEqualInt(const llvm::json::Object &obj,
+                            llvm::StringRef field, int64_t expected) {
+  auto value = requireInt(obj, field);
+  if (!value)
+    return value.takeError();
+  if (*value != expected)
+    return llvm::createStringError("metadata field '" + field + "' mismatch");
+  return llvm::Error::success();
+}
+
+llvm::Error requireEqualBool(const llvm::json::Object &obj,
+                             llvm::StringRef field, bool expected) {
+  auto value = requireBool(obj, field);
+  if (!value)
+    return value.takeError();
+  if (*value != expected)
+    return llvm::createStringError("metadata field '" + field + "' mismatch");
+  return llvm::Error::success();
+}
+
+llvm::json::Array kernelArray(const std::vector<std::string> &kernelNames) {
+  llvm::json::Array arr;
+  for (llvm::StringRef name : kernelNames)
+    arr.push_back(name);
+  return arr;
+}
+
+llvm::Error validateKernelArray(const llvm::json::Object &obj,
+                                const std::vector<std::string> &expected) {
+  const llvm::json::Array *arr = obj.getArray("kernel_names");
+  if (!arr)
+    return llvm::createStringError(
+        "metadata field 'kernel_names' missing or not an array");
+  if (arr->size() != expected.size())
+    return llvm::createStringError("metadata kernel_names size mismatch");
+  for (size_t i = 0; i < expected.size(); ++i) {
+    auto value = (*arr)[i].getAsString();
+    if (!value || *value != expected[i])
+      return llvm::createStringError("metadata kernel_names mismatch");
+  }
+  return llvm::Error::success();
+}
+
+llvm::json::Object metadataObject(const TranslationCacheRequest &request,
+                                  const KeyData &keyData,
+                                  const PipelineResult &Result,
+                                  llvm::StringRef objectSha256) {
+  llvm::json::Object Obj{
+      {"schema_version", kCacheSchemaVersion},
+      {"key", keyData.key},
+      {"source_object_sha256", keyData.sourceSha256},
+      {"source_gfx", request.SourceGfx},
+      {"target_gfx", request.TargetGfx},
+      {"source_isa", request.SourceIsa},
+      {"target_isa", request.TargetIsa},
+      {"code_isa", request.CodeIsa},
+      {"elf_machine", keyData.elfMachineHex},
+      {"elf_flags", keyData.elfFlagsHex},
+      {"orig_mach", request.OrigMach},
+      {"opt_level", static_cast<int64_t>(request.OptLevel)},
+      {"hotswap_rules_path", request.HotswapRulesPath},
+      {"hotswap_rules_sha256", keyData.rulesSha256},
+      {"strict_mode", request.StrictMode},
+      {"enable_writelane_rewrite", request.EnableWritelaneRewrite},
+      {"enable_wave_native", request.EnableWaveNative},
+      {"force_scaled_modrep", request.ForceScaledModrep},
+      {"assume_hip_global_offset_zero", request.AssumeHipGlobalOffsetZero},
+      {"hotswap_build_identity", keyData.buildIdentity},
+      {"device_libraries_identity", keyData.deviceLibrariesIdentity},
+      {"kernel_count", static_cast<int64_t>(keyData.kernelNames.size())},
+      {"kernel_names", kernelArray(keyData.kernelNames)},
+      {"cached_object_sha256", objectSha256.str()},
+      {"cached_object_size",
+       static_cast<int64_t>(Result.Hsaco ? Result.Hsaco->getBufferSize() : 0)},
+      {"lifted_count", Result.LiftedCount},
+      {"total_count", Result.TotalCount},
+      {"scaled_dispatch_factor",
+       static_cast<int64_t>(Result.ScaledDispatchFactor)},
+      {"c5_suppressed_count", Result.C5SuppressedCount},
+      {"c5_suppression_reason", Result.C5SuppressionReason},
+      {"uses_scratch_private_segment", Result.UsesScratchPrivateSegment},
+      {"source_private_segment_fixed_size",
+       static_cast<int64_t>(Result.SourcePrivateSegmentFixedSize)},
+      {"target_private_segment_fixed_size",
+       static_cast<int64_t>(Result.TargetPrivateSegmentFixedSize)},
+      {"target_enable_private_segment", Result.TargetEnablePrivateSegment},
+  };
+  if (!request.KernelName.empty())
+    Obj["kernel_name"] = request.KernelName;
+  return Obj;
+}
+
+llvm::Error validateMetadata(const TranslationCacheRequest &request,
+                             const KeyData &keyData,
+                             const llvm::json::Object &obj,
+                             llvm::StringRef objectSha256, size_t objectSize,
+                             PipelineResult &Result) {
+  if (llvm::Error e =
+          requireEqualInt(obj, "schema_version", kCacheSchemaVersion))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "key", keyData.key))
+    return e;
+  if (llvm::Error e =
+          requireEqualString(obj, "source_object_sha256", keyData.sourceSha256))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "source_gfx", request.SourceGfx))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "target_gfx", request.TargetGfx))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "source_isa", request.SourceIsa))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "target_isa", request.TargetIsa))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "code_isa", request.CodeIsa))
+    return e;
+  if (llvm::Error e =
+          requireEqualString(obj, "elf_machine", keyData.elfMachineHex))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "elf_flags", keyData.elfFlagsHex))
+    return e;
+  if (llvm::Error e = requireEqualInt(obj, "orig_mach", request.OrigMach))
+    return e;
+  if (llvm::Error e = requireEqualInt(obj, "opt_level",
+                                      static_cast<int64_t>(request.OptLevel)))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "hotswap_rules_path",
+                                         request.HotswapRulesPath))
+    return e;
+  if (llvm::Error e =
+          requireEqualString(obj, "hotswap_rules_sha256", keyData.rulesSha256))
+    return e;
+  if (llvm::Error e = requireEqualBool(obj, "strict_mode", request.StrictMode))
+    return e;
+  if (llvm::Error e = requireEqualBool(obj, "enable_writelane_rewrite",
+                                       request.EnableWritelaneRewrite))
+    return e;
+  if (llvm::Error e =
+          requireEqualBool(obj, "enable_wave_native", request.EnableWaveNative))
+    return e;
+  if (llvm::Error e = requireEqualBool(obj, "force_scaled_modrep",
+                                       request.ForceScaledModrep))
+    return e;
+  if (llvm::Error e = requireEqualBool(obj, "assume_hip_global_offset_zero",
+                                       request.AssumeHipGlobalOffsetZero))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "hotswap_build_identity",
+                                         keyData.buildIdentity))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "device_libraries_identity",
+                                         keyData.deviceLibrariesIdentity))
+    return e;
+  if (llvm::Error e = validateKernelNameField(obj, request.KernelName))
+    return e;
+  if (llvm::Error e =
+          requireEqualInt(obj, "kernel_count",
+                          static_cast<int64_t>(keyData.kernelNames.size())))
+    return e;
+  if (llvm::Error e = validateKernelArray(obj, keyData.kernelNames))
+    return e;
+  if (llvm::Error e =
+          requireEqualString(obj, "cached_object_sha256", objectSha256))
+    return e;
+  if (llvm::Error e = requireEqualInt(obj, "cached_object_size",
+                                      static_cast<int64_t>(objectSize)))
+    return e;
+
+  llvm::Expected<int64_t> lifted = requireInt(obj, "lifted_count");
+  if (!lifted)
+    return lifted.takeError();
+  llvm::Expected<int64_t> total = requireInt(obj, "total_count");
+  if (!total)
+    return total.takeError();
+  llvm::Expected<int64_t> c5Count = requireInt(obj, "c5_suppressed_count");
+  if (!c5Count)
+    return c5Count.takeError();
+  llvm::Expected<std::string> c5Reason =
+      requireString(obj, "c5_suppression_reason");
+  if (!c5Reason)
+    return c5Reason.takeError();
+  llvm::Expected<bool> usesScratch =
+      requireBool(obj, "uses_scratch_private_segment");
+  if (!usesScratch)
+    return usesScratch.takeError();
+  llvm::Expected<int64_t> sourceScratch =
+      requireInt(obj, "source_private_segment_fixed_size");
+  if (!sourceScratch)
+    return sourceScratch.takeError();
+  llvm::Expected<int64_t> targetScratch =
+      requireInt(obj, "target_private_segment_fixed_size");
+  if (!targetScratch)
+    return targetScratch.takeError();
+  llvm::Expected<bool> targetEnable =
+      requireBool(obj, "target_enable_private_segment");
+  if (!targetEnable)
+    return targetEnable.takeError();
+
+  Result.Success = true;
+  Result.LiftedCount = static_cast<int>(*lifted);
+  Result.TotalCount = static_cast<int>(*total);
+  Result.C5SuppressedCount = static_cast<int>(*c5Count);
+  Result.C5SuppressionReason = *c5Reason;
+  Result.UsesScratchPrivateSegment = *usesScratch;
+  Result.SourcePrivateSegmentFixedSize = static_cast<uint32_t>(*sourceScratch);
+  Result.TargetPrivateSegmentFixedSize = static_cast<uint32_t>(*targetScratch);
+  Result.TargetEnablePrivateSegment = *targetEnable;
+  // Optional (default 1) so cache entries written before scaled-dispatch
+  // support still load. The cache key includes the scaled-modrep flags, so a
+  // scaled transpile never collides with a non-scaled entry.
+  Result.ScaledDispatchFactor = static_cast<unsigned>(
+      obj.getInteger("scaled_dispatch_factor").value_or(1));
+  return llvm::Error::success();
+}
+
+} // namespace
+
+const char *translationCacheStatusString(TranslationCacheStatus Status) {
+  switch (Status) {
+  case TranslationCacheStatus::Disabled:
+    return "disabled";
+  case TranslationCacheStatus::Bypassed:
+    return "bypassed";
+  case TranslationCacheStatus::Miss:
+    return "miss";
+  case TranslationCacheStatus::Hit:
+    return "hit";
+  case TranslationCacheStatus::Invalid:
+    return "invalid";
+  case TranslationCacheStatus::WriteSuccess:
+    return "write_success";
+  case TranslationCacheStatus::WriteFailed:
+    return "write_failed";
+  }
+  return "invalid";
+}
+
+std::string sha256Hex(llvm::MemoryBufferRef buffer) {
+  llvm::ArrayRef data(buffer.getBuffer().bytes_begin(),
+                      buffer.getBuffer().bytes_end());
+  auto digest = llvm::SHA256::hash(data);
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  for (uint8_t byte : digest)
+    os << llvm::format_hex_no_prefix(byte, 2);
+  return os.str();
+}
+
+TranslationCacheLookup
+lookupTranslationCache(const TranslationCacheRequest &request) {
+  auto totalStart = timingStart(request.CollectTimings);
+  TranslationCacheLookup lookup;
+  auto finish = [&]() {
+    lookup.Timings.totalSeconds =
+        timingElapsed(request.CollectTimings, totalStart);
+    return std::move(lookup);
+  };
+  if (cacheDisabledByPolicy(request))
+    return finish();
+
+  auto keyBuildStart = timingStart(request.CollectTimings);
+  auto keyDataOrErr =
+      buildKeyData(request, request.CollectTimings, lookup.Timings.keyBuild);
+  lookup.Timings.keyBuildSeconds =
+      timingElapsed(request.CollectTimings, keyBuildStart);
+  if (!keyDataOrErr) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason = llvm::toString(keyDataOrErr.takeError());
+    return finish();
+  }
+  KeyData keyData = std::move(*keyDataOrErr);
+  lookup.key = keyData.key;
+  lookup.MetadataPath = cacheMetadataPath(request, keyData.key);
+  lookup.ObjectPath = cacheObjectPath(request, keyData.key);
+
+  auto metadataObjectStatStart = timingStart(request.CollectTimings);
+  const bool metadataExists = exists(lookup.MetadataPath);
+  const bool objectExists = exists(lookup.ObjectPath);
+  lookup.Timings.metadataObjectStatSeconds =
+      timingElapsed(request.CollectTimings, metadataObjectStatStart);
+  if (!metadataExists && !objectExists) {
+    lookup.Status = TranslationCacheStatus::Miss;
+    lookup.Reason = "entry not present";
+    return finish();
+  }
+  if (metadataExists != objectExists) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason = metadataExists ? "metadata exists without object"
+                                   : "object exists without metadata";
+    return finish();
+  }
+
+  auto objectReadStart = timingStart(request.CollectTimings);
+  auto objectBuffer = llvm::MemoryBuffer::getFile(lookup.ObjectPath);
+  lookup.Timings.objectReadSeconds =
+      timingElapsed(request.CollectTimings, objectReadStart);
+  if (!objectBuffer) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason =
+        "failed to read cached object: " + objectBuffer.getError().message();
+    return finish();
+  }
+  auto objectHashStart = timingStart(request.CollectTimings);
+  llvm::MemoryBufferRef objectBufRef = (*objectBuffer)->getMemBufferRef();
+  std::string objectSha = sha256Hex(objectBufRef);
+  lookup.Timings.objectHashSeconds =
+      timingElapsed(request.CollectTimings, objectHashStart);
+
+  auto metadataReadStart = timingStart(request.CollectTimings);
+  auto metadataBuffer = llvm::MemoryBuffer::getFile(lookup.MetadataPath);
+  lookup.Timings.metadataReadSeconds =
+      timingElapsed(request.CollectTimings, metadataReadStart);
+  if (!metadataBuffer) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason =
+        "failed to read cache metadata: " + metadataBuffer.getError().message();
+    return finish();
+  }
+  auto metadataParseStart = timingStart(request.CollectTimings);
+  auto parsed = llvm::json::parse((*metadataBuffer)->getBuffer());
+  lookup.Timings.metadataParseSeconds =
+      timingElapsed(request.CollectTimings, metadataParseStart);
+  if (!parsed) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason =
+        "failed to parse cache metadata: " + llvm::toString(parsed.takeError());
+    return finish();
+  }
+  const llvm::json::Object *obj = parsed->getAsObject();
+  if (!obj) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason = "cache metadata is not a JSON object";
+    return finish();
+  }
+  auto metadataValidateStart = timingStart(request.CollectTimings);
+  llvm::Error validateErr =
+      validateMetadata(request, keyData, *obj, objectSha,
+                       objectBufRef.getBufferSize(), lookup.Result);
+  lookup.Timings.metadataValidateSeconds =
+      timingElapsed(request.CollectTimings, metadataValidateStart);
+  if (validateErr) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason = llvm::toString(std::move(validateErr));
+    return finish();
+  }
+
+  lookup.Result.Hsaco = std::move(*objectBuffer);
+  lookup.Status = TranslationCacheStatus::Hit;
+  lookup.Reason = "ok";
+  return finish();
+}
+
+TranslationCacheWrite
+writeTranslationCache(const TranslationCacheRequest &request,
+                      const PipelineResult &Result) {
+  auto totalStart = timingStart(request.CollectTimings);
+  TranslationCacheWrite write;
+  auto finish = [&]() {
+    write.Timings.totalSeconds =
+        timingElapsed(request.CollectTimings, totalStart);
+    return write;
+  };
+  if (cacheDisabledByPolicy(request) || request.CacheReadonly)
+    return finish();
+
+  auto keyBuildStart = timingStart(request.CollectTimings);
+  auto keyDataOrErr =
+      buildKeyData(request, request.CollectTimings, write.Timings.keyBuild);
+  write.Timings.keyBuildSeconds =
+      timingElapsed(request.CollectTimings, keyBuildStart);
+  if (!keyDataOrErr) {
+    write.Status = TranslationCacheStatus::WriteFailed;
+    write.Reason = llvm::toString(keyDataOrErr.takeError());
+    return finish();
+  }
+  KeyData keyData = std::move(*keyDataOrErr);
+  write.key = keyData.key;
+  write.MetadataPath = cacheMetadataPath(request, keyData.key);
+  write.ObjectPath = cacheObjectPath(request, keyData.key);
+
+  if (!Result.Success || !Result.Hsaco || Result.Hsaco->getBufferSize() == 0) {
+    write.Status = TranslationCacheStatus::WriteFailed;
+    write.Reason = "refusing to cache unsuccessful or empty translation";
+    return finish();
+  }
+
+  std::string dir = cacheSubdir(request, keyData.key);
+  auto createDirectoryStart = timingStart(request.CollectTimings);
+  if (auto ec = llvm::sys::fs::create_directories(dir)) {
+    write.Timings.createDirectorySeconds =
+        timingElapsed(request.CollectTimings, createDirectoryStart);
+    write.Status = TranslationCacheStatus::WriteFailed;
+    write.Reason =
+        "failed to create cache directory '" + dir + "': " + ec.message();
+    return finish();
+  }
+  write.Timings.createDirectorySeconds =
+      timingElapsed(request.CollectTimings, createDirectoryStart);
+
+  auto objectHashStart = timingStart(request.CollectTimings);
+  std::string objectSha = sha256Hex(Result.Hsaco->getMemBufferRef());
+  write.Timings.objectHashSeconds =
+      timingElapsed(request.CollectTimings, objectHashStart);
+  auto objectWriteStart = timingStart(request.CollectTimings);
+  if (auto err = writeFileAtomic(write.ObjectPath, Result.Hsaco->getBuffer())) {
+    write.Timings.objectWriteSeconds =
+        timingElapsed(request.CollectTimings, objectWriteStart);
+    write.Status = TranslationCacheStatus::WriteFailed;
+    write.Reason =
+        "failed to write cached object: " + llvm::toString(std::move(err));
+    return finish();
+  }
+  write.Timings.objectWriteSeconds =
+      timingElapsed(request.CollectTimings, objectWriteStart);
+
+  auto metadataBuildStart = timingStart(request.CollectTimings);
+  llvm::json::Object meta = metadataObject(request, keyData, Result, objectSha);
+  write.Timings.metadataBuildSeconds =
+      timingElapsed(request.CollectTimings, metadataBuildStart);
+  auto metadataWriteStart = timingStart(request.CollectTimings);
+  if (auto err =
+          writeFileAtomic(write.MetadataPath,
+                          jsonToString(llvm::json::Value(std::move(meta))))) {
+    write.Timings.metadataWriteSeconds =
+        timingElapsed(request.CollectTimings, metadataWriteStart);
+    llvm::sys::fs::remove(write.ObjectPath);
+    write.Status = TranslationCacheStatus::WriteFailed;
+    write.Reason =
+        "failed to write cache metadata: " + llvm::toString(std::move(err));
+    return finish();
+  }
+  write.Timings.metadataWriteSeconds =
+      timingElapsed(request.CollectTimings, metadataWriteStart);
+
+  write.Status = TranslationCacheStatus::WriteSuccess;
+  write.Reason = "ok";
+  return finish();
+}
+
+std::string
+skippedKernelForTranslationCache(llvm::ArrayRef<std::string> kernelNames,
+                                 llvm::StringRef skipList) {
+  if (skipList.empty())
+    return "";
+
+  llvm::StringRef remaining(skipList);
+  while (!remaining.empty()) {
+    auto split = remaining.split(',');
+    llvm::StringRef requested = split.first.trim();
+    remaining = split.second;
+    if (requested.empty())
+      continue;
+    for (llvm::StringRef kernelName : kernelNames) {
+      if (requested == kernelName)
+        return kernelName.str();
+    }
+  }
+  return "";
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/cache/translation-cache.h
+++ b/amd/comgr/src/hotswap/cache/translation-cache.h
@@ -1,0 +1,122 @@
+#ifndef HOTSWAP_TRANSPILER_TRANSLATION_CACHE_H
+#define HOTSWAP_TRANSPILER_TRANSLATION_CACHE_H
+
+#include "pipeline.h"
+
+#include "llvm/Support/MemoryBufferRef.h"
+
+#include <string>
+
+namespace COMGR::hotswap {
+
+struct TranslationCacheKeyBuildTimings {
+  double sourceHashSeconds = 0.0;
+  double elfHeaderSeconds = 0.0;
+  double rulesHashSeconds = 0.0;
+  double loadedImageIdentitySeconds = 0.0;
+  double kernelNamesSeconds = 0.0;
+  double materialBuildSeconds = 0.0;
+  double keyHashSeconds = 0.0;
+};
+
+struct TranslationCacheLookupTimings {
+  double totalSeconds = 0.0;
+  double keyBuildSeconds = 0.0;
+  TranslationCacheKeyBuildTimings keyBuild;
+  double metadataObjectStatSeconds = 0.0;
+  double objectReadSeconds = 0.0;
+  double objectHashSeconds = 0.0;
+  double metadataReadSeconds = 0.0;
+  double metadataParseSeconds = 0.0;
+  double metadataValidateSeconds = 0.0;
+};
+
+struct TranslationCacheWriteTimings {
+  double totalSeconds = 0.0;
+  double keyBuildSeconds = 0.0;
+  TranslationCacheKeyBuildTimings keyBuild;
+  double createDirectorySeconds = 0.0;
+  double objectHashSeconds = 0.0;
+  double objectWriteSeconds = 0.0;
+  double metadataBuildSeconds = 0.0;
+  double metadataWriteSeconds = 0.0;
+};
+
+struct TranslationCacheRequest {
+  llvm::MemoryBufferRef SourceObject;
+  std::string SourceGfx;
+  std::string TargetGfx;
+  std::string SourceIsa;
+  std::string TargetIsa;
+  std::string CodeIsa;
+  std::string HotswapRulesPath;
+  std::string CacheDirectory;
+  std::string CacheSkipKernels;
+  std::string KernelName;
+  // Opaque identity of the bundled device libraries, salted into the cache
+  // key so a device-library change invalidates prior entries. Supplied by
+  // the caller (the transpiler passes COMGR::getDeviceLibrariesIdentifier())
+  // to keep this module free of comgr metadata-layer coupling.
+  std::string DeviceLibrariesIdentity;
+  int OrigMach = -1;
+  unsigned OptLevel = 0;
+  bool EnableWritelaneRewrite = true;
+  bool EnableWaveNative = true;
+  // Unconditionally select ScaledModuloReplicationProjection for wave32->wave64
+  // cross-widening (testing knob). The normal WaveNative y/z-refusal ->
+  // scaled-dispatch upgrade is automatic and needs no flag.
+  bool ForceScaledModrep = false;
+  bool AssumeHipGlobalOffsetZero = false;
+  bool StrictMode = false;
+  bool CacheDisabled = true;
+  bool CacheReadonly = false;
+  bool CollectTimings = false;
+};
+
+enum class TranslationCacheStatus {
+  Disabled,
+  Bypassed,
+  Miss,
+  Hit,
+  Invalid,
+  WriteSuccess,
+  WriteFailed,
+};
+
+struct TranslationCacheLookup {
+  TranslationCacheStatus Status = TranslationCacheStatus::Disabled;
+  std::string key;
+  std::string MetadataPath;
+  std::string ObjectPath;
+  std::string Reason;
+  TranslationCacheLookupTimings Timings;
+  PipelineResult Result;
+};
+
+struct TranslationCacheWrite {
+  TranslationCacheStatus Status = TranslationCacheStatus::Disabled;
+  std::string key;
+  std::string MetadataPath;
+  std::string ObjectPath;
+  std::string Reason;
+  TranslationCacheWriteTimings Timings;
+};
+
+const char *translationCacheStatusString(TranslationCacheStatus Status);
+
+TranslationCacheLookup
+lookupTranslationCache(const TranslationCacheRequest &request);
+
+TranslationCacheWrite
+writeTranslationCache(const TranslationCacheRequest &request,
+                      const PipelineResult &Result);
+
+std::string
+skippedKernelForTranslationCache(llvm::ArrayRef<std::string> kernelNames,
+                                 llvm::StringRef skipList);
+
+std::string sha256Hex(llvm::MemoryBufferRef buffer);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -134,8 +134,9 @@ add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapMCTests>
   COMMAND $<TARGET_FILE:HotswapProfileTests>
   COMMAND $<TARGET_FILE:RaiserScaffoldingTests>
+  COMMAND $<TARGET_FILE:TranslationCacheTests>
   COMMAND $<TARGET_FILE:DemangleSymbolNameTest>
   COMMAND $<TARGET_FILE:LoggerTests>)
 add_dependencies(test-unit HotswapElfTests HotswapMCTests HotswapProfileTests
-  RaiserScaffoldingTests DemangleSymbolNameTest LoggerTests)
+  RaiserScaffoldingTests TranslationCacheTests DemangleSymbolNameTest LoggerTests)
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/hotswap/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(rewriter)
 add_subdirectory(raiser)
+add_subdirectory(cache)

--- a/amd/comgr/test-unit/hotswap/cache/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/cache/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Unit tests for the hotswap translation cache (hotswap/cache/translation-cache.h).
+#
+# Pins the on-disk content-addressed cache contract: first-run miss then hit,
+# key sensitivity to source hash / ISA / opt-level / kernel name, and the
+# invalid/readonly/skip-list paths. The test builds its own fake AMDGPU ELF,
+# so it needs no GPU and no real code object.
+
+add_executable(TranslationCacheTests
+  TranslationCacheTest.cpp)
+
+target_link_libraries(TranslationCacheTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  hotswap::translation_cache
+  ${LLVM_PTHREAD_LIB})
+
+target_include_directories(TranslationCacheTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+
+comgr_configure_test_target(TranslationCacheTests)
+
+add_test(NAME TranslationCacheTests
+  COMMAND $<TARGET_FILE:TranslationCacheTests>)

--- a/amd/comgr/test-unit/hotswap/cache/TranslationCacheTest.cpp
+++ b/amd/comgr/test-unit/hotswap/cache/TranslationCacheTest.cpp
@@ -1,0 +1,488 @@
+//===- TranslationCacheTest.cpp - translation cache unit tests ------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+
+#include "hotswap/cache/translation-cache.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct TempDir {
+  llvm::SmallString<128> Path;
+  bool Valid = false;
+
+  explicit TempDir(const char *Prefix) {
+    std::error_code Ec = llvm::sys::fs::createUniqueDirectory(Prefix, Path);
+    Valid = !Ec;
+  }
+
+  ~TempDir() {
+    if (Valid)
+      llvm::sys::fs::remove_directories(Path);
+  }
+
+  std::string file(const char *Name) const {
+    llvm::SmallString<256> P(Path);
+    llvm::sys::path::append(P, Name);
+    return std::string(P);
+  }
+};
+
+struct ScopedEnv {
+  std::string Name;
+  std::string OldValue;
+  bool HadOldValue = false;
+
+  ScopedEnv(const char *Name, const std::string &Value) : Name(Name) {
+    if (const char *Old = std::getenv(Name)) {
+      OldValue = Old;
+      HadOldValue = true;
+    }
+    setenv(Name, Value.c_str(), 1);
+  }
+
+  ~ScopedEnv() {
+    if (HadOldValue)
+      setenv(Name.c_str(), OldValue.c_str(), 1);
+    else
+      unsetenv(Name.c_str());
+  }
+};
+
+llvm::MemoryBufferRef bufRef(llvm::ArrayRef<uint8_t> V) {
+  return llvm::MemoryBufferRef(
+      llvm::StringRef(reinterpret_cast<const char *>(V.data()), V.size()), "");
+}
+
+// Minimal AMDGPU MsgPack metadata: an `amdhsa.kernels` array with one
+// `.name`, which is all `listKernelNames` reads.
+std::string amdgpuMetadataBlob(llvm::StringRef KernelName) {
+  llvm::msgpack::Document Doc;
+  llvm::msgpack::MapDocNode Root = Doc.getRoot().getMap(/*Convert=*/true);
+
+  llvm::msgpack::DocNode Version = Doc.getArrayNode();
+  Version.getArray().push_back(Doc.getNode(static_cast<uint64_t>(1)));
+  Version.getArray().push_back(Doc.getNode(static_cast<uint64_t>(2)));
+  Root["amdhsa.version"] = Version;
+
+  llvm::msgpack::DocNode Kernel = Doc.getMapNode();
+  Kernel.getMap()[".name"] = Doc.getNode(KernelName, /*Copy=*/true);
+
+  llvm::msgpack::DocNode Kernels = Doc.getArrayNode();
+  Kernels.getArray().push_back(Kernel);
+  Root["amdhsa.kernels"] = Kernels;
+
+  std::string Blob;
+  Doc.writeToBlob(Blob);
+  return Blob;
+}
+
+// Offset of the source byte the cache tests flip to perturb the SHA-256
+// without disturbing any ELF structure the key builder parses. It lives in
+// the reserved gap fakeAmdgpuElf() leaves between the ELF header and the
+// metadata note.
+constexpr size_t HashPerturbOffset = 80;
+constexpr size_t NoteOffset = 128;
+static_assert(sizeof(llvm::ELF::Elf64_Ehdr) <= HashPerturbOffset &&
+                  HashPerturbOffset < NoteOffset,
+              "perturb byte must lie in the ELF header-to-note padding gap");
+
+// Build a 64-bit little-endian AMDGPU ELF carrying an NT_AMDGPU_METADATA
+// note naming one kernel, so that listKernelNames succeeds and the
+// translation-cache key builder accepts the object.
+//
+// Layout: [Elf64_Ehdr][padding to NoteOffset][note][.shstrtab][section
+// headers]. The padding gap holds HashPerturbOffset.
+llvm::SmallVector<uint8_t> fakeAmdgpuElf() {
+  using namespace llvm;
+  const std::string Blob = amdgpuMetadataBlob("cache_probe_kernel");
+
+  // ELF note: Nhdr, then name and desc each padded to 4 bytes. n_namesz
+  // counts the trailing NUL.
+  constexpr StringLiteral NoteName = "AMDGPU";
+  const uint32_t NameSz = NoteName.size() + 1;
+  const uint32_t DescSz = Blob.size();
+  const uint32_t NamePadded = alignTo(NameSz, 4);
+  const uint32_t NoteSize =
+      sizeof(ELF::Elf64_Nhdr) + NamePadded + alignTo(DescSz, 4);
+
+  // Section header string table; offsets are derived as names are appended.
+  std::string ShStr(1, '\0');
+  auto addSectionName = [&](StringRef Name) {
+    uint32_t Offset = ShStr.size();
+    ShStr.append(Name.begin(), Name.end());
+    ShStr.push_back('\0');
+    return Offset;
+  };
+  const uint32_t NoteNameOffset = addSectionName(".note");
+  const uint32_t ShStrNameOffset = addSectionName(".shstrtab");
+
+  const uint32_t ShStrOffset = NoteOffset + NoteSize;
+  const uint32_t ShdrOffset = alignTo(ShStrOffset + ShStr.size(), 8);
+  const uint32_t Total = ShdrOffset + 3 * sizeof(ELF::Elf64_Shdr);
+
+  SmallVector<uint8_t> D(Total, 0);
+  auto writeStruct = [&](size_t Offset, const auto &S) {
+    std::memcpy(D.data() + Offset, &S, sizeof(S));
+  };
+
+  ELF::Elf64_Ehdr Ehdr = {};
+  Ehdr.e_ident[ELF::EI_MAG0] = 0x7f;
+  Ehdr.e_ident[ELF::EI_MAG1] = 'E';
+  Ehdr.e_ident[ELF::EI_MAG2] = 'L';
+  Ehdr.e_ident[ELF::EI_MAG3] = 'F';
+  Ehdr.e_ident[ELF::EI_CLASS] = ELF::ELFCLASS64;
+  Ehdr.e_ident[ELF::EI_DATA] = ELF::ELFDATA2LSB;
+  Ehdr.e_ident[ELF::EI_VERSION] = ELF::EV_CURRENT;
+  Ehdr.e_ident[ELF::EI_OSABI] = ELF::ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ELF::ET_DYN;
+  Ehdr.e_machine = ELF::EM_AMDGPU;
+  Ehdr.e_version = ELF::EV_CURRENT;
+  Ehdr.e_flags = 0x49; // arbitrary stable EF_AMDGPU flags hashed into the key
+  Ehdr.e_ehsize = sizeof(ELF::Elf64_Ehdr);
+  Ehdr.e_shentsize = sizeof(ELF::Elf64_Shdr);
+  Ehdr.e_shnum = 3;
+  Ehdr.e_shstrndx = 2;
+  Ehdr.e_shoff = ShdrOffset;
+  writeStruct(0, Ehdr);
+
+  ELF::Elf64_Nhdr Nhdr = {};
+  Nhdr.n_namesz = NameSz;
+  Nhdr.n_descsz = DescSz;
+  Nhdr.n_type = ELF::NT_AMDGPU_METADATA;
+  writeStruct(NoteOffset, Nhdr);
+  std::memcpy(D.data() + NoteOffset + sizeof(Nhdr), NoteName.data(),
+              NoteName.size());
+  std::memcpy(D.data() + NoteOffset + sizeof(Nhdr) + NamePadded, Blob.data(),
+              DescSz);
+
+  std::memcpy(D.data() + ShStrOffset, ShStr.data(), ShStr.size());
+
+  // Section headers: [0] null, [1] .note (SHT_NOTE), [2] .shstrtab.
+  ELF::Elf64_Shdr Shdrs[3] = {};
+  Shdrs[1].sh_name = NoteNameOffset;
+  Shdrs[1].sh_type = ELF::SHT_NOTE;
+  Shdrs[1].sh_offset = NoteOffset;
+  Shdrs[1].sh_size = NoteSize;
+  Shdrs[1].sh_addralign = 4;
+  Shdrs[2].sh_name = ShStrNameOffset;
+  Shdrs[2].sh_type = ELF::SHT_STRTAB;
+  Shdrs[2].sh_offset = ShStrOffset;
+  Shdrs[2].sh_size = ShStr.size();
+  Shdrs[2].sh_addralign = 1;
+  std::memcpy(D.data() + ShdrOffset, Shdrs, sizeof(Shdrs));
+
+  return D;
+}
+
+void writeTextFile(const std::string &Path, llvm::StringRef Text) {
+  std::error_code Ec;
+  llvm::raw_fd_ostream Os(Path, Ec);
+  ASSERT_FALSE(Ec) << "cannot write " << Path << ": " << Ec.message();
+  Os << Text;
+}
+
+void writeBinaryFile(const std::string &Path,
+                     const std::vector<uint8_t> &Bytes) {
+  std::error_code Ec;
+  llvm::raw_fd_ostream Os(Path, Ec, llvm::sys::fs::OF_None);
+  ASSERT_FALSE(Ec) << "cannot write " << Path << ": " << Ec.message();
+  Os.write(reinterpret_cast<const char *>(Bytes.data()), Bytes.size());
+}
+
+COMGR::hotswap::TranslationCacheRequest makeRequest(
+    llvm::MemoryBufferRef Source, const std::string &RulesPath,
+    const std::string &SourceGfx = "gfx1250",
+    const std::string &TargetGfx = "gfx942") {
+  COMGR::hotswap::TranslationCacheRequest Request;
+  Request.SourceObject = Source;
+  Request.SourceGfx = SourceGfx;
+  Request.TargetGfx = TargetGfx;
+  Request.SourceIsa = "amdgcn-amd-amdhsa--" + SourceGfx;
+  Request.TargetIsa = "amdgcn-amd-amdhsa--" + TargetGfx;
+  Request.CodeIsa = "amdgcn-amd-amdhsa--gfx942";
+  Request.HotswapRulesPath = RulesPath;
+  Request.CacheDirectory = llvm::sys::path::parent_path(RulesPath).str();
+  Request.DeviceLibrariesIdentity = "unit-test-device-libraries-identity";
+  Request.CacheDisabled = false;
+  Request.OrigMach = 0x49;
+  Request.EnableWritelaneRewrite = true;
+  Request.EnableWaveNative = true;
+  Request.StrictMode = true;
+  return Request;
+}
+
+COMGR::hotswap::PipelineResult makeSuccessfulResult(
+    std::vector<uint8_t> Hsaco = {0x7f, 'E', 'L', 'F', 1, 2, 3}) {
+  COMGR::hotswap::PipelineResult Result;
+  Result.Success = true;
+  Result.Hsaco = llvm::MemoryBuffer::getMemBufferCopy(
+      llvm::StringRef(reinterpret_cast<const char *>(Hsaco.data()),
+                      Hsaco.size()),
+      "");
+  Result.LiftedCount = 7;
+  Result.TotalCount = 7;
+  return Result;
+}
+
+} // namespace
+
+TEST(TranslationCache, FirstRunMissWriteSecondRunHit) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+
+  auto First = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(First.Status, COMGR::hotswap::TranslationCacheStatus::Miss);
+
+  auto Result = makeSuccessfulResult();
+  auto Write = COMGR::hotswap::writeTranslationCache(Request, Result);
+  ASSERT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::WriteSuccess)
+      << Write.Reason;
+
+  auto Second = COMGR::hotswap::lookupTranslationCache(Request);
+  ASSERT_EQ(Second.Status, COMGR::hotswap::TranslationCacheStatus::Hit)
+      << Second.Reason;
+  ASSERT_TRUE(Second.Result.Hsaco && Result.Hsaco);
+  EXPECT_EQ(Second.Result.Hsaco->getBuffer(), Result.Hsaco->getBuffer());
+  EXPECT_EQ(Second.Result.LiftedCount, Result.LiftedCount);
+  EXPECT_EQ(Second.Result.TotalCount, Result.TotalCount);
+}
+
+TEST(TranslationCache, KernelNameParticipatesInCacheKey) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto WholeObject = makeRequest(bufRef(Source), Rules);
+
+  auto WholeWrite =
+      COMGR::hotswap::writeTranslationCache(WholeObject, makeSuccessfulResult());
+  ASSERT_EQ(WholeWrite.Status,
+            COMGR::hotswap::TranslationCacheStatus::WriteSuccess)
+      << WholeWrite.Reason;
+
+  auto PerKernel = WholeObject;
+  PerKernel.KernelName = "cache_probe_kernel";
+  auto PerKernelLookup = COMGR::hotswap::lookupTranslationCache(PerKernel);
+  EXPECT_EQ(PerKernelLookup.Status,
+            COMGR::hotswap::TranslationCacheStatus::Miss);
+  EXPECT_NE(PerKernelLookup.key, WholeWrite.key);
+
+  auto PerKernelWrite = COMGR::hotswap::writeTranslationCache(
+      PerKernel, makeSuccessfulResult({0x7f, 'E', 'L', 'F', 4, 5, 6}));
+  ASSERT_EQ(PerKernelWrite.Status,
+            COMGR::hotswap::TranslationCacheStatus::WriteSuccess)
+      << PerKernelWrite.Reason;
+
+  auto OtherKernel = WholeObject;
+  OtherKernel.KernelName = "other_kernel";
+  auto OtherKernelLookup = COMGR::hotswap::lookupTranslationCache(OtherKernel);
+  EXPECT_EQ(OtherKernelLookup.Status,
+            COMGR::hotswap::TranslationCacheStatus::Miss);
+  EXPECT_NE(OtherKernelLookup.key, PerKernelWrite.key);
+
+  auto WholeObjectLookup = COMGR::hotswap::lookupTranslationCache(WholeObject);
+  EXPECT_EQ(WholeObjectLookup.Status,
+            COMGR::hotswap::TranslationCacheStatus::Hit);
+}
+
+TEST(TranslationCache, ChangedInputHashCausesMiss) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  ASSERT_EQ(COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult()).Status,
+            COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+
+  Source[HashPerturbOffset] ^= 0x1;
+  auto Changed = makeRequest(bufRef(Source), Rules);
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Changed);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Miss);
+}
+
+TEST(TranslationCache, ChangedIsaCausesMiss) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  ASSERT_EQ(COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult()).Status,
+            COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+
+  auto ChangedSourceIsa = makeRequest(bufRef(Source), Rules, "gfx1200", "gfx942");
+  EXPECT_EQ(COMGR::hotswap::lookupTranslationCache(ChangedSourceIsa).Status,
+            COMGR::hotswap::TranslationCacheStatus::Miss);
+
+  auto ChangedTargetIsa = makeRequest(bufRef(Source), Rules, "gfx1250", "gfx950");
+  EXPECT_EQ(COMGR::hotswap::lookupTranslationCache(ChangedTargetIsa).Status,
+            COMGR::hotswap::TranslationCacheStatus::Miss);
+}
+
+TEST(TranslationCache, ChangedOptLevelCausesMiss) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  Request.OptLevel = 2;
+  auto Write =
+      COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
+  ASSERT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+
+  auto Changed = Request;
+  Changed.OptLevel = 0;
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Changed);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Miss);
+}
+
+TEST(TranslationCache, OldHotswapCacheDirDoesNotEnableCache) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv OldCacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", "");
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  Request.CacheDirectory = "";
+
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Disabled);
+}
+
+TEST(TranslationCache, CorruptMetadataIsInvalid) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  auto Write = COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
+  ASSERT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+
+  writeTextFile(Write.MetadataPath, "not-json\n");
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Invalid);
+  EXPECT_NE(Lookup.Reason.find("parse"), std::string::npos);
+}
+
+TEST(TranslationCache, CorruptObjectIsInvalid) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  auto Write = COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
+  ASSERT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+
+  writeBinaryFile(Write.ObjectPath, {1, 2, 3, 4});
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Invalid);
+  EXPECT_NE(Lookup.Reason.find("cached_object_sha256"), std::string::npos);
+}
+
+TEST(TranslationCache, ReadonlyMissDoesNotWrite) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  Request.CacheReadonly = true;
+
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Miss);
+
+  auto Write = COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
+  EXPECT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::Disabled);
+
+  auto Second = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(Second.Status, COMGR::hotswap::TranslationCacheStatus::Miss);
+}
+
+TEST(TranslationCache, BypassedStatusHasStableString) {
+  EXPECT_STREQ(COMGR::hotswap::translationCacheStatusString(
+                   COMGR::hotswap::TranslationCacheStatus::Bypassed),
+               "bypassed");
+}
+
+TEST(TranslationCache, SkipKernelListMatchesExactKernelName) {
+  ScopedEnv Skip("HSA_HOTSWAP_CACHE_SKIP_KERNELS",
+                 "other_kernel, target_kernel ,third_kernel");
+
+  std::vector<std::string> Kernels = {"first_kernel", "target_kernel"};
+  EXPECT_EQ(COMGR::hotswap::skippedKernelForTranslationCache(
+                Kernels, "other_kernel, target_kernel ,third_kernel"),
+            "target_kernel");
+}
+
+TEST(TranslationCache, SkipKernelListDoesNotUseSubstringMatching) {
+  ScopedEnv Skip("HSA_HOTSWAP_CACHE_SKIP_KERNELS", "target");
+
+  std::vector<std::string> Kernels = {"target_kernel"};
+  EXPECT_TRUE(
+      COMGR::hotswap::skippedKernelForTranslationCache(Kernels, "target").empty());
+}


### PR DESCRIPTION
## What

Adds a content-addressed, on-disk cache for HotSwap-transpiled code objects under `amd/comgr/src/hotswap/cache`. When the same source object, target ISA, and transpile settings recur -- which they do constantly across process restarts and repeated kernel launches -- a lookup restores the previously lowered HSACO instead of re-running the raise/opt/llc/link pipeline.

## Design

- **Key**: SHA-256 over the source object hash, source/target/code ISA, ELF machine and flags, original machine id, opt level, the hotswap rules file (path + contents), the WaveNative / writelane / scaled-modrep toggles, the kernel name (when caching a single kernel), a loaded-transpiler-image identity, and a caller-supplied device-libraries identity.
- **Storage**: `<key>.Hsaco` next to a `<key>.json` sidecar carrying the pipeline's attribution (lifted counts, scaled-dispatch factor, scratch segment sizes, C5 suppression), sharded by the first two hex digits of the key. Writes are atomic.
- **Validation**: a lookup re-derives the key, re-hashes the stored object against the sidecar, and validates every field before returning a hit, so a stale or corrupt entry reports `Invalid` rather than handing back a wrong translation.

## Dependencies

The module depends only on LLVM:
- the transpile result type it persists is declared in a local `pipeline.h`;
- the one AMDGPU metadata query it needs is a small ELF-note + MsgPack kernel-name lister in `code-object-utils`;
- the device-libraries identity is passed in through the request (the transpiler supplies `COMGR::getDeviceLibrariesIdentifier()`) rather than pulled from the comgr metadata layer.

It builds as the `hotswap::translation_cache` OBJECT library and links into `amd_comgr` unconditionally. No transpile call site is wired to it in this change; it lands as a self-contained, tested module.

## Testing

`TranslationCacheTests` (gtest) pins the miss-then-hit flow, key sensitivity (source hash / ISA / opt-level / kernel name), and the invalid / readonly / skip-list paths against a self-built fake AMDGPU ELF -- no GPU required. Built and run through a standalone comgr CMake/ninja configure: `[  PASSED  ] 12 tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)