### PR TITLE
[flang][OpenMP][NFC] Move DoConcurrent live-in/target-op helpers into shared utils

### DIFF
--- a/flang/include/flang/Utils/OpenMP.h
+++ b/flang/include/flang/Utils/OpenMP.h
@@ -10,6 +10,14 @@
 #define FORTRAN_UTILS_OPENMP_H_
 
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/IR/IRMapping.h"
+#include "llvm/ADT/DenseMap.h"
+
+#include <vector>
+
+namespace mlir {
+class ConversionPatternRewriter;
+} // namespace mlir
 
 namespace fir {
 class FirOpBuilder;
@@ -73,6 +81,46 @@ mlir::FlatSymbolRefAttr getOrGenImplicitDefaultDeclareMapper(
     fir::FirOpBuilder &firOpBuilder, mlir::Location loc,
     fir::RecordType recordType, llvm::StringRef mapperNameStr,
     RecordMemberMapperMangler mangler = {});
+
+/// Shape information for a value that is live-in to a loop nest which will be
+/// mapped to a target region. It is recovered from the live-in's defining
+/// `hlfir.declare` (if any) so that a matching declare can be regenerated
+/// inside the target region.
+struct TargetDeclareShapeCreationInfo {
+  // Note: We use `std::vector` (rather than `llvm::SmallVector` as usual) to
+  // interface more easily `ShapeShiftOp::getOrigins()` which returns
+  // `std::vector`.
+  std::vector<mlir::Value> startIndices;
+  std::vector<mlir::Value> extents;
+
+  TargetDeclareShapeCreationInfo(mlir::Value liveIn);
+
+  bool isShapedValue() const { return !extents.empty(); }
+  bool isShapeShiftedValue() const { return !startIndices.empty(); }
+};
+
+using LiveInShapeInfoMap =
+    llvm::DenseMap<mlir::Value, TargetDeclareShapeCreationInfo>;
+
+/// Build an `omp.map.info` op that maps a value defined outside a target
+/// region (a "live-in") into the region. Handles trivial scalars, character
+/// types, arrays, and Fortran derived types (using an implicit declare mapper
+/// for records with allocatable components).
+mlir::omp::MapInfoOp genMapInfoOpForLiveIn(fir::FirOpBuilder &builder,
+    mlir::Value liveIn, bool isReductionVar = false);
+
+/// Create an `omp.target` op whose region maps the given `mappedVars` (matched
+/// 1:1 with `clauseOps.mapVars`) by regenerating a device-side `hlfir.declare`
+/// for each, populating `mapper` so uses of the live-ins inside the region see
+/// the device-side declares, and cloning/mapping any remaining outsiders.
+///
+/// `loopNestClauseOps`'s loop bounds/steps are also remapped through `mapper`.
+mlir::omp::TargetOp genTargetOp(mlir::Location loc,
+    mlir::ConversionPatternRewriter &rewriter, mlir::IRMapping &mapper,
+    llvm::ArrayRef<mlir::Value> mappedVars,
+    mlir::omp::TargetExtOperands &clauseOps,
+    mlir::omp::LoopNestOperands &loopNestClauseOps,
+    const LiveInShapeInfoMap &liveInShapeInfoMap);
 } // namespace Fortran::utils::openmp
 
 #endif // FORTRAN_UTILS_OPENMP_H_

