### PR TITLE
[comgr][hotswap] Cache monotone scratch SGPR metadata

### DIFF
--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -733,6 +733,61 @@ summarizeSafeSgprUsage(PatchContext &Ctx,
   return Summary;
 }
 
+static std::string findKernelOwnerAtTextOffset(PatchContext &Ctx,
+                                               uint64_t TextOffset) {
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(TextOffset);
+  if (!FunctionRange)
+    return Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+
+  std::pair<uint64_t, uint64_t> Key{FunctionRange->Begin, FunctionRange->End};
+  DenseMap<std::pair<uint64_t, uint64_t>, std::string>::iterator Cached =
+      Ctx.FunctionKernelOwner.find(Key);
+  if (Cached != Ctx.FunctionKernelOwner.end())
+    return Cached->second;
+
+  ++Ctx.FunctionKernelOwnerLookups;
+  std::string Owner =
+      Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+  Ctx.FunctionKernelOwner.try_emplace(Key, Owner);
+  return Owner;
+}
+
+static std::optional<unsigned>
+getAllKernelDeclaredSgprHighWatermark(PatchContext &Ctx, StringRef Context) {
+  switch (Ctx.AllKernelDeclaredSgprCacheState) {
+  case AllKernelDeclaredSgprState::Valid:
+    return Ctx.AllKernelDeclaredSgprHighWatermark;
+  case AllKernelDeclaredSgprState::Failed:
+    log() << "hotswap: error: " << Context
+          << ": cached all-kernel declared SGPR analysis failed\n";
+    return std::nullopt;
+  case AllKernelDeclaredSgprState::Uncomputed:
+    break;
+  }
+
+  ++Ctx.AllKernelDeclaredSgprAnalyses;
+  // Failure is terminal. Keep the candidate local so a malformed later
+  // descriptor cannot publish a partial high-watermark.
+  Ctx.AllKernelDeclaredSgprCacheState = AllKernelDeclaredSgprState::Failed;
+  unsigned HighWatermark = 0;
+  for (const KernelDescriptorInfo &KD : Ctx.Elf.kernelDescriptors()) {
+    std::optional<unsigned> Declared =
+        Ctx.Elf.getKernelSgprCount(KD.KernelName);
+    if (!Declared) {
+      log() << "hotswap: error: " << Context
+            << ": failed to read SGPR count for kernel " << KD.KernelName
+            << "\n";
+      return std::nullopt;
+    }
+    HighWatermark = std::max(HighWatermark, *Declared);
+  }
+
+  Ctx.AllKernelDeclaredSgprHighWatermark = HighWatermark;
+  Ctx.AllKernelDeclaredSgprCacheState = AllKernelDeclaredSgprState::Valid;
+  return HighWatermark;
+}
+
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
                          unsigned Alignment, StringRef Context,
@@ -746,8 +801,7 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
 
   std::optional<ElfView::FunctionTextRange> FunctionRange =
       Ctx.Elf.findFunctionTextRangeAtOffset(TextOffset);
