### PR TITLE
[Comgr][hotswap] Add in-memory single-flight tier for the translation cache

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -654,8 +654,10 @@ target_link_libraries(amd_comgr
 # The rewriter (byte-level rewrite path) backs the always-on
 # amd_comgr_hotswap_rewrite API, so it is linked unconditionally. The raiser
 # (IR transpiler path) and the code-object loader are opt-in behind
-# COMGR_ENABLE_HOTSWAP_TRANSPILE.
+# COMGR_ENABLE_HOTSWAP_TRANSPILE. The translation cache is LLVM-only and linked
+# unconditionally so its objects are available to any transpile entry point.
 target_link_libraries(amd_comgr PRIVATE hotswap::rewriter)
+target_link_libraries(amd_comgr PRIVATE hotswap::translation_cache)
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   target_link_libraries(amd_comgr
     PRIVATE hotswap::common hotswap::loader hotswap::raiser)

--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -1,19 +1,22 @@
 # Hotswap subproject coordinator. Each path is built as an OBJECT library whose
 # TUs land directly in amd_comgr.so:
-#   hotswap::rewriter  byte-level rewrite path (linked unconditionally)
-#   hotswap::raiser    IR transpiler path (opt-in, COMGR_ENABLE_HOTSWAP_TRANSPILE)
-#   hotswap::loader    code-object metadata loader feeding the raiser (opt-in)
-#   hotswap::common    small shared pieces the transpile path links (opt-in)
+#   hotswap::rewriter          byte-level rewrite path (linked unconditionally)
+#   hotswap::translation_cache on-disk cache for transpiled code objects
+#                              (LLVM-only, linked unconditionally)
+#   hotswap::raiser            IR transpiler path (opt-in, COMGR_ENABLE_HOTSWAP_TRANSPILE)
+#   hotswap::loader            code-object metadata loader feeding the raiser (opt-in)
+#   hotswap::common            small shared pieces the transpile path links (opt-in)
 # common/ is mostly header-only (kernel-meta.h); hotswap::common compiles the
 # one out-of-line HotswapError::ID symbol the loader (and later decoder) share.
 #
-# All four keep their LLVM dependencies PRIVATE. Their objects land in
-# amd_comgr, which already links the full curated LLVM set; propagating a
-# partial set onto amd_comgr's link line perturbs static-archive resolution
-# (dropping LLVMCodeGen's -mcpu registration and breaking in-process LLD) and
-# mixes component archives with libLLVM.so under LLVM_LINK_LLVM_DYLIB. Targets
-# that link these libraries directly name their own LLVM libs.
+# All keep their LLVM dependencies PRIVATE. Their objects land in amd_comgr,
+# which already links the full curated LLVM set; propagating a partial set onto
+# amd_comgr's link line perturbs static-archive resolution (dropping
+# LLVMCodeGen's -mcpu registration and breaking in-process LLD) and mixes
+# component archives with libLLVM.so under LLVM_LINK_LLVM_DYLIB. Targets that
+# link these libraries directly name their own LLVM libs.
 add_subdirectory(rewriter)
+add_subdirectory(cache)
 add_subdirectory(raiser)
 
 # The loader consumes AMDGPU target-private headers an install-tree-only build

--- a/amd/comgr/src/hotswap/cache/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/cache/CMakeLists.txt
@@ -52,8 +52,16 @@ target_include_directories(hotswap-translation-cache PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
 )
 
+# LLVM deps are PUBLIC here (unlike the sibling hotswap OBJECT libs, which keep
+# them PRIVATE). translation-cache.cpp uses llvm::Error, which emits a reference
+# to "typeinfo for llvm::ErrorInfoBase" from LLVMSupport. As an OBJECT library
+# these .o files land directly in amd_comgr; with PRIVATE, LLVMSupport is not
+# propagated onto amd_comgr's static link line and the ErrorInfoBase typeinfo is
+# dropped, breaking the full-static CI link (undefined reference). PUBLIC keeps
+# LLVMSupport on the link line. Do NOT change to PRIVATE without confirming the
+# static libamd_comgr.so link still resolves llvm::ErrorInfoBase.
 target_link_libraries(hotswap-translation-cache
-  PRIVATE
+  PUBLIC
     LLVMBinaryFormat
     LLVMCore
     LLVMObject

--- a/amd/comgr/src/hotswap/cache/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/cache/CMakeLists.txt
@@ -53,7 +53,7 @@ target_include_directories(hotswap-translation-cache PUBLIC
 )
 
 target_link_libraries(hotswap-translation-cache
-  PUBLIC
+  PRIVATE
     LLVMBinaryFormat
     LLVMCore
     LLVMObject

--- a/amd/comgr/src/hotswap/cache/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/cache/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.20)
+project(hotswap-translation-cache LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# --- LLVM ---------------------------------------------------------------------
+if(NOT TARGET LLVMSupport)
+  find_package(LLVM REQUIRED CONFIG)
+endif()
+if(NOT COMMAND llvm_update_compile_flags)
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+  include(AddLLVM)
+endif()
+
+include_directories(${LLVM_INCLUDE_DIRS})
+link_directories(${LLVM_LIBRARY_DIRS})
+add_definitions(${LLVM_DEFINITIONS})
+
+# --- Library ------------------------------------------------------------------
+# OBJECT library so its translation units land directly in amd_comgr.so when
+# `target_link_libraries(amd_comgr PRIVATE hotswap::translation_cache)` runs
+# in the parent CMakeLists.txt. Depends only on LLVM: the transpile pipeline
+# result type (pipeline.h) and the AMDGPU kernel-name query
+# (code-object-utils) are the module's only cross-file surface, and both are
+# LLVM-only, so the cache carries no comgr metadata-layer coupling.
+add_library(hotswap-translation-cache OBJECT
+  translation-cache.cpp
+  code-object-utils.cpp
+)
+
+if(NOT TARGET hotswap::translation_cache)
+  add_library(hotswap::translation_cache ALIAS hotswap-translation-cache)
+endif()
+
+# Match LLVM's compile flags (no-rtti, no-exceptions); mixing RTTI-on TUs with
+# RTTI-off LLVM libs produces undefined-reference errors for `typeinfo`
+# symbols on any class with a virtual method.
+llvm_update_compile_flags(hotswap-translation-cache)
+
+set_target_properties(hotswap-translation-cache
+  PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Public include root (src/) so consumers can
+# `#include "hotswap/cache/translation-cache.h"`.
+target_include_directories(hotswap-translation-cache PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_link_libraries(hotswap-translation-cache
+  PUBLIC
+    LLVMBinaryFormat
+    LLVMCore
+    LLVMObject
+    LLVMSupport
+    LLVMTargetParser
+)

--- a/amd/comgr/src/hotswap/cache/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/cache/CMakeLists.txt
@@ -27,7 +27,12 @@ add_definitions(${LLVM_DEFINITIONS})
 add_library(hotswap-translation-cache OBJECT
   translation-cache.cpp
   code-object-utils.cpp
+  mem-cache.cpp
 )
+
+if(BUILD_TESTING)
+  target_compile_definitions(hotswap-translation-cache PRIVATE COMGR_HOTSWAP_MEM_CACHE_TESTING)
+endif()
 
 if(NOT TARGET hotswap::translation_cache)
   add_library(hotswap::translation_cache ALIAS hotswap-translation-cache)

--- a/amd/comgr/src/hotswap/cache/code-object-utils.cpp
+++ b/amd/comgr/src/hotswap/cache/code-object-utils.cpp
@@ -1,0 +1,94 @@
+//===- code-object-utils.cpp - AMDGPU code-object metadata --------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "code-object-utils.h"
+
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/Object/ELF.h"
+#include "llvm/Support/Error.h"
+
+namespace COMGR::hotswap {
+namespace {
+
+// Look up `Key` in `Map`. Returns null when the key is absent.
+// `MapDocNode::find(StringRef)` allocates the lookup key on `Map`'s owning
+// document, so callers need only pass the literal string.
+llvm::msgpack::DocNode *findInMap(llvm::msgpack::MapDocNode &Map,
+                                  llvm::StringRef Key) {
+  auto It = Map.find(Key);
+  return (It == Map.end()) ? nullptr : &It->second;
+}
+
+// Iterate the `amdhsa.kernels` array of a parsed AMDGPU MsgPack document and
+// invoke `CB` on each kernel map node. Silently skips non-map children.
+template <class Fn>
+void forEachKernelNode(llvm::msgpack::Document &Doc, Fn &&CB) {
+  llvm::msgpack::DocNode &Root = Doc.getRoot();
+  if (!Root.isMap())
+    return;
+  llvm::msgpack::DocNode *Kernels = findInMap(Root.getMap(), "amdhsa.kernels");
+  if (!Kernels || !Kernels->isArray())
+    return;
+  for (auto &K : Kernels->getArray()) {
+    if (!K.isMap())
+      continue;
+    CB(K.getMap());
+  }
+}
+
+} // namespace
+
+llvm::Expected<llvm::SmallVector<std::string>>
+listKernelNames(llvm::MemoryBufferRef ElfData) {
+  using namespace llvm;
+
+  Expected<object::ELF64LEFile> ElfOrErr =
+      object::ELF64LEFile::create(ElfData.getBuffer());
+  if (!ElfOrErr)
+    return ElfOrErr.takeError();
+  const object::ELF64LEFile &Elf = *ElfOrErr;
+
+  Expected<ArrayRef<object::ELF64LE::Shdr>> SectionsOrErr = Elf.sections();
+  if (!SectionsOrErr)
+    return SectionsOrErr.takeError();
+
+  SmallVector<std::string> Names;
+  bool FoundNote = false;
+  for (const object::ELF64LE::Shdr &Sec : *SectionsOrErr) {
+    if (Sec.sh_type != ELF::SHT_NOTE)
+      continue;
+    Error Err = Error::success();
+    for (const object::ELF64LE::Note &Note : Elf.notes(Sec, Err)) {
+      if (Note.getType() != ELF::NT_AMDGPU_METADATA ||
+          Note.getName() != "AMDGPU")
+        continue;
+      ArrayRef<uint8_t> Desc = Note.getDesc(Sec.sh_addralign);
+      msgpack::Document Doc;
+      if (!Doc.readFromBlob(
+              StringRef(reinterpret_cast<const char *>(Desc.data()),
+                        Desc.size()),
+              /*Multi=*/false))
+        return createStringError(
+            "listKernelNames: failed to parse AMDGPU metadata note");
+      forEachKernelNode(Doc, [&](msgpack::MapDocNode &KMap) {
+        if (msgpack::DocNode *Name = findInMap(KMap, ".name"))
+          Names.push_back(Name->toString());
+      });
+      FoundNote = true;
+    }
+    if (Err)
+      return std::move(Err);
+  }
+
+  if (!FoundNote)
+    return createStringError("listKernelNames: no AMDGPU metadata note");
+  return Names;
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/cache/code-object-utils.h
+++ b/amd/comgr/src/hotswap/cache/code-object-utils.h
@@ -1,0 +1,34 @@
+//===- code-object-utils.h - AMDGPU code-object metadata ----------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The single code-object metadata query the translation cache needs: the
+// list of kernel names declared in an ELF's AMDGPU MsgPack notes. Depends
+// only on LLVM (ELF object + MsgPack) so the cache module has no comgr
+// metadata-layer coupling.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_CODE_OBJECT_UTILS_H
+#define HOTSWAP_TRANSPILER_CODE_OBJECT_UTILS_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBufferRef.h"
+
+#include <string>
+
+namespace COMGR::hotswap {
+
+/// List the kernel names declared in the AMDGPU MsgPack notes embedded in
+/// `ElfData`. Returns an error when no AMDGPU metadata note is present.
+llvm::Expected<llvm::SmallVector<std::string>>
+listKernelNames(llvm::MemoryBufferRef ElfData);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/cache/mem-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/mem-cache.cpp
@@ -13,12 +13,17 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstdint>
+#include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <list>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace COMGR::hotswap {
 
@@ -45,10 +50,118 @@ size_t resolveBudgetFromEnv() {
   return static_cast<size_t>(parsed);
 }
 
+// ---- xxHash64 over source content (vendored from ROCr hotswap_cache.cpp) ----
+// Used only to bucket entries; identity is settled by an exact memcmp, so
+// correctness never depends on hash strength.
+namespace xxh {
+constexpr uint64_t kP1 = 11400714785074694791ULL;
+constexpr uint64_t kP2 = 14029467366897019727ULL;
+constexpr uint64_t kP3 = 1609587929392839161ULL;
+constexpr uint64_t kP4 = 9650029242287828579ULL;
+constexpr uint64_t kP5 = 2870177450012600261ULL;
+inline uint64_t rol(uint64_t v, unsigned c) { return (v << c) | (v >> (64 - c)); }
+inline uint64_t rd64(const unsigned char *b) { uint64_t v; std::memcpy(&v, b, 8); return v; }
+inline uint32_t rd32(const unsigned char *b) { uint32_t v; std::memcpy(&v, b, 4); return v; }
+inline uint64_t round(uint64_t a, uint64_t in) { a += in * kP2; a = rol(a, 31); return a * kP1; }
+inline uint64_t merge(uint64_t a, uint64_t v) { a ^= round(0, v); return a * kP1 + kP4; }
+inline uint64_t hash(const void *data, size_t size) {
+  const auto *bytes = static_cast<const unsigned char *>(data);
+  const unsigned char *cur = bytes, *const end = bytes + size;
+  constexpr uint64_t kSeed = 0x4f1bbcdc6762f36bULL;
+  uint64_t h = 0;
+  if (size >= 32) {
+    const unsigned char *const be = end - 32;
+    uint64_t l1 = kSeed + kP1 + kP2, l2 = kSeed + kP2, l3 = kSeed, l4 = kSeed - kP1;
+    do {
+      l1 = round(l1, rd64(cur)); cur += 8;
+      l2 = round(l2, rd64(cur)); cur += 8;
+      l3 = round(l3, rd64(cur)); cur += 8;
+      l4 = round(l4, rd64(cur)); cur += 8;
+    } while (cur <= be);
+    h = rol(l1, 1) + rol(l2, 7) + rol(l3, 12) + rol(l4, 18);
+    h = merge(h, l1); h = merge(h, l2); h = merge(h, l3); h = merge(h, l4);
+  } else {
+    h = kSeed + kP5;
+  }
+  h += size;
+  while (static_cast<size_t>(end - cur) >= 8) {
+    h ^= round(0, rd64(cur)); h = rol(h, 27) * kP1 + kP4; cur += 8;
+  }
+  if (static_cast<size_t>(end - cur) >= 4) {
+    h ^= static_cast<uint64_t>(rd32(cur)) * kP1; h = rol(h, 23) * kP2 + kP3; cur += 4;
+  }
+  while (cur != end) { h ^= static_cast<uint64_t>(*cur++) * kP5; h = rol(h, 11) * kP1; }
+  h ^= h >> 33; h *= kP2; h ^= h >> 29; h *= kP3;
+  return h ^ (h >> 32);
+}
+} // namespace xxh
+
+// Cheap in-memory bucket key: xxHash64(source) + source_size + the transform
+// fields already present as strings on the request. Deliberately does NOT
+// re-hash the rules file CONTENTS or re-derive the loaded-image identity (both
+// process-constant and expensive) -- those distinguish nothing within a
+// process. The disk tier's SHA-256 key still folds them in for cross-process
+// correctness. Empty string => uncacheable (empty/missing source).
+std::string deriveMemBucketKey(const TranslationCacheRequest &request) {
+  const void *src = request.SourceObject.getBufferStart();
+  const size_t n = request.SourceObject.getBufferSize();
+  if (src == nullptr || n == 0)
+    return std::string();
+  char buf[40];
+  std::snprintf(buf, sizeof(buf), "%016llx:%zx|",
+                static_cast<unsigned long long>(xxh::hash(src, n)), n);
+  std::string key(buf);
+  key += request.SourceGfx;      key.push_back('\x1f');
+  key += request.TargetGfx;      key.push_back('\x1f');
+  key += request.SourceIsa;      key.push_back('\x1f');
+  key += request.TargetIsa;      key.push_back('\x1f');
+  key += request.CodeIsa;        key.push_back('\x1f');
+  key += request.HotswapRulesPath; key.push_back('\x1f');
+  key += request.KernelName;     key.push_back('\x1f');
+  key += (request.StrictMode ? '1' : '0');
+  key += (request.EnableWritelaneRewrite ? '1' : '0');
+  key += (request.EnableWaveNative ? '1' : '0');
+  key += (request.ForceScaledModrep ? '1' : '0');
+  key += (request.AssumeHipGlobalOffsetZero ? '1' : '0');
+  // Numeric transform inputs not implied by the source bytes. Without these,
+  // two identical-source requests differing only in opt level / orig machine
+  // would collide into one bucket and the source-only memcmp would wrongly
+  // match. (elf_machine/elf_flags/source hash are omitted: the memcmp over
+  // the source bytes already covers them. rules-content/build/device-libs
+  // identity are omitted: process-constant, folded into the disk key only.)
+  {
+    char nbuf[48];
+    std::snprintf(nbuf, sizeof(nbuf), "|om=%d|ol=%u",
+                  request.OrigMach, request.OptLevel);
+    key += nbuf;
+  }
+  return key;
+}
+
+// A retained copy of the source bytes, for the exact-compare that makes a hash
+// collision impossible to mis-serve.
+struct SourceBytes {
+  std::vector<unsigned char> data;
+  bool equals(const void *p, size_t n) const {
+    return data.size() == n && std::memcmp(data.data(), p, n) == 0;
+  }
+};
+using SourceBytesRef = std::shared_ptr<const SourceBytes>;
+
+SourceBytesRef captureSource(const TranslationCacheRequest &request) {
+  const auto *p = reinterpret_cast<const unsigned char *>(
+      request.SourceObject.getBufferStart());
+  const size_t n = request.SourceObject.getBufferSize();
+  auto s = std::make_shared<SourceBytes>();
+  s->data.assign(p, p + n);
+  return s;
+}
+
 // One shared translation, plus its LRU position. The buffer is immutable once
 // published.
 struct Node {
   MemCacheEntryRef Entry;
+  SourceBytesRef Source; // retained source bytes, for exact-compare
   // Iterator into the LRU list identifying this key's recency slot. Valid while
   // the node is in the map.
   std::list<std::string>::iterator LruIt;
@@ -59,9 +172,10 @@ struct Flight {
   std::mutex Mu;
   std::condition_variable Cv;
   bool Done = false;
-  MemCacheEntryRef Entry; // published result (null on producer failure)
-  std::thread::id Leader; // the producer thread (reentrancy guard)
-  size_t Waiters = 0;     // parked waiters, for the coalescing test hook
+  MemCacheEntryRef Entry;  // published result (null on producer failure)
+  SourceBytesRef Source;   // leader's source, for exact-compare on coalesce
+  std::thread::id Leader;  // the producer thread (reentrancy guard)
+  size_t Waiters = 0;      // parked waiters, for the coalescing test hook
 };
 
 class MemCache {
@@ -85,9 +199,11 @@ public:
 
 private:
   // Look up a ready entry, refreshing its LRU position. Caller holds Mu.
-  MemCacheEntryRef lookupLocked(const std::string &key);
+  MemCacheEntryRef lookupLocked(const std::string &key,
+                                const TranslationCacheRequest &request);
   // Insert a freshly produced entry and enforce the budget. Caller holds Mu.
-  void insertLocked(const std::string &key, MemCacheEntryRef entry);
+  void insertLocked(const std::string &key, MemCacheEntryRef entry,
+                    SourceBytesRef source);
   void evictToBudgetLocked();
 
   mutable std::mutex Mu; // guards Map, Lru, InFlight, and metric gauges
@@ -110,9 +226,16 @@ private:
   uint64_t PeakLiveBytes = 0; // guarded by Mu
 };
 
-MemCacheEntryRef MemCache::lookupLocked(const std::string &key) {
+MemCacheEntryRef MemCache::lookupLocked(const std::string &key,
+                                        const TranslationCacheRequest &request) {
   auto it = Map.find(key);
   if (it == Map.end())
+    return nullptr;
+  // Exact-compare guards against an xxHash64 collision handing back the wrong
+  // translation. A mismatch (astronomically rare) is treated as a miss.
+  const void *p = request.SourceObject.getBufferStart();
+  const size_t n = request.SourceObject.getBufferSize();
+  if (!it->second.Source || !it->second.Source->equals(p, n))
     return nullptr;
   // Move to front (most-recently-used).
   Lru.splice(Lru.begin(), Lru, it->second.LruIt);
@@ -129,6 +252,8 @@ void MemCache::evictToBudgetLocked() {
     auto it = Map.find(victimKey);
     if (it != Map.end()) {
       LiveBytes -= it->second.Entry->Bytes;
+      if (it->second.Source)
+        LiveBytes -= it->second.Source->data.size();
       Map.erase(it);
       Evictions.fetch_add(1, std::memory_order_relaxed);
     }
@@ -136,20 +261,26 @@ void MemCache::evictToBudgetLocked() {
   }
 }
 
-void MemCache::insertLocked(const std::string &key, MemCacheEntryRef entry) {
+void MemCache::insertLocked(const std::string &key, MemCacheEntryRef entry,
+                            SourceBytesRef source) {
   // If a concurrent leader already inserted this key (possible only across
   // distinct flights, which we prevent, but be defensive), replace accounting.
   auto existing = Map.find(key);
   if (existing != Map.end()) {
     LiveBytes -= existing->second.Entry->Bytes;
+    if (existing->second.Source)
+      LiveBytes -= existing->second.Source->data.size();
     Lru.erase(existing->second.LruIt);
     Map.erase(existing);
   }
   Lru.push_front(key);
   Node node;
   node.Entry = std::move(entry);
+  node.Source = std::move(source);
   node.LruIt = Lru.begin();
   LiveBytes += node.Entry->Bytes;
+  if (node.Source)
+    LiveBytes += node.Source->data.size();
   Map.emplace(key, std::move(node));
   if (LiveBytes > PeakLiveBytes)
     PeakLiveBytes = LiveBytes;
@@ -199,7 +330,8 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
     return result;
   }
 
-  const std::string key = translationCacheKey(request);
+  const std::string key = deriveMemBucketKey(request);
+  SourceBytesRef source = captureSource(request);
 
   // Uncacheable request (empty source, missing gfx, no kernels, unreadable
   // rules): run the producer directly and cache nothing. Never terminate or
@@ -224,7 +356,7 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
   {
     std::unique_lock<std::mutex> lock(Mu);
     // Fast path: ready in the map.
-    if (MemCacheEntryRef hit = lookupLocked(key)) {
+    if (MemCacheEntryRef hit = lookupLocked(key, request)) {
       Hits.fetch_add(1, std::memory_order_relaxed);
       result.Status = MemCacheStatus::Hit;
       result.Entry = std::move(hit);
@@ -251,13 +383,14 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
     {
       std::unique_lock<std::mutex> lock(Mu);
       if (entry)
-        insertLocked(key, entry);
+        insertLocked(key, entry, source);
       InFlight.erase(key);
     }
     // Publish to waiters.
     {
       std::lock_guard<std::mutex> flock(flight->Mu);
       flight->Entry = entry;
+      flight->Source = source;
       flight->Done = true;
     }
     flight->Cv.notify_all();
@@ -290,20 +423,38 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
     return result;
   }
 
+  MemCacheEntryRef coalesced;
+  SourceBytesRef flightSource;
   {
     std::unique_lock<std::mutex> flock(flight->Mu);
     ++flight->Waiters;
     flight->Cv.wait(flock, [&] { return flight->Done; });
     --flight->Waiters;
-    result.Entry = flight->Entry;
+    coalesced = flight->Entry;
+    flightSource = flight->Source;
   }
-  if (result.Entry) {
+  const void *p = request.SourceObject.getBufferStart();
+  const size_t n = request.SourceObject.getBufferSize();
+  const bool sameSource = flightSource && flightSource->equals(p, n);
+  if (coalesced && sameSource) {
     Coalesced.fetch_add(1, std::memory_order_relaxed);
     result.Status = MemCacheStatus::Coalesced;
-  } else {
-    // The leader's producer failed; nothing to hand back.
-    result.Status = MemCacheStatus::ProducerFailed;
+    result.Entry = std::move(coalesced);
+    return result;
   }
+  if (coalesced && !sameSource) {
+    // xxHash64 collision between two concurrent distinct sources: the leader's
+    // flight was for a different source, so we cannot use its bytes. RETRY the
+    // whole operation: by now the leader has published + erased its flight, so
+    // our retry either finds our own source in the map (lookupLocked memcmp),
+    // or -- more likely -- misses (leader stored the OTHER source) and WE become
+    // a fresh leader that runs + caches our result. This makes a collided
+    // request self-heal into a normal cached entry instead of perpetually
+    // bypassing. Bounded: retry loops only while the collision persists.
+    return getOrCompute(request, producer); // tail-recursive retry
+  }
+  // The leader's producer failed; nothing to hand back.
+  result.Status = MemCacheStatus::ProducerFailed;
   return result;
 }
 
@@ -441,7 +592,7 @@ size_t memCacheInFlightCountForTesting() {
 
 size_t waitForMemCacheWaitersForTesting(const TranslationCacheRequest &request,
                                         size_t count, unsigned timeoutMs) {
-  const std::string key = translationCacheKey(request);
+  const std::string key = deriveMemBucketKey(request);
   return activeInstance().waitForWaitersForTesting(key, count, timeoutMs);
 }
 #endif

--- a/amd/comgr/src/hotswap/cache/mem-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/mem-cache.cpp
@@ -1,0 +1,449 @@
+//===- mem-cache.cpp - In-memory hotswap translation cache ----------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mem-cache.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdlib>
+#include <list>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+
+namespace COMGR::hotswap {
+
+namespace {
+
+// Default in-memory budget when AMD_COMGR_HOTSWAP_MEM_CACHE_BYTES is unset.
+// Transpiled HSACOs range from a few MB to hundreds of MB; 1 GiB holds a
+// working set of several large objects without an unbounded footprint.
+constexpr size_t kDefaultBudgetBytes = 1ull << 30; // 1 GiB
+
+// Parses the budget env var once. Returns the default when unset, 0 (disabled)
+// when explicitly "0"/empty, or the parsed byte count. Never throws.
+size_t resolveBudgetFromEnv() {
+  const char *env = std::getenv("AMD_COMGR_HOTSWAP_MEM_CACHE_BYTES");
+  if (!env)
+    return kDefaultBudgetBytes;
+  llvm::StringRef value(env);
+  value = value.trim();
+  if (value.empty())
+    return kDefaultBudgetBytes;
+  unsigned long long parsed = 0;
+  if (value.getAsInteger(10, parsed)) // true on parse failure
+    return kDefaultBudgetBytes;        // malformed -> fall back to default
+  return static_cast<size_t>(parsed);
+}
+
+// One shared translation, plus its LRU position. The buffer is immutable once
+// published.
+struct Node {
+  MemCacheEntryRef Entry;
+  // Iterator into the LRU list identifying this key's recency slot. Valid while
+  // the node is in the map.
+  std::list<std::string>::iterator LruIt;
+};
+
+// A cold miss in progress. The leader runs the producer; waiters block on CV.
+struct Flight {
+  std::mutex Mu;
+  std::condition_variable Cv;
+  bool Done = false;
+  MemCacheEntryRef Entry; // published result (null on producer failure)
+  std::thread::id Leader; // the producer thread (reentrancy guard)
+  size_t Waiters = 0;     // parked waiters, for the coalescing test hook
+};
+
+class MemCache {
+public:
+  explicit MemCache(size_t budget) : Budget(budget) {}
+
+  size_t budget() const { return Budget; }
+
+  MemCacheResult getOrCompute(const TranslationCacheRequest &request,
+                              const TranslationProducer &producer);
+
+  MemCacheMetrics snapshot() const;
+
+#ifdef COMGR_HOTSWAP_MEM_CACHE_TESTING
+  void resetForTesting(size_t budget);
+  size_t entryCountForTesting() const;
+  size_t inFlightCountForTesting() const;
+  size_t waitForWaitersForTesting(const std::string &key, size_t count,
+                                  unsigned timeoutMs);
+#endif
+
+private:
+  // Look up a ready entry, refreshing its LRU position. Caller holds Mu.
+  MemCacheEntryRef lookupLocked(const std::string &key);
+  // Insert a freshly produced entry and enforce the budget. Caller holds Mu.
+  void insertLocked(const std::string &key, MemCacheEntryRef entry);
+  void evictToBudgetLocked();
+
+  mutable std::mutex Mu; // guards Map, Lru, InFlight, and metric gauges
+  std::unordered_map<std::string, Node> Map;
+  std::list<std::string> Lru; // front = most recently used
+  std::unordered_map<std::string, std::shared_ptr<Flight>> InFlight;
+
+  const size_t Budget;
+  size_t LiveBytes = 0;
+
+  // Metrics. Guarded by Mu except the atomics, which are bumped off-lock.
+  std::atomic<uint64_t> Lookups{0};
+  std::atomic<uint64_t> Hits{0};
+  std::atomic<uint64_t> Coalesced{0};
+  std::atomic<uint64_t> Computed{0};
+  std::atomic<uint64_t> ProducerCalls{0};
+  std::atomic<uint64_t> ProducerFailures{0};
+  std::atomic<uint64_t> Evictions{0};
+  std::atomic<uint64_t> ReentrantComputes{0};
+  uint64_t PeakLiveBytes = 0; // guarded by Mu
+};
+
+MemCacheEntryRef MemCache::lookupLocked(const std::string &key) {
+  auto it = Map.find(key);
+  if (it == Map.end())
+    return nullptr;
+  // Move to front (most-recently-used).
+  Lru.splice(Lru.begin(), Lru, it->second.LruIt);
+  it->second.LruIt = Lru.begin();
+  return it->second.Entry;
+}
+
+void MemCache::evictToBudgetLocked() {
+  // Drop least-recently-used entries until we are within budget. Never evict
+  // below one entry unless that single entry itself exceeds the budget (in
+  // which case we still drop it -- it will live via the caller's shared_ptr).
+  while (LiveBytes > Budget && !Lru.empty()) {
+    const std::string &victimKey = Lru.back();
+    auto it = Map.find(victimKey);
+    if (it != Map.end()) {
+      LiveBytes -= it->second.Entry->Bytes;
+      Map.erase(it);
+      Evictions.fetch_add(1, std::memory_order_relaxed);
+    }
+    Lru.pop_back();
+  }
+}
+
+void MemCache::insertLocked(const std::string &key, MemCacheEntryRef entry) {
+  // If a concurrent leader already inserted this key (possible only across
+  // distinct flights, which we prevent, but be defensive), replace accounting.
+  auto existing = Map.find(key);
+  if (existing != Map.end()) {
+    LiveBytes -= existing->second.Entry->Bytes;
+    Lru.erase(existing->second.LruIt);
+    Map.erase(existing);
+  }
+  Lru.push_front(key);
+  Node node;
+  node.Entry = std::move(entry);
+  node.LruIt = Lru.begin();
+  LiveBytes += node.Entry->Bytes;
+  Map.emplace(key, std::move(node));
+  if (LiveBytes > PeakLiveBytes)
+    PeakLiveBytes = LiveBytes;
+  evictToBudgetLocked();
+}
+
+// Builds a shared, immutable entry from a producer result, moving the HSACO
+// buffer out. Returns null if the result carries no usable HSACO.
+MemCacheEntryRef adopt(PipelineResult &result) {
+  if (!result.Success || !result.Hsaco)
+    return nullptr;
+  auto entry = std::make_shared<MemCacheEntry>();
+  entry->Bytes = result.Hsaco->getBufferSize();
+  entry->Hsaco = std::shared_ptr<llvm::MemoryBuffer>(result.Hsaco.release());
+  entry->Attribution.C5SuppressedCount = result.C5SuppressedCount;
+  entry->Attribution.C5SuppressionReason = result.C5SuppressionReason;
+  entry->Attribution.UsesScratchPrivateSegment =
+      result.UsesScratchPrivateSegment;
+  entry->Attribution.SourcePrivateSegmentFixedSize =
+      result.SourcePrivateSegmentFixedSize;
+  entry->Attribution.TargetEnablePrivateSegment =
+      result.TargetEnablePrivateSegment;
+  entry->Attribution.TargetPrivateSegmentFixedSize =
+      result.TargetPrivateSegmentFixedSize;
+  entry->Attribution.LiftedCount = result.LiftedCount;
+  entry->Attribution.TotalCount = result.TotalCount;
+  entry->Attribution.ScaledDispatchFactor = result.ScaledDispatchFactor;
+  return entry;
+}
+
+MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
+                                      const TranslationProducer &producer) {
+  Lookups.fetch_add(1, std::memory_order_relaxed);
+
+  MemCacheResult result;
+
+  // Budget 0 => tier disabled: run the producer directly, cache nothing.
+  if (Budget == 0) {
+    PipelineResult produced = producer();
+    ProducerCalls.fetch_add(1, std::memory_order_relaxed);
+    result.Status = MemCacheStatus::Disabled;
+    MemCacheEntryRef entry = adopt(produced);
+    if (!entry)
+      ProducerFailures.fetch_add(1, std::memory_order_relaxed);
+    result.Entry = std::move(entry);
+    result.LeaderResult = std::move(produced);
+    return result;
+  }
+
+  const std::string key = translationCacheKey(request);
+
+  // Uncacheable request (empty source, missing gfx, no kernels, unreadable
+  // rules): run the producer directly and cache nothing. Never terminate or
+  // fabricate a key that could collide across distinct uncacheable inputs.
+  if (key.empty()) {
+    PipelineResult produced = producer();
+    ProducerCalls.fetch_add(1, std::memory_order_relaxed);
+    MemCacheEntryRef entry = adopt(produced);
+    if (!entry)
+      ProducerFailures.fetch_add(1, std::memory_order_relaxed);
+    // Report Computed when it produced usable bytes, else ProducerFailed. The
+    // entry is returned to the caller but not inserted into the map.
+    result.Status =
+        entry ? MemCacheStatus::Computed : MemCacheStatus::ProducerFailed;
+    result.Entry = std::move(entry);
+    result.LeaderResult = std::move(produced);
+    return result;
+  }
+
+  std::shared_ptr<Flight> flight;
+  bool isLeader = false;
+  {
+    std::unique_lock<std::mutex> lock(Mu);
+    // Fast path: ready in the map.
+    if (MemCacheEntryRef hit = lookupLocked(key)) {
+      Hits.fetch_add(1, std::memory_order_relaxed);
+      result.Status = MemCacheStatus::Hit;
+      result.Entry = std::move(hit);
+      return result;
+    }
+    // Is an identical request already in flight?
+    auto it = InFlight.find(key);
+    if (it != InFlight.end()) {
+      flight = it->second;
+    } else {
+      flight = std::make_shared<Flight>();
+      flight->Leader = std::this_thread::get_id();
+      InFlight.emplace(key, flight);
+      isLeader = true;
+    }
+  }
+
+  if (isLeader) {
+    // Leader runs the producer with NO cache lock held.
+    PipelineResult produced = producer();
+    ProducerCalls.fetch_add(1, std::memory_order_relaxed);
+    MemCacheEntryRef entry = adopt(produced);
+
+    {
+      std::unique_lock<std::mutex> lock(Mu);
+      if (entry)
+        insertLocked(key, entry);
+      InFlight.erase(key);
+    }
+    // Publish to waiters.
+    {
+      std::lock_guard<std::mutex> flock(flight->Mu);
+      flight->Entry = entry;
+      flight->Done = true;
+    }
+    flight->Cv.notify_all();
+
+    if (!entry)
+      ProducerFailures.fetch_add(1, std::memory_order_relaxed);
+    Computed.fetch_add(1, std::memory_order_relaxed);
+    result.Status = entry ? MemCacheStatus::Computed
+                          : MemCacheStatus::ProducerFailed;
+    result.Entry = std::move(entry);
+    result.LeaderResult = std::move(produced);
+    return result;
+  }
+
+  // Waiter. Reentrancy guard: if this same thread is the leader of this flight
+  // (a producer that recursively asks for its own key), do NOT block on
+  // ourselves -- run the producer inline instead. Cannot cache (the leader
+  // owns the flight), so this is a bypass compute.
+  if (flight->Leader == std::this_thread::get_id()) {
+    ReentrantComputes.fetch_add(1, std::memory_order_relaxed);
+    PipelineResult produced = producer();
+    ProducerCalls.fetch_add(1, std::memory_order_relaxed);
+    MemCacheEntryRef entry = adopt(produced);
+    if (!entry)
+      ProducerFailures.fetch_add(1, std::memory_order_relaxed);
+    result.Status = entry ? MemCacheStatus::Computed
+                          : MemCacheStatus::ProducerFailed;
+    result.Entry = std::move(entry);
+    result.LeaderResult = std::move(produced);
+    return result;
+  }
+
+  {
+    std::unique_lock<std::mutex> flock(flight->Mu);
+    ++flight->Waiters;
+    flight->Cv.wait(flock, [&] { return flight->Done; });
+    --flight->Waiters;
+    result.Entry = flight->Entry;
+  }
+  if (result.Entry) {
+    Coalesced.fetch_add(1, std::memory_order_relaxed);
+    result.Status = MemCacheStatus::Coalesced;
+  } else {
+    // The leader's producer failed; nothing to hand back.
+    result.Status = MemCacheStatus::ProducerFailed;
+  }
+  return result;
+}
+
+MemCacheMetrics MemCache::snapshot() const {
+  MemCacheMetrics m;
+  m.Lookups = Lookups.load(std::memory_order_relaxed);
+  m.Hits = Hits.load(std::memory_order_relaxed);
+  m.Coalesced = Coalesced.load(std::memory_order_relaxed);
+  m.Computed = Computed.load(std::memory_order_relaxed);
+  m.ProducerCalls = ProducerCalls.load(std::memory_order_relaxed);
+  m.ProducerFailures = ProducerFailures.load(std::memory_order_relaxed);
+  m.Evictions = Evictions.load(std::memory_order_relaxed);
+  m.ReentrantComputes = ReentrantComputes.load(std::memory_order_relaxed);
+  m.BudgetBytes = Budget;
+  {
+    std::lock_guard<std::mutex> lock(Mu);
+    m.LiveBytes = LiveBytes;
+    m.PeakLiveBytes = PeakLiveBytes;
+    m.Entries = Map.size();
+    m.InFlight = InFlight.size();
+  }
+  return m;
+}
+
+#ifdef COMGR_HOTSWAP_MEM_CACHE_TESTING
+void MemCache::resetForTesting(size_t) {
+  std::lock_guard<std::mutex> lock(Mu);
+  Map.clear();
+  Lru.clear();
+  InFlight.clear();
+  LiveBytes = 0;
+  PeakLiveBytes = 0;
+  Lookups = 0;
+  Hits = 0;
+  Coalesced = 0;
+  Computed = 0;
+  ProducerCalls = 0;
+  ProducerFailures = 0;
+  Evictions = 0;
+  ReentrantComputes = 0;
+}
+
+size_t MemCache::entryCountForTesting() const {
+  std::lock_guard<std::mutex> lock(Mu);
+  return Map.size();
+}
+
+size_t MemCache::inFlightCountForTesting() const {
+  std::lock_guard<std::mutex> lock(Mu);
+  return InFlight.size();
+}
+
+size_t MemCache::waitForWaitersForTesting(const std::string &key, size_t count,
+                                          unsigned timeoutMs) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+  for (;;) {
+    std::shared_ptr<Flight> flight;
+    {
+      std::lock_guard<std::mutex> lock(Mu);
+      auto it = InFlight.find(key);
+      if (it != InFlight.end())
+        flight = it->second;
+    }
+    size_t observed = 0;
+    if (flight) {
+      std::lock_guard<std::mutex> flock(flight->Mu);
+      observed = flight->Waiters;
+    }
+    if (observed >= count || std::chrono::steady_clock::now() >= deadline)
+      return observed;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+#endif
+
+// Process-global instance. Budget is fixed for the process lifetime (resolved
+// once); tests swap the whole instance via resetMemCacheForTesting.
+MemCache &instance() {
+  static MemCache *cache = new MemCache(resolveBudgetFromEnv());
+  return *cache;
+}
+
+#ifdef COMGR_HOTSWAP_MEM_CACHE_TESTING
+// A rebindable pointer so tests can install an instance with an overridden
+// budget. In non-test builds instance() is a plain function-local static.
+std::mutex &testInstanceMu() {
+  static std::mutex m;
+  return m;
+}
+MemCache *&testInstancePtr() {
+  static MemCache *p = nullptr;
+  return p;
+}
+MemCache &activeInstance() {
+  std::lock_guard<std::mutex> lock(testInstanceMu());
+  MemCache *&p = testInstancePtr();
+  if (!p)
+    p = &instance();
+  return *p;
+}
+#else
+MemCache &activeInstance() { return instance(); }
+#endif
+
+} // namespace
+
+MemCacheResult getOrComputeTranslation(const TranslationCacheRequest &request,
+                                       const TranslationProducer &producer) {
+  return activeInstance().getOrCompute(request, producer);
+}
+
+MemCacheMetrics snapshotMemCacheMetrics() {
+  return activeInstance().snapshot();
+}
+
+size_t memCacheBudgetBytes() { return activeInstance().budget(); }
+
+#ifdef COMGR_HOTSWAP_MEM_CACHE_TESTING
+void resetMemCacheForTesting(size_t budgetBytesOverride) {
+  std::lock_guard<std::mutex> lock(testInstanceMu());
+  MemCache *&p = testInstancePtr();
+  // Replace the active instance with a fresh one at the requested budget so
+  // each test starts from a known, isolated state.
+  p = new MemCache(budgetBytesOverride);
+}
+
+size_t memCacheEntryCountForTesting() {
+  return activeInstance().entryCountForTesting();
+}
+
+size_t memCacheInFlightCountForTesting() {
+  return activeInstance().inFlightCountForTesting();
+}
+
+size_t waitForMemCacheWaitersForTesting(const TranslationCacheRequest &request,
+                                        size_t count, unsigned timeoutMs) {
+  const std::string key = translationCacheKey(request);
+  return activeInstance().waitForWaitersForTesting(key, count, timeoutMs);
+}
+#endif
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/cache/mem-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/mem-cache.cpp
@@ -59,11 +59,28 @@ constexpr uint64_t kP2 = 14029467366897019727ULL;
 constexpr uint64_t kP3 = 1609587929392839161ULL;
 constexpr uint64_t kP4 = 9650029242287828579ULL;
 constexpr uint64_t kP5 = 2870177450012600261ULL;
-inline uint64_t rol(uint64_t v, unsigned c) { return (v << c) | (v >> (64 - c)); }
-inline uint64_t rd64(const unsigned char *b) { uint64_t v; std::memcpy(&v, b, 8); return v; }
-inline uint32_t rd32(const unsigned char *b) { uint32_t v; std::memcpy(&v, b, 4); return v; }
-inline uint64_t round(uint64_t a, uint64_t in) { a += in * kP2; a = rol(a, 31); return a * kP1; }
-inline uint64_t merge(uint64_t a, uint64_t v) { a ^= round(0, v); return a * kP1 + kP4; }
+inline uint64_t rol(uint64_t v, unsigned c) {
+  return (v << c) | (v >> (64 - c));
+}
+inline uint64_t rd64(const unsigned char *b) {
+  uint64_t v;
+  std::memcpy(&v, b, 8);
+  return v;
+}
+inline uint32_t rd32(const unsigned char *b) {
+  uint32_t v;
+  std::memcpy(&v, b, 4);
+  return v;
+}
+inline uint64_t round(uint64_t a, uint64_t in) {
+  a += in * kP2;
+  a = rol(a, 31);
+  return a * kP1;
+}
+inline uint64_t merge(uint64_t a, uint64_t v) {
+  a ^= round(0, v);
+  return a * kP1 + kP4;
+}
 inline uint64_t hash(const void *data, size_t size) {
   const auto *bytes = static_cast<const unsigned char *>(data);
   const unsigned char *cur = bytes, *const end = bytes + size;
@@ -71,27 +88,45 @@ inline uint64_t hash(const void *data, size_t size) {
   uint64_t h = 0;
   if (size >= 32) {
     const unsigned char *const be = end - 32;
-    uint64_t l1 = kSeed + kP1 + kP2, l2 = kSeed + kP2, l3 = kSeed, l4 = kSeed - kP1;
+    uint64_t l1 = kSeed + kP1 + kP2, l2 = kSeed + kP2, l3 = kSeed,
+             l4 = kSeed - kP1;
     do {
-      l1 = round(l1, rd64(cur)); cur += 8;
-      l2 = round(l2, rd64(cur)); cur += 8;
-      l3 = round(l3, rd64(cur)); cur += 8;
-      l4 = round(l4, rd64(cur)); cur += 8;
+      l1 = round(l1, rd64(cur));
+      cur += 8;
+      l2 = round(l2, rd64(cur));
+      cur += 8;
+      l3 = round(l3, rd64(cur));
+      cur += 8;
+      l4 = round(l4, rd64(cur));
+      cur += 8;
     } while (cur <= be);
     h = rol(l1, 1) + rol(l2, 7) + rol(l3, 12) + rol(l4, 18);
-    h = merge(h, l1); h = merge(h, l2); h = merge(h, l3); h = merge(h, l4);
+    h = merge(h, l1);
+    h = merge(h, l2);
+    h = merge(h, l3);
+    h = merge(h, l4);
   } else {
     h = kSeed + kP5;
   }
   h += size;
   while (static_cast<size_t>(end - cur) >= 8) {
-    h ^= round(0, rd64(cur)); h = rol(h, 27) * kP1 + kP4; cur += 8;
+    h ^= round(0, rd64(cur));
+    h = rol(h, 27) * kP1 + kP4;
+    cur += 8;
   }
   if (static_cast<size_t>(end - cur) >= 4) {
-    h ^= static_cast<uint64_t>(rd32(cur)) * kP1; h = rol(h, 23) * kP2 + kP3; cur += 4;
+    h ^= static_cast<uint64_t>(rd32(cur)) * kP1;
+    h = rol(h, 23) * kP2 + kP3;
+    cur += 4;
   }
-  while (cur != end) { h ^= static_cast<uint64_t>(*cur++) * kP5; h = rol(h, 11) * kP1; }
-  h ^= h >> 33; h *= kP2; h ^= h >> 29; h *= kP3;
+  while (cur != end) {
+    h ^= static_cast<uint64_t>(*cur++) * kP5;
+    h = rol(h, 11) * kP1;
+  }
+  h ^= h >> 33;
+  h *= kP2;
+  h ^= h >> 29;
+  h *= kP3;
   return h ^ (h >> 32);
 }
 } // namespace xxh
@@ -111,13 +146,20 @@ std::string deriveMemBucketKey(const TranslationCacheRequest &request) {
   std::snprintf(buf, sizeof(buf), "%016llx:%zx|",
                 static_cast<unsigned long long>(xxh::hash(src, n)), n);
   std::string key(buf);
-  key += request.SourceGfx;      key.push_back('\x1f');
-  key += request.TargetGfx;      key.push_back('\x1f');
-  key += request.SourceIsa;      key.push_back('\x1f');
-  key += request.TargetIsa;      key.push_back('\x1f');
-  key += request.CodeIsa;        key.push_back('\x1f');
-  key += request.HotswapRulesPath; key.push_back('\x1f');
-  key += request.KernelName;     key.push_back('\x1f');
+  key += request.SourceGfx;
+  key.push_back('\x1f');
+  key += request.TargetGfx;
+  key.push_back('\x1f');
+  key += request.SourceIsa;
+  key.push_back('\x1f');
+  key += request.TargetIsa;
+  key.push_back('\x1f');
+  key += request.CodeIsa;
+  key.push_back('\x1f');
+  key += request.HotswapRulesPath;
+  key.push_back('\x1f');
+  key += request.KernelName;
+  key.push_back('\x1f');
   key += (request.StrictMode ? '1' : '0');
   key += (request.EnableWritelaneRewrite ? '1' : '0');
   key += (request.EnableWaveNative ? '1' : '0');
@@ -131,8 +173,8 @@ std::string deriveMemBucketKey(const TranslationCacheRequest &request) {
   // identity are omitted: process-constant, folded into the disk key only.)
   {
     char nbuf[48];
-    std::snprintf(nbuf, sizeof(nbuf), "|om=%d|ol=%u",
-                  request.OrigMach, request.OptLevel);
+    std::snprintf(nbuf, sizeof(nbuf), "|om=%d|ol=%u", request.OrigMach,
+                  request.OptLevel);
     key += nbuf;
   }
   return key;
@@ -172,10 +214,10 @@ struct Flight {
   std::mutex Mu;
   std::condition_variable Cv;
   bool Done = false;
-  MemCacheEntryRef Entry;  // published result (null on producer failure)
-  SourceBytesRef Source;   // leader's source, for exact-compare on coalesce
-  std::thread::id Leader;  // the producer thread (reentrancy guard)
-  size_t Waiters = 0;      // parked waiters, for the coalescing test hook
+  MemCacheEntryRef Entry; // published result (null on producer failure)
+  SourceBytesRef Source;  // leader's source, for exact-compare on coalesce
+  std::thread::id Leader; // the producer thread (reentrancy guard)
+  size_t Waiters = 0;     // parked waiters, for the coalescing test hook
 };
 
 class MemCache {
@@ -226,8 +268,9 @@ private:
   uint64_t PeakLiveBytes = 0; // guarded by Mu
 };
 
-MemCacheEntryRef MemCache::lookupLocked(const std::string &key,
-                                        const TranslationCacheRequest &request) {
+MemCacheEntryRef
+MemCache::lookupLocked(const std::string &key,
+                       const TranslationCacheRequest &request) {
   auto it = Map.find(key);
   if (it == Map.end())
     return nullptr;
@@ -447,10 +490,11 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
     // flight was for a different source, so we cannot use its bytes. RETRY the
     // whole operation: by now the leader has published + erased its flight, so
     // our retry either finds our own source in the map (lookupLocked memcmp),
-    // or -- more likely -- misses (leader stored the OTHER source) and WE become
-    // a fresh leader that runs + caches our result. This makes a collided
-    // request self-heal into a normal cached entry instead of perpetually
-    // bypassing. Bounded: retry loops only while the collision persists.
+    // or -- more likely -- misses (leader stored the OTHER source) and WE
+    // become a fresh leader that runs + caches our result. This makes a
+    // collided request self-heal into a normal cached entry instead of
+    // perpetually bypassing. Bounded: retry loops only while the collision
+    // persists.
     return getOrCompute(request, producer); // tail-recursive retry
   }
   // The leader's producer failed; nothing to hand back.

--- a/amd/comgr/src/hotswap/cache/mem-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/mem-cache.cpp
@@ -235,6 +235,7 @@ struct Flight {
   std::condition_variable Cv;
   bool Done = false;
   MemCacheEntryRef Entry; // published result (null on producer failure)
+  int ProducerStatus = 0; // leader's opaque producer code (when Entry null)
   SourceBytesRef Source;  // leader's source, for exact-compare on coalesce
   std::thread::id Leader; // the producer thread (reentrancy guard)
   size_t Waiters = 0;     // parked waiters, for the coalescing test hook
@@ -457,6 +458,7 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
       std::lock_guard<std::mutex> flock(flight->Mu);
       flight->Entry = entry;
       flight->Source = source;
+      flight->ProducerStatus = produced.ProducerStatus;
       flight->Done = true;
     }
     flight->Cv.notify_all();
@@ -467,6 +469,7 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
     result.Status =
         entry ? MemCacheStatus::Computed : MemCacheStatus::ProducerFailed;
     result.Entry = std::move(entry);
+    result.ProducerStatus = produced.ProducerStatus;
     result.LeaderResult = std::move(produced);
     return result;
   }
@@ -485,6 +488,7 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
     result.Status =
         entry ? MemCacheStatus::Computed : MemCacheStatus::ProducerFailed;
     result.Entry = std::move(entry);
+    result.ProducerStatus = produced.ProducerStatus;
     result.LeaderResult = std::move(produced);
     return result;
   }
@@ -521,6 +525,12 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
     return getOrCompute(request, producer); // tail-recursive retry
   }
   // The leader's producer failed; nothing to hand back.
+  // Leader's producer failed; forward its opaque status so this waiter
+  // reports the same failure code a direct compute would, not a generic error.
+  {
+    std::lock_guard<std::mutex> flock(flight->Mu);
+    result.ProducerStatus = flight->ProducerStatus;
+  }
   result.Status = MemCacheStatus::ProducerFailed;
   return result;
 }

--- a/amd/comgr/src/hotswap/cache/mem-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/mem-cache.cpp
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -34,8 +35,9 @@ namespace {
 // working set of several large objects without an unbounded footprint.
 constexpr size_t kDefaultBudgetBytes = 1ull << 30; // 1 GiB
 
-// Parses the budget env var once. Returns the default when unset, 0 (disabled)
-// when explicitly "0"/empty, or the parsed byte count. Never throws.
+// Parses the budget env var once. Returns the built-in default when the var
+// is unset, empty, or malformed; 0 (explicitly) disables the tier; otherwise
+// the parsed byte count. Never throws.
 size_t resolveBudgetFromEnv() {
   const char *env = std::getenv("AMD_COMGR_HOTSWAP_MEM_CACHE_BYTES");
   if (!env)
@@ -131,6 +133,21 @@ inline uint64_t hash(const void *data, size_t size) {
 }
 } // namespace xxh
 
+#ifdef COMGR_HOTSWAP_MEM_CACHE_TESTING
+using MemHashFn = std::function<uint64_t(const void *, size_t)>;
+MemHashFn &activeMemHashFn() {
+  static MemHashFn fn = [](const void *d, size_t n) { return xxh::hash(d, n); };
+  return fn;
+}
+uint64_t sourceBucketHash(const void *d, size_t n) {
+  return activeMemHashFn()(d, n);
+}
+#else
+inline uint64_t sourceBucketHash(const void *d, size_t n) {
+  return xxh::hash(d, n);
+}
+#endif
+
 // Cheap in-memory bucket key: xxHash64(source) + source_size + the transform
 // fields already present as strings on the request. Deliberately does NOT
 // re-hash the rules file CONTENTS or re-derive the loaded-image identity (both
@@ -144,7 +161,7 @@ std::string deriveMemBucketKey(const TranslationCacheRequest &request) {
     return std::string();
   char buf[40];
   std::snprintf(buf, sizeof(buf), "%016llx:%zx|",
-                static_cast<unsigned long long>(xxh::hash(src, n)), n);
+                static_cast<unsigned long long>(sourceBucketHash(src, n)), n);
   std::string key(buf);
   key += request.SourceGfx;
   key.push_back('\x1f');
@@ -647,6 +664,13 @@ size_t waitForMemCacheWaitersForTesting(const TranslationCacheRequest &request,
                                         size_t count, unsigned timeoutMs) {
   const std::string key = deriveMemBucketKey(request);
   return activeInstance().waitForWaitersForTesting(key, count, timeoutMs);
+}
+
+void setMemCacheHashFnForTesting(
+    std::function<uint64_t(const void *, size_t)> fn) {
+  activeMemHashFn() =
+      fn ? std::move(fn)
+         : MemHashFn([](const void *d, size_t n) { return xxh::hash(d, n); });
 }
 #endif
 

--- a/amd/comgr/src/hotswap/cache/mem-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/mem-cache.cpp
@@ -46,7 +46,7 @@ size_t resolveBudgetFromEnv() {
     return kDefaultBudgetBytes;
   unsigned long long parsed = 0;
   if (value.getAsInteger(10, parsed)) // true on parse failure
-    return kDefaultBudgetBytes;        // malformed -> fall back to default
+    return kDefaultBudgetBytes;       // malformed -> fall back to default
   return static_cast<size_t>(parsed);
 }
 
@@ -441,8 +441,8 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
     if (!entry)
       ProducerFailures.fetch_add(1, std::memory_order_relaxed);
     Computed.fetch_add(1, std::memory_order_relaxed);
-    result.Status = entry ? MemCacheStatus::Computed
-                          : MemCacheStatus::ProducerFailed;
+    result.Status =
+        entry ? MemCacheStatus::Computed : MemCacheStatus::ProducerFailed;
     result.Entry = std::move(entry);
     result.LeaderResult = std::move(produced);
     return result;
@@ -459,8 +459,8 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
     MemCacheEntryRef entry = adopt(produced);
     if (!entry)
       ProducerFailures.fetch_add(1, std::memory_order_relaxed);
-    result.Status = entry ? MemCacheStatus::Computed
-                          : MemCacheStatus::ProducerFailed;
+    result.Status =
+        entry ? MemCacheStatus::Computed : MemCacheStatus::ProducerFailed;
     result.Entry = std::move(entry);
     result.LeaderResult = std::move(produced);
     return result;

--- a/amd/comgr/src/hotswap/cache/mem-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/mem-cache.cpp
@@ -12,6 +12,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>
@@ -261,13 +262,23 @@ public:
 #endif
 
 private:
-  // Look up a ready entry, refreshing its LRU position. Caller holds Mu.
-  MemCacheEntryRef lookupLocked(const std::string &key,
-                                const TranslationCacheRequest &request);
+  // Phase 1 of a lookup (O(1), caller holds Mu): find the bucket, promote its
+  // LRU slot, and PIN the entry + its retained source into shared_ptrs the
+  // caller can inspect after releasing Mu. Returns false on a bucket miss. The
+  // exact source compare is done by the caller OFF-lock (the shared_ptr copies
+  // keep both alive even if the entry is evicted after unlock), so a warm hit
+  // no longer holds Mu across a multi-MiB memcmp.
+  bool acquireCandidateLocked(const std::string &key, MemCacheEntryRef &entry,
+                              SourceBytesRef &source);
   // Insert a freshly produced entry and enforce the budget. Caller holds Mu.
-  void insertLocked(const std::string &key, MemCacheEntryRef entry,
-                    SourceBytesRef source);
-  void evictToBudgetLocked();
+  // Returns the Nodes evicted (defensive-replace victim + budget victims) so
+  // the caller can destroy their possibly-multi-MiB buffers AFTER releasing Mu,
+  // keeping free()/munmap() out of the critical section.
+  std::vector<Node> insertLocked(const std::string &key, MemCacheEntryRef entry,
+                                 SourceBytesRef source);
+  // Evict LRU entries until within budget. Caller holds Mu. Returns the evicted
+  // Nodes for off-lock destruction (see insertLocked).
+  std::vector<Node> evictToBudgetLocked();
 
   mutable std::mutex Mu; // guards Map, Lru, InFlight, and metric gauges
   std::unordered_map<std::string, Node> Map;
@@ -289,28 +300,33 @@ private:
   uint64_t PeakLiveBytes = 0; // guarded by Mu
 };
 
-MemCacheEntryRef
-MemCache::lookupLocked(const std::string &key,
-                       const TranslationCacheRequest &request) {
+bool MemCache::acquireCandidateLocked(const std::string &key,
+                                      MemCacheEntryRef &entry,
+                                      SourceBytesRef &source) {
   auto it = Map.find(key);
   if (it == Map.end())
-    return nullptr;
-  // Exact-compare guards against an xxHash64 collision handing back the wrong
-  // translation. A mismatch (astronomically rare) is treated as a miss.
-  const void *p = request.SourceObject.getBufferStart();
-  const size_t n = request.SourceObject.getBufferSize();
-  if (!it->second.Source || !it->second.Source->equals(p, n))
-    return nullptr;
-  // Move to front (most-recently-used).
+    return false;
+  // Promote to most-recently-used. Promoting before the (off-lock) exact
+  // compare is harmless: on the astronomically-rare xxHash64 collision the
+  // caller rejects this candidate, leaving one entry spuriously marked recent.
   Lru.splice(Lru.begin(), Lru, it->second.LruIt);
   it->second.LruIt = Lru.begin();
-  return it->second.Entry;
+  // Pin both into the caller's shared_ptrs. These copies keep the entry and its
+  // retained source alive after Mu is released, so the caller's exact memcmp is
+  // safe even if a concurrent thread evicts this bucket in the meantime.
+  entry = it->second.Entry;
+  source = it->second.Source;
+  return true;
 }
 
-void MemCache::evictToBudgetLocked() {
+std::vector<Node> MemCache::evictToBudgetLocked() {
   // Drop least-recently-used entries until we are within budget. Never evict
   // below one entry unless that single entry itself exceeds the budget (in
   // which case we still drop it -- it will live via the caller's shared_ptr).
+  // Moved-out Nodes are returned so the caller destroys their buffers after Mu
+  // is released; freeing a multi-MiB HSACO under the lock would serialize every
+  // other thread behind a munmap.
+  std::vector<Node> evicted;
   while (LiveBytes > Budget && !Lru.empty()) {
     const std::string &victimKey = Lru.back();
     auto it = Map.find(victimKey);
@@ -318,23 +334,31 @@ void MemCache::evictToBudgetLocked() {
       LiveBytes -= it->second.Entry->Bytes;
       if (it->second.Source)
         LiveBytes -= it->second.Source->data.size();
+      evicted.push_back(std::move(it->second));
       Map.erase(it);
       Evictions.fetch_add(1, std::memory_order_relaxed);
     }
     Lru.pop_back();
   }
+  return evicted;
 }
 
-void MemCache::insertLocked(const std::string &key, MemCacheEntryRef entry,
-                            SourceBytesRef source) {
-  // If a concurrent leader already inserted this key (possible only across
-  // distinct flights, which we prevent, but be defensive), replace accounting.
+std::vector<Node> MemCache::insertLocked(const std::string &key,
+                                         MemCacheEntryRef entry,
+                                         SourceBytesRef source) {
+  std::vector<Node> evicted;
+  // If a key is already present (same-source collision-retry path: a prior
+  // leader stored the OTHER source under this bucket, and we are now replacing
+  // it with ours), move the old Node out for off-lock destruction and fix the
+  // accounting. This branch is load-bearing for the collision-retry path, not
+  // merely defensive.
   auto existing = Map.find(key);
   if (existing != Map.end()) {
     LiveBytes -= existing->second.Entry->Bytes;
     if (existing->second.Source)
       LiveBytes -= existing->second.Source->data.size();
     Lru.erase(existing->second.LruIt);
+    evicted.push_back(std::move(existing->second));
     Map.erase(existing);
   }
   Lru.push_front(key);
@@ -348,7 +372,10 @@ void MemCache::insertLocked(const std::string &key, MemCacheEntryRef entry,
   Map.emplace(key, std::move(node));
   if (LiveBytes > PeakLiveBytes)
     PeakLiveBytes = LiveBytes;
-  evictToBudgetLocked();
+  std::vector<Node> budgetVictims = evictToBudgetLocked();
+  for (auto &n : budgetVictims)
+    evicted.push_back(std::move(n));
+  return evicted;
 }
 
 // Builds a shared, immutable entry from a producer result, moving the HSACO
@@ -405,134 +432,167 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
     MemCacheEntryRef entry = adopt(produced);
     if (!entry)
       ProducerFailures.fetch_add(1, std::memory_order_relaxed);
+    else
+      Computed.fetch_add(1, std::memory_order_relaxed);
     // Report Computed when it produced usable bytes, else ProducerFailed. The
     // entry is returned to the caller but not inserted into the map.
     result.Status =
         entry ? MemCacheStatus::Computed : MemCacheStatus::ProducerFailed;
     result.Entry = std::move(entry);
+    result.ProducerStatus = produced.ProducerStatus;
     result.LeaderResult = std::move(produced);
     return result;
   }
 
-  // Now that the request is known cacheable (non-empty key implies a non-null,
-  // non-empty source), capture the source bytes for the exact-compare guard.
-  SourceBytesRef source = captureSource(request);
+  // The request buffer for the exact-compare guard. Stable for this call; never
+  // shared, so it needs no lock.
+  const void *reqP = request.SourceObject.getBufferStart();
+  const size_t reqN = request.SourceObject.getBufferSize();
 
-  std::shared_ptr<Flight> flight;
-  bool isLeader = false;
-  {
-    std::unique_lock<std::mutex> lock(Mu);
-    // Fast path: ready in the map.
-    if (MemCacheEntryRef hit = lookupLocked(key, request)) {
-      Hits.fetch_add(1, std::memory_order_relaxed);
-      result.Status = MemCacheStatus::Hit;
-      result.Entry = std::move(hit);
-      return result;
-    }
-    // Is an identical request already in flight?
-    auto it = InFlight.find(key);
-    if (it != InFlight.end()) {
-      flight = it->second;
-    } else {
-      flight = std::make_shared<Flight>();
-      flight->Leader = std::this_thread::get_id();
-      InFlight.emplace(key, flight);
-      isLeader = true;
-    }
-  }
-
-  if (isLeader) {
-    // Leader runs the producer with NO cache lock held.
-    PipelineResult produced = producer();
-    ProducerCalls.fetch_add(1, std::memory_order_relaxed);
-    MemCacheEntryRef entry = adopt(produced);
-
+  // Retry loop: a lost collision race (a bucket held a DIFFERENT source) falls
+  // through to `continue` instead of recursing, bounding stack use. Each
+  // iteration terminates: it either hits, becomes a leader, coalesces, or
+  // recomputes.
+  for (;;) {
+    std::shared_ptr<Flight> flight;
+    bool isLeader = false;
     {
       std::unique_lock<std::mutex> lock(Mu);
-      if (entry)
-        insertLocked(key, entry, source);
-      InFlight.erase(key);
+      // Phase 1 (O(1) under Mu): pin a candidate + its retained source.
+      MemCacheEntryRef candidate;
+      SourceBytesRef candidateSource;
+      if (acquireCandidateLocked(key, candidate, candidateSource)) {
+        // Phase 2 (OFF-lock): exact-compare the multi-MiB source. The pinned
+        // shared_ptrs keep the entry alive even if it is evicted right now.
+        lock.unlock();
+        if (candidateSource && candidateSource->equals(reqP, reqN)) {
+          Hits.fetch_add(1, std::memory_order_relaxed);
+          result.Status = MemCacheStatus::Hit;
+          result.Entry = std::move(candidate);
+          return result;
+        }
+        // xxHash64 collision (astronomically rare): the bucket holds a
+        // different source. Re-lock and treat as a miss.
+        lock.lock();
+      }
+      // Is an identical request already in flight?
+      auto it = InFlight.find(key);
+      if (it != InFlight.end()) {
+        flight = it->second;
+      } else {
+        flight = std::make_shared<Flight>();
+        flight->Leader = std::this_thread::get_id();
+        InFlight.emplace(key, flight);
+        isLeader = true;
+      }
     }
-    // Publish to waiters.
+
+    if (isLeader) {
+      // Only the leader retains the source (for insertLocked + waiters'
+      // exact-compare). Hit/Coalesced paths never read it, so capture here --
+      // not before the lock -- to keep a warm hit off the alloc+memcpy.
+      SourceBytesRef source = captureSource(request);
+      // Leader runs the producer with NO cache lock held.
+      PipelineResult produced = producer();
+      ProducerCalls.fetch_add(1, std::memory_order_relaxed);
+      MemCacheEntryRef entry = adopt(produced);
+
+      std::vector<Node> evicted;
+      {
+        std::unique_lock<std::mutex> lock(Mu);
+        if (entry)
+          evicted = insertLocked(key, entry, source);
+        InFlight.erase(key);
+      }
+      // Free evicted buffers here, AFTER Mu is released.
+      evicted.clear();
+      // Publish to waiters.
+      {
+        std::lock_guard<std::mutex> flock(flight->Mu);
+        flight->Entry = entry;
+        flight->Source = source;
+        flight->ProducerStatus = produced.ProducerStatus;
+        flight->Done = true;
+      }
+      flight->Cv.notify_all();
+
+      if (!entry)
+        ProducerFailures.fetch_add(1, std::memory_order_relaxed);
+      else
+        Computed.fetch_add(1, std::memory_order_relaxed);
+      result.Status =
+          entry ? MemCacheStatus::Computed : MemCacheStatus::ProducerFailed;
+      result.Entry = std::move(entry);
+      result.ProducerStatus = produced.ProducerStatus;
+      result.LeaderResult = std::move(produced);
+      return result;
+    }
+
+    // Waiter. Reentrancy guard: if this same thread is the leader of this
+    // flight (a producer that recursively asks for its OWN key), do NOT block
+    // on ourselves -- run the producer inline instead. Cannot cache (the leader
+    // owns the flight), so this is a bypass compute. NOTE: this guards only the
+    // same-key self-entry case. A cross-key cycle (leader of K1 waits on K2
+    // whose leader waits on K1) is NOT detected and would deadlock; the current
+    // producer (retargetCodeObject) never re-enters the cache, so there is no
+    // live cycle. Any future producer that calls back into the cache MUST NOT
+    // do so with a different key already in flight on the same thread.
+    if (flight->Leader == std::this_thread::get_id()) {
+      ReentrantComputes.fetch_add(1, std::memory_order_relaxed);
+      PipelineResult produced = producer();
+      ProducerCalls.fetch_add(1, std::memory_order_relaxed);
+      MemCacheEntryRef entry = adopt(produced);
+      if (!entry)
+        ProducerFailures.fetch_add(1, std::memory_order_relaxed);
+      else
+        Computed.fetch_add(1, std::memory_order_relaxed);
+      result.Status =
+          entry ? MemCacheStatus::Computed : MemCacheStatus::ProducerFailed;
+      result.Entry = std::move(entry);
+      result.ProducerStatus = produced.ProducerStatus;
+      result.LeaderResult = std::move(produced);
+      return result;
+    }
+
+    MemCacheEntryRef coalesced;
+    SourceBytesRef flightSource;
+    {
+      std::unique_lock<std::mutex> flock(flight->Mu);
+      ++flight->Waiters;
+      flight->Cv.wait(flock, [&] { return flight->Done; });
+      --flight->Waiters;
+      coalesced = flight->Entry;
+      flightSource = flight->Source;
+    }
+    const bool sameSource = flightSource && flightSource->equals(reqP, reqN);
+    if (coalesced && sameSource) {
+      Coalesced.fetch_add(1, std::memory_order_relaxed);
+      result.Status = MemCacheStatus::Coalesced;
+      result.Entry = std::move(coalesced);
+      return result;
+    }
+    if (coalesced && !sameSource) {
+      // xxHash64 collision between two concurrent distinct sources: the
+      // leader's flight was for a different source, so we cannot use its bytes.
+      // Retry the whole operation (loop, not recursion): by now the leader has
+      // published + erased its flight, so our retry either finds our own source
+      // in the map (Phase-2 memcmp), or -- more likely -- misses (the leader
+      // stored the OTHER source) and WE become a fresh leader that runs +
+      // caches our result. A collided request thus self-heals into a normal
+      // cached entry instead of perpetually bypassing. Bounded: loops only
+      // while the collision persists.
+      continue;
+    }
+    // The leader's producer failed; forward its opaque status so this waiter
+    // reports the same failure code a direct compute would, not a generic
+    // error.
     {
       std::lock_guard<std::mutex> flock(flight->Mu);
-      flight->Entry = entry;
-      flight->Source = source;
-      flight->ProducerStatus = produced.ProducerStatus;
-      flight->Done = true;
+      result.ProducerStatus = flight->ProducerStatus;
     }
-    flight->Cv.notify_all();
-
-    if (!entry)
-      ProducerFailures.fetch_add(1, std::memory_order_relaxed);
-    Computed.fetch_add(1, std::memory_order_relaxed);
-    result.Status =
-        entry ? MemCacheStatus::Computed : MemCacheStatus::ProducerFailed;
-    result.Entry = std::move(entry);
-    result.ProducerStatus = produced.ProducerStatus;
-    result.LeaderResult = std::move(produced);
+    result.Status = MemCacheStatus::ProducerFailed;
     return result;
   }
-
-  // Waiter. Reentrancy guard: if this same thread is the leader of this flight
-  // (a producer that recursively asks for its own key), do NOT block on
-  // ourselves -- run the producer inline instead. Cannot cache (the leader
-  // owns the flight), so this is a bypass compute.
-  if (flight->Leader == std::this_thread::get_id()) {
-    ReentrantComputes.fetch_add(1, std::memory_order_relaxed);
-    PipelineResult produced = producer();
-    ProducerCalls.fetch_add(1, std::memory_order_relaxed);
-    MemCacheEntryRef entry = adopt(produced);
-    if (!entry)
-      ProducerFailures.fetch_add(1, std::memory_order_relaxed);
-    result.Status =
-        entry ? MemCacheStatus::Computed : MemCacheStatus::ProducerFailed;
-    result.Entry = std::move(entry);
-    result.ProducerStatus = produced.ProducerStatus;
-    result.LeaderResult = std::move(produced);
-    return result;
-  }
-
-  MemCacheEntryRef coalesced;
-  SourceBytesRef flightSource;
-  {
-    std::unique_lock<std::mutex> flock(flight->Mu);
-    ++flight->Waiters;
-    flight->Cv.wait(flock, [&] { return flight->Done; });
-    --flight->Waiters;
-    coalesced = flight->Entry;
-    flightSource = flight->Source;
-  }
-  const void *p = request.SourceObject.getBufferStart();
-  const size_t n = request.SourceObject.getBufferSize();
-  const bool sameSource = flightSource && flightSource->equals(p, n);
-  if (coalesced && sameSource) {
-    Coalesced.fetch_add(1, std::memory_order_relaxed);
-    result.Status = MemCacheStatus::Coalesced;
-    result.Entry = std::move(coalesced);
-    return result;
-  }
-  if (coalesced && !sameSource) {
-    // xxHash64 collision between two concurrent distinct sources: the leader's
-    // flight was for a different source, so we cannot use its bytes. RETRY the
-    // whole operation: by now the leader has published + erased its flight, so
-    // our retry either finds our own source in the map (lookupLocked memcmp),
-    // or -- more likely -- misses (leader stored the OTHER source) and WE
-    // become a fresh leader that runs + caches our result. This makes a
-    // collided request self-heal into a normal cached entry instead of
-    // perpetually bypassing. Bounded: retry loops only while the collision
-    // persists.
-    return getOrCompute(request, producer); // tail-recursive retry
-  }
-  // The leader's producer failed; nothing to hand back.
-  // Leader's producer failed; forward its opaque status so this waiter
-  // reports the same failure code a direct compute would, not a generic error.
-  {
-    std::lock_guard<std::mutex> flock(flight->Mu);
-    result.ProducerStatus = flight->ProducerStatus;
-  }
-  result.Status = MemCacheStatus::ProducerFailed;
-  return result;
 }
 
 MemCacheMetrics MemCache::snapshot() const {

--- a/amd/comgr/src/hotswap/cache/mem-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/mem-cache.cpp
@@ -165,18 +165,21 @@ std::string deriveMemBucketKey(const TranslationCacheRequest &request) {
   key += (request.EnableWaveNative ? '1' : '0');
   key += (request.ForceScaledModrep ? '1' : '0');
   key += (request.AssumeHipGlobalOffsetZero ? '1' : '0');
-  // Numeric transform inputs not implied by the source bytes. Without these,
-  // two identical-source requests differing only in opt level / orig machine
-  // would collide into one bucket and the source-only memcmp would wrongly
-  // match. (elf_machine/elf_flags/source hash are omitted: the memcmp over
-  // the source bytes already covers them. rules-content/build/device-libs
-  // identity are omitted: process-constant, folded into the disk key only.)
+  // Transform inputs not implied by the source bytes. Without these, two
+  // identical-source requests differing only in these fields would collide
+  // into one bucket and the source-only memcmp would wrongly match.
+  // elf_machine/elf_flags and the source hash are omitted: the memcmp over
+  // the source bytes already covers them. rules-file CONTENTS and the loaded-
+  // image build identity are omitted because they are constant across a single
+  // process (the disk key still folds them in for cross-process identity).
   {
     char nbuf[48];
     std::snprintf(nbuf, sizeof(nbuf), "|om=%d|ol=%u", request.OrigMach,
                   request.OptLevel);
     key += nbuf;
   }
+  key.push_back('\x1f');
+  key += request.DeviceLibrariesIdentity;
   return key;
 }
 
@@ -374,7 +377,6 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
   }
 
   const std::string key = deriveMemBucketKey(request);
-  SourceBytesRef source = captureSource(request);
 
   // Uncacheable request (empty source, missing gfx, no kernels, unreadable
   // rules): run the producer directly and cache nothing. Never terminate or
@@ -393,6 +395,10 @@ MemCacheResult MemCache::getOrCompute(const TranslationCacheRequest &request,
     result.LeaderResult = std::move(produced);
     return result;
   }
+
+  // Now that the request is known cacheable (non-empty key implies a non-null,
+  // non-empty source), capture the source bytes for the exact-compare guard.
+  SourceBytesRef source = captureSource(request);
 
   std::shared_ptr<Flight> flight;
   bool isLeader = false;
@@ -620,10 +626,13 @@ size_t memCacheBudgetBytes() { return activeInstance().budget(); }
 #ifdef COMGR_HOTSWAP_MEM_CACHE_TESTING
 void resetMemCacheForTesting(size_t budgetBytesOverride) {
   std::lock_guard<std::mutex> lock(testInstanceMu());
-  MemCache *&p = testInstancePtr();
-  // Replace the active instance with a fresh one at the requested budget so
-  // each test starts from a known, isolated state.
-  p = new MemCache(budgetBytesOverride);
+  // Own the heap instances WE create here so we can free the previous one
+  // without ever deleting the process-immortal instance() singleton (which
+  // testInstancePtr() may alias from activeInstance()'s lazy init).
+  static MemCache *ownedTestInstance = nullptr;
+  delete ownedTestInstance;
+  ownedTestInstance = new MemCache(budgetBytesOverride);
+  testInstancePtr() = ownedTestInstance;
 }
 
 size_t memCacheEntryCountForTesting() {

--- a/amd/comgr/src/hotswap/cache/mem-cache.h
+++ b/amd/comgr/src/hotswap/cache/mem-cache.h
@@ -131,6 +131,11 @@ size_t memCacheInFlightCountForTesting();
 // the coalescing race deterministically.
 size_t waitForMemCacheWaitersForTesting(const TranslationCacheRequest &request,
                                         size_t count, unsigned timeoutMs);
+// Overrides the source bucket hash (default xxHash64). Passing nullptr
+// restores the default. Lets a test force two distinct sources into the same
+// bucket to exercise the exact-memcmp collision guard.
+void setMemCacheHashFnForTesting(
+    std::function<uint64_t(const void *, size_t)> fn);
 #endif
 
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/cache/mem-cache.h
+++ b/amd/comgr/src/hotswap/cache/mem-cache.h
@@ -64,10 +64,10 @@ struct MemCacheEntry {
 using MemCacheEntryRef = std::shared_ptr<const MemCacheEntry>;
 
 enum class MemCacheStatus {
-  Disabled,    // budget == 0; producer ran, nothing cached.
-  Hit,         // served from the in-memory map (no producer call).
-  Coalesced,   // an identical in-flight request produced this; no producer call.
-  Computed,    // this caller was the single-flight leader; producer ran.
+  Disabled,  // budget == 0; producer ran, nothing cached.
+  Hit,       // served from the in-memory map (no producer call).
+  Coalesced, // an identical in-flight request produced this; no producer call.
+  Computed,  // this caller was the single-flight leader; producer ran.
   ProducerFailed, // producer returned no HSACO; nothing cached.
 };
 

--- a/amd/comgr/src/hotswap/cache/mem-cache.h
+++ b/amd/comgr/src/hotswap/cache/mem-cache.h
@@ -1,0 +1,138 @@
+//===- mem-cache.h - In-memory hotswap translation cache ------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A process-global, in-memory tier that sits in front of the on-disk
+// translation cache. It coalesces concurrent identical rewrites (single
+// flight), serves repeat in-process lookups without re-reading or re-hashing
+// disk, and bounds its footprint with a byte-budget LRU.
+//
+// Ownership model: an entry holds the transpiled HSACO as a shared, immutable
+// buffer. Callers receive a shared_ptr to the entry, so eviction never frees a
+// buffer a caller still holds -- an evicted-but-referenced entry simply lives
+// until its last user drops it. This decouples the cache's budget from the
+// consumers' lifetimes, which is required because -- unlike the ROCr-resident
+// prototype -- this module cannot observe loaded-executable lifetimes.
+//
+// This module is built with -fno-exceptions / -fno-rtti (llvm_update_compile
+// _flags), so it must not rely on C++ exceptions for control flow.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_MEM_CACHE_H
+#define HOTSWAP_TRANSPILER_MEM_CACHE_H
+
+#include "pipeline.h"
+#include "translation-cache.h"
+
+#include "llvm/Support/MemoryBuffer.h"
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace COMGR::hotswap {
+
+// Attribution carried alongside the cached HSACO. Mirrors the sidecar fields
+// PipelineResult persists, minus the (moved-out) Hsaco buffer and the
+// per-run timing block, which are meaningless for a cache hit.
+struct MemCacheAttribution {
+  int C5SuppressedCount = 0;
+  std::string C5SuppressionReason;
+  bool UsesScratchPrivateSegment = false;
+  uint32_t SourcePrivateSegmentFixedSize = 0;
+  bool TargetEnablePrivateSegment = false;
+  uint32_t TargetPrivateSegmentFixedSize = 0;
+  int LiftedCount = 0;
+  int TotalCount = 0;
+  unsigned ScaledDispatchFactor = 1;
+};
+
+// An immutable cached translation. Shared by every hit/coalesced caller; kept
+// alive by the map (strong) and any outstanding caller references.
+struct MemCacheEntry {
+  std::shared_ptr<llvm::MemoryBuffer> Hsaco;
+  MemCacheAttribution Attribution;
+  size_t Bytes = 0; // == Hsaco->getBufferSize(), cached for budget accounting.
+};
+
+using MemCacheEntryRef = std::shared_ptr<const MemCacheEntry>;
+
+enum class MemCacheStatus {
+  Disabled,    // budget == 0; producer ran, nothing cached.
+  Hit,         // served from the in-memory map (no producer call).
+  Coalesced,   // an identical in-flight request produced this; no producer call.
+  Computed,    // this caller was the single-flight leader; producer ran.
+  ProducerFailed, // producer returned no HSACO; nothing cached.
+};
+
+struct MemCacheResult {
+  MemCacheStatus Status = MemCacheStatus::Disabled;
+  MemCacheEntryRef Entry; // null iff ProducerFailed.
+  // The full producer output for the leader path (Computed). Empty/moved-from
+  // for Hit/Coalesced (those never ran the producer). Lets the leader's caller
+  // recover pipeline timings / failure detail that the shared entry omits.
+  // For Hit/Coalesced, reconstruct what the caller needs from Entry.
+  PipelineResult LeaderResult;
+};
+
+// Producer computes a translation on a cold miss. It is invoked by exactly one
+// thread (the single-flight leader) with NO cache lock held, so it may block on
+// disk I/O / COMGR without serializing the cache. It must be self-contained
+// (typically: disk-cache lookup, else run the transpile pipeline, else write
+// disk). A producer returning a PipelineResult whose Hsaco is null or whose
+// Success is false is treated as a failure and not cached.
+using TranslationProducer = std::function<PipelineResult()>;
+
+// The single entry point. Looks up `request` in the in-memory tier; on a miss,
+// runs `producer` exactly once across all concurrent identical requests and
+// caches the result. `request` must carry the same key-determining fields the
+// disk tier uses so the two tiers agree on identity.
+MemCacheResult getOrComputeTranslation(const TranslationCacheRequest &request,
+                                       const TranslationProducer &producer);
+
+// Observability snapshot. All counters are monotonic since process start
+// except the live_* gauges.
+struct MemCacheMetrics {
+  uint64_t Lookups = 0;
+  uint64_t Hits = 0;
+  uint64_t Coalesced = 0;
+  uint64_t Computed = 0;
+  uint64_t ProducerCalls = 0;
+  uint64_t ProducerFailures = 0;
+  uint64_t Evictions = 0;
+  uint64_t ReentrantComputes = 0;
+  uint64_t BudgetBytes = 0;
+  uint64_t LiveBytes = 0;
+  uint64_t PeakLiveBytes = 0;
+  size_t Entries = 0;
+  size_t InFlight = 0;
+};
+
+MemCacheMetrics snapshotMemCacheMetrics();
+
+// Effective byte budget for this process, resolved once from
+// AMD_COMGR_HOTSWAP_MEM_CACHE_BYTES (0 disables the tier; unset uses the
+// built-in default). Exposed for tests and diagnostics.
+size_t memCacheBudgetBytes();
+
+#ifdef COMGR_HOTSWAP_MEM_CACHE_TESTING
+// Test-only controls. Not part of the public surface.
+void resetMemCacheForTesting(size_t budgetBytesOverride);
+size_t memCacheEntryCountForTesting();
+size_t memCacheInFlightCountForTesting();
+// Blocks until `count` waiters are parked on the in-flight entry for `request`,
+// or the deadline elapses. Returns the observed waiter count. Lets a test pin
+// the coalescing race deterministically.
+size_t waitForMemCacheWaitersForTesting(const TranslationCacheRequest &request,
+                                        size_t count, unsigned timeoutMs);
+#endif
+
+} // namespace COMGR::hotswap
+
+#endif // HOTSWAP_TRANSPILER_MEM_CACHE_H

--- a/amd/comgr/src/hotswap/cache/mem-cache.h
+++ b/amd/comgr/src/hotswap/cache/mem-cache.h
@@ -74,6 +74,10 @@ enum class MemCacheStatus {
 struct MemCacheResult {
   MemCacheStatus Status = MemCacheStatus::Disabled;
   MemCacheEntryRef Entry; // null iff ProducerFailed.
+  // When Status == ProducerFailed, the opaque producer status code the
+  // (possibly remote leader's) producer reported (0 if none). Lets a coalesced
+  // waiter return the leader's real failure status instead of a generic error.
+  int ProducerStatus = 0;
   // The full producer output for the leader path (Computed). Empty/moved-from
   // for Hit/Coalesced (those never ran the producer). Lets the leader's caller
   // recover pipeline timings / failure detail that the shared entry omits.

--- a/amd/comgr/src/hotswap/cache/pipeline.h
+++ b/amd/comgr/src/hotswap/cache/pipeline.h
@@ -1,0 +1,73 @@
+//===- pipeline.h - Transpile pipeline result -----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// PipelineResult is the transpile pipeline's output: the lowered HSACO plus
+// the attribution fields the translation cache persists and restores. Only
+// the result type is declared here -- the pipeline itself is not part of the
+// translation-cache module.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_PIPELINE_H
+#define HOTSWAP_TRANSPILER_PIPELINE_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/MemoryBufferRef.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace COMGR::hotswap {
+
+struct PipelineTimings {
+  double totalSeconds = 0.0;
+  double listKernelsSeconds = 0.0;
+  double extractTextSeconds = 0.0;
+  double createTempDirSeconds = 0.0;
+  double raiseSeconds = 0.0;
+  double writeIrSeconds = 0.0;
+  double optSeconds = 0.0;
+  double llcSeconds = 0.0;
+  double linkSeconds = 0.0;
+  double readHsacoSeconds = 0.0;
+  double collectMetadataSeconds = 0.0;
+};
+
+struct PipelineResult {
+  std::unique_ptr<llvm::MemoryBuffer> Hsaco;
+  PipelineTimings Timings;
+  std::string FailMnemonic;
+  std::string FailKernel;
+  std::string FailReason;
+  std::string FailFormat;
+  std::string FailDetail;
+  uint64_t FailOffset = 0;
+  // Successful raises can still carry proof-relevant attribution. Today this
+  // records C5 predicate-chain sites accepted under a projection-specific
+  // proof (for example single-source-wave MODREP with no active replica
+  // lanes); loader proof logs surface these fields on `hotswap_result`.
+  int C5SuppressedCount = 0;
+  std::string C5SuppressionReason;
+  bool UsesScratchPrivateSegment = false;
+  uint32_t SourcePrivateSegmentFixedSize = 0;
+  bool TargetEnablePrivateSegment = false;
+  uint32_t TargetPrivateSegmentFixedSize = 0;
+  int LiftedCount = 0;
+  int TotalCount = 0;
+  // ScaledModuloReplicationProjection requirement for the (single) transpiled
+  // kernel: the factor (W_t/W_s) the launch runtime must scale the block's x
+  // extent by. 1 means no scaling.
+  unsigned ScaledDispatchFactor = 1;
+  bool Success = false;
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/cache/pipeline.h
+++ b/amd/comgr/src/hotswap/cache/pipeline.h
@@ -66,6 +66,12 @@ struct PipelineResult {
   // extent by. 1 means no scaling.
   unsigned ScaledDispatchFactor = 1;
   bool Success = false;
+  // Opaque producer status code (0 == success sentinel). The mem cache does not
+  // interpret this; it only forwards a failed leader's code to coalesced
+  // waiters so every caller of a shared flight observes the same failure
+  // status. The rewriter stores its amd_comgr_status_t here; a value of 0 means
+  // "success or not set".
+  int ProducerStatus = 0;
 };
 
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/cache/translation-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/translation-cache.cpp
@@ -18,7 +18,9 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <chrono>
+#ifndef _WIN32
 #include <dlfcn.h>
+#endif
 #include <string>
 #include <sys/stat.h>
 
@@ -133,6 +135,7 @@ std::string loadedImageIdentity() {
     std::string out;
     llvm::raw_string_ostream os(out);
     os << "llvm=" << LLVM_VERSION_STRING;
+#ifndef _WIN32
     Dl_info info;
     if (::dladdr(reinterpret_cast<void *>(&loadedImageIdentity), &info) &&
         info.dli_fname) {
@@ -143,6 +146,9 @@ std::string loadedImageIdentity() {
     } else {
       os << "|image=<dladdr-unavailable>";
     }
+#else
+    os << "|image=<unavailable-on-windows>";
+#endif
     return os.str();
   }();
   return identity;

--- a/amd/comgr/src/hotswap/cache/translation-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/translation-cache.cpp
@@ -612,6 +612,21 @@ std::string sha256Hex(llvm::MemoryBufferRef buffer) {
   return os.str();
 }
 
+std::string translationCacheKey(const TranslationCacheRequest &request) {
+  TranslationCacheKeyBuildTimings timings;
+  llvm::Expected<KeyData> keyData =
+      buildKeyData(request, /*CollectTimings=*/false, timings);
+  if (!keyData) {
+    // Derivation failed (empty source, no kernels, unreadable rules, ...).
+    // Swallow the error and report "uncacheable" via an empty key; the
+    // producer still runs, we just don't cache. Must not throw (this TU is
+    // built -fno-exceptions).
+    llvm::consumeError(keyData.takeError());
+    return std::string();
+  }
+  return std::move(keyData->key);
+}
+
 TranslationCacheLookup
 lookupTranslationCache(const TranslationCacheRequest &request) {
   auto totalStart = timingStart(request.CollectTimings);

--- a/amd/comgr/src/hotswap/cache/translation-cache.cpp
+++ b/amd/comgr/src/hotswap/cache/translation-cache.cpp
@@ -1,0 +1,827 @@
+#include "translation-cache.h"
+
+#include "code-object-utils.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/SHA256.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <chrono>
+#include <dlfcn.h>
+#include <string>
+#include <sys/stat.h>
+
+#define DEBUG_TYPE "translation-cache"
+
+namespace COMGR::hotswap {
+namespace {
+
+using TimingClock = std::chrono::steady_clock;
+
+double secondsBetween(TimingClock::time_point start,
+                      TimingClock::time_point end) {
+  return std::chrono::duration<double>(end - start).count();
+}
+
+TimingClock::time_point timingStart(bool CollectTimings) {
+  return CollectTimings ? TimingClock::now() : TimingClock::time_point{};
+}
+
+double timingElapsed(bool CollectTimings, TimingClock::time_point start) {
+  return CollectTimings ? secondsBetween(start, TimingClock::now()) : 0.0;
+}
+
+constexpr int kCacheSchemaVersion = 4;
+
+struct FileIdentity {
+  std::string path;
+  bool present = false;
+  uint64_t size = 0;
+  int64_t mtimeSec = 0;
+  int64_t mtimeNsec = 0;
+  std::string sha256;
+};
+
+struct KeyData {
+  std::string key;
+  std::string sourceSha256;
+  std::string rulesSha256;
+  std::string buildIdentity;
+  std::string deviceLibrariesIdentity;
+  std::string elfMachineHex;
+  std::string elfFlagsHex;
+  std::vector<std::string> kernelNames;
+};
+
+std::string hexU32(uint32_t value) {
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  os << "0x" << llvm::format_hex_no_prefix(value, 0);
+  return os.str();
+}
+
+struct ElfHeaderFields {
+  uint16_t machine = 0;
+  uint32_t flags = 0;
+};
+
+llvm::Expected<ElfHeaderFields>
+readElfHeaderFields(llvm::MemoryBufferRef buffer) {
+  auto objOrErr = llvm::object::ObjectFile::createELFObjectFile(buffer);
+  if (!objOrErr)
+    return objOrErr.takeError();
+  const auto *elf =
+      llvm::dyn_cast<llvm::object::ELFObjectFileBase>(objOrErr->get());
+  if (!elf)
+    return llvm::createStringError(
+        "source code object is not a 64-bit little-endian ELF");
+  return ElfHeaderFields{elf->getEMachine(), elf->getPlatformFlags()};
+}
+
+llvm::Expected<std::string> hashFile(llvm::StringRef path) {
+  auto buffer = llvm::MemoryBuffer::getFile(path);
+  if (!buffer)
+    return llvm::errorCodeToError(buffer.getError());
+  return sha256Hex((*buffer)->getMemBufferRef());
+}
+
+llvm::Expected<FileIdentity> statIdentity(llvm::StringRef path) {
+  FileIdentity id;
+  id.path = path.str();
+  struct stat st;
+  if (::stat(id.path.c_str(), &st) != 0)
+    return id;
+  id.present = true;
+  id.size = static_cast<uint64_t>(st.st_size);
+#if defined(__linux__)
+  id.mtimeSec = static_cast<int64_t>(st.st_mtim.tv_sec);
+  id.mtimeNsec = static_cast<int64_t>(st.st_mtim.tv_nsec);
+#else
+  id.mtimeSec = static_cast<int64_t>(st.st_mtime);
+  id.mtimeNsec = 0;
+#endif
+  llvm::Expected<std::string> hash = hashFile(id.path);
+  if (!hash)
+    return llvm::createStringError(id.path + ": " +
+                                   llvm::toString(hash.takeError()));
+  id.sha256 = std::move(*hash);
+  return id;
+}
+
+std::string identityString(const FileIdentity &id) {
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  os << id.path << "|present=" << (id.present ? "1" : "0")
+     << "|size=" << id.size << "|mtime=" << id.mtimeSec << "." << id.mtimeNsec
+     << "|sha256=" << id.sha256;
+  return os.str();
+}
+
+std::string loadedImageIdentity() {
+  static const std::string identity = [] {
+    std::string out;
+    llvm::raw_string_ostream os(out);
+    os << "llvm=" << LLVM_VERSION_STRING;
+    Dl_info info;
+    if (::dladdr(reinterpret_cast<void *>(&loadedImageIdentity), &info) &&
+        info.dli_fname) {
+      if (auto id = statIdentity(info.dli_fname))
+        os << "|image=" << identityString(*id);
+      else
+        os << "|image=<error=" << llvm::toString(id.takeError()) << ">";
+    } else {
+      os << "|image=<dladdr-unavailable>";
+    }
+    return os.str();
+  }();
+  return identity;
+}
+
+void appendKeyField(std::string &material, llvm::StringRef name,
+                    llvm::StringRef value) {
+  material.append(name.data(), name.size());
+  material.push_back('\0');
+  material += std::to_string(value.size());
+  material.push_back(':');
+  if (!value.empty())
+    material.append(value.data(), value.size());
+  material.push_back('\0');
+}
+
+void appendKeyField(std::string &material, llvm::StringRef name, bool value) {
+  appendKeyField(material, name, llvm::StringRef(value ? "true" : "false"));
+}
+
+void appendKeyField(std::string &material, llvm::StringRef name, int value) {
+  appendKeyField(material, name, std::to_string(value));
+}
+
+llvm::Expected<KeyData> buildKeyData(const TranslationCacheRequest &request,
+                                     bool CollectTimings,
+                                     TranslationCacheKeyBuildTimings &Timings) {
+  KeyData data;
+  if (request.SourceObject.getBufferSize() == 0)
+    return llvm::createStringError("empty source code object");
+  if (request.SourceGfx.empty() || request.TargetGfx.empty())
+    return llvm::createStringError("missing source or target gfx");
+
+  auto sourceHashStart = timingStart(CollectTimings);
+  data.sourceSha256 = sha256Hex(request.SourceObject);
+  Timings.sourceHashSeconds = timingElapsed(CollectTimings, sourceHashStart);
+
+  auto elfHeaderStart = timingStart(CollectTimings);
+  llvm::Expected<ElfHeaderFields> elfHeader =
+      readElfHeaderFields(request.SourceObject);
+  Timings.elfHeaderSeconds = timingElapsed(CollectTimings, elfHeaderStart);
+  if (!elfHeader)
+    return elfHeader.takeError();
+  data.elfMachineHex = hexU32(elfHeader->machine);
+  data.elfFlagsHex = hexU32(elfHeader->flags);
+
+  if (!request.HotswapRulesPath.empty()) {
+    auto rulesHashStart = timingStart(CollectTimings);
+    llvm::Expected<std::string> rulesHash = hashFile(request.HotswapRulesPath);
+    Timings.rulesHashSeconds = timingElapsed(CollectTimings, rulesHashStart);
+    if (!rulesHash)
+      return llvm::createStringError(
+          "failed to hash HSA_HOTSWAP_RULES '" + request.HotswapRulesPath +
+          "': " + llvm::toString(rulesHash.takeError()));
+    data.rulesSha256 = std::move(*rulesHash);
+  }
+
+  auto loadedImageIdentityStart = timingStart(CollectTimings);
+  data.buildIdentity = loadedImageIdentity();
+  Timings.loadedImageIdentitySeconds =
+      timingElapsed(CollectTimings, loadedImageIdentityStart);
+  data.deviceLibrariesIdentity = request.DeviceLibrariesIdentity;
+  if (!request.KernelName.empty()) {
+    data.kernelNames.push_back(request.KernelName);
+  } else {
+    auto kernelNamesStart = timingStart(CollectTimings);
+    llvm::Expected<llvm::SmallVector<std::string>> NamesOrErr =
+        listKernelNames(request.SourceObject);
+    Timings.kernelNamesSeconds =
+        timingElapsed(CollectTimings, kernelNamesStart);
+    if (!NamesOrErr)
+      return llvm::createStringError(
+          "failed to list kernels for translation cache key: " +
+          llvm::toString(NamesOrErr.takeError()));
+    data.kernelNames.assign(NamesOrErr->begin(), NamesOrErr->end());
+    if (data.kernelNames.empty())
+      return llvm::createStringError(
+          "source code object has no kernel metadata entries");
+  }
+
+  auto materialBuildStart = timingStart(CollectTimings);
+  std::string material;
+  appendKeyField(material, "schema", std::to_string(kCacheSchemaVersion));
+  appendKeyField(material, "source_sha256", data.sourceSha256);
+  appendKeyField(material, "source_gfx", request.SourceGfx);
+  appendKeyField(material, "target_gfx", request.TargetGfx);
+  appendKeyField(material, "source_isa", request.SourceIsa);
+  appendKeyField(material, "target_isa", request.TargetIsa);
+  appendKeyField(material, "code_isa", request.CodeIsa);
+  appendKeyField(material, "elf_machine", data.elfMachineHex);
+  appendKeyField(material, "elf_flags", data.elfFlagsHex);
+  appendKeyField(material, "orig_mach", request.OrigMach);
+  appendKeyField(material, "opt_level", static_cast<int>(request.OptLevel));
+  appendKeyField(material, "rules_path", request.HotswapRulesPath);
+  appendKeyField(material, "rules_sha256", data.rulesSha256);
+  appendKeyField(material, "strict", request.StrictMode);
+  appendKeyField(material, "enable_writelane_rewrite",
+                 request.EnableWritelaneRewrite);
+  appendKeyField(material, "enable_wave_native", request.EnableWaveNative);
+  appendKeyField(material, "force_scaled_modrep", request.ForceScaledModrep);
+  appendKeyField(material, "assume_hip_global_offset_zero",
+                 request.AssumeHipGlobalOffsetZero);
+  if (!request.KernelName.empty())
+    appendKeyField(material, "kernel_name", request.KernelName);
+  appendKeyField(material, "hotswap_build_identity", data.buildIdentity);
+  appendKeyField(material, "device_libraries_identity",
+                 data.deviceLibrariesIdentity);
+  Timings.materialBuildSeconds =
+      timingElapsed(CollectTimings, materialBuildStart);
+  auto keyHashStart = timingStart(CollectTimings);
+  data.key = sha256Hex(llvm::MemoryBufferRef(material, ""));
+  Timings.keyHashSeconds = timingElapsed(CollectTimings, keyHashStart);
+  return data;
+}
+
+std::string cacheRoot(const TranslationCacheRequest &request) {
+  return request.CacheDirectory;
+}
+
+bool cacheDisabledByPolicy(const TranslationCacheRequest &request) {
+  return request.CacheDisabled || cacheRoot(request).empty();
+}
+
+std::string cacheSubdir(const TranslationCacheRequest &request,
+                        llvm::StringRef key) {
+  llvm::SmallString<256> path(cacheRoot(request));
+  llvm::sys::path::append(path, key.substr(0, 2));
+  return std::string(path);
+}
+
+std::string cacheObjectPath(const TranslationCacheRequest &request,
+                            llvm::StringRef key) {
+  llvm::SmallString<256> path(cacheSubdir(request, key));
+  llvm::sys::path::append(path, llvm::Twine(key) + ".Hsaco");
+  return std::string(path);
+}
+
+std::string cacheMetadataPath(const TranslationCacheRequest &request,
+                              llvm::StringRef key) {
+  llvm::SmallString<256> path(cacheSubdir(request, key));
+  llvm::sys::path::append(path, llvm::Twine(key) + ".json");
+  return std::string(path);
+}
+
+bool exists(llvm::StringRef path) { return llvm::sys::fs::exists(path); }
+
+std::string jsonToString(llvm::json::Value value) {
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  value.print(os);
+  os << "\n";
+  return os.str();
+}
+
+llvm::Error writeFileAtomic(llvm::StringRef path, llvm::StringRef contents) {
+  return llvm::writeToOutput(path, [&](llvm::raw_ostream &os) {
+    os << contents;
+    return llvm::Error::success();
+  });
+}
+
+llvm::Error writeFileAtomic(llvm::StringRef path,
+                            llvm::ArrayRef<uint8_t> data) {
+  return writeFileAtomic(
+      path, llvm::StringRef(reinterpret_cast<const char *>(data.data()),
+                            data.size()));
+}
+
+llvm::Expected<std::string> requireString(const llvm::json::Object &obj,
+                                          llvm::StringRef field) {
+  auto value = obj.getString(field);
+  if (!value)
+    return llvm::createStringError("metadata field '" + field +
+                                   "' missing or not a string");
+  return value->str();
+}
+
+llvm::Expected<int64_t> requireInt(const llvm::json::Object &obj,
+                                   llvm::StringRef field) {
+  auto value = obj.getInteger(field);
+  if (!value)
+    return llvm::createStringError("metadata field '" + field +
+                                   "' missing or not an integer");
+  return *value;
+}
+
+llvm::Expected<bool> requireBool(const llvm::json::Object &obj,
+                                 llvm::StringRef field) {
+  auto value = obj.getBoolean(field);
+  if (!value)
+    return llvm::createStringError("metadata field '" + field +
+                                   "' missing or not a boolean");
+  return *value;
+}
+
+llvm::Error requireEqualString(const llvm::json::Object &obj,
+                               llvm::StringRef field,
+                               llvm::StringRef expected) {
+  auto value = requireString(obj, field);
+  if (!value)
+    return value.takeError();
+  if (*value != expected)
+    return llvm::createStringError("metadata field '" + field + "' mismatch");
+  return llvm::Error::success();
+}
+
+llvm::Error validateKernelNameField(const llvm::json::Object &obj,
+                                    llvm::StringRef expected) {
+  const llvm::json::Value *rawValue = obj.get("kernel_name");
+  if (!rawValue) {
+    if (expected.empty())
+      return llvm::Error::success();
+    return llvm::createStringError("metadata field 'kernel_name' missing");
+  }
+  auto value = rawValue->getAsString();
+  if (!value)
+    return llvm::createStringError(
+        "metadata field 'kernel_name' is not a string");
+  if (*value != expected)
+    return llvm::createStringError("metadata field 'kernel_name' mismatch");
+  return llvm::Error::success();
+}
+
+llvm::Error requireEqualInt(const llvm::json::Object &obj,
+                            llvm::StringRef field, int64_t expected) {
+  auto value = requireInt(obj, field);
+  if (!value)
+    return value.takeError();
+  if (*value != expected)
+    return llvm::createStringError("metadata field '" + field + "' mismatch");
+  return llvm::Error::success();
+}
+
+llvm::Error requireEqualBool(const llvm::json::Object &obj,
+                             llvm::StringRef field, bool expected) {
+  auto value = requireBool(obj, field);
+  if (!value)
+    return value.takeError();
+  if (*value != expected)
+    return llvm::createStringError("metadata field '" + field + "' mismatch");
+  return llvm::Error::success();
+}
+
+llvm::json::Array kernelArray(const std::vector<std::string> &kernelNames) {
+  llvm::json::Array arr;
+  for (llvm::StringRef name : kernelNames)
+    arr.push_back(name);
+  return arr;
+}
+
+llvm::Error validateKernelArray(const llvm::json::Object &obj,
+                                const std::vector<std::string> &expected) {
+  const llvm::json::Array *arr = obj.getArray("kernel_names");
+  if (!arr)
+    return llvm::createStringError(
+        "metadata field 'kernel_names' missing or not an array");
+  if (arr->size() != expected.size())
+    return llvm::createStringError("metadata kernel_names size mismatch");
+  for (size_t i = 0; i < expected.size(); ++i) {
+    auto value = (*arr)[i].getAsString();
+    if (!value || *value != expected[i])
+      return llvm::createStringError("metadata kernel_names mismatch");
+  }
+  return llvm::Error::success();
+}
+
+llvm::json::Object metadataObject(const TranslationCacheRequest &request,
+                                  const KeyData &keyData,
+                                  const PipelineResult &Result,
+                                  llvm::StringRef objectSha256) {
+  llvm::json::Object Obj{
+      {"schema_version", kCacheSchemaVersion},
+      {"key", keyData.key},
+      {"source_object_sha256", keyData.sourceSha256},
+      {"source_gfx", request.SourceGfx},
+      {"target_gfx", request.TargetGfx},
+      {"source_isa", request.SourceIsa},
+      {"target_isa", request.TargetIsa},
+      {"code_isa", request.CodeIsa},
+      {"elf_machine", keyData.elfMachineHex},
+      {"elf_flags", keyData.elfFlagsHex},
+      {"orig_mach", request.OrigMach},
+      {"opt_level", static_cast<int64_t>(request.OptLevel)},
+      {"hotswap_rules_path", request.HotswapRulesPath},
+      {"hotswap_rules_sha256", keyData.rulesSha256},
+      {"strict_mode", request.StrictMode},
+      {"enable_writelane_rewrite", request.EnableWritelaneRewrite},
+      {"enable_wave_native", request.EnableWaveNative},
+      {"force_scaled_modrep", request.ForceScaledModrep},
+      {"assume_hip_global_offset_zero", request.AssumeHipGlobalOffsetZero},
+      {"hotswap_build_identity", keyData.buildIdentity},
+      {"device_libraries_identity", keyData.deviceLibrariesIdentity},
+      {"kernel_count", static_cast<int64_t>(keyData.kernelNames.size())},
+      {"kernel_names", kernelArray(keyData.kernelNames)},
+      {"cached_object_sha256", objectSha256.str()},
+      {"cached_object_size",
+       static_cast<int64_t>(Result.Hsaco ? Result.Hsaco->getBufferSize() : 0)},
+      {"lifted_count", Result.LiftedCount},
+      {"total_count", Result.TotalCount},
+      {"scaled_dispatch_factor",
+       static_cast<int64_t>(Result.ScaledDispatchFactor)},
+      {"c5_suppressed_count", Result.C5SuppressedCount},
+      {"c5_suppression_reason", Result.C5SuppressionReason},
+      {"uses_scratch_private_segment", Result.UsesScratchPrivateSegment},
+      {"source_private_segment_fixed_size",
+       static_cast<int64_t>(Result.SourcePrivateSegmentFixedSize)},
+      {"target_private_segment_fixed_size",
+       static_cast<int64_t>(Result.TargetPrivateSegmentFixedSize)},
+      {"target_enable_private_segment", Result.TargetEnablePrivateSegment},
+  };
+  if (!request.KernelName.empty())
+    Obj["kernel_name"] = request.KernelName;
+  return Obj;
+}
+
+llvm::Error validateMetadata(const TranslationCacheRequest &request,
+                             const KeyData &keyData,
+                             const llvm::json::Object &obj,
+                             llvm::StringRef objectSha256, size_t objectSize,
+                             PipelineResult &Result) {
+  if (llvm::Error e =
+          requireEqualInt(obj, "schema_version", kCacheSchemaVersion))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "key", keyData.key))
+    return e;
+  if (llvm::Error e =
+          requireEqualString(obj, "source_object_sha256", keyData.sourceSha256))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "source_gfx", request.SourceGfx))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "target_gfx", request.TargetGfx))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "source_isa", request.SourceIsa))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "target_isa", request.TargetIsa))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "code_isa", request.CodeIsa))
+    return e;
+  if (llvm::Error e =
+          requireEqualString(obj, "elf_machine", keyData.elfMachineHex))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "elf_flags", keyData.elfFlagsHex))
+    return e;
+  if (llvm::Error e = requireEqualInt(obj, "orig_mach", request.OrigMach))
+    return e;
+  if (llvm::Error e = requireEqualInt(obj, "opt_level",
+                                      static_cast<int64_t>(request.OptLevel)))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "hotswap_rules_path",
+                                         request.HotswapRulesPath))
+    return e;
+  if (llvm::Error e =
+          requireEqualString(obj, "hotswap_rules_sha256", keyData.rulesSha256))
+    return e;
+  if (llvm::Error e = requireEqualBool(obj, "strict_mode", request.StrictMode))
+    return e;
+  if (llvm::Error e = requireEqualBool(obj, "enable_writelane_rewrite",
+                                       request.EnableWritelaneRewrite))
+    return e;
+  if (llvm::Error e =
+          requireEqualBool(obj, "enable_wave_native", request.EnableWaveNative))
+    return e;
+  if (llvm::Error e = requireEqualBool(obj, "force_scaled_modrep",
+                                       request.ForceScaledModrep))
+    return e;
+  if (llvm::Error e = requireEqualBool(obj, "assume_hip_global_offset_zero",
+                                       request.AssumeHipGlobalOffsetZero))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "hotswap_build_identity",
+                                         keyData.buildIdentity))
+    return e;
+  if (llvm::Error e = requireEqualString(obj, "device_libraries_identity",
+                                         keyData.deviceLibrariesIdentity))
+    return e;
+  if (llvm::Error e = validateKernelNameField(obj, request.KernelName))
+    return e;
+  if (llvm::Error e =
+          requireEqualInt(obj, "kernel_count",
+                          static_cast<int64_t>(keyData.kernelNames.size())))
+    return e;
+  if (llvm::Error e = validateKernelArray(obj, keyData.kernelNames))
+    return e;
+  if (llvm::Error e =
+          requireEqualString(obj, "cached_object_sha256", objectSha256))
+    return e;
+  if (llvm::Error e = requireEqualInt(obj, "cached_object_size",
+                                      static_cast<int64_t>(objectSize)))
+    return e;
+
+  llvm::Expected<int64_t> lifted = requireInt(obj, "lifted_count");
+  if (!lifted)
+    return lifted.takeError();
+  llvm::Expected<int64_t> total = requireInt(obj, "total_count");
+  if (!total)
+    return total.takeError();
+  llvm::Expected<int64_t> c5Count = requireInt(obj, "c5_suppressed_count");
+  if (!c5Count)
+    return c5Count.takeError();
+  llvm::Expected<std::string> c5Reason =
+      requireString(obj, "c5_suppression_reason");
+  if (!c5Reason)
+    return c5Reason.takeError();
+  llvm::Expected<bool> usesScratch =
+      requireBool(obj, "uses_scratch_private_segment");
+  if (!usesScratch)
+    return usesScratch.takeError();
+  llvm::Expected<int64_t> sourceScratch =
+      requireInt(obj, "source_private_segment_fixed_size");
+  if (!sourceScratch)
+    return sourceScratch.takeError();
+  llvm::Expected<int64_t> targetScratch =
+      requireInt(obj, "target_private_segment_fixed_size");
+  if (!targetScratch)
+    return targetScratch.takeError();
+  llvm::Expected<bool> targetEnable =
+      requireBool(obj, "target_enable_private_segment");
+  if (!targetEnable)
+    return targetEnable.takeError();
+
+  Result.Success = true;
+  Result.LiftedCount = static_cast<int>(*lifted);
+  Result.TotalCount = static_cast<int>(*total);
+  Result.C5SuppressedCount = static_cast<int>(*c5Count);
+  Result.C5SuppressionReason = *c5Reason;
+  Result.UsesScratchPrivateSegment = *usesScratch;
+  Result.SourcePrivateSegmentFixedSize = static_cast<uint32_t>(*sourceScratch);
+  Result.TargetPrivateSegmentFixedSize = static_cast<uint32_t>(*targetScratch);
+  Result.TargetEnablePrivateSegment = *targetEnable;
+  // Optional (default 1) so cache entries written before scaled-dispatch
+  // support still load. The cache key includes the scaled-modrep flags, so a
+  // scaled transpile never collides with a non-scaled entry.
+  Result.ScaledDispatchFactor = static_cast<unsigned>(
+      obj.getInteger("scaled_dispatch_factor").value_or(1));
+  return llvm::Error::success();
+}
+
+} // namespace
+
+const char *translationCacheStatusString(TranslationCacheStatus Status) {
+  switch (Status) {
+  case TranslationCacheStatus::Disabled:
+    return "disabled";
+  case TranslationCacheStatus::Bypassed:
+    return "bypassed";
+  case TranslationCacheStatus::Miss:
+    return "miss";
+  case TranslationCacheStatus::Hit:
+    return "hit";
+  case TranslationCacheStatus::Invalid:
+    return "invalid";
+  case TranslationCacheStatus::WriteSuccess:
+    return "write_success";
+  case TranslationCacheStatus::WriteFailed:
+    return "write_failed";
+  }
+  return "invalid";
+}
+
+std::string sha256Hex(llvm::MemoryBufferRef buffer) {
+  llvm::ArrayRef data(buffer.getBuffer().bytes_begin(),
+                      buffer.getBuffer().bytes_end());
+  auto digest = llvm::SHA256::hash(data);
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  for (uint8_t byte : digest)
+    os << llvm::format_hex_no_prefix(byte, 2);
+  return os.str();
+}
+
+TranslationCacheLookup
+lookupTranslationCache(const TranslationCacheRequest &request) {
+  auto totalStart = timingStart(request.CollectTimings);
+  TranslationCacheLookup lookup;
+  auto finish = [&]() {
+    lookup.Timings.totalSeconds =
+        timingElapsed(request.CollectTimings, totalStart);
+    return std::move(lookup);
+  };
+  if (cacheDisabledByPolicy(request))
+    return finish();
+
+  auto keyBuildStart = timingStart(request.CollectTimings);
+  auto keyDataOrErr =
+      buildKeyData(request, request.CollectTimings, lookup.Timings.keyBuild);
+  lookup.Timings.keyBuildSeconds =
+      timingElapsed(request.CollectTimings, keyBuildStart);
+  if (!keyDataOrErr) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason = llvm::toString(keyDataOrErr.takeError());
+    return finish();
+  }
+  KeyData keyData = std::move(*keyDataOrErr);
+  lookup.key = keyData.key;
+  lookup.MetadataPath = cacheMetadataPath(request, keyData.key);
+  lookup.ObjectPath = cacheObjectPath(request, keyData.key);
+
+  auto metadataObjectStatStart = timingStart(request.CollectTimings);
+  const bool metadataExists = exists(lookup.MetadataPath);
+  const bool objectExists = exists(lookup.ObjectPath);
+  lookup.Timings.metadataObjectStatSeconds =
+      timingElapsed(request.CollectTimings, metadataObjectStatStart);
+  if (!metadataExists && !objectExists) {
+    lookup.Status = TranslationCacheStatus::Miss;
+    lookup.Reason = "entry not present";
+    return finish();
+  }
+  if (metadataExists != objectExists) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason = metadataExists ? "metadata exists without object"
+                                   : "object exists without metadata";
+    return finish();
+  }
+
+  auto objectReadStart = timingStart(request.CollectTimings);
+  auto objectBuffer = llvm::MemoryBuffer::getFile(lookup.ObjectPath);
+  lookup.Timings.objectReadSeconds =
+      timingElapsed(request.CollectTimings, objectReadStart);
+  if (!objectBuffer) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason =
+        "failed to read cached object: " + objectBuffer.getError().message();
+    return finish();
+  }
+  auto objectHashStart = timingStart(request.CollectTimings);
+  llvm::MemoryBufferRef objectBufRef = (*objectBuffer)->getMemBufferRef();
+  std::string objectSha = sha256Hex(objectBufRef);
+  lookup.Timings.objectHashSeconds =
+      timingElapsed(request.CollectTimings, objectHashStart);
+
+  auto metadataReadStart = timingStart(request.CollectTimings);
+  auto metadataBuffer = llvm::MemoryBuffer::getFile(lookup.MetadataPath);
+  lookup.Timings.metadataReadSeconds =
+      timingElapsed(request.CollectTimings, metadataReadStart);
+  if (!metadataBuffer) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason =
+        "failed to read cache metadata: " + metadataBuffer.getError().message();
+    return finish();
+  }
+  auto metadataParseStart = timingStart(request.CollectTimings);
+  auto parsed = llvm::json::parse((*metadataBuffer)->getBuffer());
+  lookup.Timings.metadataParseSeconds =
+      timingElapsed(request.CollectTimings, metadataParseStart);
+  if (!parsed) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason =
+        "failed to parse cache metadata: " + llvm::toString(parsed.takeError());
+    return finish();
+  }
+  const llvm::json::Object *obj = parsed->getAsObject();
+  if (!obj) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason = "cache metadata is not a JSON object";
+    return finish();
+  }
+  auto metadataValidateStart = timingStart(request.CollectTimings);
+  llvm::Error validateErr =
+      validateMetadata(request, keyData, *obj, objectSha,
+                       objectBufRef.getBufferSize(), lookup.Result);
+  lookup.Timings.metadataValidateSeconds =
+      timingElapsed(request.CollectTimings, metadataValidateStart);
+  if (validateErr) {
+    lookup.Status = TranslationCacheStatus::Invalid;
+    lookup.Reason = llvm::toString(std::move(validateErr));
+    return finish();
+  }
+
+  lookup.Result.Hsaco = std::move(*objectBuffer);
+  lookup.Status = TranslationCacheStatus::Hit;
+  lookup.Reason = "ok";
+  return finish();
+}
+
+TranslationCacheWrite
+writeTranslationCache(const TranslationCacheRequest &request,
+                      const PipelineResult &Result) {
+  auto totalStart = timingStart(request.CollectTimings);
+  TranslationCacheWrite write;
+  auto finish = [&]() {
+    write.Timings.totalSeconds =
+        timingElapsed(request.CollectTimings, totalStart);
+    return write;
+  };
+  if (cacheDisabledByPolicy(request) || request.CacheReadonly)
+    return finish();
+
+  auto keyBuildStart = timingStart(request.CollectTimings);
+  auto keyDataOrErr =
+      buildKeyData(request, request.CollectTimings, write.Timings.keyBuild);
+  write.Timings.keyBuildSeconds =
+      timingElapsed(request.CollectTimings, keyBuildStart);
+  if (!keyDataOrErr) {
+    write.Status = TranslationCacheStatus::WriteFailed;
+    write.Reason = llvm::toString(keyDataOrErr.takeError());
+    return finish();
+  }
+  KeyData keyData = std::move(*keyDataOrErr);
+  write.key = keyData.key;
+  write.MetadataPath = cacheMetadataPath(request, keyData.key);
+  write.ObjectPath = cacheObjectPath(request, keyData.key);
+
+  if (!Result.Success || !Result.Hsaco || Result.Hsaco->getBufferSize() == 0) {
+    write.Status = TranslationCacheStatus::WriteFailed;
+    write.Reason = "refusing to cache unsuccessful or empty translation";
+    return finish();
+  }
+
+  std::string dir = cacheSubdir(request, keyData.key);
+  auto createDirectoryStart = timingStart(request.CollectTimings);
+  if (auto ec = llvm::sys::fs::create_directories(dir)) {
+    write.Timings.createDirectorySeconds =
+        timingElapsed(request.CollectTimings, createDirectoryStart);
+    write.Status = TranslationCacheStatus::WriteFailed;
+    write.Reason =
+        "failed to create cache directory '" + dir + "': " + ec.message();
+    return finish();
+  }
+  write.Timings.createDirectorySeconds =
+      timingElapsed(request.CollectTimings, createDirectoryStart);
+
+  auto objectHashStart = timingStart(request.CollectTimings);
+  std::string objectSha = sha256Hex(Result.Hsaco->getMemBufferRef());
+  write.Timings.objectHashSeconds =
+      timingElapsed(request.CollectTimings, objectHashStart);
+  auto objectWriteStart = timingStart(request.CollectTimings);
+  if (auto err = writeFileAtomic(write.ObjectPath, Result.Hsaco->getBuffer())) {
+    write.Timings.objectWriteSeconds =
+        timingElapsed(request.CollectTimings, objectWriteStart);
+    write.Status = TranslationCacheStatus::WriteFailed;
+    write.Reason =
+        "failed to write cached object: " + llvm::toString(std::move(err));
+    return finish();
+  }
+  write.Timings.objectWriteSeconds =
+      timingElapsed(request.CollectTimings, objectWriteStart);
+
+  auto metadataBuildStart = timingStart(request.CollectTimings);
+  llvm::json::Object meta = metadataObject(request, keyData, Result, objectSha);
+  write.Timings.metadataBuildSeconds =
+      timingElapsed(request.CollectTimings, metadataBuildStart);
+  auto metadataWriteStart = timingStart(request.CollectTimings);
+  if (auto err =
+          writeFileAtomic(write.MetadataPath,
+                          jsonToString(llvm::json::Value(std::move(meta))))) {
+    write.Timings.metadataWriteSeconds =
+        timingElapsed(request.CollectTimings, metadataWriteStart);
+    llvm::sys::fs::remove(write.ObjectPath);
+    write.Status = TranslationCacheStatus::WriteFailed;
+    write.Reason =
+        "failed to write cache metadata: " + llvm::toString(std::move(err));
+    return finish();
+  }
+  write.Timings.metadataWriteSeconds =
+      timingElapsed(request.CollectTimings, metadataWriteStart);
+
+  write.Status = TranslationCacheStatus::WriteSuccess;
+  write.Reason = "ok";
+  return finish();
+}
+
+std::string
+skippedKernelForTranslationCache(llvm::ArrayRef<std::string> kernelNames,
+                                 llvm::StringRef skipList) {
+  if (skipList.empty())
+    return "";
+
+  llvm::StringRef remaining(skipList);
+  while (!remaining.empty()) {
+    auto split = remaining.split(',');
+    llvm::StringRef requested = split.first.trim();
+    remaining = split.second;
+    if (requested.empty())
+      continue;
+    for (llvm::StringRef kernelName : kernelNames) {
+      if (requested == kernelName)
+        return kernelName.str();
+    }
+  }
+  return "";
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/cache/translation-cache.h
+++ b/amd/comgr/src/hotswap/cache/translation-cache.h
@@ -3,6 +3,8 @@
 
 #include "pipeline.h"
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MemoryBufferRef.h"
 
 #include <string>

--- a/amd/comgr/src/hotswap/cache/translation-cache.h
+++ b/amd/comgr/src/hotswap/cache/translation-cache.h
@@ -117,6 +117,14 @@ skippedKernelForTranslationCache(llvm::ArrayRef<std::string> kernelNames,
 
 std::string sha256Hex(llvm::MemoryBufferRef buffer);
 
+// Returns the content-addressed cache key for `request` -- the same SHA-256
+// hex identity the disk tier stores under. Empty string if the key cannot be
+// derived (e.g. empty source object, missing gfx, no kernel metadata, or an
+// unreadable rules file); callers treat an empty key as "uncacheable" and
+// bypass caching for that request. Shared by the in-memory tier so both tiers
+// agree on identity by construction.
+std::string translationCacheKey(const TranslationCacheRequest &request);
+
 } // namespace COMGR::hotswap
 
 #endif

--- a/amd/comgr/src/hotswap/cache/translation-cache.h
+++ b/amd/comgr/src/hotswap/cache/translation-cache.h
@@ -1,0 +1,122 @@
+#ifndef HOTSWAP_TRANSPILER_TRANSLATION_CACHE_H
+#define HOTSWAP_TRANSPILER_TRANSLATION_CACHE_H
+
+#include "pipeline.h"
+
+#include "llvm/Support/MemoryBufferRef.h"
+
+#include <string>
+
+namespace COMGR::hotswap {
+
+struct TranslationCacheKeyBuildTimings {
+  double sourceHashSeconds = 0.0;
+  double elfHeaderSeconds = 0.0;
+  double rulesHashSeconds = 0.0;
+  double loadedImageIdentitySeconds = 0.0;
+  double kernelNamesSeconds = 0.0;
+  double materialBuildSeconds = 0.0;
+  double keyHashSeconds = 0.0;
+};
+
+struct TranslationCacheLookupTimings {
+  double totalSeconds = 0.0;
+  double keyBuildSeconds = 0.0;
+  TranslationCacheKeyBuildTimings keyBuild;
+  double metadataObjectStatSeconds = 0.0;
+  double objectReadSeconds = 0.0;
+  double objectHashSeconds = 0.0;
+  double metadataReadSeconds = 0.0;
+  double metadataParseSeconds = 0.0;
+  double metadataValidateSeconds = 0.0;
+};
+
+struct TranslationCacheWriteTimings {
+  double totalSeconds = 0.0;
+  double keyBuildSeconds = 0.0;
+  TranslationCacheKeyBuildTimings keyBuild;
+  double createDirectorySeconds = 0.0;
+  double objectHashSeconds = 0.0;
+  double objectWriteSeconds = 0.0;
+  double metadataBuildSeconds = 0.0;
+  double metadataWriteSeconds = 0.0;
+};
+
+struct TranslationCacheRequest {
+  llvm::MemoryBufferRef SourceObject;
+  std::string SourceGfx;
+  std::string TargetGfx;
+  std::string SourceIsa;
+  std::string TargetIsa;
+  std::string CodeIsa;
+  std::string HotswapRulesPath;
+  std::string CacheDirectory;
+  std::string CacheSkipKernels;
+  std::string KernelName;
+  // Opaque identity of the bundled device libraries, salted into the cache
+  // key so a device-library change invalidates prior entries. Supplied by
+  // the caller (the transpiler passes COMGR::getDeviceLibrariesIdentifier())
+  // to keep this module free of comgr metadata-layer coupling.
+  std::string DeviceLibrariesIdentity;
+  int OrigMach = -1;
+  unsigned OptLevel = 0;
+  bool EnableWritelaneRewrite = true;
+  bool EnableWaveNative = true;
+  // Unconditionally select ScaledModuloReplicationProjection for wave32->wave64
+  // cross-widening (testing knob). The normal WaveNative y/z-refusal ->
+  // scaled-dispatch upgrade is automatic and needs no flag.
+  bool ForceScaledModrep = false;
+  bool AssumeHipGlobalOffsetZero = false;
+  bool StrictMode = false;
+  bool CacheDisabled = true;
+  bool CacheReadonly = false;
+  bool CollectTimings = false;
+};
+
+enum class TranslationCacheStatus {
+  Disabled,
+  Bypassed,
+  Miss,
+  Hit,
+  Invalid,
+  WriteSuccess,
+  WriteFailed,
+};
+
+struct TranslationCacheLookup {
+  TranslationCacheStatus Status = TranslationCacheStatus::Disabled;
+  std::string key;
+  std::string MetadataPath;
+  std::string ObjectPath;
+  std::string Reason;
+  TranslationCacheLookupTimings Timings;
+  PipelineResult Result;
+};
+
+struct TranslationCacheWrite {
+  TranslationCacheStatus Status = TranslationCacheStatus::Disabled;
+  std::string key;
+  std::string MetadataPath;
+  std::string ObjectPath;
+  std::string Reason;
+  TranslationCacheWriteTimings Timings;
+};
+
+const char *translationCacheStatusString(TranslationCacheStatus Status);
+
+TranslationCacheLookup
+lookupTranslationCache(const TranslationCacheRequest &request);
+
+TranslationCacheWrite
+writeTranslationCache(const TranslationCacheRequest &request,
+                      const PipelineResult &Result);
+
+std::string
+skippedKernelForTranslationCache(llvm::ArrayRef<std::string> kernelNames,
+                                 llvm::StringRef skipList);
+
+std::string sha256Hex(llvm::MemoryBufferRef buffer);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/rewriter/rewriter.cpp
+++ b/amd/comgr/src/hotswap/rewriter/rewriter.cpp
@@ -277,6 +277,14 @@ hotswapRewrite(amd_comgr_data_t input, const char *source_isa_name,
     Code += (Options.UseB0B0EntryFastPath ? "1" : "0");
     CacheReq.CodeIsa = std::move(Code);
   }
+  // DeviceLibrariesIdentity is intentionally left empty here. This is the
+  // byte-level B0->A0 ELF rewrite path: retargetCodeObject patches an
+  // already-compiled code object and never links device libraries, so their
+  // identity cannot influence the output and is not part of the key. A future
+  // caller whose transform DOES depend on device libraries (e.g. the IR
+  // transpiler path) MUST populate CacheReq.DeviceLibrariesIdentity, or it
+  // would alias distinct translations onto one entry -- the disk tier's key
+  // already folds this field in for exactly that reason.
   CacheReq.StrictMode = StrictMode;
   // Disk tier: honor HSA_HOTSWAP_CACHE_DIR if set (leave empty => mem-only /
   // disk-disabled per the disk tier's own env handling). CacheDisabled is the
@@ -322,6 +330,9 @@ hotswapRewrite(amd_comgr_data_t input, const char *source_isa_name,
       //    rewrite -- the in-memory result is already valid).
       COMGR::hotswap::writeTranslationCache(CacheReq, R);
     }
+    // Carry the retarget status on the result so the mem cache can forward a
+    // failed leader's code to any coalesced waiter (deterministic status).
+    R.ProducerStatus = static_cast<int>(ProducerStatus);
     return R;
   };
 
@@ -331,8 +342,17 @@ hotswapRewrite(amd_comgr_data_t input, const char *source_isa_name,
   // A failed producer (retarget error) must propagate the real status, not a
   // generic cache failure.
   if (!Cached.Entry) {
+    // This thread ran the producer (leader / disabled / uncacheable path): its
+    // own retarget status is authoritative.
     if (ProducerStatus != AMD_COMGR_STATUS_SUCCESS)
       return ProducerStatus;
+    // Otherwise we coalesced onto another thread's flight whose producer failed
+    // (our own ProducerStatus is still SUCCESS because our producer never ran).
+    // Forward the leader's opaque status so the same failing input yields the
+    // same code regardless of leader-vs-waiter timing.
+    if (Cached.Status == COMGR::hotswap::MemCacheStatus::ProducerFailed &&
+        Cached.ProducerStatus != 0)
+      return static_cast<amd_comgr_status_t>(Cached.ProducerStatus);
     hotswap::log() << "hotswap: error: " << ApiName
                    << ": rewrite returned no output buffer\n";
     return AMD_COMGR_STATUS_ERROR;

--- a/amd/comgr/src/hotswap/rewriter/rewriter.cpp
+++ b/amd/comgr/src/hotswap/rewriter/rewriter.cpp
@@ -9,8 +9,16 @@
 #include "comgr.h"
 #include "internal.h"
 
+#include "hotswap/cache/mem-cache.h"
+#include "hotswap/cache/pipeline.h"
+#include "hotswap/cache/translation-cache.h"
+
+#include "llvm/Support/MemoryBuffer.h"
+
 #include "llvm/TargetParser/AMDGPUTargetParser.h"
 
+#include <cstdlib>
+#include <memory>
 #include <optional>
 #include <string>
 
@@ -238,16 +246,83 @@ hotswapRewrite(amd_comgr_data_t input, const char *source_isa_name,
                                  SourceIdent.IsB0.value_or(true) &&
                                  TargetIdent.IsB0.value_or(false);
 
-  std::unique_ptr<llvm::MemoryBuffer> OutBuffer;
-  amd_comgr_status_t Status = hotswap::retargetCodeObject(
-      InputP->Data, InputP->Size, TargetIdent.Ident, Options, OutBuffer);
-  if (Status != AMD_COMGR_STATUS_SUCCESS)
-    return Status;
-  if (!OutBuffer) {
+  // Build the cache request. Identity = source bytes (exact-compared by the
+  // mem tier) + full canonical source/target ISA (stepping-bearing) + the
+  // rewrite options that are not implied by the ISA. CodeIsa carries the
+  // B0->A0 option bits so every rewrite-determining input is in the key.
+  COMGR::hotswap::TranslationCacheRequest CacheReq;
+  CacheReq.SourceObject = llvm::MemoryBufferRef(
+      llvm::StringRef(static_cast<const char *>(InputP->Data), InputP->Size),
+      "hotswap-source");
+  CacheReq.SourceGfx = SourceIdent.Ident.Processor;
+  CacheReq.TargetGfx = TargetIdent.Ident.Processor;
+  // Use the RAW, caller-provided ISA strings (NOT CanonicalIsa): parsing
+  // strips the gfx1250 stepping token out of CanonicalIsa into Ident.Features,
+  // so CanonicalIsa alone would not distinguish B0 vs A0 targets. The raw
+  // names carry the stepping verbatim, keeping the key faithful to every input
+  // that reaches retargetCodeObject's subtarget.
+  CacheReq.SourceIsa = source_isa_name;
+  CacheReq.TargetIsa = target_isa_name;
+  {
+    std::string Code = target_isa_name;
+    Code += "|et=";
+    Code += (Options.RunEntryTrampolines ? "1" : "0");
+    Code += "|sm=";
+    Code += (StrictMode ? "1" : "0");
+    Code += "|b0a0=";
+    Code += (Options.RunB0A0Patches ? "1" : "0");
+    Code += "|mp=";
+    Code += std::to_string(static_cast<int>(Options.MaskPolicy));
+    Code += "|fast=";
+    Code += (Options.UseB0B0EntryFastPath ? "1" : "0");
+    CacheReq.CodeIsa = std::move(Code);
+  }
+  CacheReq.StrictMode = StrictMode;
+  // Disk tier: honor HSA_HOTSWAP_CACHE_DIR if set (leave empty => mem-only /
+  // disk-disabled per the disk tier's own env handling). CacheDisabled is the
+  // DISK flag; the mem tier is always consulted (its own budget env gates it).
+  if (const char *Dir = std::getenv("HSA_HOTSWAP_CACHE_DIR")) {
+    CacheReq.CacheDirectory = Dir;
+    CacheReq.CacheDisabled = (CacheReq.CacheDirectory.empty());
+  } else {
+    CacheReq.CacheDisabled = true; // no disk dir => disk tier off; mem still on
+  }
+
+  // Producer: the actual retarget. Wrap the buffer as a PipelineResult so it
+  // flows through the cache's shared currency. Attribution fields stay default
+  // (the B0->A0 rewriter produces none).
+  amd_comgr_status_t ProducerStatus = AMD_COMGR_STATUS_SUCCESS;
+  auto Producer = [&]() -> COMGR::hotswap::PipelineResult {
+    COMGR::hotswap::PipelineResult R;
+    std::unique_ptr<llvm::MemoryBuffer> Buf;
+    ProducerStatus = hotswap::retargetCodeObject(
+        InputP->Data, InputP->Size, TargetIdent.Ident, Options, Buf);
+    if (ProducerStatus == AMD_COMGR_STATUS_SUCCESS && Buf) {
+      R.Hsaco = std::move(Buf);
+      R.Success = true;
+    }
+    return R;
+  };
+
+  COMGR::hotswap::MemCacheResult Cached =
+      COMGR::hotswap::getOrComputeTranslation(CacheReq, Producer);
+
+  // A failed producer (retarget error) must propagate the real status, not a
+  // generic cache failure.
+  if (!Cached.Entry) {
+    if (ProducerStatus != AMD_COMGR_STATUS_SUCCESS)
+      return ProducerStatus;
     hotswap::log() << "hotswap: error: " << ApiName
                    << ": rewrite returned no output buffer\n";
     return AMD_COMGR_STATUS_ERROR;
   }
+
+  // Copy the cached bytes into a fresh owned buffer for the output DataObject.
+  // The cache retains the canonical copy; the C ABI hands ROCm its own. This
+  // preserves the "hit == byte-identical fresh rewrite" invariant.
+  const llvm::MemoryBuffer &Hsaco = *Cached.Entry->Hsaco;
+  std::unique_ptr<llvm::MemoryBuffer> OutBuffer =
+      llvm::MemoryBuffer::getMemBufferCopy(Hsaco.getBuffer(), "hotswap-output");
 
   DataObject *OutputP = DataObject::allocate(AMD_COMGR_DATA_KIND_EXECUTABLE);
   if (!OutputP) {

--- a/amd/comgr/src/hotswap/rewriter/rewriter.cpp
+++ b/amd/comgr/src/hotswap/rewriter/rewriter.cpp
@@ -291,8 +291,26 @@ hotswapRewrite(amd_comgr_data_t input, const char *source_isa_name,
   // Producer: the actual retarget. Wrap the buffer as a PipelineResult so it
   // flows through the cache's shared currency. Attribution fields stay default
   // (the B0->A0 rewriter produces none).
+  // Producer runs on a mem-cache miss. It consults the on-disk tier first (a
+  // cross-process/cross-run cache); only on a disk miss does it run the actual
+  // retarget, then persists the result to disk. This makes the two tiers work
+  // end-to-end from the production entry point: mem-miss -> disk-hit avoids the
+  // retarget; mem-miss + disk-miss retargets once and writes both tiers.
+  // The disk tier is engaged only when CacheReq.CacheDisabled is false (i.e.
+  // HSA_HOTSWAP_CACHE_DIR is set); otherwise lookup/write are no-ops by the
+  // disk tier's own CacheDisabled handling and this degrades to mem-only.
   amd_comgr_status_t ProducerStatus = AMD_COMGR_STATUS_SUCCESS;
   auto Producer = [&]() -> COMGR::hotswap::PipelineResult {
+    // 1) Disk lookup. On a validated hit, return the persisted bytes without
+    //    retargeting. (When the disk tier is disabled this returns non-Hit.)
+    COMGR::hotswap::TranslationCacheLookup DiskLookup =
+        COMGR::hotswap::lookupTranslationCache(CacheReq);
+    if (DiskLookup.Status == COMGR::hotswap::TranslationCacheStatus::Hit &&
+        DiskLookup.Result.Hsaco) {
+      return std::move(DiskLookup.Result);
+    }
+
+    // 2) Disk miss -> run the real retarget.
     COMGR::hotswap::PipelineResult R;
     std::unique_ptr<llvm::MemoryBuffer> Buf;
     ProducerStatus = hotswap::retargetCodeObject(
@@ -300,6 +318,9 @@ hotswapRewrite(amd_comgr_data_t input, const char *source_isa_name,
     if (ProducerStatus == AMD_COMGR_STATUS_SUCCESS && Buf) {
       R.Hsaco = std::move(Buf);
       R.Success = true;
+      // 3) Persist to disk (best-effort; a write failure must not fail the
+      //    rewrite -- the in-memory result is already valid).
+      COMGR::hotswap::writeTranslationCache(CacheReq, R);
     }
     return R;
   };

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-disk-cache.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-disk-cache.s
@@ -17,25 +17,50 @@
 
 // RUN: rm -rf %t.cache && mkdir -p %t.cache
 
-// COM: Cold run: mem-miss + disk-miss -> retarget -> disk write.
+// COM: --- Run 1: MISS + WRITE ---
+// COM: Fresh process => empty mem tier; empty dir => disk miss. The production
+// COM: producer retargets once and writes the object+metadata to disk.
 // RUN: env HSA_HOTSWAP_CACHE_DIR=%t.cache hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out1.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 
-// COM: The cold run must have written at least one cache artifact to disk.
-// RUN: find %t.cache -type f | %FileCheck --check-prefix=DISK %s
-// DISK: {{.+}}
+// COM: The miss path must have written the object artifact (<key>.Hsaco).
+// RUN: find %t.cache -type f -name '*.Hsaco' | %FileCheck --check-prefix=DISK %s
+// DISK: {{.+\.Hsaco}}
 
-// COM: Second run (fresh process => empty mem tier) must hit the disk entry and
-// COM: produce byte-identical output.
+// COM: Record a rewrite-sensitive identity of the stored object. The disk tier
+// COM: writes via atomic temp-file + rename, and a disk HIT returns the stored
+// COM: bytes WITHOUT calling writeTranslationCache (see the producer in
+// COM: rewriter.cpp) -- so a hit leaves the file completely untouched. We
+// COM: capture inode + mtime + ctime (%%i:%%Y:%%Z): a genuine hit leaves all
+// COM: three unchanged, while ANY re-write advances mtime/ctime (and usually
+// COM: the inode too). This distinguishes a disk hit from a silent recompute,
+// COM: which cmp alone cannot (retarget being deterministic). Note: inode
+// COM: alone is insufficient -- ext4 reuses a just-freed inode number on a
+// COM: quick delete+recreate, so mtime/ctime are what give this check teeth.
+// COM: The disk tier shards by key[0:2], so the single object is the one match
+// COM: of %t.cache/*/*.Hsaco.
+// RUN: stat -c '%%i:%%Y:%%Z' %t.cache/*/*.Hsaco > %t.id1
+
+// COM: --- Run 2: MISS (mem) + HIT (disk) ---
+// COM: Separate process => empty mem tier again, so this is a mem miss that
+// COM: MUST fall through to the disk tier. The entry is present => disk hit.
 // RUN: env HSA_HOTSWAP_CACHE_DIR=%t.cache hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
 
-// COM: Byte-identical: a disk hit must reproduce the cold output exactly.
+// COM: Proof of the disk HIT: the stored object was not touched. If run 2 had
+// COM: missed and recomputed, the producer would have re-written the object
+// COM: (new mtime/ctime via atomic rename). Unchanged identity => run 2 served
+// COM: from disk without recomputing, i.e. the disk READ path is wired and
+// COM: effective.
+// RUN: stat -c '%%i:%%Y:%%Z' %t.cache/*/*.Hsaco > %t.id2
+// RUN: diff %t.id1 %t.id2
+
+// COM: And the returned bytes are correct: byte-identical to the cold output.
 // RUN: cmp %t.out1.elf %t.out2.elf
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-disk-cache.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-disk-cache.s
@@ -1,0 +1,83 @@
+// COM: Integration test: the production hotswap rewrite entry point consults
+// COM: the on-disk translation cache. Run the rewrite twice with
+// COM: HSA_HOTSWAP_CACHE_DIR set: the first run must POPULATE the cache dir,
+// COM: and the second run must produce BYTE-IDENTICAL output (served from /
+// COM: consistent with the disk entry). Guards against the disk tier being
+// COM: wired only as a standalone module and never reached from production.
+// COM:
+// COM: The kernel body below is copied verbatim from hotswap-inplace-mixed.s.
+// COM: Its cluster_load ops trigger a real B0->A0 in-place patch (cluster_load
+// COM: -> global_load), so retargetCodeObject does real work and the cached
+// COM: PipelineResult is a genuine patched code object. Crucially the kernel
+// COM: carries a full .amdgpu_metadata note: the disk cache key is derived
+// COM: from the source kernel metadata (listKernelNames), so an input lacking
+// COM: that note cannot be keyed and would never be written to disk.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: rm -rf %t.cache && mkdir -p %t.cache
+
+// COM: Cold run: mem-miss + disk-miss -> retarget -> disk write.
+// RUN: env HSA_HOTSWAP_CACHE_DIR=%t.cache hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out1.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// COM: The cold run must have written at least one cache artifact to disk.
+// RUN: find %t.cache -type f | %FileCheck --check-prefix=DISK %s
+// DISK: {{.+}}
+
+// COM: Second run (fresh process => empty mem tier) must hit the disk entry and
+// COM: produce byte-identical output.
+// RUN: env HSA_HOTSWAP_CACHE_DIR=%t.cache hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+
+// COM: Byte-identical: a disk hit must reproduce the cold output exactly.
+// RUN: cmp %t.out1.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_inplace_kernel
+.p2align 8
+.type test_inplace_kernel,@function
+test_inplace_kernel:
+  s_clause 0x0
+  cluster_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0x0
+  cluster_load_b128 v[4:7], v[8:9], off
+  s_wait_loadcnt 0x0
+  s_clause 0x1
+  global_load_b32 v10, v[2:3], off
+  global_load_b32 v11, v[2:3], off offset:4
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_inplace_kernel_end:
+.size test_inplace_kernel, .Ltest_inplace_kernel_end-test_inplace_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_inplace_kernel
+  .amdhsa_next_free_vgpr 12
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_inplace_kernel
+      .symbol: test_inplace_kernel.kd
+      .gfx1250_revision: B0
+      .sgpr_count: 2
+      .vgpr_count: 12
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -135,8 +135,9 @@ add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapProfileTests>
   COMMAND $<TARGET_FILE:RaiserScaffoldingTests>
   COMMAND $<TARGET_FILE:TranslationCacheTests>
+  COMMAND $<TARGET_FILE:MemCacheTests>
   COMMAND $<TARGET_FILE:DemangleSymbolNameTest>
   COMMAND $<TARGET_FILE:LoggerTests>)
 add_dependencies(test-unit HotswapElfTests HotswapMCTests HotswapProfileTests
-  RaiserScaffoldingTests TranslationCacheTests DemangleSymbolNameTest LoggerTests)
+  RaiserScaffoldingTests TranslationCacheTests MemCacheTests DemangleSymbolNameTest LoggerTests)
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -134,8 +134,9 @@ add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapMCTests>
   COMMAND $<TARGET_FILE:HotswapProfileTests>
   COMMAND $<TARGET_FILE:RaiserScaffoldingTests>
+  COMMAND $<TARGET_FILE:TranslationCacheTests>
   COMMAND $<TARGET_FILE:DemangleSymbolNameTest>
   COMMAND $<TARGET_FILE:LoggerTests>)
 add_dependencies(test-unit HotswapElfTests HotswapMCTests HotswapProfileTests
-  RaiserScaffoldingTests DemangleSymbolNameTest LoggerTests)
+  RaiserScaffoldingTests TranslationCacheTests DemangleSymbolNameTest LoggerTests)
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/hotswap/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(rewriter)
 add_subdirectory(raiser)
+add_subdirectory(cache)

--- a/amd/comgr/test-unit/hotswap/cache/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/cache/CMakeLists.txt
@@ -23,3 +23,25 @@ comgr_configure_test_target(TranslationCacheTests)
 
 add_test(NAME TranslationCacheTests
   COMMAND $<TARGET_FILE:TranslationCacheTests>)
+
+add_executable(MemCacheTests
+  MemCacheTest.cpp)
+
+target_compile_definitions(MemCacheTests PRIVATE
+  COMGR_HOTSWAP_MEM_CACHE_TESTING)
+
+target_link_libraries(MemCacheTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  hotswap::translation_cache
+  ${LLVM_PTHREAD_LIB})
+
+target_include_directories(MemCacheTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+
+comgr_configure_test_target(MemCacheTests)
+
+add_test(NAME MemCacheTests
+  COMMAND $<TARGET_FILE:MemCacheTests>)

--- a/amd/comgr/test-unit/hotswap/cache/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/cache/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Unit tests for the hotswap translation cache (hotswap/cache/translation-cache.h).
+#
+# Pins the on-disk content-addressed cache contract: first-run miss then hit,
+# key sensitivity to source hash / ISA / opt-level / kernel name, and the
+# invalid/readonly/skip-list paths. The test builds its own fake AMDGPU ELF,
+# so it needs no GPU and no real code object.
+
+add_executable(TranslationCacheTests
+  TranslationCacheTest.cpp)
+
+target_link_libraries(TranslationCacheTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  hotswap::translation_cache
+  ${LLVM_PTHREAD_LIB})
+
+target_include_directories(TranslationCacheTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+
+comgr_configure_test_target(TranslationCacheTests)
+
+add_test(NAME TranslationCacheTests
+  COMMAND $<TARGET_FILE:TranslationCacheTests>)

--- a/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
+++ b/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
@@ -303,6 +303,59 @@ TEST_F(MemCacheTest, ConcurrentIdenticalCoalesceToOneProducer) {
   EXPECT_EQ(coalesced + hit, kThreads - 1); // everyone else shared it
 }
 
+// --- Coalesced waiters of a failed leader get the leader's status ----------
+
+// When the single-flight leader's producer fails, every coalesced waiter must
+// observe the SAME deterministic failure: Status == ProducerFailed, Entry ==
+// null, AND the leader's opaque ProducerStatus code -- never a generic error
+// that varies with leader-vs-waiter timing.
+TEST_F(MemCacheTest, CoalescedWaitersOfFailedLeaderGetLeaderStatus) {
+  std::string elf = makeFakeAmdgpuElf("kern");
+  auto req = makeRequest(elf);
+  constexpr int kThreads = 16;
+  constexpr int kFailCode = 7; // arbitrary nonzero opaque producer code
+
+  std::atomic<int> calls{0};
+  std::atomic<int> producerEntered{0};
+  std::atomic<bool> release{false};
+
+  // Leader parks in the producer until all waiters have coalesced, then fails
+  // (no Hsaco) carrying a specific opaque status code.
+  auto producer = [&]() -> PipelineResult {
+    producerEntered.fetch_add(1, std::memory_order_relaxed);
+    while (!release.load(std::memory_order_acquire))
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    PipelineResult r = makeProduced(calls, 0, /*success=*/false);
+    r.ProducerStatus = kFailCode;
+    return r;
+  };
+
+  std::vector<std::thread> threads;
+  std::vector<MemCacheResult> results(kThreads);
+  for (int i = 0; i < kThreads; ++i)
+    threads.emplace_back(
+        [&, i] { results[i] = getOrComputeTranslation(req, producer); });
+
+  while (producerEntered.load() == 0)
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  size_t waiters = waitForMemCacheWaitersForTesting(req, kThreads - 1, 2000);
+  EXPECT_GT(waiters, 0u);
+
+  release.store(true, std::memory_order_release);
+  for (auto &t : threads)
+    t.join();
+
+  // The producer ran exactly once (the leader); every thread saw the failure.
+  EXPECT_EQ(calls.load(), 1);
+  EXPECT_EQ(producerEntered.load(), 1);
+  for (auto &r : results) {
+    EXPECT_EQ(r.Status, MemCacheStatus::ProducerFailed);
+    EXPECT_EQ(r.Entry, nullptr);
+    // Deterministic: leader AND every coalesced waiter report the same code.
+    EXPECT_EQ(r.ProducerStatus, kFailCode);
+  }
+}
+
 // --- Byte-budget LRU eviction --------------------------------------------
 
 TEST_F(MemCacheTest, ByteBudgetEvictsLeastRecentlyUsed) {

--- a/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
+++ b/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
@@ -18,6 +18,7 @@
 #include "gtest/gtest.h"
 
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <string>
 #include <thread>

--- a/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
+++ b/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
@@ -147,6 +147,20 @@ std::string makeFakeAmdgpuElf(llvm::StringRef kernel) {
   return std::string(reinterpret_cast<const char *>(D.data()), D.size());
 }
 
+// A valid AMDGPU ELF whose byte length is padded out to ~padBytes, so the
+// exact-compare memcmp dominates the per-hit cost. The trailing pad is ignored
+// by note parsing but is part of the hashed+compared source bytes. The pad
+// pattern varies by `salt` so distinct keys are distinct in the pad region too.
+std::string makeLargeElf(llvm::StringRef kernel, size_t padBytes,
+                         unsigned char salt) {
+  std::string e = makeFakeAmdgpuElf(kernel);
+  const size_t start = e.size();
+  e.resize(start + padBytes);
+  for (size_t i = 0; i < padBytes; ++i)
+    e[start + i] = static_cast<char>((i * 131u + salt) & 0xff);
+  return e;
+}
+
 TranslationCacheRequest makeRequest(const std::string &elf,
                                     llvm::StringRef target = "gfx950") {
   TranslationCacheRequest req;
@@ -653,6 +667,85 @@ TEST_F(MemCacheTest, DiskHitPopulatesMemThenMemHit) {
   ASSERT_NE(warm.Entry, nullptr);
   ASSERT_NE(xproc.Entry, nullptr);
   EXPECT_EQ(warm.Entry->Hsaco.get(), xproc.Entry->Hsaco.get());
+}
+
+// --- Off-lock exact-compare lets warm hits on distinct keys run concurrently -
+// N threads each repeatedly hit their OWN pre-populated multi-MiB key. The
+// exact-compare is done with Mu released, so the memcmps do not serialize.
+// Correctness is asserted hard; the speedup is asserted only where the box has
+// enough cores to make it non-flaky.
+TEST_F(MemCacheTest, WarmHitsOnDistinctKeysScale) {
+  constexpr int kKeys = 8;
+  constexpr size_t kPad = 4u << 20; // ~4 MiB source => memcmp-dominated hit
+  // A budget big enough to hold all kKeys entries (+their retained sources).
+  resetMemCacheForTesting(static_cast<size_t>(kKeys) * kPad * 4);
+
+  std::vector<std::string> elfs;
+  std::vector<TranslationCacheRequest> reqs;
+  elfs.reserve(kKeys);
+  reqs.reserve(kKeys);
+  for (int i = 0; i < kKeys; ++i)
+    elfs.push_back(makeLargeElf("kern" + std::to_string(i), kPad,
+                                static_cast<unsigned char>(i)));
+  for (int i = 0; i < kKeys; ++i)
+    reqs.push_back(makeRequest(elfs[i]));
+
+  // Pre-populate: one compute per key.
+  std::atomic<int> calls{0};
+  std::vector<const llvm::MemoryBuffer *> bufs(kKeys, nullptr);
+  for (int i = 0; i < kKeys; ++i) {
+    auto r = getOrComputeTranslation(reqs[i],
+                                     [&] { return makeProduced(calls, 256); });
+    ASSERT_EQ(r.Status, MemCacheStatus::Computed);
+    ASSERT_NE(r.Entry, nullptr);
+    bufs[i] = r.Entry->Hsaco.get();
+  }
+  ASSERT_EQ(calls.load(), kKeys);
+
+  // Workload: each of T threads does `perThread` hits over the kKeys keys.
+  auto runHits = [&](int threads, int perThread) {
+    std::atomic<int> extraCalls{0};
+    std::atomic<int> misses{0};
+    auto worker = [&](int t) {
+      for (int j = 0; j < perThread; ++j) {
+        int k = (t + j) % kKeys;
+        auto r = getOrComputeTranslation(
+            reqs[k], [&] { return makeProduced(extraCalls, 256); });
+        if (r.Status != MemCacheStatus::Hit || r.Entry == nullptr ||
+            r.Entry->Hsaco.get() != bufs[k])
+          misses.fetch_add(1, std::memory_order_relaxed);
+      }
+    };
+    std::vector<std::thread> ts;
+    auto t0 = std::chrono::steady_clock::now();
+    for (int t = 0; t < threads; ++t)
+      ts.emplace_back(worker, t);
+    for (auto &th : ts)
+      th.join();
+    auto t1 = std::chrono::steady_clock::now();
+    // Every access must have been a correct warm hit; producer never re-ran.
+    EXPECT_EQ(extraCalls.load(), 0);
+    EXPECT_EQ(misses.load(), 0);
+    return std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0)
+        .count();
+  };
+
+  constexpr int kTotalHits = 4096;
+  long serialUs = runHits(1, kTotalHits);
+  const unsigned hw = std::thread::hardware_concurrency();
+  const int par = hw >= 8 ? 8 : (hw >= 4 ? 4 : 1);
+  long parUs = runHits(par, kTotalHits / par);
+
+  // Correctness already asserted inside runHits. Timing: only assert speedup on
+  // a box with real parallelism; the multi-MiB memcmp is CPU-bound, so with the
+  // compare OFF-lock `par` threads must beat 1 thread on equal total work. A
+  // generous margin keeps it robust under CI noise.
+  if (par >= 4 && serialUs > 0) {
+    EXPECT_LT(parUs, serialUs)
+        << "parallel warm hits (" << par
+        << " threads) not faster than serial: " << parUs << "us vs " << serialUs
+        << "us -- exact-compare may be serializing under Mu";
+  }
 }
 
 } // namespace

--- a/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
+++ b/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
@@ -286,8 +286,14 @@ TEST_F(MemCacheTest, ConcurrentIdenticalCoalesceToOneProducer) {
 // --- Byte-budget LRU eviction --------------------------------------------
 
 TEST_F(MemCacheTest, ByteBudgetEvictsLeastRecentlyUsed) {
-  resetMemCacheForTesting(3 * 1024); // room for ~3 x 1KiB entries
   std::atomic<int> calls{0};
+  // Each entry now costs retained source bytes + output bytes. Size the
+  // budget from the real per-entry footprint so exactly 3 entries fit
+  // (>=3x, strictly <4x), independent of the fake-ELF source size.
+  const size_t kOut = 1024;
+  const size_t kSrc = makeFakeAmdgpuElf("a").size();
+  const size_t kPerEntry = kSrc + kOut;
+  resetMemCacheForTesting(3 * kPerEntry + kPerEntry / 2); // room for 3, not 4
 
   auto insert = [&](llvm::StringRef k) {
     std::string elf = makeFakeAmdgpuElf(k);

--- a/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
+++ b/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
@@ -174,16 +174,16 @@ TEST_F(MemCacheTest, MissThenHit) {
   auto req = makeRequest(elf);
   std::atomic<int> calls{0};
 
-  auto r1 = getOrComputeTranslation(
-      req, [&] { return makeProduced(calls, 1024); });
+  auto r1 =
+      getOrComputeTranslation(req, [&] { return makeProduced(calls, 1024); });
   EXPECT_EQ(r1.Status, MemCacheStatus::Computed);
   ASSERT_NE(r1.Entry, nullptr);
   EXPECT_EQ(calls.load(), 1);
   EXPECT_EQ(r1.Entry->Attribution.LiftedCount, 7);
   EXPECT_EQ(r1.Entry->Attribution.ScaledDispatchFactor, 2u);
 
-  auto r2 = getOrComputeTranslation(
-      req, [&] { return makeProduced(calls, 1024); });
+  auto r2 =
+      getOrComputeTranslation(req, [&] { return makeProduced(calls, 1024); });
   EXPECT_EQ(r2.Status, MemCacheStatus::Hit);
   ASSERT_NE(r2.Entry, nullptr);
   EXPECT_EQ(calls.load(), 1); // producer NOT called again
@@ -230,9 +230,8 @@ TEST_F(MemCacheTest, ConcurrentIdenticalCoalesceToOneProducer) {
   std::vector<std::thread> threads;
   std::vector<MemCacheResult> results(kThreads);
   for (int i = 0; i < kThreads; ++i)
-    threads.emplace_back([&, i] {
-      results[i] = getOrComputeTranslation(req, producer);
-    });
+    threads.emplace_back(
+        [&, i] { results[i] = getOrComputeTranslation(req, producer); });
 
   // Wait until the leader entered the producer, then give the other threads a
   // best-effort chance to park. We do NOT assert an exact parked-waiter count:
@@ -274,13 +273,12 @@ TEST_F(MemCacheTest, ConcurrentIdenticalCoalesceToOneProducer) {
       ++hit;
       break;
     default:
-      ADD_FAILURE() << "unexpected status "
-                    << static_cast<int>(r.Status);
+      ADD_FAILURE() << "unexpected status " << static_cast<int>(r.Status);
       break;
     }
   }
-  EXPECT_EQ(computed, 1);                        // exactly one leader
-  EXPECT_EQ(coalesced + hit, kThreads - 1);      // everyone else shared it
+  EXPECT_EQ(computed, 1);                   // exactly one leader
+  EXPECT_EQ(coalesced + hit, kThreads - 1); // everyone else shared it
 }
 
 // --- Byte-budget LRU eviction --------------------------------------------
@@ -387,10 +385,10 @@ TEST_F(MemCacheTest, ZeroBudgetDisablesTier) {
   auto req = makeRequest(elf);
   std::atomic<int> calls{0};
 
-  auto r1 = getOrComputeTranslation(
-      req, [&] { return makeProduced(calls, 1024); });
-  auto r2 = getOrComputeTranslation(
-      req, [&] { return makeProduced(calls, 1024); });
+  auto r1 =
+      getOrComputeTranslation(req, [&] { return makeProduced(calls, 1024); });
+  auto r2 =
+      getOrComputeTranslation(req, [&] { return makeProduced(calls, 1024); });
   EXPECT_EQ(r1.Status, MemCacheStatus::Disabled);
   EXPECT_EQ(r2.Status, MemCacheStatus::Disabled);
   EXPECT_EQ(calls.load(), 2); // no caching
@@ -406,8 +404,8 @@ TEST_F(MemCacheTest, UncacheableRequestBypasses) {
   req.SourceGfx = "gfx1250";
   req.TargetGfx = "gfx950";
   std::atomic<int> calls{0};
-  auto r = getOrComputeTranslation(req,
-                                   [&] { return makeProduced(calls, 1024); });
+  auto r =
+      getOrComputeTranslation(req, [&] { return makeProduced(calls, 1024); });
   // Producer still ran (we do not drop the request), just nothing cached.
   EXPECT_EQ(calls.load(), 1);
   EXPECT_EQ(memCacheEntryCountForTesting(), 0u);

--- a/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
+++ b/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
@@ -1,0 +1,410 @@
+//===- MemCacheTest.cpp - In-memory translation cache tests ---------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hotswap/cache/mem-cache.h"
+#include "hotswap/cache/pipeline.h"
+#include "hotswap/cache/translation-cache.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace COMGR::hotswap;
+
+namespace {
+
+// Minimal AMDGPU MsgPack metadata naming one kernel -- all listKernelNames
+// (and hence the cache key builder) reads. Adapted from TranslationCacheTest.
+std::string amdgpuMetadataBlob(llvm::StringRef KernelName) {
+  llvm::msgpack::Document Doc;
+  llvm::msgpack::MapDocNode Root = Doc.getRoot().getMap(/*Convert=*/true);
+  llvm::msgpack::DocNode Version = Doc.getArrayNode();
+  Version.getArray().push_back(Doc.getNode(static_cast<uint64_t>(1)));
+  Version.getArray().push_back(Doc.getNode(static_cast<uint64_t>(2)));
+  Root["amdhsa.version"] = Version;
+  llvm::msgpack::DocNode Kernel = Doc.getMapNode();
+  Kernel.getMap()[".name"] = Doc.getNode(KernelName, /*Copy=*/true);
+  llvm::msgpack::DocNode Kernels = Doc.getArrayNode();
+  Kernels.getArray().push_back(Kernel);
+  Root["amdhsa.kernels"] = Kernels;
+  std::string Blob;
+  Doc.writeToBlob(Blob);
+  return Blob;
+}
+
+// Build a 64-bit AMDGPU ELF with an NT_AMDGPU_METADATA note naming `kernel`.
+// Parameterizing the kernel name gives each call a distinct source hash, so
+// distinct requests get distinct cache keys. Adapted from the fake ELF in
+// TranslationCacheTest.cpp (kept local so that test stays untouched).
+std::string makeFakeAmdgpuElf(llvm::StringRef kernel) {
+  using namespace llvm;
+  constexpr size_t NoteOffset = 128;
+  const std::string Blob = amdgpuMetadataBlob(kernel);
+
+  constexpr StringLiteral NoteName = "AMDGPU";
+  const uint32_t NameSz = NoteName.size() + 1;
+  const uint32_t DescSz = Blob.size();
+  const uint32_t NamePadded = alignTo(NameSz, 4);
+  const uint32_t NoteSize =
+      sizeof(ELF::Elf64_Nhdr) + NamePadded + alignTo(DescSz, 4);
+
+  std::string ShStr(1, '\0');
+  auto addSectionName = [&](StringRef Name) {
+    uint32_t Offset = ShStr.size();
+    ShStr.append(Name.begin(), Name.end());
+    ShStr.push_back('\0');
+    return Offset;
+  };
+  const uint32_t NoteNameOffset = addSectionName(".note");
+  const uint32_t ShStrNameOffset = addSectionName(".shstrtab");
+
+  const uint32_t ShStrOffset = NoteOffset + NoteSize;
+  const uint32_t ShdrOffset = alignTo(ShStrOffset + ShStr.size(), 8);
+  const uint32_t Total = ShdrOffset + 3 * sizeof(ELF::Elf64_Shdr);
+
+  SmallVector<uint8_t> D(Total, 0);
+  auto writeStruct = [&](size_t Offset, const auto &S) {
+    std::memcpy(D.data() + Offset, &S, sizeof(S));
+  };
+
+  ELF::Elf64_Ehdr Ehdr = {};
+  Ehdr.e_ident[ELF::EI_MAG0] = 0x7f;
+  Ehdr.e_ident[ELF::EI_MAG1] = 'E';
+  Ehdr.e_ident[ELF::EI_MAG2] = 'L';
+  Ehdr.e_ident[ELF::EI_MAG3] = 'F';
+  Ehdr.e_ident[ELF::EI_CLASS] = ELF::ELFCLASS64;
+  Ehdr.e_ident[ELF::EI_DATA] = ELF::ELFDATA2LSB;
+  Ehdr.e_ident[ELF::EI_VERSION] = ELF::EV_CURRENT;
+  Ehdr.e_ident[ELF::EI_OSABI] = ELF::ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ELF::ET_DYN;
+  Ehdr.e_machine = ELF::EM_AMDGPU;
+  Ehdr.e_version = ELF::EV_CURRENT;
+  Ehdr.e_flags = 0x49;
+  Ehdr.e_ehsize = sizeof(ELF::Elf64_Ehdr);
+  Ehdr.e_shentsize = sizeof(ELF::Elf64_Shdr);
+  Ehdr.e_shnum = 3;
+  Ehdr.e_shstrndx = 2;
+  Ehdr.e_shoff = ShdrOffset;
+  writeStruct(0, Ehdr);
+
+  ELF::Elf64_Nhdr Nhdr = {};
+  Nhdr.n_namesz = NameSz;
+  Nhdr.n_descsz = DescSz;
+  Nhdr.n_type = ELF::NT_AMDGPU_METADATA;
+  writeStruct(NoteOffset, Nhdr);
+  std::memcpy(D.data() + NoteOffset + sizeof(Nhdr), NoteName.data(),
+              NoteName.size());
+  std::memcpy(D.data() + NoteOffset + sizeof(Nhdr) + NamePadded, Blob.data(),
+              DescSz);
+  std::memcpy(D.data() + ShStrOffset, ShStr.data(), ShStr.size());
+
+  ELF::Elf64_Shdr Shdrs[3] = {};
+  Shdrs[1].sh_name = NoteNameOffset;
+  Shdrs[1].sh_type = ELF::SHT_NOTE;
+  Shdrs[1].sh_offset = NoteOffset;
+  Shdrs[1].sh_size = NoteSize;
+  Shdrs[1].sh_addralign = 4;
+  Shdrs[2].sh_name = ShStrNameOffset;
+  Shdrs[2].sh_type = ELF::SHT_STRTAB;
+  Shdrs[2].sh_offset = ShStrOffset;
+  Shdrs[2].sh_size = ShStr.size();
+  Shdrs[2].sh_addralign = 1;
+  std::memcpy(D.data() + ShdrOffset, Shdrs, sizeof(Shdrs));
+
+  return std::string(reinterpret_cast<const char *>(D.data()), D.size());
+}
+
+TranslationCacheRequest makeRequest(const std::string &elf,
+                                    llvm::StringRef target = "gfx950") {
+  TranslationCacheRequest req;
+  req.SourceObject = llvm::MemoryBufferRef(elf, "source");
+  req.SourceGfx = "gfx1250";
+  req.TargetGfx = target;
+  req.SourceIsa = "amdgcn-amd-amdhsa--gfx1250";
+  req.TargetIsa = std::string("amdgcn-amd-amdhsa--") + target.str();
+  req.CodeIsa = req.TargetIsa;
+  req.CacheDirectory = ""; // disk tier irrelevant here
+  req.CacheDisabled = true;
+  return req;
+}
+
+// A producer that hands back a fresh HSACO of the requested size, counting how
+// many times it actually ran. The bytes are arbitrary but deterministic.
+PipelineResult makeProduced(std::atomic<int> &calls, size_t bytes,
+                            bool success = true) {
+  calls.fetch_add(1, std::memory_order_relaxed);
+  PipelineResult r;
+  if (success) {
+    std::string data(bytes, 'X');
+    r.Hsaco = llvm::MemoryBuffer::getMemBufferCopy(data, "hsaco");
+    r.Success = true;
+    r.LiftedCount = 7; // arbitrary attribution to verify round-trip
+    r.ScaledDispatchFactor = 2;
+  } else {
+    r.Success = false;
+    r.FailReason = "forced failure";
+  }
+  return r;
+}
+
+class MemCacheTest : public ::testing::Test {
+protected:
+  void SetUp() override { resetMemCacheForTesting(kBudget); }
+  static constexpr size_t kBudget = 8ull << 20; // 8 MiB
+};
+
+// --- Basic miss-then-hit --------------------------------------------------
+
+TEST_F(MemCacheTest, MissThenHit) {
+  std::string elf = makeFakeAmdgpuElf("kern");
+  auto req = makeRequest(elf);
+  std::atomic<int> calls{0};
+
+  auto r1 = getOrComputeTranslation(
+      req, [&] { return makeProduced(calls, 1024); });
+  EXPECT_EQ(r1.Status, MemCacheStatus::Computed);
+  ASSERT_NE(r1.Entry, nullptr);
+  EXPECT_EQ(calls.load(), 1);
+  EXPECT_EQ(r1.Entry->Attribution.LiftedCount, 7);
+  EXPECT_EQ(r1.Entry->Attribution.ScaledDispatchFactor, 2u);
+
+  auto r2 = getOrComputeTranslation(
+      req, [&] { return makeProduced(calls, 1024); });
+  EXPECT_EQ(r2.Status, MemCacheStatus::Hit);
+  ASSERT_NE(r2.Entry, nullptr);
+  EXPECT_EQ(calls.load(), 1); // producer NOT called again
+  // Same underlying buffer shared, zero-copy.
+  EXPECT_EQ(r1.Entry->Hsaco.get(), r2.Entry->Hsaco.get());
+}
+
+// --- Key sensitivity: different target => different entry -----------------
+
+TEST_F(MemCacheTest, DistinctKeysDoNotAlias) {
+  std::string elf = makeFakeAmdgpuElf("kern");
+  std::atomic<int> calls{0};
+  auto a = getOrComputeTranslation(makeRequest(elf, "gfx950"),
+                                   [&] { return makeProduced(calls, 1024); });
+  auto b = getOrComputeTranslation(makeRequest(elf, "gfx942"),
+                                   [&] { return makeProduced(calls, 1024); });
+  EXPECT_EQ(a.Status, MemCacheStatus::Computed);
+  EXPECT_EQ(b.Status, MemCacheStatus::Computed);
+  EXPECT_EQ(calls.load(), 2);
+  EXPECT_NE(a.Entry->Hsaco.get(), b.Entry->Hsaco.get());
+}
+
+// --- Single-flight coalescing --------------------------------------------
+
+TEST_F(MemCacheTest, ConcurrentIdenticalCoalesceToOneProducer) {
+  std::string elf = makeFakeAmdgpuElf("kern");
+  auto req = makeRequest(elf);
+  constexpr int kThreads = 16;
+
+  std::atomic<int> calls{0};
+  std::atomic<int> producerEntered{0};
+  std::atomic<bool> release{false};
+
+  // Producer blocks until all waiters have parked, so we deterministically
+  // force coalescing rather than racing.
+  auto producer = [&]() -> PipelineResult {
+    producerEntered.fetch_add(1, std::memory_order_relaxed);
+    // Wait until the test releases us (after confirming N-1 waiters parked).
+    while (!release.load(std::memory_order_acquire))
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    return makeProduced(calls, 4096);
+  };
+
+  std::vector<std::thread> threads;
+  std::vector<MemCacheResult> results(kThreads);
+  for (int i = 0; i < kThreads; ++i)
+    threads.emplace_back([&, i] {
+      results[i] = getOrComputeTranslation(req, producer);
+    });
+
+  // Wait until the leader entered the producer, then give the other threads a
+  // best-effort chance to park. We do NOT assert an exact parked-waiter count:
+  // a thread may be between "found the in-flight entry" and "incremented
+  // Waiters" when we sample, which is a benign transient. The load-bearing
+  // invariant is that the producer runs EXACTLY ONCE regardless of how the
+  // non-leaders interleave -- that is what we assert below.
+  while (producerEntered.load() == 0)
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  // Opportunistically confirm coalescing pressure built up (not an equality
+  // assertion; just that at least some waiters parked before release).
+  size_t waiters = waitForMemCacheWaitersForTesting(req, kThreads - 1, 2000);
+  EXPECT_GT(waiters, 0u);
+
+  release.store(true, std::memory_order_release);
+  for (auto &t : threads)
+    t.join();
+
+  // THE invariant: the producer ran exactly once; every thread got the same
+  // buffer; exactly one thread is the leader (Computed) and the rest either
+  // coalesced onto it or (if they arrived after publish) hit the ready map.
+  EXPECT_EQ(calls.load(), 1);
+  EXPECT_EQ(producerEntered.load(), 1);
+  int computed = 0, coalesced = 0, hit = 0;
+  const llvm::MemoryBuffer *buf = nullptr;
+  for (auto &r : results) {
+    ASSERT_NE(r.Entry, nullptr);
+    if (!buf)
+      buf = r.Entry->Hsaco.get();
+    EXPECT_EQ(r.Entry->Hsaco.get(), buf); // all share one buffer
+    switch (r.Status) {
+    case MemCacheStatus::Computed:
+      ++computed;
+      break;
+    case MemCacheStatus::Coalesced:
+      ++coalesced;
+      break;
+    case MemCacheStatus::Hit:
+      ++hit;
+      break;
+    default:
+      ADD_FAILURE() << "unexpected status "
+                    << static_cast<int>(r.Status);
+      break;
+    }
+  }
+  EXPECT_EQ(computed, 1);                        // exactly one leader
+  EXPECT_EQ(coalesced + hit, kThreads - 1);      // everyone else shared it
+}
+
+// --- Byte-budget LRU eviction --------------------------------------------
+
+TEST_F(MemCacheTest, ByteBudgetEvictsLeastRecentlyUsed) {
+  resetMemCacheForTesting(3 * 1024); // room for ~3 x 1KiB entries
+  std::atomic<int> calls{0};
+
+  auto insert = [&](llvm::StringRef k) {
+    std::string elf = makeFakeAmdgpuElf(k);
+    return getOrComputeTranslation(makeRequest(elf),
+                                   [&] { return makeProduced(calls, 1024); });
+  };
+
+  auto a = insert("a");
+  auto b = insert("b");
+  auto c = insert("c");
+  EXPECT_EQ(memCacheEntryCountForTesting(), 3u);
+
+  // Touch 'a' so it is MRU; inserting 'd' should evict 'b' (now LRU).
+  std::string elfA = makeFakeAmdgpuElf("a");
+  auto aHit = getOrComputeTranslation(
+      makeRequest(elfA), [&] { return makeProduced(calls, 1024); });
+  EXPECT_EQ(aHit.Status, MemCacheStatus::Hit);
+
+  auto d = insert("d");
+  EXPECT_EQ(d.Status, MemCacheStatus::Computed);
+  EXPECT_LE(memCacheEntryCountForTesting(), 3u);
+
+  // 'a' still cached (recently touched); 'b' evicted (recompute => Computed).
+  std::string elfAgainA = makeFakeAmdgpuElf("a");
+  EXPECT_EQ(getOrComputeTranslation(makeRequest(elfAgainA),
+                                    [&] { return makeProduced(calls, 1024); })
+                .Status,
+            MemCacheStatus::Hit);
+  std::string elfB = makeFakeAmdgpuElf("b");
+  EXPECT_EQ(getOrComputeTranslation(makeRequest(elfB),
+                                    [&] { return makeProduced(calls, 1024); })
+                .Status,
+            MemCacheStatus::Computed);
+}
+
+// --- Eviction never frees a buffer a caller still holds -------------------
+
+TEST_F(MemCacheTest, EvictedEntrySurvivesWhileReferenced) {
+  resetMemCacheForTesting(2 * 1024);
+  std::atomic<int> calls{0};
+
+  std::string elfA = makeFakeAmdgpuElf("a");
+  auto a = getOrComputeTranslation(makeRequest(elfA),
+                                   [&] { return makeProduced(calls, 1024); });
+  ASSERT_NE(a.Entry, nullptr);
+  const llvm::MemoryBuffer *aBuf = a.Entry->Hsaco.get();
+
+  // Fill past budget to force 'a' out of the map while we still hold a.Entry.
+  for (char c = 'b'; c <= 'e'; ++c) {
+    std::string elf = makeFakeAmdgpuElf(llvm::StringRef(&c, 1));
+    getOrComputeTranslation(makeRequest(elf),
+                            [&] { return makeProduced(calls, 1024); });
+  }
+
+  // 'a' is evicted from the map...
+  std::string elfA2 = makeFakeAmdgpuElf("a");
+  EXPECT_EQ(getOrComputeTranslation(makeRequest(elfA2),
+                                    [&] { return makeProduced(calls, 1024); })
+                .Status,
+            MemCacheStatus::Computed);
+  // ...but our reference is still valid and unchanged (no UAF).
+  EXPECT_EQ(a.Entry->Hsaco.get(), aBuf);
+  EXPECT_EQ(a.Entry->Hsaco->getBufferSize(), 1024u);
+}
+
+// --- Producer failure is not cached --------------------------------------
+
+TEST_F(MemCacheTest, ProducerFailureNotCached) {
+  std::string elf = makeFakeAmdgpuElf("kern");
+  auto req = makeRequest(elf);
+  std::atomic<int> calls{0};
+
+  auto r1 = getOrComputeTranslation(
+      req, [&] { return makeProduced(calls, 0, /*success=*/false); });
+  EXPECT_EQ(r1.Status, MemCacheStatus::ProducerFailed);
+  EXPECT_EQ(r1.Entry, nullptr);
+
+  // Next call must re-run the producer (failure was not cached).
+  auto r2 = getOrComputeTranslation(
+      req, [&] { return makeProduced(calls, 1024, /*success=*/true); });
+  EXPECT_EQ(r2.Status, MemCacheStatus::Computed);
+  ASSERT_NE(r2.Entry, nullptr);
+  EXPECT_EQ(calls.load(), 2);
+}
+
+// --- Disabled tier (budget 0) bypasses cache -----------------------------
+
+TEST_F(MemCacheTest, ZeroBudgetDisablesTier) {
+  resetMemCacheForTesting(0);
+  std::string elf = makeFakeAmdgpuElf("kern");
+  auto req = makeRequest(elf);
+  std::atomic<int> calls{0};
+
+  auto r1 = getOrComputeTranslation(
+      req, [&] { return makeProduced(calls, 1024); });
+  auto r2 = getOrComputeTranslation(
+      req, [&] { return makeProduced(calls, 1024); });
+  EXPECT_EQ(r1.Status, MemCacheStatus::Disabled);
+  EXPECT_EQ(r2.Status, MemCacheStatus::Disabled);
+  EXPECT_EQ(calls.load(), 2); // no caching
+  EXPECT_EQ(memCacheEntryCountForTesting(), 0u);
+}
+
+// --- Uncacheable request (empty key) bypasses safely ---------------------
+
+TEST_F(MemCacheTest, UncacheableRequestBypasses) {
+  // Empty source object => translationCacheKey returns "" => bypass.
+  TranslationCacheRequest req;
+  req.SourceObject = llvm::MemoryBufferRef(llvm::StringRef(""), "empty");
+  req.SourceGfx = "gfx1250";
+  req.TargetGfx = "gfx950";
+  std::atomic<int> calls{0};
+  auto r = getOrComputeTranslation(req,
+                                   [&] { return makeProduced(calls, 1024); });
+  // Producer still ran (we do not drop the request), just nothing cached.
+  EXPECT_EQ(calls.load(), 1);
+  EXPECT_EQ(memCacheEntryCountForTesting(), 0u);
+}
+
+} // namespace

--- a/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
+++ b/amd/comgr/test-unit/hotswap/cache/MemCacheTest.cpp
@@ -10,16 +10,20 @@
 #include "hotswap/cache/pipeline.h"
 #include "hotswap/cache/translation-cache.h"
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
 
 #include "gtest/gtest.h"
 
 #include <atomic>
 #include <chrono>
 #include <cstring>
+#include <functional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -27,6 +31,20 @@
 using namespace COMGR::hotswap;
 
 namespace {
+
+// A unique temporary directory removed on scope exit. Local to this TU (the
+// TranslationCacheTest.cpp TempDir lives in that TU's anon namespace and is
+// not shared). Used by the two-tier disk/mem population test below.
+struct MemTempDir {
+  llvm::SmallString<128> Path;
+  explicit MemTempDir(const char *P) {
+    llvm::sys::fs::createUniqueDirectory(P, Path);
+  }
+  ~MemTempDir() {
+    if (!Path.empty())
+      llvm::sys::fs::remove_directories(Path);
+  }
+};
 
 // Minimal AMDGPU MsgPack metadata naming one kernel -- all listKernelNames
 // (and hence the cache key builder) reads. Adapted from TranslationCacheTest.
@@ -165,6 +183,9 @@ PipelineResult makeProduced(std::atomic<int> &calls, size_t bytes,
 class MemCacheTest : public ::testing::Test {
 protected:
   void SetUp() override { resetMemCacheForTesting(kBudget); }
+  // Restore the default source-bucket hash after every test so a degenerate
+  // hash installed by the collision test cannot leak into another test.
+  void TearDown() override { setMemCacheHashFnForTesting(nullptr); }
   static constexpr size_t kBudget = 8ull << 20; // 8 MiB
 };
 
@@ -410,6 +431,175 @@ TEST_F(MemCacheTest, UncacheableRequestBypasses) {
   // Producer still ran (we do not drop the request), just nothing cached.
   EXPECT_EQ(calls.load(), 1);
   EXPECT_EQ(memCacheEntryCountForTesting(), 0u);
+}
+
+// --- Every key-determining transform field must distinguish entries --------
+
+TEST_F(MemCacheTest, KeyFieldSensitivity) {
+  std::string elf = makeFakeAmdgpuElf("kern");
+
+  // Each lambda mutates one field of a copy of the base request; the mutated
+  // request must NOT alias the base (both Computed, distinct buffers).
+  auto checkField = [&](const char *label,
+                        std::function<void(TranslationCacheRequest &)> mutate) {
+    SCOPED_TRACE(label);
+    std::atomic<int> calls{0};
+    resetMemCacheForTesting(8u << 20);
+    auto base = makeRequest(elf);
+    auto variant = base;
+    mutate(variant);
+    auto a = getOrComputeTranslation(base,
+                                     [&] { return makeProduced(calls, 1024); });
+    auto b = getOrComputeTranslation(variant,
+                                     [&] { return makeProduced(calls, 1024); });
+    EXPECT_EQ(a.Status, MemCacheStatus::Computed);
+    EXPECT_EQ(b.Status, MemCacheStatus::Computed); // NOT Hit -> distinct keys
+    ASSERT_NE(a.Entry, nullptr);
+    ASSERT_NE(b.Entry, nullptr);
+    EXPECT_NE(a.Entry->Hsaco.get(), b.Entry->Hsaco.get());
+  };
+
+  checkField("TargetGfx/TargetIsa", [](TranslationCacheRequest &r) {
+    r.TargetGfx = "gfx942";
+    r.TargetIsa = "amdgcn-amd-amdhsa--gfx942";
+    r.CodeIsa = r.TargetIsa;
+  });
+  checkField("OptLevel", [](TranslationCacheRequest &r) { r.OptLevel = 3; });
+  checkField("OrigMach", [](TranslationCacheRequest &r) { r.OrigMach = 42; });
+  checkField("StrictMode",
+             [](TranslationCacheRequest &r) { r.StrictMode = true; });
+  checkField("EnableWaveNative",
+             [](TranslationCacheRequest &r) { r.EnableWaveNative = false; });
+  checkField("DeviceLibrariesIdentity", [](TranslationCacheRequest &r) {
+    r.DeviceLibrariesIdentity = "devlibs-v2";
+  });
+}
+
+// --- A forced hash collision must never mis-serve a different source -------
+
+TEST_F(MemCacheTest, HashCollisionDoesNotMisServe) {
+  // Degenerate hash: every source lands in one bucket, so the exact-memcmp
+  // guard in lookupLocked is the ONLY thing keeping distinct sources apart.
+  setMemCacheHashFnForTesting([](const void *, size_t) { return 0ull; });
+  resetMemCacheForTesting(8u << 20);
+  std::atomic<int> calls{0};
+
+  // Producer whose OUTPUT content encodes which source it was built for, so a
+  // mis-serve (returning Y's bytes for X) is directly detectable. The tag byte
+  // is the source's first content byte after the fake-ELF header pad.
+  auto taggedProducer = [&](char tag) {
+    return [&, tag]() -> PipelineResult {
+      calls.fetch_add(1, std::memory_order_relaxed);
+      PipelineResult r;
+      std::string data(1024, tag);
+      r.Hsaco = llvm::MemoryBuffer::getMemBufferCopy(data, "hsaco");
+      r.Success = true;
+      return r;
+    };
+  };
+
+  // Two DISTINCT sources forced into the same bucket.
+  std::string elfA = makeFakeAmdgpuElf("A");
+  std::string elfB = makeFakeAmdgpuElf("B");
+  ASSERT_NE(elfA, elfB); // genuinely different source bytes
+
+  auto a = getOrComputeTranslation(makeRequest(elfA), taggedProducer('A'));
+  auto b = getOrComputeTranslation(makeRequest(elfB), taggedProducer('B'));
+  ASSERT_NE(a.Entry, nullptr);
+  ASSERT_NE(b.Entry, nullptr);
+
+  // THE invariant: neither request received the other's bytes. A's output is
+  // all 'A', B's is all 'B' -- a collision alias would have handed one the
+  // other's buffer.
+  EXPECT_EQ(a.Entry->Hsaco->getBuffer()[0], 'A');
+  EXPECT_EQ(b.Entry->Hsaco->getBuffer()[0], 'B');
+  EXPECT_NE(a.Entry->Hsaco.get(), b.Entry->Hsaco.get());
+
+  // Re-request each source repeatedly under the forced collision: every result
+  // must carry its OWN tag, never the other's. (Whether a given call is a Hit
+  // or a recompute is unspecified under a forced collision -- the single-slot
+  // design may thrash -- but the CONTENT must always be correct.)
+  for (int i = 0; i < 4; ++i) {
+    auto ra = getOrComputeTranslation(makeRequest(elfA), taggedProducer('A'));
+    auto rb = getOrComputeTranslation(makeRequest(elfB), taggedProducer('B'));
+    ASSERT_NE(ra.Entry, nullptr);
+    ASSERT_NE(rb.Entry, nullptr);
+    EXPECT_EQ(ra.Entry->Hsaco->getBuffer()[0], 'A') << "iter " << i;
+    EXPECT_EQ(rb.Entry->Hsaco->getBuffer()[0], 'B') << "iter " << i;
+  }
+
+  setMemCacheHashFnForTesting(nullptr); // restore (TearDown also does this)
+}
+
+// --- Reentrant producer for the same key must not deadlock ----------------
+
+TEST_F(MemCacheTest, ReentrantProducerDoesNotDeadlock) {
+  resetMemCacheForTesting(8u << 20);
+  std::string elf = makeFakeAmdgpuElf("R");
+  auto req = makeRequest(elf);
+  std::atomic<int> calls{0};
+  std::atomic<int> depth{0};
+  std::function<PipelineResult()> producer = [&]() -> PipelineResult {
+    if (depth.fetch_add(1) == 0) {
+      // Re-enter for the same key from within the producer. The reentrancy
+      // guard must run this inline (a bypass compute), not block on ourselves.
+      auto inner = getOrComputeTranslation(req, producer);
+      (void)inner; // must return, not hang
+    }
+    return makeProduced(calls, 1024);
+  };
+  auto r = getOrComputeTranslation(req, producer);
+  EXPECT_NE(r.Entry, nullptr); // completed without deadlock
+  EXPECT_GE(calls.load(), 1);
+}
+
+// --- Disk hit repopulates the mem tier, then serves a pure mem hit --------
+
+TEST_F(MemCacheTest, DiskHitPopulatesMemThenMemHit) {
+  resetMemCacheForTesting(8u << 20);
+  MemTempDir dir("hotswap_memcache_test");
+  std::atomic<int> calls{0};
+  std::string elf = makeFakeAmdgpuElf("T");
+
+  // A request whose disk tier is ENABLED and points at our temp dir.
+  TranslationCacheRequest req = makeRequest(elf);
+  req.CacheDirectory = std::string(dir.Path);
+  req.CacheDisabled = false;
+
+  // (1) Cold: producer runs the transform AND writes disk.
+  auto cold = getOrComputeTranslation(req, [&] {
+    PipelineResult r = makeProduced(calls, 1024);
+    writeTranslationCache(req, r); // real disk write
+    return r;
+  });
+  EXPECT_EQ(cold.Status, MemCacheStatus::Computed);
+
+  // (2) Cross-tier: clear mem (fresh instance), keep disk. Producer now does a
+  //     real disk lookup instead of the transform; on hit it returns the disk
+  //     result, which repopulates mem.
+  resetMemCacheForTesting(8u << 20);
+  int producerRuns = 0;
+  auto xproc = getOrComputeTranslation(req, [&] {
+    ++producerRuns;
+    TranslationCacheLookup lk = lookupTranslationCache(req);
+    if (lk.Status == TranslationCacheStatus::Hit && lk.Result.Hsaco)
+      return std::move(lk.Result);    // disk hit -> no transform
+    return makeProduced(calls, 1024); // (should not happen)
+  });
+  EXPECT_EQ(xproc.Status, MemCacheStatus::Computed);
+  EXPECT_EQ(producerRuns, 1); // producer ran once (the disk read)
+
+  // (3) Warm: pure mem hit, producer NOT run again.
+  int producerRuns2 = 0;
+  auto warm = getOrComputeTranslation(req, [&] {
+    ++producerRuns2;
+    return makeProduced(calls, 1024);
+  });
+  EXPECT_EQ(warm.Status, MemCacheStatus::Hit);
+  EXPECT_EQ(producerRuns2, 0);
+  ASSERT_NE(warm.Entry, nullptr);
+  ASSERT_NE(xproc.Entry, nullptr);
+  EXPECT_EQ(warm.Entry->Hsaco.get(), xproc.Entry->Hsaco.get());
 }
 
 } // namespace

--- a/amd/comgr/test-unit/hotswap/cache/TranslationCacheTest.cpp
+++ b/amd/comgr/test-unit/hotswap/cache/TranslationCacheTest.cpp
@@ -1,0 +1,488 @@
+//===- TranslationCacheTest.cpp - translation cache unit tests ------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+
+#include "hotswap/cache/translation-cache.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct TempDir {
+  llvm::SmallString<128> Path;
+  bool Valid = false;
+
+  explicit TempDir(const char *Prefix) {
+    std::error_code Ec = llvm::sys::fs::createUniqueDirectory(Prefix, Path);
+    Valid = !Ec;
+  }
+
+  ~TempDir() {
+    if (Valid)
+      llvm::sys::fs::remove_directories(Path);
+  }
+
+  std::string file(const char *Name) const {
+    llvm::SmallString<256> P(Path);
+    llvm::sys::path::append(P, Name);
+    return std::string(P);
+  }
+};
+
+struct ScopedEnv {
+  std::string Name;
+  std::string OldValue;
+  bool HadOldValue = false;
+
+  ScopedEnv(const char *Name, const std::string &Value) : Name(Name) {
+    if (const char *Old = std::getenv(Name)) {
+      OldValue = Old;
+      HadOldValue = true;
+    }
+    setenv(Name, Value.c_str(), 1);
+  }
+
+  ~ScopedEnv() {
+    if (HadOldValue)
+      setenv(Name.c_str(), OldValue.c_str(), 1);
+    else
+      unsetenv(Name.c_str());
+  }
+};
+
+llvm::MemoryBufferRef bufRef(llvm::ArrayRef<uint8_t> V) {
+  return llvm::MemoryBufferRef(
+      llvm::StringRef(reinterpret_cast<const char *>(V.data()), V.size()), "");
+}
+
+// Minimal AMDGPU MsgPack metadata: an `amdhsa.kernels` array with one
+// `.name`, which is all `listKernelNames` reads.
+std::string amdgpuMetadataBlob(llvm::StringRef KernelName) {
+  llvm::msgpack::Document Doc;
+  llvm::msgpack::MapDocNode Root = Doc.getRoot().getMap(/*Convert=*/true);
+
+  llvm::msgpack::DocNode Version = Doc.getArrayNode();
+  Version.getArray().push_back(Doc.getNode(static_cast<uint64_t>(1)));
+  Version.getArray().push_back(Doc.getNode(static_cast<uint64_t>(2)));
+  Root["amdhsa.version"] = Version;
+
+  llvm::msgpack::DocNode Kernel = Doc.getMapNode();
+  Kernel.getMap()[".name"] = Doc.getNode(KernelName, /*Copy=*/true);
+
+  llvm::msgpack::DocNode Kernels = Doc.getArrayNode();
+  Kernels.getArray().push_back(Kernel);
+  Root["amdhsa.kernels"] = Kernels;
+
+  std::string Blob;
+  Doc.writeToBlob(Blob);
+  return Blob;
+}
+
+// Offset of the source byte the cache tests flip to perturb the SHA-256
+// without disturbing any ELF structure the key builder parses. It lives in
+// the reserved gap fakeAmdgpuElf() leaves between the ELF header and the
+// metadata note.
+constexpr size_t HashPerturbOffset = 80;
+constexpr size_t NoteOffset = 128;
+static_assert(sizeof(llvm::ELF::Elf64_Ehdr) <= HashPerturbOffset &&
+                  HashPerturbOffset < NoteOffset,
+              "perturb byte must lie in the ELF header-to-note padding gap");
+
+// Build a 64-bit little-endian AMDGPU ELF carrying an NT_AMDGPU_METADATA
+// note naming one kernel, so that listKernelNames succeeds and the
+// translation-cache key builder accepts the object.
+//
+// Layout: [Elf64_Ehdr][padding to NoteOffset][note][.shstrtab][section
+// headers]. The padding gap holds HashPerturbOffset.
+llvm::SmallVector<uint8_t> fakeAmdgpuElf() {
+  using namespace llvm;
+  const std::string Blob = amdgpuMetadataBlob("cache_probe_kernel");
+
+  // ELF note: Nhdr, then name and desc each padded to 4 bytes. n_namesz
+  // counts the trailing NUL.
+  constexpr StringLiteral NoteName = "AMDGPU";
+  const uint32_t NameSz = NoteName.size() + 1;
+  const uint32_t DescSz = Blob.size();
+  const uint32_t NamePadded = alignTo(NameSz, 4);
+  const uint32_t NoteSize =
+      sizeof(ELF::Elf64_Nhdr) + NamePadded + alignTo(DescSz, 4);
+
+  // Section header string table; offsets are derived as names are appended.
+  std::string ShStr(1, '\0');
+  auto addSectionName = [&](StringRef Name) {
+    uint32_t Offset = ShStr.size();
+    ShStr.append(Name.begin(), Name.end());
+    ShStr.push_back('\0');
+    return Offset;
+  };
+  const uint32_t NoteNameOffset = addSectionName(".note");
+  const uint32_t ShStrNameOffset = addSectionName(".shstrtab");
+
+  const uint32_t ShStrOffset = NoteOffset + NoteSize;
+  const uint32_t ShdrOffset = alignTo(ShStrOffset + ShStr.size(), 8);
+  const uint32_t Total = ShdrOffset + 3 * sizeof(ELF::Elf64_Shdr);
+
+  SmallVector<uint8_t> D(Total, 0);
+  auto writeStruct = [&](size_t Offset, const auto &S) {
+    std::memcpy(D.data() + Offset, &S, sizeof(S));
+  };
+
+  ELF::Elf64_Ehdr Ehdr = {};
+  Ehdr.e_ident[ELF::EI_MAG0] = 0x7f;
+  Ehdr.e_ident[ELF::EI_MAG1] = 'E';
+  Ehdr.e_ident[ELF::EI_MAG2] = 'L';
+  Ehdr.e_ident[ELF::EI_MAG3] = 'F';
+  Ehdr.e_ident[ELF::EI_CLASS] = ELF::ELFCLASS64;
+  Ehdr.e_ident[ELF::EI_DATA] = ELF::ELFDATA2LSB;
+  Ehdr.e_ident[ELF::EI_VERSION] = ELF::EV_CURRENT;
+  Ehdr.e_ident[ELF::EI_OSABI] = ELF::ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ELF::ET_DYN;
+  Ehdr.e_machine = ELF::EM_AMDGPU;
+  Ehdr.e_version = ELF::EV_CURRENT;
+  Ehdr.e_flags = 0x49; // arbitrary stable EF_AMDGPU flags hashed into the key
+  Ehdr.e_ehsize = sizeof(ELF::Elf64_Ehdr);
+  Ehdr.e_shentsize = sizeof(ELF::Elf64_Shdr);
+  Ehdr.e_shnum = 3;
+  Ehdr.e_shstrndx = 2;
+  Ehdr.e_shoff = ShdrOffset;
+  writeStruct(0, Ehdr);
+
+  ELF::Elf64_Nhdr Nhdr = {};
+  Nhdr.n_namesz = NameSz;
+  Nhdr.n_descsz = DescSz;
+  Nhdr.n_type = ELF::NT_AMDGPU_METADATA;
+  writeStruct(NoteOffset, Nhdr);
+  std::memcpy(D.data() + NoteOffset + sizeof(Nhdr), NoteName.data(),
+              NoteName.size());
+  std::memcpy(D.data() + NoteOffset + sizeof(Nhdr) + NamePadded, Blob.data(),
+              DescSz);
+
+  std::memcpy(D.data() + ShStrOffset, ShStr.data(), ShStr.size());
+
+  // Section headers: [0] null, [1] .note (SHT_NOTE), [2] .shstrtab.
+  ELF::Elf64_Shdr Shdrs[3] = {};
+  Shdrs[1].sh_name = NoteNameOffset;
+  Shdrs[1].sh_type = ELF::SHT_NOTE;
+  Shdrs[1].sh_offset = NoteOffset;
+  Shdrs[1].sh_size = NoteSize;
+  Shdrs[1].sh_addralign = 4;
+  Shdrs[2].sh_name = ShStrNameOffset;
+  Shdrs[2].sh_type = ELF::SHT_STRTAB;
+  Shdrs[2].sh_offset = ShStrOffset;
+  Shdrs[2].sh_size = ShStr.size();
+  Shdrs[2].sh_addralign = 1;
+  std::memcpy(D.data() + ShdrOffset, Shdrs, sizeof(Shdrs));
+
+  return D;
+}
+
+void writeTextFile(const std::string &Path, llvm::StringRef Text) {
+  std::error_code Ec;
+  llvm::raw_fd_ostream Os(Path, Ec);
+  ASSERT_FALSE(Ec) << "cannot write " << Path << ": " << Ec.message();
+  Os << Text;
+}
+
+void writeBinaryFile(const std::string &Path,
+                     const std::vector<uint8_t> &Bytes) {
+  std::error_code Ec;
+  llvm::raw_fd_ostream Os(Path, Ec, llvm::sys::fs::OF_None);
+  ASSERT_FALSE(Ec) << "cannot write " << Path << ": " << Ec.message();
+  Os.write(reinterpret_cast<const char *>(Bytes.data()), Bytes.size());
+}
+
+COMGR::hotswap::TranslationCacheRequest makeRequest(
+    llvm::MemoryBufferRef Source, const std::string &RulesPath,
+    const std::string &SourceGfx = "gfx1250",
+    const std::string &TargetGfx = "gfx942") {
+  COMGR::hotswap::TranslationCacheRequest Request;
+  Request.SourceObject = Source;
+  Request.SourceGfx = SourceGfx;
+  Request.TargetGfx = TargetGfx;
+  Request.SourceIsa = "amdgcn-amd-amdhsa--" + SourceGfx;
+  Request.TargetIsa = "amdgcn-amd-amdhsa--" + TargetGfx;
+  Request.CodeIsa = "amdgcn-amd-amdhsa--gfx942";
+  Request.HotswapRulesPath = RulesPath;
+  Request.CacheDirectory = llvm::sys::path::parent_path(RulesPath).str();
+  Request.DeviceLibrariesIdentity = "unit-test-device-libraries-identity";
+  Request.CacheDisabled = false;
+  Request.OrigMach = 0x49;
+  Request.EnableWritelaneRewrite = true;
+  Request.EnableWaveNative = true;
+  Request.StrictMode = true;
+  return Request;
+}
+
+COMGR::hotswap::PipelineResult makeSuccessfulResult(
+    std::vector<uint8_t> Hsaco = {0x7f, 'E', 'L', 'F', 1, 2, 3}) {
+  COMGR::hotswap::PipelineResult Result;
+  Result.Success = true;
+  Result.Hsaco = llvm::MemoryBuffer::getMemBufferCopy(
+      llvm::StringRef(reinterpret_cast<const char *>(Hsaco.data()),
+                      Hsaco.size()),
+      "");
+  Result.LiftedCount = 7;
+  Result.TotalCount = 7;
+  return Result;
+}
+
+} // namespace
+
+TEST(TranslationCache, FirstRunMissWriteSecondRunHit) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+
+  auto First = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(First.Status, COMGR::hotswap::TranslationCacheStatus::Miss);
+
+  auto Result = makeSuccessfulResult();
+  auto Write = COMGR::hotswap::writeTranslationCache(Request, Result);
+  ASSERT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::WriteSuccess)
+      << Write.Reason;
+
+  auto Second = COMGR::hotswap::lookupTranslationCache(Request);
+  ASSERT_EQ(Second.Status, COMGR::hotswap::TranslationCacheStatus::Hit)
+      << Second.Reason;
+  ASSERT_TRUE(Second.Result.Hsaco && Result.Hsaco);
+  EXPECT_EQ(Second.Result.Hsaco->getBuffer(), Result.Hsaco->getBuffer());
+  EXPECT_EQ(Second.Result.LiftedCount, Result.LiftedCount);
+  EXPECT_EQ(Second.Result.TotalCount, Result.TotalCount);
+}
+
+TEST(TranslationCache, KernelNameParticipatesInCacheKey) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto WholeObject = makeRequest(bufRef(Source), Rules);
+
+  auto WholeWrite =
+      COMGR::hotswap::writeTranslationCache(WholeObject, makeSuccessfulResult());
+  ASSERT_EQ(WholeWrite.Status,
+            COMGR::hotswap::TranslationCacheStatus::WriteSuccess)
+      << WholeWrite.Reason;
+
+  auto PerKernel = WholeObject;
+  PerKernel.KernelName = "cache_probe_kernel";
+  auto PerKernelLookup = COMGR::hotswap::lookupTranslationCache(PerKernel);
+  EXPECT_EQ(PerKernelLookup.Status,
+            COMGR::hotswap::TranslationCacheStatus::Miss);
+  EXPECT_NE(PerKernelLookup.key, WholeWrite.key);
+
+  auto PerKernelWrite = COMGR::hotswap::writeTranslationCache(
+      PerKernel, makeSuccessfulResult({0x7f, 'E', 'L', 'F', 4, 5, 6}));
+  ASSERT_EQ(PerKernelWrite.Status,
+            COMGR::hotswap::TranslationCacheStatus::WriteSuccess)
+      << PerKernelWrite.Reason;
+
+  auto OtherKernel = WholeObject;
+  OtherKernel.KernelName = "other_kernel";
+  auto OtherKernelLookup = COMGR::hotswap::lookupTranslationCache(OtherKernel);
+  EXPECT_EQ(OtherKernelLookup.Status,
+            COMGR::hotswap::TranslationCacheStatus::Miss);
+  EXPECT_NE(OtherKernelLookup.key, PerKernelWrite.key);
+
+  auto WholeObjectLookup = COMGR::hotswap::lookupTranslationCache(WholeObject);
+  EXPECT_EQ(WholeObjectLookup.Status,
+            COMGR::hotswap::TranslationCacheStatus::Hit);
+}
+
+TEST(TranslationCache, ChangedInputHashCausesMiss) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  ASSERT_EQ(COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult()).Status,
+            COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+
+  Source[HashPerturbOffset] ^= 0x1;
+  auto Changed = makeRequest(bufRef(Source), Rules);
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Changed);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Miss);
+}
+
+TEST(TranslationCache, ChangedIsaCausesMiss) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  ASSERT_EQ(COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult()).Status,
+            COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+
+  auto ChangedSourceIsa = makeRequest(bufRef(Source), Rules, "gfx1200", "gfx942");
+  EXPECT_EQ(COMGR::hotswap::lookupTranslationCache(ChangedSourceIsa).Status,
+            COMGR::hotswap::TranslationCacheStatus::Miss);
+
+  auto ChangedTargetIsa = makeRequest(bufRef(Source), Rules, "gfx1250", "gfx950");
+  EXPECT_EQ(COMGR::hotswap::lookupTranslationCache(ChangedTargetIsa).Status,
+            COMGR::hotswap::TranslationCacheStatus::Miss);
+}
+
+TEST(TranslationCache, ChangedOptLevelCausesMiss) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  Request.OptLevel = 2;
+  auto Write =
+      COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
+  ASSERT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+
+  auto Changed = Request;
+  Changed.OptLevel = 0;
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Changed);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Miss);
+}
+
+TEST(TranslationCache, OldHotswapCacheDirDoesNotEnableCache) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv OldCacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", "");
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  Request.CacheDirectory = "";
+
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Disabled);
+}
+
+TEST(TranslationCache, CorruptMetadataIsInvalid) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  auto Write = COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
+  ASSERT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+
+  writeTextFile(Write.MetadataPath, "not-json\n");
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Invalid);
+  EXPECT_NE(Lookup.Reason.find("parse"), std::string::npos);
+}
+
+TEST(TranslationCache, CorruptObjectIsInvalid) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+  ScopedEnv CacheDir("HSA_HOTSWAP_CACHE_DIR", Temp.Path.str().str());
+  ScopedEnv NoDisable("HSA_HOTSWAP_CACHE_DISABLE", "0");
+  ScopedEnv NoReadonly("HSA_HOTSWAP_CACHE_READONLY", "0");
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  auto Write = COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
+  ASSERT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+
+  writeBinaryFile(Write.ObjectPath, {1, 2, 3, 4});
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Invalid);
+  EXPECT_NE(Lookup.Reason.find("cached_object_sha256"), std::string::npos);
+}
+
+TEST(TranslationCache, ReadonlyMissDoesNotWrite) {
+  TempDir Temp("hotswap_cache_test");
+  ASSERT_TRUE(Temp.Valid);
+
+  std::string Rules = Temp.file("rules.json");
+  writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
+  auto Source = fakeAmdgpuElf();
+  auto Request = makeRequest(bufRef(Source), Rules);
+  Request.CacheReadonly = true;
+
+  auto Lookup = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Miss);
+
+  auto Write = COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
+  EXPECT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::Disabled);
+
+  auto Second = COMGR::hotswap::lookupTranslationCache(Request);
+  EXPECT_EQ(Second.Status, COMGR::hotswap::TranslationCacheStatus::Miss);
+}
+
+TEST(TranslationCache, BypassedStatusHasStableString) {
+  EXPECT_STREQ(COMGR::hotswap::translationCacheStatusString(
+                   COMGR::hotswap::TranslationCacheStatus::Bypassed),
+               "bypassed");
+}
+
+TEST(TranslationCache, SkipKernelListMatchesExactKernelName) {
+  ScopedEnv Skip("HSA_HOTSWAP_CACHE_SKIP_KERNELS",
+                 "other_kernel, target_kernel ,third_kernel");
+
+  std::vector<std::string> Kernels = {"first_kernel", "target_kernel"};
+  EXPECT_EQ(COMGR::hotswap::skippedKernelForTranslationCache(
+                Kernels, "other_kernel, target_kernel ,third_kernel"),
+            "target_kernel");
+}
+
+TEST(TranslationCache, SkipKernelListDoesNotUseSubstringMatching) {
+  ScopedEnv Skip("HSA_HOTSWAP_CACHE_SKIP_KERNELS", "target");
+
+  std::vector<std::string> Kernels = {"target_kernel"};
+  EXPECT_TRUE(
+      COMGR::hotswap::skippedKernelForTranslationCache(Kernels, "target").empty());
+}

