### PR TITLE
[comgr][hotswap] Reuse locally dead SGPR pairs for far returns

### DIFF
--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -676,7 +676,8 @@ summarizeSafeSgprUsage(PatchContext &Ctx,
 
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
-                         unsigned Alignment, StringRef Context) {
+                         unsigned Alignment, StringRef Context,
+                         bool ReportNoSpace) {
   if (Count == 0 || Alignment == 0 || (Alignment & (Alignment - 1)) != 0) {
     log() << "hotswap: error: " << Context
           << ": invalid global SGPR block request (count=" << Count
@@ -773,8 +774,10 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
   }
   unsigned Base = (HighWatermark + Alignment - 1) & ~(Alignment - 1);
   if (Base > Ctx.Config.MaxSgprs || Count > Ctx.Config.MaxSgprs - Base) {
-    log() << "hotswap: error: " << Context << ": no aligned block of " << Count
-          << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs << "\n";
+    if (ReportNoSpace)
+      log() << "hotswap: error: " << Context << ": no aligned block of "
+            << Count << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs
+            << "\n";
     return std::nullopt;
   }
   return SafeSgprScratchBlock{Base, Count};
@@ -1371,15 +1374,63 @@ bool isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx,
   return RegisterBits.any() && !Live->anyCommon(RegisterBits);
 }
 
+// When no aligned pair fits above the kernel's declared high-water mark, scan
+// every aligned numbered SGPR pair from the top down for one whose incoming
+// value is dead: neither read by the replacement nor live across the site's
+// continuation. Bit MaxSgprs of each mask tracks aggregate VCC and is never a
+// numbered scratch candidate. Fails closed if either proof is unavailable.
 static std::optional<SafeSgprScratchBlock>
-reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset) {
+findLocallyDeadSgprPair(PatchContext &Ctx, uint64_t InstOffset,
+                        uint32_t InstSize, ArrayRef<uint8_t> Replacement) {
+  if (Ctx.Config.MaxSgprs < 2)
+    return std::nullopt;
+  std::optional<BitVector> ReplacementIncoming =
+      getReplacementIncomingSgprs(Replacement, Ctx.LS, Ctx.Config.MaxSgprs);
+  if (!ReplacementIncoming)
+    return std::nullopt;
+  std::optional<BitVector> Live =
+      getLiveSgprsAtContinuation(Ctx, InstOffset, InstSize);
+  if (!Live)
+    return std::nullopt;
+  BitVector Unsafe = *ReplacementIncoming;
+  Unsafe |= *Live;
+
+  for (unsigned Base = (Ctx.Config.MaxSgprs - 2) & ~1u;; Base -= 2) {
+    if (!Unsafe.test(Base) && !Unsafe.test(Base + 1)) {
+      SafeSgprScratchBlock Scratch{Base, 2};
+      if (commitSafeSgprScratchBlock(Ctx, InstOffset, Scratch,
+                                     "locally dead far return"))
+        return Scratch;
+    }
+    if (Base == 0)
+      break;
+  }
+  return std::nullopt;
+}
+
+static std::optional<SafeSgprScratchBlock>
+reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+                     ArrayRef<uint8_t> Replacement) {
   std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
-      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return");
-  if (!Scratch)
-    return std::nullopt;
-  if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch, "safe far return"))
-    return std::nullopt;
-  return Scratch;
+      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return",
+      /*ReportNoSpace=*/false);
+  if (Scratch) {
+    if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch,
+                                    "safe far return"))
+      return std::nullopt;
+    return Scratch;
+  }
+
+  // The high-water block is exhausted. Scan for any numbered pair that is
+  // provably dead at this site before declining to the s_branch island planner.
+  if (std::optional<SafeSgprScratchBlock> LocalPair =
+          findLocallyDeadSgprPair(Ctx, InstOffset, InstSize, Replacement)) {
+    log() << "hotswap: safe far return: reusing locally dead s["
+          << LocalPair->Base << ":" << LocalPair->Base + 1 << "] at 0x"
+          << utohexstr(InstOffset) << "\n";
+    return LocalPair;
+  }
+  return std::nullopt;
 }
 
 bool isSBranchReachable(uint64_t From, uint64_t To) {
@@ -1466,7 +1517,7 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
       return declineFar(Twine(InstSize) + " B, smaller than " +
                         Twine(MinInstSize) + " B forward branch");
     std::optional<SafeSgprScratchBlock> Scratch =
-        reserveSafeFarReturn(Ctx, InstOffset);
+        reserveSafeFarReturn(Ctx, InstOffset, InstSize, Replacement);
     if (!Scratch)
       return declineFar("no safe SGPR triple for set-PC return");
     T.Bytes.insert(T.Bytes.end(), SetPcReturnReserveBytes, uint8_t{0});

--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -1271,19 +1271,23 @@ std::optional<BitVector> getLiveSgprsAtContinuation(PatchContext &Ctx,
   }
   using FunctionKey = std::pair<uint64_t, uint64_t>;
   FunctionKey Key{FunctionRange->Begin, FunctionRange->End};
-  // Deferred trampolines are logical mutations of their source functions, but
-  // their source branches are not written into Ctx.Text until final fixup.
-  // Decoding the current bytes after one is queued would therefore omit the
-  // replacement's effects and its new control-flow edges. Fail closed for the
-  // affected function until finalization rather than prove liveness from an
-  // incomplete program image. A trampoline without a resolved function range
-  // may affect any queried function and also forces the conservative result.
-  if (Ctx.HasUnresolvedPendingTrampoline ||
-      Ctx.PendingTrampolineFunctions.contains(Key)) {
+  // A trampoline whose source function is unknown may add a control-flow edge
+  // into any function, so it can invalidate this function's liveness in ways
+  // the current .text does not show. Fail closed until finalization.
+  //
+  // A resolved in-function trampoline does not: its source keeps its original
+  // bytes in Ctx.Text until fixup (emitToTrampoline only queues it), so the
+  // decode here is faithful, and at finalization it only redirects the source
+  // through an appended pool that returns to the same continuation. That leaves
+  // the incoming-live set at every continuation in this function unchanged, so
+  // the scratch-liveness proof this query serves stays valid. Do not fail
+  // closed on it, or a function with more far sites than its high-water
+  // headroom can never reuse a locally dead pair for its later sites.
+  if (Ctx.HasUnresolvedPendingTrampoline) {
     log() << "hotswap: SGPR continuation liveness failed closed for source at "
              "0x"
           << utohexstr(InstOffset)
-          << ": pending trampoline source bytes are not finalized\n";
+          << ": a trampoline with no resolved function is pending\n";
     return std::nullopt;
   }
   DenseMap<FunctionKey, CurrentFunctionSgprLiveness>::iterator Cached =
@@ -1352,11 +1356,11 @@ void noteCurrentTextMutation(PatchContext &Ctx) {
 }
 
 void notePendingTrampolineMutation(PatchContext &Ctx, const Trampoline &T) {
-  if (!T.HasFunctionRange) {
+  // Only a trampoline with no resolved source function forces later liveness
+  // queries closed. A resolved in-function trampoline preserves continuation
+  // liveness (see getLiveSgprsAtContinuation), so it needs no record here.
+  if (!T.HasFunctionRange)
     Ctx.HasUnresolvedPendingTrampoline = true;
-    return;
-  }
-  Ctx.PendingTrampolineFunctions.insert({T.FunctionStart, T.FunctionEnd});
 }
 
 bool isRegisterDefinitelyDeadAtContinuation(PatchContext &Ctx,

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -1318,10 +1318,9 @@ struct PatchContext {
   uint64_t TextMutationGeneration = 0;
   llvm::DenseMap<std::pair<uint64_t, uint64_t>, CurrentFunctionSgprLiveness>
       CurrentFunctionSgprLivenessCache{0};
-  // Deferred trampoline source branches are logical mutations that do not
-  // reach Text until final fixup. Index their owning functions so current-text
-  // liveness can reject incomplete program images in O(1) per query.
-  llvm::DenseSet<std::pair<uint64_t, uint64_t>> PendingTrampolineFunctions{0};
+  // Set once a deferred trampoline with no resolved source function is queued.
+  // Such a trampoline can add a control-flow edge into any function, so all
+  // later current-text liveness queries must fail closed until finalization.
   bool HasUnresolvedPendingTrampoline = false;
 };
 

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -1366,7 +1366,8 @@ struct SafeSgprScratchBlock {
 /// nullopt after logging when no block fits below RewriteConfig::MaxSgprs.
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
-                         unsigned Alignment, llvm::StringRef Context);
+                         unsigned Alignment, llvm::StringRef Context,
+                         bool ReportNoSpace = true);
 
 /// Charge a previously selected global block to the kernel owning \p
 /// TextOffset. If the site is in an ordinary device function, conservatively

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-locally-dead-sgpr.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-locally-dead-sgpr.s
@@ -1,0 +1,79 @@
+// COM: A far trampoline needs an aligned scratch SGPR pair for its set-PC
+// COM: return. When a kernel declares the full numbered SGPR file (s0-s105),
+// COM: no aligned pair fits above the high-water mark, so the watermark search
+// COM: fails. The dead-pair fallback then scans every aligned pair from the
+// COM: top down and reuses one whose incoming value is dead at the site's
+// COM: continuation, rescuing a rewrite that would otherwise fail closed.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// COM: The reused pair is the highest aligned pair proven dead at the
+// COM: continuation; s105 is written before the patched site, leaving
+// COM: s[104:105] dead, so both far edges route through it.
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// DISASM-LABEL: <test_far>:
+// DISASM: s_get_pc_i64 s[104:105]
+// DISASM-NEXT: s_add_nc_u64 s[104:105], s[104:105],
+// DISASM-NEXT: s_set_pc_i64 s[104:105]
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_far
+.p2align 8
+.type test_far,@function
+test_far:
+  s_mov_b32 s105, 0
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_endpgm
+.size test_far, .-test_far
+
+.type gateway_barrier,@function
+gateway_barrier:
+  s_endpgm
+.size gateway_barrier, .-gateway_barrier
+.fill 32, 1, 0
+
+  // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
+  // s_branch's +-128 KB reach from the tensor_load above (forces the
+  // long-branch path).
+  .rept 40000
+    s_mov_b32 s0, s1
+  .endr
+.Ltest_far_end:
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_far
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_far
+      .symbol: test_far.kd
+      .sgpr_count: 106
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-locally-dead-sgpr.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-locally-dead-sgpr.s
@@ -4,6 +4,11 @@
 // COM: fails. The dead-pair fallback then scans every aligned pair from the
 // COM: top down and reuses one whose incoming value is dead at the site's
 // COM: continuation, rescuing a rewrite that would otherwise fail closed.
+// COM:
+// COM: The kernel has two far sites in one function. The first queues a
+// COM: deferred trampoline; the second must still prove its own continuation
+// COM: liveness while that trampoline is pending, so both reuse a locally dead
+// COM: pair instead of the second failing closed.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -13,15 +18,14 @@
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 
-// COM: The reused pair is the highest aligned pair proven dead at the
-// COM: continuation; s105 is written before the patched site, leaving
-// COM: s[104:105] dead, so both far edges route through it.
+// COM: Both far edges route through an aligned locally dead pair via an
+// COM: SGPR-backed set-PC sequence, never gfx1250's broken s_add_pc_i64.
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
 // RUN:   --implicit-check-not=s_add_pc_i64 %s
 // DISASM-LABEL: <test_far>:
-// DISASM: s_get_pc_i64 s[104:105]
-// DISASM-NEXT: s_add_nc_u64 s[104:105], s[104:105],
-// DISASM-NEXT: s_set_pc_i64 s[104:105]
+// DISASM: s_get_pc_i64 s[{{[0-9]+}}:{{[0-9]+}}]
+// DISASM-NEXT: s_add_nc_u64 s[{{[0-9]+}}:{{[0-9]+}}], s[{{[0-9]+}}:{{[0-9]+}}],
+// DISASM-NEXT: s_set_pc_i64 s[{{[0-9]+}}:{{[0-9]+}}]
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -36,28 +40,31 @@
 .type test_far,@function
 test_far:
   s_mov_b32 s105, 0
-  tensor_load_to_lds s[0:3], s[4:11]
-  s_endpgm
-.size test_far, .-test_far
-
-.type gateway_barrier,@function
-gateway_barrier:
-  s_endpgm
-.size gateway_barrier, .-gateway_barrier
-.fill 32, 1, 0
-
-  // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
-  // s_branch's +-128 KB reach from the tensor_load above (forces the
-  // long-branch path).
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], v[32:39]
+  // Interior filler keeps the second WMMA beyond s_branch reach of the first
+  // site's appended pool, so it too takes the far path while the first
+  // trampoline is still pending.
   .rept 40000
     s_mov_b32 s0, s1
   .endr
-.Ltest_far_end:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], v[32:39]
+  s_endpgm
+.size test_far, .-test_far
+
+.rept 8
+  s_nop 0
+.endr
+
+  // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
+  // s_branch's +-128 KB reach from the WMMA sites above (forces far).
+  .rept 40000
+    s_mov_b32 s0, s1
+  .endr
 
 .rodata
 .p2align 8
 .amdhsa_kernel test_far