-  std::string Owner =
-      Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+  std::string Owner = findKernelOwnerAtTextOffset(Ctx, TextOffset);
   bool ScanWholeObject = Owner.empty() || !FunctionRange;
   SafeSgprUsageSummary *Usage = nullptr;
   if (!ScanWholeObject) {
@@ -756,6 +810,7 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
     DenseMap<FunctionKey, SafeSgprUsageSummary>::iterator Cached =
         Ctx.FunctionSgprUsage.find(Key);
     if (Cached == Ctx.FunctionSgprUsage.end()) {
+      ++Ctx.FunctionSgprUsageAnalyses;
       std::vector<InternalDecodedInst>::const_iterator Begin = std::lower_bound(
           Ctx.Decoded.cbegin(), Ctx.Decoded.cend(), FunctionRange->Begin,
           [](const InternalDecodedInst &DI, uint64_t Offset) {
@@ -813,17 +868,11 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
     // A device function can be reached from kernels with different declared
     // register footprints. Without a complete call graph, keep the block above
     // every declaration and charge every kernel in the commit step.
-    for (const KernelDescriptorInfo &KD : Ctx.Elf.kernelDescriptors()) {
-      std::optional<unsigned> Declared =
-          Ctx.Elf.getKernelSgprCount(KD.KernelName);
-      if (!Declared) {
-        log() << "hotswap: error: " << Context
-              << ": failed to read SGPR count for kernel " << KD.KernelName
-              << "\n";
-        return std::nullopt;
-      }
-      HighWatermark = std::max(HighWatermark, *Declared);
-    }
+    std::optional<unsigned> DeclaredHighWatermark =
+        getAllKernelDeclaredSgprHighWatermark(Ctx, Context);
+    if (!DeclaredHighWatermark)
+      return std::nullopt;
+    HighWatermark = std::max(HighWatermark, *DeclaredHighWatermark);
   }
 
   if (HighWatermark > std::numeric_limits<unsigned>::max() - (Alignment - 1)) {
@@ -853,8 +902,7 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
     return false;
   }
 
-  std::string Owner =
-      Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+  std::string Owner = findKernelOwnerAtTextOffset(Ctx, TextOffset);
   bool ChargedOwner = false;
 
   // llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp::getNumExtraSGPRs returns
@@ -862,7 +910,28 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
   // requirement. This may conservatively overstate a kernel that does not use
   // VCC, but never mistakes VCC for numbered s0-s105 registers.
   constexpr unsigned VccSgprs = 2;
+  if (Block.Count > std::numeric_limits<unsigned>::max() - Block.Base ||
+      VccSgprs >
+          std::numeric_limits<unsigned>::max() - (Block.Base + Block.Count)) {
+    log() << "hotswap: error: " << Context
+          << ": SGPR descriptor requirement overflows unsigned\n";
+    return false;
+  }
   unsigned RequiredSgprs = Block.Base + Block.Count + VccSgprs;
+  unsigned CoveredRequirement = Ctx.AllKernelSgprRequirement;
+  if (!Owner.empty()) {
+    StringMap<unsigned>::iterator Committed =
+        Ctx.KernelSgprRequirements.find(Owner);
+    if (Committed != Ctx.KernelSgprRequirements.end())
+      CoveredRequirement = std::max(CoveredRequirement, Committed->second);
+  }
+  if (CoveredRequirement >= RequiredSgprs)
+    return true;
+
+  // Preflight every selected descriptor before mutating KernelStats. This
+  // keeps a malformed later descriptor from leaving a partial commitment that
+  // the monotone cache cannot describe.
+  SmallVector<std::pair<StringRef, unsigned>, 8> Updates;
   for (const KernelDescriptorInfo &KD : Descriptors) {
     if (!Owner.empty() && KD.KernelName != Owner)
       continue;
@@ -877,8 +946,13 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
     }
     if (*Current >= RequiredSgprs)
       continue;
-    KernelPatchStats &Stats = Ctx.KernelStats[KD.KernelName];
-    Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, RequiredSgprs - *Current);
+    unsigned Existing = 0;
+    StringMap<KernelPatchStats>::iterator Stats =
+        Ctx.KernelStats.find(KD.KernelName);
+    if (Stats != Ctx.KernelStats.end())
+      Existing = Stats->second.ExtraSgprs;
+    Updates.push_back(
+        {KD.KernelName, std::max(Existing, RequiredSgprs - *Current)});
   }
 
   if (!ChargedOwner) {
@@ -886,6 +960,15 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
           << "' has no descriptor\n";
     return false;
   }
+
+  for (const std::pair<StringRef, unsigned> &Update : Updates)
+    Ctx.KernelStats[Update.first].ExtraSgprs =
+        std::max(Ctx.KernelStats[Update.first].ExtraSgprs, Update.second);
+  ++Ctx.SgprDescriptorChargePasses;
+  if (Owner.empty())
+    Ctx.AllKernelSgprRequirement = RequiredSgprs;
+  else
+    Ctx.KernelSgprRequirements[Owner] = RequiredSgprs;
   return true;
 }
 

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -1285,6 +1285,12 @@ struct SafeSgprUsageSummary {
   unsigned HighWatermark = 0;
 };
 