--- a/flang/lib/Optimizer/OpenMP/DoConcurrentConversion.cpp
+++ b/flang/lib/Optimizer/OpenMP/DoConcurrentConversion.cpp
@@ -207,52 +207,6 @@ static void localizeLoopLocalValue(mlir::Value local, mlir::Region &allocRegion,
 
 class DoConcurrentConversion
     : public mlir::OpConversionPattern<fir::DoConcurrentOp> {
-private:
-  struct TargetDeclareShapeCreationInfo {
-    // Note: We use `std::vector` (rather than `llvm::SmallVector` as usual) to
-    // interface more easily `ShapeShiftOp::getOrigins()` which returns
-    // `std::vector`.
-    std::vector<mlir::Value> startIndices;
-    std::vector<mlir::Value> extents;
-
-    TargetDeclareShapeCreationInfo(mlir::Value liveIn) {
-      mlir::Value shape = nullptr;
-      mlir::Operation *liveInDefiningOp = liveIn.getDefiningOp();
-      auto declareOp =
-          mlir::dyn_cast_if_present<hlfir::DeclareOp>(liveInDefiningOp);
-
-      if (declareOp != nullptr)
-        shape = declareOp.getShape();
-
-      if (!shape)
-        return;
-
-      auto shapeOp =
-          mlir::dyn_cast_if_present<fir::ShapeOp>(shape.getDefiningOp());
-      auto shapeShiftOp =
-          mlir::dyn_cast_if_present<fir::ShapeShiftOp>(shape.getDefiningOp());
-
-      if (!shapeOp && !shapeShiftOp)
-        TODO(liveIn.getLoc(),
-             "Shapes not defined by `fir.shape` or `fir.shape_shift` op's are"
-             "not supported yet.");
-
-      if (shapeShiftOp != nullptr)
-        startIndices = shapeShiftOp.getOrigins();
-
-      extents = shapeOp != nullptr
-                    ? std::vector<mlir::Value>(shapeOp.getExtents().begin(),
-                                               shapeOp.getExtents().end())
-                    : shapeShiftOp.getExtents();
-    }
-
-    bool isShapedValue() const { return !extents.empty(); }
-    bool isShapeShiftedValue() const { return !startIndices.empty(); }
-  };
-
-  using LiveInShapeInfoMap =
-      llvm::DenseMap<mlir::Value, TargetDeclareShapeCreationInfo>;
-
 public:
   using mlir::OpConversionPattern<fir::DoConcurrentOp>::OpConversionPattern;
 
@@ -307,7 +261,7 @@ public:
       genLoopNestClauseOps(doLoop.getLoc(), rewriter, loop, loopNestClauseOps,
                            isTargetDevice ? nullptr : &targetClauseOps);
 
-      LiveInShapeInfoMap liveInShapeInfoMap;
+      Fortran::utils::openmp::LiveInShapeInfoMap liveInShapeInfoMap;
       fir::FirOpBuilder builder(
           rewriter,
           fir::getKindMapping(doLoop->getParentOfType<mlir::ModuleOp>()));
@@ -316,16 +270,18 @@ public:
         bool isReductionVar = llvm::find(loop.getReduceVars(), liveIn) !=
                               loop.getReduceVars().end();
         targetClauseOps.mapVars.push_back(
-            genMapInfoOpForLiveIn(builder, liveIn, isReductionVar));
+            Fortran::utils::openmp::genMapInfoOpForLiveIn(builder, liveIn,
+                                                          isReductionVar));
         liveInShapeInfoMap.insert(
-            {liveIn, TargetDeclareShapeCreationInfo(liveIn)});
+            {liveIn,
+             Fortran::utils::openmp::TargetDeclareShapeCreationInfo(liveIn)});
       }
 
       targetClauseOps.kernelType = mlir::omp::TargetExecModeAttr::get(
           rewriter.getContext(), mlir::omp::TargetExecMode::spmd);
-      targetOp =
-          genTargetOp(doLoop.getLoc(), rewriter, mapper, loopNestLiveIns,
-                      targetClauseOps, loopNestClauseOps, liveInShapeInfoMap);
+      targetOp = Fortran::utils::openmp::genTargetOp(
+          doLoop.getLoc(), rewriter, mapper, loopNestLiveIns, targetClauseOps,
+          loopNestClauseOps, liveInShapeInfoMap);
       auto teamsOp = genTeamsOp(rewriter, loop, mapper);
       targetOp.setCombined(true);
       teamsOp.setCombined(true);
@@ -641,7 +597,8 @@ private:
               mlir::IRMapping &mapper, llvm::ArrayRef<mlir::Value> mappedVars,
               mlir::omp::TargetExtOperands &clauseOps,
               mlir::omp::LoopNestOperands &loopNestClauseOps,
