### PR TITLE
[Offload][OMPT] Call device tracing entry points directly

### DIFF
--- a/offload/include/OpenMP/OMPT/OmptCommonDefs.h
+++ b/offload/include/OpenMP/OMPT/OmptCommonDefs.h
@@ -90,26 +90,27 @@
       ompt_callback_##CallbackName##_fn(__VA_ARGS__);                          \
   } while (0)
 
-typedef ompt_set_result_t (*libomptarget_ompt_set_trace_ompt_t)(
-    int Device, unsigned int Enable, unsigned int EventTy);
-typedef int (*libomptarget_ompt_start_trace_t)(int,
-                                               ompt_callback_buffer_request_t,
-                                               ompt_callback_buffer_complete_t);
-typedef int (*libomptarget_ompt_flush_trace_t)(int);
-typedef int (*libomptarget_ompt_stop_trace_t)(int);
-typedef int (*libomptarget_ompt_advance_buffer_cursor_t)(
-    ompt_device_t *, ompt_buffer_t *, size_t, ompt_buffer_cursor_t,
-    ompt_buffer_cursor_t *);
-typedef ompt_get_record_ompt_t libomptarget_ompt_get_record_ompt_t;
-typedef ompt_device_time_t (*libomptarget_ompt_get_device_time_t)(
-    ompt_device_t *);
-typedef ompt_translate_time_t libomptarget_ompt_translate_time_t;
-typedef ompt_device_time_t (*libomptarget_ompt_get_device_time_t)(
-    ompt_device_t *);
-typedef ompt_record_t (*libomptarget_ompt_get_record_type_t)(
-    ompt_buffer_t *, ompt_buffer_cursor_t);
-typedef void (*libomptarget_ompt_set_timestamp_t)(uint64_t start, uint64_t end);
-typedef void (*libomptarget_ompt_set_granted_teams_t)(uint32_t);
+/// Device-independent OMPT tracing entry points, implemented by libomptarget
+/// and linked into the same library as their plugin-side callers.
+extern "C" {
+ompt_set_result_t libomptarget_ompt_set_trace_ompt(int DeviceId,
+                                                   unsigned int Enable,
+                                                   unsigned int EventTy);
+int libomptarget_ompt_start_trace(int DeviceId,
+                                  ompt_callback_buffer_request_t Request,
+                                  ompt_callback_buffer_complete_t Complete);
+int libomptarget_ompt_flush_trace(int DeviceId);
+int libomptarget_ompt_stop_trace(int DeviceId);
+int libomptarget_ompt_advance_buffer_cursor(ompt_device_t *Device,
+                                            ompt_buffer_t *Buffer, size_t Size,
+                                            ompt_buffer_cursor_t CurrentPos,
+                                            ompt_buffer_cursor_t *NextPos);
+ompt_record_t
+libomptarget_ompt_get_record_type(ompt_buffer_t *Buffer,
+                                  ompt_buffer_cursor_t CurrentPos);
+void libomptarget_ompt_set_granted_teams(uint32_t NumTeams);
+void libomptarget_ompt_set_timestamp(uint64_t Start, uint64_t Stop);
+} // extern "C"
 
 /// Function type def used for maintaining unique target region, target
 /// operations ids

--- a/offload/plugins-nextgen/common/OMPT/OmptDeviceTracing.h
+++ b/offload/plugins-nextgen/common/OMPT/OmptDeviceTracing.h
@@ -18,10 +18,8 @@
 
 #include "OpenMP/OMPT/OmptCommonDefs.h"
 
-#include "llvm/Support/DynamicLibrary.h"
-
 #include <map>
-#include <memory>
+#include <mutex>
 
 #pragma push_macro("DEBUG_PREFIX")
 #undef DEBUG_PREFIX