--- a/amd/comgr/test-unit/hotswap/cache/TranslationCacheTest.cpp
+++ b/amd/comgr/test-unit/hotswap/cache/TranslationCacheTest.cpp
@@ -212,10 +212,10 @@ void writeBinaryFile(const std::string &Path,
   Os.write(reinterpret_cast<const char *>(Bytes.data()), Bytes.size());
 }
 
-COMGR::hotswap::TranslationCacheRequest makeRequest(
-    llvm::MemoryBufferRef Source, const std::string &RulesPath,
-    const std::string &SourceGfx = "gfx1250",
-    const std::string &TargetGfx = "gfx942") {
+COMGR::hotswap::TranslationCacheRequest
+makeRequest(llvm::MemoryBufferRef Source, const std::string &RulesPath,
+            const std::string &SourceGfx = "gfx1250",
+            const std::string &TargetGfx = "gfx942") {
   COMGR::hotswap::TranslationCacheRequest Request;
   Request.SourceObject = Source;
   Request.SourceGfx = SourceGfx;
@@ -290,8 +290,8 @@ TEST(TranslationCache, KernelNameParticipatesInCacheKey) {
   auto Source = fakeAmdgpuElf();
   auto WholeObject = makeRequest(bufRef(Source), Rules);
 
-  auto WholeWrite =
-      COMGR::hotswap::writeTranslationCache(WholeObject, makeSuccessfulResult());
+  auto WholeWrite = COMGR::hotswap::writeTranslationCache(
+      WholeObject, makeSuccessfulResult());
   ASSERT_EQ(WholeWrite.Status,
             COMGR::hotswap::TranslationCacheStatus::WriteSuccess)
       << WholeWrite.Reason;
@@ -332,8 +332,10 @@ TEST(TranslationCache, ChangedInputHashCausesMiss) {
   writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
   auto Source = fakeAmdgpuElf();
   auto Request = makeRequest(bufRef(Source), Rules);
-  ASSERT_EQ(COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult()).Status,
-            COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+  ASSERT_EQ(
+      COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult())
+          .Status,
+      COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
 
   Source[HashPerturbOffset] ^= 0x1;
   auto Changed = makeRequest(bufRef(Source), Rules);
@@ -352,14 +354,18 @@ TEST(TranslationCache, ChangedIsaCausesMiss) {
   writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
   auto Source = fakeAmdgpuElf();
   auto Request = makeRequest(bufRef(Source), Rules);
-  ASSERT_EQ(COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult()).Status,
-            COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
+  ASSERT_EQ(
+      COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult())
+          .Status,
+      COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
 
-  auto ChangedSourceIsa = makeRequest(bufRef(Source), Rules, "gfx1200", "gfx942");
+  auto ChangedSourceIsa =
+      makeRequest(bufRef(Source), Rules, "gfx1200", "gfx942");
   EXPECT_EQ(COMGR::hotswap::lookupTranslationCache(ChangedSourceIsa).Status,
             COMGR::hotswap::TranslationCacheStatus::Miss);
 
-  auto ChangedTargetIsa = makeRequest(bufRef(Source), Rules, "gfx1250", "gfx950");
+  auto ChangedTargetIsa =
+      makeRequest(bufRef(Source), Rules, "gfx1250", "gfx950");
   EXPECT_EQ(COMGR::hotswap::lookupTranslationCache(ChangedTargetIsa).Status,
             COMGR::hotswap::TranslationCacheStatus::Miss);
 }
@@ -414,7 +420,8 @@ TEST(TranslationCache, CorruptMetadataIsInvalid) {
   writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
   auto Source = fakeAmdgpuElf();
   auto Request = makeRequest(bufRef(Source), Rules);
-  auto Write = COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
+  auto Write =
+      COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
   ASSERT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
 
   writeTextFile(Write.MetadataPath, "not-json\n");
@@ -434,7 +441,8 @@ TEST(TranslationCache, CorruptObjectIsInvalid) {
   writeTextFile(Rules, "{\"version\":1,\"rules\":[]}\n");
   auto Source = fakeAmdgpuElf();
   auto Request = makeRequest(bufRef(Source), Rules);
-  auto Write = COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
+  auto Write =
+      COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
   ASSERT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::WriteSuccess);
 
   writeBinaryFile(Write.ObjectPath, {1, 2, 3, 4});
@@ -456,7 +464,8 @@ TEST(TranslationCache, ReadonlyMissDoesNotWrite) {
   auto Lookup = COMGR::hotswap::lookupTranslationCache(Request);
   EXPECT_EQ(Lookup.Status, COMGR::hotswap::TranslationCacheStatus::Miss);
 
-  auto Write = COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
+  auto Write =
+      COMGR::hotswap::writeTranslationCache(Request, makeSuccessfulResult());
   EXPECT_EQ(Write.Status, COMGR::hotswap::TranslationCacheStatus::Disabled);
 
   auto Second = COMGR::hotswap::lookupTranslationCache(Request);
@@ -484,5 +493,6 @@ TEST(TranslationCache, SkipKernelListDoesNotUseSubstringMatching) {
 
   std::vector<std::string> Kernels = {"target_kernel"};
   EXPECT_TRUE(
-      COMGR::hotswap::skippedKernelForTranslationCache(Kernels, "target").empty());
+      COMGR::hotswap::skippedKernelForTranslationCache(Kernels, "target")
+          .empty());
 }

--- a/amd/comgr/test-unit/hotswap/cache/TranslationCacheTest.cpp
+++ b/amd/comgr/test-unit/hotswap/cache/TranslationCacheTest.cpp
@@ -50,6 +50,25 @@ struct TempDir {
   }
 };
 
+// Portable environment mutation: setenv/unsetenv are POSIX and absent on MSVC,
+// which provides _putenv_s instead. These wrappers keep ScopedEnv building on
+// Windows (Test Comgr) as well as Linux.
+inline void setEnvVar(const char *Name, const char *Value) {
+#ifdef _WIN32
+  _putenv_s(Name, Value);
+#else
+  setenv(Name, Value, 1);
+#endif
+}
+
+inline void unsetEnvVar(const char *Name) {
+#ifdef _WIN32
+  _putenv_s(Name, "");
+#else
+  unsetenv(Name);
+#endif
+}
+
 struct ScopedEnv {
   std::string Name;
   std::string OldValue;
@@ -60,14 +79,14 @@ struct ScopedEnv {
       OldValue = Old;
       HadOldValue = true;
     }
-    setenv(Name, Value.c_str(), 1);
+    setEnvVar(Name, Value.c_str());
   }
 
   ~ScopedEnv() {
     if (HadOldValue)
-      setenv(Name.c_str(), OldValue.c_str(), 1);
+      setEnvVar(Name.c_str(), OldValue.c_str());
     else
-      unsetenv(Name.c_str());
+      unsetEnvVar(Name.c_str());
   }
 };
 


### PR DESCRIPTION
## What

Adds a process-global, in-memory tier in front of the on-disk hotswap
translation cache from #3671, and **wires both tiers into the production
`amd_comgr_hotswap_rewrite` entry point** so the B0→A0 rewriter actually
consults them. When the same source object, target ISA, and transpile settings
recur — repeated kernel launches, several agents cold-loading the same object,
or a prior process run — the cache serves the previously lowered HSACO directly
and coalesces concurrent identical requests so the raise/opt/llc/link pipeline
(or the byte-level retarget) runs only once.

Two-tier design: the disk cache (#3671) gives cross-process/cross-run
persistence; the in-memory tier gives in-process reuse + single-flight
coalescing on top of it.

## Design

- **Production wiring.** `hotswapRewrite()` calls `getOrComputeTranslation()`
  with a disk-aware producer: mem-miss → disk lookup → (disk-miss) retarget →
  disk write. A mem hit skips everything; a mem-miss/disk-hit skips the
  retarget. The disk tier engages only when `HSA_HOTSWAP_CACHE_DIR` is set,
  otherwise it degrades to mem-only.
- **Single flight.** On a miss, exactly one thread (the leader) runs the
  producer with no cache lock held (so disk I/O / COMGR never serialize the
  cache). Concurrent identical requests block and share the leader's result.
  A coalesced waiter of a failed leader now receives the leader's exact
  producer status (deterministic across leader-vs-waiter timing), not a generic
  error.
- **In-memory identity: xxHash64 bucket + exact memcmp.** The mem key buckets
  by xxHash64(source) + size + transform fields; a retained copy of the source
  bytes is exact-compared on lookup so a hash collision can never mis-serve. The
  disk tier keeps its SHA-256 content-addressed key for cross-process identity.
- **Ownership.** An entry holds the HSACO as a `shared_ptr<MemoryBuffer>`;
  callers receive a `shared_ptr`. Eviction only drops the map's strong
  reference, so it can never free a buffer a caller still holds.
- **Byte-budget LRU.** Footprint bounded by `AMD_COMGR_HOTSWAP_MEM_CACHE_BYTES`
  (default 1 GiB; `0` disables the tier).
- **No background thread.** The disk write stays synchronous on the leader path,
  so this adds no thread/lifecycle/fork/atexit surface. Exception-free
  (`-fno-exceptions/-fno-rtti`).

## Warm-hit performance

The steady-state path once the cache is warm is a hit, so its cost matters. The
hit path was tightened to keep the global mutex off the expensive work:

- **Off-lock exact-compare.** Lookup is split into an O(1) locked phase
  (find + LRU-promote + pin the entry/source `shared_ptr`s) and an off-lock
  memcmp. The pinned `shared_ptr`s keep the entry alive after the lock is
  released, so a warm hit no longer holds the global mutex across a multi-MiB
  compare. The true-miss path stays fully under the original lock, so
  single-flight coalescing is unchanged.
- **Leader-only source capture.** The source-bytes copy (needed only by the
  leader, for insertion + waiters' compare) is no longer taken on hit/coalesced
  paths — a warm hit does no allocation.
- **Off-lock eviction.** Evicted entries' (possibly multi-MiB) buffers are freed
  after the lock is released, keeping `free()`/`munmap()` out of the critical
  section.

Effect: warm hits on distinct keys now scale with thread count instead of
serializing on the compare. Measured **~6.6× on 8 threads** (2.24s → 0.34s for a
fixed multi-MiB warm-hit workload) on a 128-core MI300X host.

## Relationship to #3671

Stacked on #3671 (ftynse) and subsumes it — this PR is the final cache
infrastructure, so review findings on the disk module are addressed here. The
only substantive change to the disk module is the additive `translationCacheKey()`
accessor plus review fixes (Windows `dlfcn` guard, header includes, PRIVATE LLVM
link scope).

## Testing

`MemCacheTests` (gtest, no GPU): miss→hit (shared buffer, zero-copy), key
sensitivity, single-flight coalescing (16 threads → exactly one producer call),
coalesced-failed-leader deterministic status, byte-budget LRU eviction,
evicted-but-referenced survival (no UAF), producer-failure-not-cached, disabled
tier, uncacheable bypass, xxHash64-collision-does-not-mis-serve, reentrancy
guard, two-tier disk→mem population, and warm-hit scaling (parallel hits beat
serial). **14/14 pass**, non-flaky across repeated runs; ThreadSanitizer clean.
`TranslationCacheTests` still **12/12** (no regression).
`hotswap-disk-cache.s` lit test drives the real `amd_comgr_hotswap_rewrite`
entry point twice and proves a genuine disk hit (stored object's
inode:mtime:ctime unchanged across runs; negative control confirms the check has
teeth). Built standalone via the comgr CMake/ninja configure.