+enum class AllKernelDeclaredSgprState {
+  Uncomputed,
+  Valid,
+  Failed,
+};
+
 /// Current-text, per-function SGPR liveness cached for one mutation
 /// generation. Bits [0, MaxSgprs) name numbered SGPRs; bit MaxSgprs names VCC.
 struct CurrentFunctionSgprLiveness {
@@ -1372,6 +1378,30 @@ struct PatchContext {
   std::optional<SafeSgprUsageSummary> WholeObjectSgprUsage;
   llvm::DenseMap<std::pair<uint64_t, uint64_t>, SafeSgprUsageSummary>
       FunctionSgprUsage{0};
+  // Counts cold production analyses, so tests and profiling can distinguish
+  // repeated cache hits from recomputation.
+  uint64_t FunctionSgprUsageAnalyses = 0;
+  // Kernel ownership and scratch-SGPR descriptor charging are immutable or
+  // monotone during one rewrite. Cache both so a promoted relay in a large
+  // non-kernel function does not repeat the same symbol lookup and full
+  // kernel-descriptor scan for every source instruction.
+  llvm::DenseMap<std::pair<uint64_t, uint64_t>, std::string>
+      FunctionKernelOwner{0};
+  // Counts cold function-to-kernel symbol lookups. Cache hits do not advance
+  // this counter.
+  uint64_t FunctionKernelOwnerLookups = 0;
+  // Ownerless device-function queries must stay above every kernel's declared
+  // SGPR count. Publish the high-watermark only after every descriptor has
+  // been validated; a malformed declaration is a sticky terminal failure.
+  AllKernelDeclaredSgprState AllKernelDeclaredSgprCacheState =
+      AllKernelDeclaredSgprState::Uncomputed;
+  unsigned AllKernelDeclaredSgprHighWatermark = 0;
+  // Counts cold all-descriptor analyses, including the one scan that records
+  // a terminal failure. Cache hits do not advance this counter.
+  uint64_t AllKernelDeclaredSgprAnalyses = 0;
+  unsigned AllKernelSgprRequirement = 0;
+  llvm::StringMap<unsigned> KernelSgprRequirements;
+  uint64_t SgprDescriptorChargePasses = 0;
   // Occupancy checks may run at several patch sites in one kernel. Cache the
   // immutable metadata so the AMDGPU note is parsed at most once per field.
   llvm::StringMap<std::optional<KernelWorkgroupMetadata>>

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -2983,6 +2983,351 @@ TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {
       commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Block, "unit test"));
 }
 
