### PR TITLE
[comgr][hotswap] Make branch-island allocation transactional

### DIFF
--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -44,6 +44,7 @@
 #include <cstdio>
 #include <limits>
 #include <mutex>
+#include <set>
 #include <tuple>
 
 using namespace llvm;
@@ -4612,39 +4613,110 @@ countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
   return Slots;
 }
 
-static std::optional<SmallVector<uint64_t, 4>>
+using BranchGatewayHead = std::pair<uint64_t, size_t>;
+using BranchGatewayHeadSet = std::set<BranchGatewayHead>;
+
+static bool hasFreeBranchGatewaySlot(const NopSled &Sled) {
+  uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+  return Sled.WritePos <= UsableEnd && MinInstSize <= UsableEnd - Sled.WritePos;
+}
+
+static BranchGatewayHeadSet
+buildBranchGatewayHeads(const std::vector<NopSled> &Gateways) {
+  BranchGatewayHeadSet Heads;
+  for (size_t I = 0; I != Gateways.size(); ++I)
+    if (hasFreeBranchGatewaySlot(Gateways[I]))
+      Heads.insert({Gateways[I].WritePos, I});
+  return Heads;
+}
+
+static void
+subtractOccupiedBranchGatewaySlots(std::vector<NopSled> &Gateways,
+                                   const DenseSet<uint64_t> &Occupied) {
+  SmallVector<uint64_t, 32> SortedOccupied(Occupied.begin(), Occupied.end());
+  llvm::sort(SortedOccupied);
+  std::vector<NopSled> Available;
+  Available.reserve(Gateways.size());
+  for (const NopSled &Sled : Gateways) {
+    uint64_t Cursor = Sled.WritePos;
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    if (Cursor >= UsableEnd)
+      continue;
+    SmallVector<uint64_t, 32>::const_iterator It =
+        llvm::lower_bound(SortedOccupied, Cursor);
+    while (It != SortedOccupied.end() && *It < UsableEnd) {
+      if (Cursor < *It)
+        Available.push_back(
+            {Cursor, *It, Cursor, Sled.FunctionStart, Sled.FunctionEnd});
+      Cursor = std::max(Cursor, *It + MinInstSize);
+      ++It;
+    }
+    if (Cursor < UsableEnd)
+      Available.push_back(
+          {Cursor, UsableEnd, Cursor, Sled.FunctionStart, Sled.FunctionEnd});
+  }
+  Gateways = std::move(Available);
+}
+
+std::optional<SmallVector<uint64_t, 4>>
 allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
                              uint64_t FromOffset, uint64_t TargetOffset) {
   struct Allocation {
     size_t SledIndex = 0;
     uint64_t PreviousWritePos = 0;
   };
+  BranchGatewayHeadSet Heads = buildBranchGatewayHeads(Gateways);
+  DenseSet<uint64_t> Occupied;
   SmallVector<Allocation, 4> Allocations;
   SmallVector<uint64_t, 4> Islands;
-  DenseSet<size_t> UsedSleds;
   uint64_t Current = FromOffset;
 
   while (!isSBranchReachable(Current, TargetOffset)) {
     bool Forward = TargetOffset > Current;
     size_t BestIndex = Gateways.size();
     uint64_t BestOffset = 0;
-    for (size_t I = 0; I != Gateways.size(); ++I) {
-      NopSled &Sled = Gateways[I];
-      if (UsedSleds.contains(I) || FromOffset < Sled.FunctionStart ||
-          FromOffset >= Sled.FunctionEnd)
-        continue;
-      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-      bool MakesProgress =
-          Forward ? Sled.WritePos > Current && Sled.WritePos < TargetOffset
-                  : Sled.WritePos < Current && Sled.WritePos > TargetOffset;
-      if (!MakesProgress || Sled.WritePos > UsableEnd ||
-          MinInstSize > UsableEnd - Sled.WritePos ||
-          !isSBranchReachable(Current, Sled.WritePos))
-        continue;
-      if (BestIndex == Gateways.size() ||
-          (Forward ? Sled.WritePos > BestOffset : Sled.WritePos < BestOffset)) {
-        BestIndex = I;
-        BestOffset = Sled.WritePos;
+
+    if (Forward) {
+      uint64_t ReachEnd =
+          Current > std::numeric_limits<uint64_t>::max() - MaxSledDistance
+              ? std::numeric_limits<uint64_t>::max()
+              : Current + MaxSledDistance;
+      uint64_t Upper = std::min(TargetOffset, ReachEnd);
+      BranchGatewayHeadSet::const_iterator It =
+          TargetOffset <= ReachEnd
+              ? Heads.lower_bound({Upper, 0})
+              : Heads.upper_bound({Upper, std::numeric_limits<size_t>::max()});
+      while (It != Heads.begin()) {
+        --It;
+        if (It->first <= Current)
+          break;
+        const NopSled &Sled = Gateways[It->second];
+        if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd ||
+            Sled.WritePos != It->first ||
+            !isSBranchReachable(Current, It->first))
+          continue;
+        BestIndex = It->second;
+        BestOffset = It->first;
+        break;
+      }
+    } else {
+      uint64_t ReachBegin =
+          Current > MaxSledDistance ? Current - MaxSledDistance : 0;
+      uint64_t Lower = TargetOffset == std::numeric_limits<uint64_t>::max()
+                           ? TargetOffset
+                           : TargetOffset + 1;
+      Lower = std::max(Lower, ReachBegin);
+      for (BranchGatewayHeadSet::const_iterator It =
+               Heads.lower_bound({Lower, 0});
+           It != Heads.end() && It->first < Current; ++It) {
+        const NopSled &Sled = Gateways[It->second];
+        if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd ||
+            Sled.WritePos != It->first ||
+            !isSBranchReachable(Current, It->first))
+          continue;
+        BestIndex = It->second;
+        BestOffset = It->first;
+        break;
       }
     }
 
@@ -4656,13 +4728,24 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
       return std::nullopt;
     }
 
-    NopSled &Best = Gateways[BestIndex];
-    Allocations.push_back({BestIndex, Best.WritePos});
-    Islands.push_back(Best.WritePos);
-    Current = Best.WritePos;
-    Best.WritePos += MinInstSize;
-    UsedSleds.insert(BestIndex);
+    BranchGatewayHeadSet::iterator AliasBegin =
+        Heads.lower_bound({BestOffset, 0});
+    BranchGatewayHeadSet::iterator AliasEnd =
+        Heads.upper_bound({BestOffset, std::numeric_limits<size_t>::max()});
+    for (BranchGatewayHeadSet::const_iterator It = AliasBegin; It != AliasEnd;
+         ++It) {
+      NopSled &Alias = Gateways[It->second];
+      Allocations.push_back({It->second, Alias.WritePos});
+      Alias.WritePos += MinInstSize;
+    }
+    Heads.erase(AliasBegin, AliasEnd);
+    Occupied.insert(BestOffset);
+    Islands.push_back(BestOffset);
+    Current = BestOffset;
   }