-              const LiveInShapeInfoMap &liveInShapeInfoMap) const {
+              const Fortran::utils::openmp::LiveInShapeInfoMap
+                  &liveInShapeInfoMap) const {
     auto targetOp = mlir::omp::TargetOp::create(rewriter, loc, clauseOps);
     auto argIface = llvm::cast<mlir::omp::BlockArgOpenMPOpInterface>(*targetOp);
 
@@ -724,10 +681,11 @@ private:
     return targetOp;
   }
 
-  hlfir::DeclareOp genLiveInDeclare(
-      fir::FirOpBuilder &builder, mlir::omp::TargetOp targetOp,
-      mlir::Value liveInArg, mlir::omp::MapInfoOp liveInMapInfoOp,
-      const TargetDeclareShapeCreationInfo &targetShapeCreationInfo) const {
+  hlfir::DeclareOp
+  genLiveInDeclare(fir::FirOpBuilder &builder, mlir::omp::TargetOp targetOp,
+                   mlir::Value liveInArg, mlir::omp::MapInfoOp liveInMapInfoOp,
+                   const Fortran::utils::openmp::TargetDeclareShapeCreationInfo
+                       &targetShapeCreationInfo) const {
     mlir::Type liveInType = liveInArg.getType();
     std::string liveInName = liveInMapInfoOp.getName().has_value()
                                  ? liveInMapInfoOp.getName().value().str()

--- a/flang/lib/Utils/CMakeLists.txt
+++ b/flang/lib/Utils/CMakeLists.txt
@@ -11,11 +11,13 @@ add_flang_library(FortranUtils
 
   DEPENDS
   FIRDialect
+  FIRDialectSupport
   FIRBuilder
   HLFIRDialect
 
   LINK_LIBS
   FIRDialect
+  FIRDialectSupport
   FIRBuilder
   FIRSupport
   FortranEvaluate

--- a/flang/lib/Utils/OpenMP.cpp
+++ b/flang/lib/Utils/OpenMP.cpp
@@ -11,11 +11,13 @@
 #include "flang/Lower/ConvertExprToHLFIR.h"
 #include "flang/Optimizer/Builder/DirectivesCommon.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Builder/Todo.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/Support/InternalNames.h"
 
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/RegionUtils.h"
 
 namespace Fortran::utils::openmp {
@@ -367,5 +369,278 @@ mlir::FlatSymbolRefAttr getOrGenImplicitDefaultDeclareMapper(
   clauseOps.mapVars.emplace_back(mapOp);
   mlir::omp::DeclareMapperInfoOp::create(firOpBuilder, loc, clauseOps);
   return mlir::FlatSymbolRefAttr::get(firOpBuilder.getContext(), mapperNameStr);
+}
+
+TargetDeclareShapeCreationInfo::TargetDeclareShapeCreationInfo(
+    mlir::Value liveIn) {
+  mlir::Value shape = nullptr;
+  mlir::Operation *liveInDefiningOp = liveIn.getDefiningOp();
+  auto declareOp =
+      mlir::dyn_cast_if_present<hlfir::DeclareOp>(liveInDefiningOp);
+
+  if (declareOp != nullptr)
+    shape = declareOp.getShape();
+
+  if (!shape)
+    return;
+
+  auto shapeOp = mlir::dyn_cast_if_present<fir::ShapeOp>(shape.getDefiningOp());
+  auto shapeShiftOp =
+      mlir::dyn_cast_if_present<fir::ShapeShiftOp>(shape.getDefiningOp());
+
+  if (!shapeOp && !shapeShiftOp)
+    TODO(liveIn.getLoc(),
+        "Shapes not defined by `fir.shape` or `fir.shape_shift` op's are"
+        "not supported yet.");
+
+  if (shapeShiftOp != nullptr)
+    startIndices = shapeShiftOp.getOrigins();
+
+  extents = shapeOp != nullptr
+      ? std::vector<mlir::Value>(
+            shapeOp.getExtents().begin(), shapeOp.getExtents().end())
+      : shapeShiftOp.getExtents();
+}
+
+namespace {
+void genBoundsOps(fir::FirOpBuilder &builder, mlir::Value liveIn,
+    mlir::Value rawAddr, llvm::SmallVectorImpl<mlir::Value> &boundsOps) {
+  fir::ExtendedValue extVal = hlfir::translateToExtendedValue(rawAddr.getLoc(),
+      builder, hlfir::Entity{liveIn},
+      /*contiguousHint=*/
+      true)
+                                  .first;
+  fir::factory::AddrAndBoundsInfo info = fir::factory::getDataOperandBaseAddr(
+      builder, rawAddr, /*isOptional=*/false, rawAddr.getLoc());
+  boundsOps = fir::factory::genImplicitBoundsOps<mlir::omp::MapBoundsOp,
+      mlir::omp::MapBoundsType>(builder, info, extVal,
+      /*dataExvIsAssumedSize=*/false, rawAddr.getLoc());
+}
+
+hlfir::DeclareOp genLiveInDeclare(fir::FirOpBuilder &builder,
+    mlir::omp::TargetOp targetOp, mlir::Value liveInArg,
+    mlir::omp::MapInfoOp liveInMapInfoOp,
+    const TargetDeclareShapeCreationInfo &targetShapeCreationInfo) {
+  mlir::Type liveInType = liveInArg.getType();
+  std::string liveInName = liveInMapInfoOp.getName().has_value()
+      ? liveInMapInfoOp.getName().value().str()
+      : std::string("");
+  if (fir::isa_ref_type(liveInType))
+    liveInType = fir::unwrapRefType(liveInType);
+
+  mlir::Value shape = [&]() -> mlir::Value {
+    if (!targetShapeCreationInfo.isShapedValue())
+      return {};
+
+    if (targetShapeCreationInfo.isShapeShiftedValue()) {
+      llvm::SmallVector<mlir::Value> shapeShiftOperands;
+
+      size_t shapeIdx = 0;
+      for (auto [startIndex, extent] :
+          llvm::zip_equal(targetShapeCreationInfo.startIndices,
+              targetShapeCreationInfo.extents)) {
+        shapeShiftOperands.push_back(Fortran::utils::openmp::mapTemporaryValue(
+            builder, targetOp, startIndex,
+            liveInName + ".start_idx.dim" + std::to_string(shapeIdx)));
+        shapeShiftOperands.push_back(
+            Fortran::utils::openmp::mapTemporaryValue(builder, targetOp, extent,
+                liveInName + ".extent.dim" + std::to_string(shapeIdx)));
+        ++shapeIdx;
+      }
+
+      auto shapeShiftType = fir::ShapeShiftType::get(
+          builder.getContext(), shapeShiftOperands.size() / 2);
+      return fir::ShapeShiftOp::create(
+          builder, liveInArg.getLoc(), shapeShiftType, shapeShiftOperands);
+    }
+
+    llvm::SmallVector<mlir::Value> shapeOperands;
+    size_t shapeIdx = 0;
+    for (auto extent : targetShapeCreationInfo.extents) {
+      shapeOperands.push_back(
+          Fortran::utils::openmp::mapTemporaryValue(builder, targetOp, extent,
+              liveInName + ".extent.dim" + std::to_string(shapeIdx)));
+      ++shapeIdx;
+    }
+
+    return fir::ShapeOp::create(builder, liveInArg.getLoc(), shapeOperands);
+  }();
+
+  return hlfir::DeclareOp::create(
+      builder, liveInArg.getLoc(), liveInArg, liveInName, shape);
+}
+} // namespace
+
+mlir::omp::MapInfoOp genMapInfoOpForLiveIn(
+    fir::FirOpBuilder &builder, mlir::Value liveIn, bool isReductionVar) {
+  mlir::Value rawAddr = liveIn;
+  llvm::StringRef name;
+
+  mlir::Operation *liveInDefiningOp = liveIn.getDefiningOp();
+  auto declareOp =
+      mlir::dyn_cast_if_present<hlfir::DeclareOp>(liveInDefiningOp);
+
+  if (declareOp != nullptr) {
+    // Use the raw address to avoid unboxing `fir.box` values whenever
+    // possible. Put differently, if we have access to the direct value memory
+    // reference/address, we use it.
+    rawAddr = declareOp.getOriginalBase();
+    name = declareOp.getUniqName();
+  }
+
+  if (!llvm::isa<mlir::omp::PointerLikeType>(rawAddr.getType())) {
+    mlir::OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointAfter(liveInDefiningOp);
+    auto copyVal = builder.createTemporary(liveIn.getLoc(), liveIn.getType());
+    builder.createStoreWithConvert(copyVal.getLoc(), liveIn, copyVal);
+    rawAddr = copyVal;
+  }
+
+  mlir::Type liveInType = liveIn.getType();
+  mlir::Type eleType = liveInType;
+  if (auto refType = mlir::dyn_cast<fir::ReferenceType>(liveInType))
+    eleType = refType.getElementType();
+
+  mlir::omp::ClauseMapFlags mapFlag = mlir::omp::ClauseMapFlags::implicit;
+  mlir::omp::VariableCaptureKind captureKind =
+      mlir::omp::VariableCaptureKind::ByRef;
+
+  if (isReductionVar) {
+    mapFlag |= mlir::omp::ClauseMapFlags::to;
+    mapFlag |= mlir::omp::ClauseMapFlags::from;
+  } else if (fir::isa_trivial(eleType) || fir::isa_char(eleType)) {
+    captureKind = mlir::omp::VariableCaptureKind::ByCopy;
+  } else if (!fir::isa_builtin_cptr_type(eleType)) {
+    mapFlag |= mlir::omp::ClauseMapFlags::to;
+    mapFlag |= mlir::omp::ClauseMapFlags::from;
+  }
+
+  llvm::SmallVector<mlir::Value> boundsOps;
+  genBoundsOps(builder, liveIn, rawAddr, boundsOps);
+
+  auto asRecordType = [&](mlir::Type eleType) {
+    return mlir::dyn_cast<fir::RecordType>(
+        fir::getDerivedType(fir::unwrapRefType(eleType)));
+  };
+
+  fir::RecordType recordType = asRecordType(eleType);
+
+  bool requiresImplcitMapper = [&]() {
+    if (!recordType)
+      return false;
+
+    for (auto [fieldName, fieldType] : recordType.getTypeList()) {
+      if (fir::isAllocatableType(fieldType))
+        return true;
+
+      if (asRecordType(fieldType))
+        TODO(liveIn.getLoc(), "Nested record types are not supported yet.");
+    }
+
+    return false;
+  }();
+
+  mlir::FlatSymbolRefAttr mapperId;
+  if (requiresImplcitMapper) {
+    std::string mapperIdName =
+        recordType.getName().str() + llvm::omp::OmpDefaultMapperName;
+    // TODO Add a mangler callback once nested record types are supported.
+    mapperId = Fortran::utils::openmp::getOrGenImplicitDefaultDeclareMapper(
+        builder, liveIn.getLoc(), recordType, mapperIdName);
+  }
+
+  return Fortran::utils::openmp::createMapInfoOp(builder, liveIn.getLoc(),
+      rawAddr,
+      /*varPtrPtr=*/{}, name.str(), boundsOps,
+      /*members=*/{},
+      /*membersIndex=*/mlir::ArrayAttr{}, mapFlag, captureKind,
+      rawAddr.getType(), /*partialMap=*/false, mapperId);
+}
+
+mlir::omp::TargetOp genTargetOp(mlir::Location loc,
+    mlir::ConversionPatternRewriter &rewriter, mlir::IRMapping &mapper,
+    llvm::ArrayRef<mlir::Value> mappedVars,
+    mlir::omp::TargetExtOperands &clauseOps,
+    mlir::omp::LoopNestOperands &loopNestClauseOps,
+    const LiveInShapeInfoMap &liveInShapeInfoMap) {
+  auto targetOp = mlir::omp::TargetOp::create(rewriter, loc, clauseOps);
+  auto argIface = llvm::cast<mlir::omp::BlockArgOpenMPOpInterface>(*targetOp);
+
+  mlir::Region &region = targetOp.getRegion();
+
+  llvm::SmallVector<mlir::Type> regionArgTypes;
+  llvm::SmallVector<mlir::Location> regionArgLocs;
+
+  for (auto var : llvm::concat<const mlir::Value>(
+           clauseOps.hostEvalVars, clauseOps.mapVars)) {
+    regionArgTypes.push_back(var.getType());
+    regionArgLocs.push_back(var.getLoc());
+  }
+
+  rewriter.createBlock(&region, {}, regionArgTypes, regionArgLocs);
+  fir::FirOpBuilder builder(rewriter,
+      fir::getKindMapping(targetOp->getParentOfType<mlir::ModuleOp>()));
+
+  // Within the loop, it is possible that we discover other values that need
+  // to be mapped to the target region (the shape info values for arrays, for
+  // example). Therefore, the map block args might be extended and resized.
+  // Hence, we invoke `argIface.getMapBlockArgs()` every iteration to make
+  // sure we access the proper vector of data.
+  int idx = 0;
+  for (auto [mapInfoOp, mappedVar] :
+      llvm::zip_equal(clauseOps.mapVars, mappedVars)) {
+    auto miOp = mlir::cast<mlir::omp::MapInfoOp>(mapInfoOp.getDefiningOp());
+    hlfir::DeclareOp liveInDeclare =
+        genLiveInDeclare(builder, targetOp, argIface.getMapBlockArgs()[idx],
+            miOp, liveInShapeInfoMap.at(mappedVar));
+    ++idx;
+
+    // If `mappedVar.getDefiningOp()` is a `fir::BoxAddrOp`, we probably
+    // need to "unpack" the box by getting the defining op of it's value.
+    // However, we did not hit this case in reality yet so leaving it as a
+    // todo for now.
+    if (mlir::isa<fir::BoxAddrOp>(mappedVar.getDefiningOp()))
+      TODO(mappedVar.getLoc(),
+          "Mapped variabled defined by `BoxAddrOp` are not supported yet");
+
+    auto mapHostValueToDevice = [&](mlir::Value hostValue,
+                                    mlir::Value deviceValue) {
+      if (!llvm::isa<mlir::omp::PointerLikeType>(hostValue.getType()))
+        mapper.map(
+            hostValue, builder.loadIfRef(hostValue.getLoc(), deviceValue));
+      else
+        mapper.map(hostValue, deviceValue);
+    };
+
+    mapHostValueToDevice(mappedVar, liveInDeclare.getOriginalBase());
+
+    if (auto origDeclareOp = mlir::dyn_cast_if_present<hlfir::DeclareOp>(
+            mappedVar.getDefiningOp()))
+      mapHostValueToDevice(origDeclareOp.getBase(), liveInDeclare.getBase());
+  }
+
+  for (auto [arg, hostEval] :
+      llvm::zip_equal(argIface.getHostEvalBlockArgs(), clauseOps.hostEvalVars))
+    mapper.map(hostEval, arg);
+
+  for (unsigned i = 0; i < loopNestClauseOps.loopLowerBounds.size(); ++i) {
+    loopNestClauseOps.loopLowerBounds[i] =
+        mapper.lookup(loopNestClauseOps.loopLowerBounds[i]);
+    loopNestClauseOps.loopUpperBounds[i] =
+        mapper.lookup(loopNestClauseOps.loopUpperBounds[i]);
+    loopNestClauseOps.loopSteps[i] =
+        mapper.lookup(loopNestClauseOps.loopSteps[i]);
+  }
+
+  // Check if cloning the bounds introduced any dependency on the outer
+  // region. If so, then either clone them as well if they are
+  // MemoryEffectFree, or else copy them to a new temporary and add them to
+  // the map and block_argument lists and replace their uses with the new
+  // temporary.
+  Fortran::utils::openmp::cloneOrMapRegionOutsiders(builder, targetOp);
+  rewriter.setInsertionPoint(
+      mlir::omp::TerminatorOp::create(rewriter, targetOp.getLoc()));
+
+  return targetOp;
 }
 } // namespace Fortran::utils::openmp


### PR DESCRIPTION
This relocates the OpenMP "live-in target-region" helpers out of the `DoConcurrentConversion` pass and into the
shared `Fortran::utils::openmp` utilities (`flang/lib/Utils/OpenMP.{h,cpp}`), so they can be reused by other passes.