+TEST(SafeSgprScratchBlock,
+     ProductionCachesHitIsolateFunctionKeysAndMatchFreshQueries) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> First =
+      assembleInstructions("s_mov_b32 s10, s0\ns_endpgm", S);
+  llvm::SmallVector<uint8_t> Second =
+      assembleInstructions("s_mov_b32 s20, s0\ns_endpgm", S);
+  ASSERT_FALSE(First.empty());
+  ASSERT_FALSE(Second.empty());
+
+  constexpr uint64_t FunctionSize = 0x40;
+  std::vector<uint8_t> Text(2 * FunctionSize);
+  for (size_t Offset = 0; Offset != Text.size(); Offset += MinInstSize)
+    std::copy(S.SNopBytes.begin(), S.SNopBytes.end(), Text.begin() + Offset);
+  std::copy(First.begin(), First.end(), Text.begin());
+  std::copy(Second.begin(), Second.end(), Text.begin() + FunctionSize);
+
+  comgr_test::MultiKernelDescriptorElfOptions Options;
+  Options.TextSize = Text.size();
+  Options.Text = Text;
+  Options.Kernels.push_back({/*Name=*/"kernel0",
+                             /*EntryVAddr=*/Options.TextAddr,
+                             /*KdVAddr=*/Options.RodataAddr, /*EntryOffset=*/0,
+                             /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true,
+                             /*MetadataSgprCount=*/4});
+  Options.Kernels.push_back(
+      {/*Name=*/"kernel1", /*EntryVAddr=*/Options.TextAddr + FunctionSize,
+       /*KdVAddr=*/Options.RodataAddr + 0x40, /*EntryOffset=*/0,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true,
+       /*MetadataSgprCount=*/4});
+  std::vector<uint8_t> Object =
+      comgr_test::makeMultiKernelDescriptorElf(Options);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Object.data(), Object.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(View.textData(), View.textSize(), S, Decoded));
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+
+  std::optional<SafeSgprScratchBlock> FirstCold =
+      findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/2,
+                               /*Alignment=*/2, "unit test");
+  std::optional<SafeSgprScratchBlock> FirstHit =
+      findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/2,
+                               /*Alignment=*/2, "unit test");
+  std::optional<SafeSgprScratchBlock> SecondCold =
+      findSafeSgprScratchBlock(Ctx, /*TextOffset=*/FunctionSize, /*Count=*/2,
+                               /*Alignment=*/2, "unit test");
+  std::optional<SafeSgprScratchBlock> SecondHit =
+      findSafeSgprScratchBlock(Ctx, /*TextOffset=*/FunctionSize, /*Count=*/2,
+                               /*Alignment=*/2, "unit test");
+  ASSERT_TRUE(FirstCold);
+  ASSERT_TRUE(FirstHit);
+  ASSERT_TRUE(SecondCold);
+  ASSERT_TRUE(SecondHit);
+  EXPECT_EQ(FirstCold->Base, 12u);
+  EXPECT_EQ(SecondCold->Base, 22u);
+  EXPECT_EQ(FirstHit->Base, FirstCold->Base);
+  EXPECT_EQ(SecondHit->Base, SecondCold->Base);
+  EXPECT_EQ(Ctx.FunctionKernelOwnerLookups, 2u);
+  EXPECT_EQ(Ctx.FunctionSgprUsageAnalyses, 2u);
+  EXPECT_EQ(Ctx.FunctionKernelOwner.size(), 2u);
+  EXPECT_EQ(Ctx.FunctionSgprUsage.size(), 2u);
+
+  // Fresh contexts bypass both caches. Their production results are the
+  // uncached oracle for the two cached outputs above.
+  std::vector<Trampoline> FreshTrampolines;
+  std::vector<NopSled> FreshSleds;
+  LivenessInfo FreshLiveness;
+  llvm::StringMap<KernelPatchStats> FreshKernelStats;
+  std::vector<ScratchPatchInfo> FreshScratchPatches;
+  DirectControlFlowInfo FreshControlFlow;
+  HotswapProfile FreshProf(/*Enabled=*/false);
+  PatchContext FreshCtx{Config,
+                        Decoded,
+                        View.textData(),
+                        View.textSize(),
+                        /*PoolBaseOffset=*/0,
+                        S,
+                        FreshTrampolines,
+                        FreshSleds,
+                        View,
+                        FreshLiveness,
+                        FreshKernelStats,
+                        FreshScratchPatches,
+                        FreshControlFlow,
+                        FreshProf};
+  std::optional<SafeSgprScratchBlock> FirstFresh =
+      findSafeSgprScratchBlock(FreshCtx, /*TextOffset=*/0, /*Count=*/2,
+                               /*Alignment=*/2, "unit test");
+  std::optional<SafeSgprScratchBlock> SecondFresh =
+      findSafeSgprScratchBlock(FreshCtx, /*TextOffset=*/FunctionSize,
+                               /*Count=*/2, /*Alignment=*/2, "unit test");
+  ASSERT_TRUE(FirstFresh);
+  ASSERT_TRUE(SecondFresh);
+  EXPECT_EQ(FirstFresh->Base, FirstCold->Base);
+  EXPECT_EQ(FirstFresh->Count, FirstCold->Count);
+  EXPECT_EQ(SecondFresh->Base, SecondCold->Base);
+  EXPECT_EQ(SecondFresh->Count, SecondCold->Count);
+  EXPECT_EQ(FreshCtx.FunctionKernelOwnerLookups, 2u);
+  EXPECT_EQ(FreshCtx.FunctionSgprUsageAnalyses, 2u);
+}
+
+TEST(SafeSgprScratchBlock,
+     OwnerlessDeclaredHighWatermarkCacheHitsForSharedFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t FunctionSize = 0x40;
+  constexpr uint64_t SharedOffset = 2 * FunctionSize;
+  llvm::SmallVector<uint8_t> End = assembleSingleInst("s_endpgm", S);
+  llvm::SmallVector<uint8_t> Shared =
+      assembleInstructions("s_mov_b32 s10, s0\ns_endpgm", S);
+  ASSERT_FALSE(End.empty());
+  ASSERT_FALSE(Shared.empty());
+  std::vector<uint8_t> Text(3 * FunctionSize);
+  for (size_t Offset = 0; Offset != Text.size(); Offset += MinInstSize)
+    std::copy(S.SNopBytes.begin(), S.SNopBytes.end(), Text.begin() + Offset);
+  std::copy(End.begin(), End.end(), Text.begin());
+  std::copy(End.begin(), End.end(), Text.begin() + FunctionSize);
+  std::copy(Shared.begin(), Shared.end(), Text.begin() + SharedOffset);
+
+  comgr_test::MultiKernelDescriptorElfOptions Options;
+  Options.TextSize = Text.size();
+  Options.Text = Text;
+  Options.Kernels = {
+      {"kernel0", Options.TextAddr, Options.RodataAddr, /*EntryOffset=*/0,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true,
+       /*MetadataSgprCount=*/4},
+      {"kernel1", Options.TextAddr + FunctionSize, Options.RodataAddr + 0x40,
+       /*EntryOffset=*/0,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true,
+       /*MetadataSgprCount=*/18},
+  };
+  Options.DeviceFunctions.push_back(
+      {"shared", Options.TextAddr + SharedOffset, FunctionSize});
+  std::vector<uint8_t> Bytes =
+      comgr_test::makeMultiKernelDescriptorElf(Options);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Bytes.data(), Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(View.textData(), View.textSize(), S, Decoded));
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprCacheState,
+            AllKernelDeclaredSgprState::Uncomputed);
+  std::optional<SafeSgprScratchBlock> Cold = findSafeSgprScratchBlock(
+      Ctx, SharedOffset, /*Count=*/2, /*Alignment=*/2, "unit test");
+  std::optional<SafeSgprScratchBlock> Hit =
+      findSafeSgprScratchBlock(Ctx, SharedOffset + MinInstSize, /*Count=*/2,
+                               /*Alignment=*/2, "unit test");
+  ASSERT_TRUE(Cold);
+  ASSERT_TRUE(Hit);
+  EXPECT_EQ(Cold->Base, 18u);
+  EXPECT_EQ(Cold->Count, 2u);
+  EXPECT_EQ(Hit->Base, Cold->Base);
+  EXPECT_EQ(Hit->Count, Cold->Count);
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprCacheState,
+            AllKernelDeclaredSgprState::Valid);
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprHighWatermark, 18u);
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprAnalyses, 1u);
+  EXPECT_EQ(Ctx.FunctionKernelOwnerLookups, 1u);
+  EXPECT_EQ(Ctx.FunctionKernelOwner.size(), 1u);
+  EXPECT_TRUE(Ctx.WholeObjectSgprUsage.has_value());
+}
+
+TEST(SafeSgprScratchBlock,
+     OwnerlessFailureIsStickyAtomicAndPreservesOwnerCommitment) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t FunctionSize = 0x40;
+  constexpr uint64_t SharedOffset = 2 * FunctionSize;
+  llvm::SmallVector<uint8_t> End = assembleSingleInst("s_endpgm", S);
+  llvm::SmallVector<uint8_t> Shared =
+      assembleInstructions("s_mov_b32 s10, s0\ns_endpgm", S);
+  ASSERT_FALSE(End.empty());
+  ASSERT_FALSE(Shared.empty());
+  std::vector<uint8_t> Text(3 * FunctionSize);
+  for (size_t Offset = 0; Offset != Text.size(); Offset += MinInstSize)
+    std::copy(S.SNopBytes.begin(), S.SNopBytes.end(), Text.begin() + Offset);
+  std::copy(End.begin(), End.end(), Text.begin());
+  std::copy(End.begin(), End.end(), Text.begin() + FunctionSize);
+  std::copy(Shared.begin(), Shared.end(), Text.begin() + SharedOffset);
+
+  comgr_test::MultiKernelDescriptorElfOptions Options;
+  Options.TextSize = Text.size();
+  Options.Text = Text;
+  Options.Kernels = {
+      {"valid", Options.TextAddr, Options.RodataAddr, /*EntryOffset=*/0,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true,
+       /*MetadataSgprCount=*/4},
+      {"malformed", Options.TextAddr + FunctionSize, Options.RodataAddr + 0x40,
+       /*EntryOffset=*/0,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true,
+       /*MetadataSgprCount=*/0,
+       /*MetadataSgprCountAsString=*/true},
+  };
+  Options.DeviceFunctions.push_back(
+      {"shared", Options.TextAddr + SharedOffset, FunctionSize});
+  std::vector<uint8_t> Bytes =
+      comgr_test::makeMultiKernelDescriptorElf(Options);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Bytes.data(), Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(View.textData(), View.textSize(), S, Decoded));
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow,
+                   Prof};
+
+  // Establish an owner-specific commitment before the malformed kernel is
+  // consulted by an ownerless request.
+  std::optional<SafeSgprScratchBlock> Owned = findSafeSgprScratchBlock(
+      Ctx, /*TextOffset=*/0, /*Count=*/2, /*Alignment=*/2, "unit test");
+  ASSERT_TRUE(Owned);
+  EXPECT_EQ(Owned->Base, 4u);
+  EXPECT_EQ(Owned->Count, 2u);
+  ASSERT_TRUE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, *Owned, "unit test"));
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprCacheState,
+            AllKernelDeclaredSgprState::Uncomputed);
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprAnalyses, 0u);
+  EXPECT_EQ(Ctx.AllKernelSgprRequirement, 0u);
+  ASSERT_EQ(Ctx.KernelSgprRequirements.size(), 1u);
+  EXPECT_EQ(Ctx.KernelSgprRequirements["valid"], 8u);
+  EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 1u);
+  ASSERT_EQ(KernelStats.size(), 1u);
+  EXPECT_EQ(KernelStats["valid"].ExtraSgprs, 4u);
+
+  // The valid descriptor is visited before the malformed metadata entry. The
+  // first ownerless query records one terminal failure; the repeat is a cache
+  // hit and must not rescan either descriptor.
+  EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, SharedOffset, /*Count=*/2,
+                                        /*Alignment=*/2, "unit test"));
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprCacheState,
+            AllKernelDeclaredSgprState::Failed);
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprHighWatermark, 0u);
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprAnalyses, 1u);
+  EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, SharedOffset + MinInstSize,
+                                        /*Count=*/2, /*Alignment=*/2,
+                                        "unit test"));
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprCacheState,
+            AllKernelDeclaredSgprState::Failed);
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprAnalyses, 1u);
+
+  // A direct later global commit still preflights all selected descriptors.
+  // Its queued update for the valid kernel must not leak past the malformed
+  // descriptor or disturb the prior owner-specific commitment.
+  const SafeSgprScratchBlock Global{/*Base=*/8, /*Count=*/2};
+  EXPECT_FALSE(
+      commitSafeSgprScratchBlock(Ctx, SharedOffset, Global, "unit test"));
+  ASSERT_EQ(KernelStats.size(), 1u);
+  EXPECT_EQ(KernelStats["valid"].ExtraSgprs, 4u);
+  EXPECT_EQ(Ctx.AllKernelSgprRequirement, 0u);
+  ASSERT_EQ(Ctx.KernelSgprRequirements.size(), 1u);
+  EXPECT_EQ(Ctx.KernelSgprRequirements["valid"], 8u);
+  EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 1u);
+
+  // The terminal all-kernel failure is scoped to ownerless queries. The valid
+  // owner's cached query and commitment remain usable without another scan.
+  std::optional<SafeSgprScratchBlock> OwnedHit = findSafeSgprScratchBlock(
+      Ctx, /*TextOffset=*/0, /*Count=*/2, /*Alignment=*/2, "unit test");
+  ASSERT_TRUE(OwnedHit);
+  EXPECT_EQ(OwnedHit->Base, Owned->Base);
+  EXPECT_TRUE(commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, *OwnedHit,
+                                         "unit test"));
+  EXPECT_EQ(Ctx.SgprDescriptorChargePasses, 1u);
+  EXPECT_EQ(Ctx.FunctionKernelOwnerLookups, 2u);
+  EXPECT_EQ(Ctx.FunctionSgprUsageAnalyses, 1u);
+  EXPECT_EQ(Ctx.AllKernelDeclaredSgprAnalyses, 1u);
+}
+
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {
   std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64}, {100, 128, 100, 100, 128}};
   EXPECT_EQ(findNearestSled(Sleds, 0, std::numeric_limits<uint64_t>::max()),

--- a/amd/comgr/test-unit/hotswap/rewriter/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/hotswap/rewriter/comgr-test-elf-utils.h
@@ -487,24 +487,48 @@ struct MultiKernelDescriptorElfOptions {
     // kernel. Leave false to model a descriptor that has no metadata entry.
     bool EmitMetadata = false;
     unsigned MetadataSgprCount = 0;
+    bool MetadataSgprCountAsString = false;
+  };
+
+  struct DeviceFunction {
+    std::string Name;
+    uint64_t EntryVAddr = 0;
+    uint64_t Size = 0;
   };
 
   uint16_t ElfType = llvm::ELF::ET_DYN;
   uint64_t TextAddr = 0x1000;
   uint64_t TextSize = 0x400;
+  std::vector<uint8_t> Text;
   uint64_t RodataAddr = 0x2000;
   std::vector<Kernel> Kernels;
+  // Additional STT_FUNC symbols without kernel descriptors.
+  std::vector<DeviceFunction> DeviceFunctions;
 };
 
 inline std::vector<uint8_t>
 makeMultiKernelMetadataBlob(const MultiKernelDescriptorElfOptions &Options) {
-  KernelDescriptorElfOptions MetaOpts;
-  for (const MultiKernelDescriptorElfOptions::Kernel &K : Options.Kernels)
-    if (K.EmitMetadata)
-      MetaOpts.MetadataKernels.push_back({K.Name, K.MetadataSgprCount});
-  if (MetaOpts.MetadataKernels.empty())
+  llvm::msgpack::Document Doc;
+  llvm::msgpack::MapDocNode Root = Doc.getRoot().getMap(/*Convert=*/true);
+  llvm::msgpack::ArrayDocNode Kernels = Doc.getArrayNode();
+  bool HasMetadata = false;
+  for (const MultiKernelDescriptorElfOptions::Kernel &K : Options.Kernels) {
+    if (!K.EmitMetadata)
+      continue;
+    HasMetadata = true;
+    llvm::msgpack::MapDocNode Kernel = Doc.getMapNode();
+    Kernel[".name"] = Doc.getNode(K.Name, /*Copy=*/true);
+    if (K.MetadataSgprCountAsString)
+      Kernel[".sgpr_count"] = Doc.getNode("not-an-integer", /*Copy=*/true);
+    else
+      Kernel[".sgpr_count"] = static_cast<uint64_t>(K.MetadataSgprCount);
+    Kernels.push_back(Kernel);
+  }
+  if (!HasMetadata)
     return {};
-  std::string Blob = makeAmdgpuMetadataBlob(MetaOpts);
+  Root["amdhsa.kernels"] = Kernels;
+  std::string Blob;
+  Doc.writeToBlob(Blob);
   return makeAmdgpuMetadataNote(Blob);
 }
 
