### PR TITLE
[Comgr][hotswap] Keep hotswap LLVM deps off amd_comgr's link line

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -592,9 +592,9 @@ target_link_libraries(amd_comgr
     ${LLVM_LIBS}
     ${CLANG_LIBS})
 
-# hotswap link edges — must come after the curated LLVM set above so
-# static-archive resolution pulls in the full set (incl. LLVMCodeGen's -mcpu
-# registration) before the hotswap libraries' partial LLVM deps.
+# hotswap link edges. Both are OBJECT libraries with PRIVATE LLVM deps, so they
+# contribute only their objects and leave the curated LLVM set above unchanged;
+# keep them after that block regardless.
 #
 # The rewriter (byte-level rewrite path) backs the always-on
 # amd_comgr_hotswap_rewrite API, so it is linked unconditionally. The raiser

--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -3,5 +3,12 @@
 #   hotswap::rewriter  byte-level rewrite path (linked unconditionally)
 #   hotswap::raiser    IR transpiler path (opt-in, COMGR_ENABLE_HOTSWAP_TRANSPILE)
 # Shared, path-agnostic headers live in common/ (header-only, no target).
+#
+# Both keep their LLVM dependencies PRIVATE. Their objects land in amd_comgr,
+# which already links the full curated LLVM set; propagating a partial set onto
+# amd_comgr's link line perturbs static-archive resolution (dropping
+# LLVMCodeGen's -mcpu registration and breaking in-process LLD) and mixes
+# component archives with libLLVM.so under LLVM_LINK_LLVM_DYLIB. Targets that
+# link these libraries directly name their own LLVM libs.
 add_subdirectory(rewriter)
 add_subdirectory(raiser)

--- a/amd/comgr/src/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/raiser/CMakeLists.txt
@@ -45,9 +45,13 @@ target_include_directories(hotswap-raiser PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
 )
 
+# PRIVATE keeps these out of the link interface, but CMake still records them as
+# $<LINK_ONLY:> for an OBJECT library; clear the interface so consumers get the
+# objects only (see ../CMakeLists.txt).
 target_link_libraries(hotswap-raiser
-  PUBLIC
+  PRIVATE
     LLVMCore
     LLVMSupport
     LLVMTargetParser
 )
+set_target_properties(hotswap-raiser PROPERTIES INTERFACE_LINK_LIBRARIES "")

--- a/amd/comgr/src/hotswap/rewriter/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/rewriter/CMakeLists.txt
@@ -84,4 +84,8 @@ llvm_map_components_to_libnames(hotswap_rewriter_llvm_libs
   AMDGPUDisassembler
   AMDGPUInfo)
 
-target_link_libraries(hotswap-rewriter PUBLIC ${hotswap_rewriter_llvm_libs})
+# PRIVATE keeps these out of the link interface, but CMake still records them as
+# $<LINK_ONLY:> for an OBJECT library; clear the interface so consumers get the
+# objects only (see ../CMakeLists.txt).
+target_link_libraries(hotswap-rewriter PRIVATE ${hotswap_rewriter_llvm_libs})
+set_target_properties(hotswap-rewriter PROPERTIES INTERFACE_LINK_LIBRARIES "")

--- a/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
@@ -10,9 +10,14 @@
 add_executable(RaiserScaffoldingTests
   RaiserScaffoldingTest.cpp)
 
+# hotswap::raiser keeps its LLVM dependencies PRIVATE, so name them here.
+llvm_map_components_to_libnames(COMGR_TEST_UNIT_RAISER_LIBS
+  Core Support TargetParser)
+
 target_link_libraries(RaiserScaffoldingTests PRIVATE
   ${COMGR_GTEST_LIBS}
   hotswap::raiser
+  ${COMGR_TEST_UNIT_RAISER_LIBS}
   ${LLVM_PTHREAD_LIB})
 
 target_include_directories(RaiserScaffoldingTests PRIVATE


### PR DESCRIPTION
The hotswap rewriter and raiser OBJECT libraries declared their LLVM component dependencies PUBLIC, merging a partial LLVM set into amd_comgr's link line. That reintroduces the failure fixed by #2987: with static-archive linking, resolution order can drop LLVMCodeGen's CommandFlags.cpp, whose `cl::opt` registers `-mcpu`, and in-process LLD then rejects the forwarded `-plugin-opt=mcpu=<gpu>`:

```
  ld.lld: error: -plugin-opt=mcpu=: Unknown command line argument
  '-mcpu=gfx1250'.
```

Those sets are also not dylib-aware, so under `LLVM_LINK_LLVM_DYLIB` they put component archives next to libLLVM.so, giving amd_comgr two copies of the `cl::opt` registry and the same error by a different route.

Make the dependencies PRIVATE and clear INTERFACE_LINK_LIBRARIES -- CMake records even PRIVATE deps of an OBJECT library as `$<LINK_ONLY:>` -- so the libraries contribute only their objects.

amd_comgr's link line is now identical with `COMGR_ENABLE_HOTSWAP_TRANSPILE` ON and OFF. The one target that links `hotswap::raiser` directly, RaiserScaffoldingTests, names its own LLVM libraries.

FIXES: LCOMPILER-2521