-  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_vgpr 40
   .amdhsa_next_free_sgpr 106
 .end_amdhsa_kernel
 
@@ -69,7 +76,7 @@ gateway_barrier:
     - .name: test_far
       .symbol: test_far.kd
       .sgpr_count: 106
-      .vgpr_count: 1
+      .vgpr_count: 40
       .kernarg_segment_size: 0
       .group_segment_fixed_size: 0
       .private_segment_fixed_size: 0

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-long-branch.s
@@ -38,19 +38,12 @@
 // RUN:   | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES
 
-// COM: A kernel with no aligned two-SGPR block fails closed instead of
-// COM: emitting the unsafe return or clobbering a live register.
-// RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s105, 0/' \
-// RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 106/' \
-// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.full-sgpr.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
-// RUN:   %t.full-sgpr.s -o %t.full-sgpr.elf
-// RUN: hotswap-rewrite %t.full-sgpr.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
-// FAIL: RESULT: ERROR
+// COM: A kernel that declares the full numbered SGPR file no longer fails
+// COM: closed here: the locally-dead-pair fallback reuses an aligned pair that
+// COM: is dead at the site. That path is covered by
+// COM: hotswap-trampoline-locally-dead-sgpr.s.
 
-// COM: A metadata-less object also fails closed because scratch usage cannot
+// COM: A metadata-less object still fails closed because scratch usage cannot
 // COM: be charged to its owning kernel.
 // RUN: sed '/^.amdgpu_metadata$/,/^.end_amdgpu_metadata$/d' %s > %t.nometa.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