@@ -520,6 +544,7 @@ makeMultiKernelDescriptorElf(const MultiKernelDescriptorElfOptions &Options) {
       "\0.text\0.rodata\0.strtab\0.symtab\0.shstrtab\0";
 
   const size_t NumKernels = Options.Kernels.size();
+  const size_t NumDeviceFunctions = Options.DeviceFunctions.size();
   assert(NumKernels > 0 && "multi-kernel ELF needs at least one kernel");
 
   // .rodata must span the highest descriptor block. Each KdVAddr must sit at or
@@ -532,12 +557,20 @@ makeMultiKernelDescriptorElf(const MultiKernelDescriptorElfOptions &Options) {
            "entry vaddr outside .text");
     RodataSpan = std::max(RodataSpan, K.KdVAddr - Options.RodataAddr + KdBytes);
   }
+  for (const MultiKernelDescriptorElfOptions::DeviceFunction &F :
+       Options.DeviceFunctions) {
+    assert(F.EntryVAddr >= Options.TextAddr &&
+           F.EntryVAddr < Options.TextAddr + Options.TextSize &&
+           F.Size <= Options.TextAddr + Options.TextSize - F.EntryVAddr &&
+           "device function outside .text");
+  }
 
-  // String table: null byte, then per kernel "<name>\0" and "<name>.kd\0".
+  // String table: null byte, per-kernel names, then device-function names.
   // Duplicates are emitted verbatim so repeated symbols stay independent.
   std::string StrTab;
   StrTab.push_back('\0');
   std::vector<uint32_t> FuncNameOff(NumKernels), KdNameOff(NumKernels);