@@ -35,11 +33,6 @@ namespace llvm {
 namespace omp {
 namespace target {
 namespace ompt {
-
-// Declare OMPT device tracing function entry points
-#define declareOmptTracingFn(Name) extern libomptarget_##Name##_t Name##_fn;
-FOREACH_OMPT_DEVICE_TRACING_FN_IMPLEMENTAIONS(declareOmptTracingFn)
-#undef declareOmptTracingFn
 
 // Declare OMPT device tracing function mutexes
 #define declareOmptTracingFnMutex(Name) extern std::mutex Name##_mutex;
@@ -94,32 +87,6 @@ extern std::map<int32_t, uint64_t> TracedDevices;
 
 /// OMPT global tracing status. Indicates if at least one device is traced.
 extern bool TracingActive;
-
-/// Parent library pointer
-extern std::shared_ptr<llvm::sys::DynamicLibrary> ParentLibrary;
-
-/// Get the parent library by pointer. If it is not already set, it will set the
-/// parent library pointer.
-std::shared_ptr<llvm::sys::DynamicLibrary> getParentLibrary();
-
-/// Set the parent library by filename
-void setParentLibrary(const char *Filename);
-
-/// Search for FuncName inside the parent library and assign to FuncPtr.
-/// IMPORTANT: This function assumes that the *caller* holds the respective lock
-/// for FuncPtr.
-template <typename FT>
-void ensureFuncPtrLoaded(const std::string &FuncName, FT *FuncPtr) {
-  if (*FuncPtr == nullptr) {
-    if ((ParentLibrary == nullptr && getParentLibrary() == nullptr) ||
-        !ParentLibrary->isValid())
-      return;
-    void *SymbolPtr = ParentLibrary->getAddressOfSymbol(FuncName.c_str());
-    if (SymbolPtr == nullptr)
-      return;
-    *FuncPtr = reinterpret_cast<FT>(SymbolPtr);
-  }
-}
 
 } // namespace ompt
 } // namespace target

--- a/offload/plugins-nextgen/common/OMPT/OmptTracing.cpp
+++ b/offload/plugins-nextgen/common/OMPT/OmptTracing.cpp
@@ -16,24 +16,15 @@
 #include "OmptDeviceTracing.h"
 #include "omp-tools.h"
 
-#include "llvm/Support/DynamicLibrary.h"
-
 #include <atomic>
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
-#include <memory>
 #include <mutex>
 
 #pragma push_macro("DEBUG_PREFIX")
 #undef DEBUG_PREFIX
 #define DEBUG_PREFIX "OMPT"
-
-// Define OMPT device tracing function entry points
-#define defineOmptTracingFn(Name)                                              \
-  libomptarget_##Name##_t llvm::omp::target::ompt::Name##_fn = nullptr;
-FOREACH_OMPT_DEVICE_TRACING_FN_IMPLEMENTAIONS(defineOmptTracingFn)
-#undef defineOmptTracingFn
 
 // Define OMPT device tracing function mutexes
 #define defineOmptTracingFnMutex(Name)                                         \
@@ -46,33 +37,10 @@ std::mutex llvm::omp::target::ompt::DeviceIdWritingMutex;
 using namespace llvm::omp::target::ompt;
 using namespace llvm::omp::target::debug;
 
-std::shared_ptr<llvm::sys::DynamicLibrary>
-    llvm::omp::target::ompt::ParentLibrary(nullptr);
-
 double llvm::omp::target::ompt::HostToDeviceSlope = .0;
 double llvm::omp::target::ompt::HostToDeviceOffset = .0;
 
 std::map<ompt_device_t *, int32_t> llvm::omp::target::ompt::Devices;
-
-std::shared_ptr<llvm::sys::DynamicLibrary>
-llvm::omp::target::ompt::getParentLibrary() {
-  static bool ParentLibraryAssigned = false;
-  if (!ParentLibraryAssigned) {
-    setParentLibrary("libomptarget.so");
-    ParentLibraryAssigned = true;
-  }
-  return ParentLibrary;
-}
-
-void llvm::omp::target::ompt::setParentLibrary(const char *Filename) {
-  if (ParentLibrary)
-    return;
-  std::string ErrorMsg;
-  ParentLibrary = std::make_shared<llvm::sys::DynamicLibrary>(
-      llvm::sys::DynamicLibrary::getPermanentLibrary(Filename, &ErrorMsg));
-  if ((ParentLibrary == nullptr) || (!ParentLibrary->isValid()))
-    REPORT() << "Failed to set parent library: " << ErrorMsg.c_str();
-}
 
 int llvm::omp::target::ompt::getDeviceId(ompt_device_t *Device) {
   // Block other threads, which might trigger an erase (for the same device)
@@ -130,10 +98,7 @@ OMPT_API_ROUTINE ompt_set_result_t ompt_set_trace_ompt(ompt_device_t *Device,
   }
 
   std::unique_lock<std::mutex> Lock(ompt_set_trace_ompt_mutex);
-  ensureFuncPtrLoaded<libomptarget_ompt_set_trace_ompt_t>(
-      "libomptarget_ompt_set_trace_ompt", &ompt_set_trace_ompt_fn);
-  assert(ompt_set_trace_ompt_fn && "libomptarget_ompt_set_trace_ompt loaded");
-  return ompt_set_trace_ompt_fn(DeviceId, Enable, EventTy);
+  return libomptarget_ompt_set_trace_ompt(DeviceId, Enable, EventTy);
 }
 
 OMPT_API_ROUTINE int
@@ -149,7 +114,7 @@ ompt_start_trace(ompt_device_t *Device, ompt_callback_buffer_request_t Request,
   }
 
   {
-    // Protect the function pointer
+    // Serialize the state changes performed below
     std::unique_lock<std::mutex> Lock(ompt_start_trace_mutex);
 
     if (Request && Complete) {
@@ -163,23 +128,15 @@ ompt_start_trace(ompt_device_t *Device, ompt_callback_buffer_request_t Request,
         REPORT() << "May not enable kernel profiling for invalid device id=" <<
                DeviceId;
     }
-
-    // Call libomptarget specific function
-    ensureFuncPtrLoaded<libomptarget_ompt_start_trace_t>(
-        "libomptarget_ompt_start_trace", &ompt_start_trace_fn);
-    assert(ompt_start_trace_fn && "libomptarget_ompt_start_trace loaded");
   }
-  return ompt_start_trace_fn(DeviceId, Request, Complete);
+  return libomptarget_ompt_start_trace(DeviceId, Request, Complete);
 }
 
 OMPT_API_ROUTINE int ompt_flush_trace(ompt_device_t *Device) {
   ODBG(ODT_Tool) << "Executing ompt_flush_trace";
 
   std::unique_lock<std::mutex> Lock(ompt_flush_trace_mutex);
-  ensureFuncPtrLoaded<libomptarget_ompt_flush_trace_t>(
-      "libomptarget_ompt_flush_trace", &ompt_flush_trace_fn);
-  assert(ompt_flush_trace_fn && "libomptarget_ompt_flush_trace loaded");
-  return ompt_flush_trace_fn(getDeviceId(Device));
+  return libomptarget_ompt_flush_trace(getDeviceId(Device));
 }
 
 OMPT_API_ROUTINE int ompt_stop_trace(ompt_device_t *Device) {
@@ -193,7 +150,7 @@ OMPT_API_ROUTINE int ompt_stop_trace(ompt_device_t *Device) {
   }
 
   {
-    // Protect the function pointer
+    // Serialize the state changes performed below
     std::unique_lock<std::mutex> Lock(ompt_stop_trace_mutex);
     llvm::omp::target::ompt::disableDeviceTracing(DeviceId);
     // Disable asynchronous memory copy profiling
@@ -202,13 +159,10 @@ OMPT_API_ROUTINE int ompt_stop_trace(ompt_device_t *Device) {
     if (DeviceId >= 0)
       setGlobalOmptKernelProfile(Device, /*Enable=*/0);
     else
-      REPORT() << "May not disable kernel profiling for invalid device id=" <<
-             DeviceId;
-    ensureFuncPtrLoaded<libomptarget_ompt_stop_trace_t>(
-        "libomptarget_ompt_stop_trace", &ompt_stop_trace_fn);
-    assert(ompt_stop_trace_fn && "libomptarget_ompt_stop_trace loaded");
+      REPORT() << "May not disable kernel profiling for invalid device id="
+               << DeviceId;
   }
-  return ompt_stop_trace_fn(DeviceId);
+  return libomptarget_ompt_stop_trace(DeviceId);
 }
 
 OMPT_API_ROUTINE ompt_record_ompt_t *
@@ -231,27 +185,18 @@ OMPT_API_ROUTINE int ompt_advance_buffer_cursor(ompt_device_t *Device,
                                                 ompt_buffer_cursor_t *NextPos) {
   // Note: The input parameter size is unused here. It refers to the
   // bytes returned in the corresponding callback.
-  // Advance can be called concurrently, so synchronize setting the
-  // function pointer. The actual libomptarget function does not need
-  // to be synchronized since it must be working on logically disjoint
-  // buffers.
+  // Advance can be called concurrently. The actual libomptarget function
+  // does not need to be synchronized since it must be working on logically
+  // disjoint buffers.
   std::unique_lock<std::mutex> Lock(ompt_advance_buffer_cursor_mutex);
-  ensureFuncPtrLoaded<libomptarget_ompt_advance_buffer_cursor_t>(
-      "libomptarget_ompt_advance_buffer_cursor",
-      &ompt_advance_buffer_cursor_fn);
-  assert(ompt_advance_buffer_cursor_fn &&
-         "libomptarget_ompt_advance_buffer_cursor loaded");
-  return ompt_advance_buffer_cursor_fn(Device, Buffer, Size, CurrentPos,
-                                       NextPos);
+  return libomptarget_ompt_advance_buffer_cursor(Device, Buffer, Size,
+                                                 CurrentPos, NextPos);
 }
 
 OMPT_API_ROUTINE ompt_record_t
 ompt_get_record_type(ompt_buffer_t *Buffer, ompt_buffer_cursor_t CurrentPos) {
   std::unique_lock<std::mutex> Lock(ompt_get_record_type_mutex);
-  ensureFuncPtrLoaded<libomptarget_ompt_get_record_type_t>(
-      "libomptarget_ompt_get_record_type", &ompt_get_record_type_fn);
-  assert(ompt_get_record_type_fn && "libomptarget_ompt_get_record_type loaded");
-  return ompt_get_record_type_fn(Buffer, CurrentPos);
+  return libomptarget_ompt_get_record_type(Buffer, CurrentPos);
 }
 
 OMPT_API_ROUTINE ompt_device_time_t
@@ -274,10 +219,8 @@ OMPT_API_ROUTINE double ompt_translate_time(ompt_device_t *Device,
 void llvm::omp::target::ompt::setOmptTimestamp(uint64_t StartTime,
                                                uint64_t EndTime) {
   std::unique_lock<std::mutex> Lock(ompt_set_timestamp_mutex);
-  ensureFuncPtrLoaded<libomptarget_ompt_set_timestamp_t>(
-      "libomptarget_ompt_set_timestamp", &ompt_set_timestamp_fn);
   // No need to hold a lock
-  ompt_set_timestamp_fn(StartTime, EndTime);
+  libomptarget_ompt_set_timestamp(StartTime, EndTime);
 }
 
 void llvm::omp::target::ompt::setOmptHostToDeviceRate(double Slope,
@@ -288,10 +231,8 @@ void llvm::omp::target::ompt::setOmptHostToDeviceRate(double Slope,
 
 void llvm::omp::target::ompt::setOmptGrantedNumTeams(uint64_t NumTeams) {
   std::unique_lock<std::mutex> Lock(ompt_set_granted_teams_mutex);
-  ensureFuncPtrLoaded<libomptarget_ompt_set_granted_teams_t>(
-      "libomptarget_ompt_set_granted_teams", &ompt_set_granted_teams_fn);
   // No need to hold a lock
-  ompt_set_granted_teams_fn(NumTeams);
+  libomptarget_ompt_set_granted_teams(NumTeams);
 }
 
 ompt_interface_fn_t llvm::omp::target::ompt::lookupDeviceTracingFn(


### PR DESCRIPTION
PluginOmpt is linked into libomptarget.so, which exports the libomptarget_ompt_* entry points, so resolve them at link time rather than through dlopen and dlsym. Declaring them in OmptCommonDefs.h type-checks the boundary and removes ParentLibrary, ensureFuncPtrLoaded() and the generated function pointers.

This also fixes a crash: getPermanentLibrary() received the bare soname, so under LLVM_LINK_LLVM_DYLIB=ON it resolved against libLLVM.so's DT_RUNPATH, which does not cover a per-target install directory. The lookup then failed and setOmptTimestamp() called through a null pointer on every device allocation.

The mutexes are left untouched; a follow-up reduces them. Dropping the lines below ompt_stop_trace()'s dead REPORT() branch brings its continuation into clang-format's range, so that one statement is reflowed here; the dead branch itself goes in a follow-up.

AI-assisted.