@@ -58,6 +51,7 @@
 // RUN: hotswap-rewrite %t.nometa.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
+// FAIL: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text


### PR DESCRIPTION
A far trampoline needs an aligned scratch SGPR pair for its set-PC return.
When a kernel declares the full numbered SGPR file (up to s105 on gfx1250) no
aligned pair fits above the high-water mark, so the watermark search fails, the
far site is declined, and the whole rewrite fails closed. On the offline
gfx1250 corpus this affects a real class of objects: 23,579 objects declare a
kernel at sgpr_count 107, and the far+full-SGPR ones (e.g. a 16.8 MB hipBLASLt
object with 45 such kernels) cannot be rewritten at all today.

The first commit adds `findLocallyDeadSgprPair` as a fallback: when the
high-water block is exhausted, scan every aligned numbered pair from the top
down and reuse one whose incoming value is provably dead at the site, neither
read by the replacement nor live across the continuation, using the current-text
liveness primitives landed in #3618 (`getReplacementIncomingSgprs`,
`getLiveSgprsAtContinuation`). The watermark search gains a `ReportNoSpace`
flag so it stays quiet when a fallback follows. This is the corrected,
current-layout re-extraction of the exhausted-SGPR search policy that used to
live in the older #3604 draft, rebuilt on #3618's partial-VCC-correct liveness
rather than that draft's own removed walker.

The fallback alone was not enough: the continuation-liveness query fails closed
whenever any deferred trampoline is pending for the queried function, so a
function with more far sites than its SGPR headroom rescued only its first site
and declined the rest. The second commit narrows that guard. An in-function
pending trampoline keeps its source's original bytes in .text until final fixup
(emitToTrampoline only queues it), and at finalization only redirects the
source through an appended pool that returns to the same continuation, so the
incoming-live set at every continuation is unchanged and the proof stays valid.
Only a trampoline with no resolved source function can add an edge into an
arbitrary function, so that case stays fail-closed; the now-unused per-function
pending set is removed.

Together this converts 42 corpus objects (21 unique kernels, duplicated across
kpack/ and objects/ paths) from fail to pass with zero regressions and zero
pass->pass output-hash changes -- the change only ever touches objects that
previously declined a far site. Peak RSS rises (~1.0 GB -> ~1.3 GB) because the
large functions now build liveness instead of failing early.

Verified with two LIT fixtures: `hotswap-trampoline-locally-dead-sgpr.s` covers
a full-SGPR kernel with two far sites in one function -- the first queues a
trampoline, the second reuses a dead pair while it is pending -- and asserts a
valid SGPR-backed set-PC with no s_add_pc_i64, idempotent; the full-SGPR
fail-closed assertion in `hotswap-trampoline-long-branch.s` is updated to match
the new behavior. Full HotSwap LIT suite 127/127; offline corpus 42 newly
passing, 0 regressions; clang-format clean.