+  std::vector<uint32_t> DeviceFuncNameOff(NumDeviceFunctions);
   for (size_t I = 0; I < NumKernels; ++I) {
     FuncNameOff[I] = static_cast<uint32_t>(StrTab.size());
     StrTab += Options.Kernels[I].Name;
@@ -547,12 +580,17 @@ makeMultiKernelDescriptorElf(const MultiKernelDescriptorElfOptions &Options) {
     StrTab += ".kd";
     StrTab.push_back('\0');
   }
+  for (size_t I = 0; I < NumDeviceFunctions; ++I) {
+    DeviceFuncNameOff[I] = static_cast<uint32_t>(StrTab.size());
+    StrTab += Options.DeviceFunctions[I].Name;
+    StrTab.push_back('\0');
+  }
 
   std::vector<uint8_t> MetadataNote = makeMultiKernelMetadataBlob(Options);
   const bool HasMetadataNote = !MetadataNote.empty();
 
-  // Symbols: null [0], then per kernel a STT_FUNC entry and STT_OBJECT .kd.
-  const uint64_t SymCount = 1 + 2 * NumKernels;
+  // Symbols: null [0], per-kernel STT_FUNC/.kd pairs, then device functions.
+  const uint64_t SymCount = 1 + 2 * NumKernels + NumDeviceFunctions;
 
   const uint64_t RodataOff = alignTo8(TextOffset + Options.TextSize);
   const uint64_t StrTabOff = alignTo8(RodataOff + RodataSpan);
@@ -571,6 +609,10 @@ makeMultiKernelDescriptorElf(const MultiKernelDescriptorElfOptions &Options) {
   uint8_t *Buf = Bytes.data();
   std::memcpy(Buf + StrTabOff, StrTab.data(), StrTab.size());
   std::memcpy(Buf + ShStrTabOff, ShStrTab, sizeof(ShStrTab));
+  assert(Options.Text.size() <= Options.TextSize &&
+         "text bytes exceed multi-kernel .text size");
+  if (!Options.Text.empty())
+    std::memcpy(Buf + TextOffset, Options.Text.data(), Options.Text.size());
   if (HasMetadataNote)
     std::memcpy(Buf + NoteOff, MetadataNote.data(), MetadataNote.size());
 
@@ -676,6 +718,19 @@ makeMultiKernelDescriptorElf(const MultiKernelDescriptorElfOptions &Options) {
     KdSym.st_size = KdBytes;
     std::memcpy(Buf + SymTabOff + (2 + 2 * I) * sizeof(Elf64_Sym), &KdSym,
                 sizeof(KdSym));
+  }
+
+  for (size_t I = 0; I < NumDeviceFunctions; ++I) {
+    const MultiKernelDescriptorElfOptions::DeviceFunction &F =
+        Options.DeviceFunctions[I];
+    Elf64_Sym FuncSym{};
+    FuncSym.st_name = DeviceFuncNameOff[I];
+    FuncSym.setBindingAndType(STB_GLOBAL, STT_FUNC);
+    FuncSym.st_shndx = 1;
+    FuncSym.st_value = F.EntryVAddr;
+    FuncSym.st_size = F.Size;
+    std::memcpy(Buf + SymTabOff + (1 + 2 * NumKernels + I) * sizeof(Elf64_Sym),
+                &FuncSym, sizeof(FuncSym));
   }
 
   return Bytes;


### PR DESCRIPTION
Supersedes ROCm/llvm-project#3612 with a focused implementation on current
`amd-staging`. This change has no unmerged PR dependency.

## Scope

Kernel ownership, per-kernel declared SGPR counts, and scratch-SGPR descriptor
charging are immutable or monotone during one rewrite, but the far-return
scratch path recomputes them at every patch site.

- Memoize the function-to-kernel symbol lookup on the enclosing function text
  range.
- Memoize the all-descriptor declared-SGPR scan behind an
  `Uncomputed`/`Valid`/`Failed` state. The high-watermark is published only
  after every descriptor validates, so a malformed later declaration cannot
  expose a partial value; failure is a sticky terminal state.
- Track the requirement already charged per kernel, and for the ownerless case
  across all kernels, so a covered site returns early. The charge loop now
  preflights every descriptor before mutating `KernelStats`, keeping a
  malformed later descriptor from leaving a partial commitment the monotone
  cache cannot describe.

Cold-analysis counters are exposed for tests and profiling; cache hits do not
advance them.

These caches read declared SGPR counts from ELF metadata and the symbol table,
neither of which the pass mutates, so they are independent of the
`TextMutationGeneration` invalidation that guards current-text liveness.

## Why this matters

The ownerless device-function query rescans every kernel descriptor per site,
so uncached cost grows with sites x kernels. The offline corpus contains
objects with 256 and 2756 kernel descriptors receiving tens to hundreds of
thousands of site queries, where that product reaches the 10^8 range.

On current `amd-staging` the ownerless path is not yet reached, so this is
groundwork rather than a measurable speedup today; the function-owner cache
does already serve 99.95% of its calls from cache on the heaviest object.

## Validation

Against `a8910630027e`:

- Build clean; `git clang-format` reports no changes.
- comgr unit tests: 279 passed, 0 failed (`HotswapMCTests` 178 -> 181 with the
  three added `SafeSgprScratchBlock` cases).
- COMGR lit: 159 passed, 14 unsupported, 1 failed. The failure is
  `compile-hip-system-libstdcxx.hip`, a pre-existing system-libstdc++
  environment issue on this host that reproduces on unmodified `amd-staging`.
- Offline gfx1250 corpus, 2685 objects, both this branch and unmodified
  `amd-staging`: 2645 pass / 37 fail / 3 timeout on both. Row-by-row there are
  **0 status differences, 0 result differences, and 0 output SHA-256
  differences**, so every rewritten object is byte-identical. Total CPU
  differs by +0.11%.

The complete ASAN suite and MI400 matrix remain pending, so this stays a draft
until those landing gates complete.