+
+  if (!Occupied.empty())
+    subtractOccupiedBranchGatewaySlots(Gateways, Occupied);
   return Islands;
 }
 

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -1572,6 +1572,13 @@ llvm::Expected<uint64_t> countReachableSetPcGatewaySlots(
     uint64_t TargetOffset, unsigned SgprBase, uint64_t MaxSlots,
     bool UseVcc = false, bool PreserveVcc = false);
 
+/// Allocate a monotonic chain of short-branch islands between \p FromOffset and
+/// \p TargetOffset. Sled cursor updates are transactional: failure restores
+/// every consumed cursor, while physical aliases advance together on success.
+std::optional<llvm::SmallVector<uint64_t, 4>>
+allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
+                             uint64_t FromOffset, uint64_t TargetOffset);
+
 /// Return whether an s_branch at \p From can encode \p To, including the
 /// instruction-relative PC base, alignment, signed range, and overflow checks.
 bool isSBranchReachable(uint64_t From, uint64_t To);

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -3003,6 +3003,111 @@ TEST(FindNearestSled, HandlesLargeUnsignedOffsets) {
   EXPECT_EQ(Sled, &Sleds[1]);
 }
 
+TEST(BranchIslandAllocator, AcceptsExactPositiveReachBoundary) {
+  std::vector<NopSled> Gateways = {
+      {MaxSledDistance, MaxSledDistance + MinInstSize, MaxSledDistance,
+       /*FunctionStart=*/0, /*FunctionEnd=*/3 * MaxSledDistance}};
+  std::optional<llvm::SmallVector<uint64_t, 4>> Islands =
+      allocateForwardBranchIslands(Gateways, /*FromOffset=*/0,
+                                   /*TargetOffset=*/2 * MaxSledDistance);
+  ASSERT_TRUE(Islands);
+  ASSERT_EQ(Islands->size(), 1u);
+  EXPECT_EQ(Islands->front(), MaxSledDistance);
+}
+
+TEST(BranchIslandAllocator, LeavesGatewaysUntouchedForDirectBranch) {
+  std::vector<NopSled> Gateways = {{/*Start=*/100, /*End=*/140,
+                                    /*WritePos=*/108,
+                                    /*FunctionStart=*/0, /*FunctionEnd=*/200}};
+  std::optional<llvm::SmallVector<uint64_t, 4>> Islands =
+      allocateForwardBranchIslands(Gateways, /*FromOffset=*/0,
+                                   /*TargetOffset=*/64);
+  ASSERT_TRUE(Islands);
+  EXPECT_TRUE(Islands->empty());
+  ASSERT_EQ(Gateways.size(), 1u);
+  EXPECT_EQ(Gateways[0].Start, 100u);
+  EXPECT_EQ(Gateways[0].End, 140u);
+  EXPECT_EQ(Gateways[0].WritePos, 108u);
+  EXPECT_EQ(Gateways[0].FunctionStart, 0u);
+  EXPECT_EQ(Gateways[0].FunctionEnd, 200u);
+}
+
+TEST(BranchIslandAllocator, RoutesBackwardAtNegativeReachBoundary) {
+  std::vector<NopSled> Gateways = {
+      {2 * MinInstSize, 3 * MinInstSize, 2 * MinInstSize,
+       /*FunctionStart=*/0, /*FunctionEnd=*/3 * MaxSledDistance},
+      {MaxSledDistance + MinInstSize, MaxSledDistance + 2 * MinInstSize,
+       MaxSledDistance + MinInstSize,
+       /*FunctionStart=*/0, /*FunctionEnd=*/3 * MaxSledDistance}};
+  std::optional<llvm::SmallVector<uint64_t, 4>> Islands =
+      allocateForwardBranchIslands(Gateways,
+                                   /*FromOffset=*/2 * MaxSledDistance,
+                                   /*TargetOffset=*/0);
+  ASSERT_TRUE(Islands);
+  EXPECT_EQ(*Islands, (llvm::SmallVector<uint64_t, 4>{
+                          MaxSledDistance + MinInstSize, 2 * MinInstSize}));
+}
+
+TEST(BranchIslandAllocator, RollsBackPartialChainAndPhysicalAliases) {
+  constexpr uint64_t Head = 170000;
+  std::vector<NopSled> Gateways = {
+      {Head, Head + MinInstSize, Head, 0, 400000},
+      {Head, Head + 2 * MinInstSize, Head, 0, 400000}};
+  std::optional<llvm::SmallVector<uint64_t, 4>> Islands =
+      allocateForwardBranchIslands(Gateways, /*FromOffset=*/300000,
+                                   /*TargetOffset=*/0);
+  EXPECT_FALSE(Islands);
+  ASSERT_EQ(Gateways.size(), 2u);
+  EXPECT_EQ(Gateways[0].WritePos, Head);
+  EXPECT_EQ(Gateways[1].WritePos, Head);
+}
+
+TEST(BranchIslandAllocator, CoAdvancesEqualPhysicalAliases) {
+  std::vector<NopSled> Gateways = {
+      {MaxSledDistance, MaxSledDistance + 2 * MinInstSize, MaxSledDistance, 0,
+       3 * MaxSledDistance},
+      {MaxSledDistance, MaxSledDistance + 3 * MinInstSize, MaxSledDistance, 0,
+       3 * MaxSledDistance}};
+  std::optional<llvm::SmallVector<uint64_t, 4>> Islands =
+      allocateForwardBranchIslands(Gateways, /*FromOffset=*/0,
+                                   /*TargetOffset=*/2 * MaxSledDistance);
+  ASSERT_TRUE(Islands);
+  ASSERT_EQ(Gateways.size(), 2u);
+  EXPECT_EQ(Gateways[0].WritePos, MaxSledDistance + MinInstSize);
+  EXPECT_EQ(Gateways[1].WritePos, MaxSledDistance + MinInstSize);
+}
+
+TEST(BranchIslandAllocator, SplitsPartiallyOverlappingPhysicalAliases) {
+  constexpr uint64_t OccupiedOffset = 108;
+  std::vector<NopSled> Gateways = {{100, 140, 100, 0, 200000},
+                                   {OccupiedOffset,
+                                    OccupiedOffset + MinInstSize,
+                                    OccupiedOffset, 0, 200000}};
+  std::optional<llvm::SmallVector<uint64_t, 4>> Islands =
+      allocateForwardBranchIslands(Gateways, /*FromOffset=*/0,
+                                   /*TargetOffset=*/131080);
+  ASSERT_TRUE(Islands);
+  ASSERT_EQ(Islands->size(), 1u);
+  EXPECT_EQ(Islands->front(), OccupiedOffset);
+  for (const NopSled &Sled : Gateways)
+    EXPECT_FALSE(Sled.WritePos <= OccupiedOffset && OccupiedOffset < Sled.End);
+}
+
+TEST(BranchIslandAllocator, SkipsGatewayFromDifferentFunction) {
+  std::vector<NopSled> Gateways = {
+      {MaxSledDistance, MaxSledDistance + MinInstSize, MaxSledDistance,
+       /*FunctionStart=*/1, /*FunctionEnd=*/300000},
+      {130000, 130000 + MinInstSize, 130000,
+       /*FunctionStart=*/0, /*FunctionEnd=*/300000},
+      {260000, 260000 + MinInstSize, 260000,
+       /*FunctionStart=*/0, /*FunctionEnd=*/300000}};
+  std::optional<llvm::SmallVector<uint64_t, 4>> Islands =
+      allocateForwardBranchIslands(Gateways, /*FromOffset=*/0,
+                                   /*TargetOffset=*/262144);
+  ASSERT_TRUE(Islands);
+  EXPECT_EQ(*Islands, (llvm::SmallVector<uint64_t, 4>{130000, 260000}));
+}
+
 // -- assembleSingleInst / decodeTextSection round-trip ------------------------
 
 TEST(AssembleDecode, SNopRoundTrip) {


### PR DESCRIPTION
Supersedes ROCm/llvm-project#3609 with a focused implementation on current
`amd-staging`.

## Scope

- Index available branch-gateway heads so each routing hop uses a bounded
  directional lookup instead of rescanning every sled.
- Allocate a complete island chain transactionally and leave the gateway
  inventory unchanged when routing fails.
- Co-advance exact physical aliases and split partially overlapping aliases so
  an occupied instruction word cannot be reused.
- Preserve exact positive and negative branch-reach boundaries, direct-branch
  behavior, and function ownership.

Pair-backed/source-tail promotion remains separate in ROCm/llvm-project#3611.
This change has no unmerged PR dependency.

## Tests

On `mi300x`, for exact head `d66e2a72cdaf4e89bcf7949fd414d6878fd918f0`:

- Release focused allocator tests: 7/7 passed.
- ASAN focused allocator tests with leak detection: 7/7 passed.
- `git diff --check`: clean.

The complete COMGR/ASAN suites, differential corpus gate, and MI400 matrix
remain pending. This PR is intentionally a draft until those landing gates
complete.
