### PR TITLE
[Comgr][hotswap] Map MC opcodes to canonical ops and decode kernel .text

### DIFF
--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -36,4 +36,10 @@ if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   list(APPEND COMGR_HOTSWAP_LIBS
     hotswap::common hotswap::loader hotswap::raiser hotswap::decoder)
 endif()
+# Created only when amd_comgr does not link LLVMAMDGPUUtils, and linked by
+# amd_comgr alone: the AMDGPU MC tables it carries are a second definition
+# anywhere the static AMDGPU components are on the link line.
+if(TARGET hotswap::amdgpu-mc-tables)
+  list(APPEND COMGR_HOTSWAP_LIBS hotswap::amdgpu-mc-tables)
+endif()
 set(COMGR_HOTSWAP_LIBS "${COMGR_HOTSWAP_LIBS}" PARENT_SCOPE)

--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -36,10 +36,4 @@ if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   list(APPEND COMGR_HOTSWAP_LIBS
     hotswap::common hotswap::loader hotswap::raiser hotswap::decoder)
 endif()
-# Created only when amd_comgr does not link LLVMAMDGPUUtils, and linked by
-# amd_comgr alone: the AMDGPU MC tables it carries are a second definition
-# anywhere the static AMDGPU components are on the link line.
-if(TARGET hotswap::amdgpu-mc-tables)
-  list(APPEND COMGR_HOTSWAP_LIBS hotswap::amdgpu-mc-tables)
-endif()
 set(COMGR_HOTSWAP_LIBS "${COMGR_HOTSWAP_LIBS}" PARENT_SCOPE)

--- a/amd/comgr/src/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/decoder/CMakeLists.txt
@@ -61,6 +61,8 @@ add_library(hotswap-decoder OBJECT
   amdgpu-formats.cpp
   canonical-op.cpp
   isa-profile.cpp
+  opcode-map.cpp
+  decode.cpp
 )
 
 if(NOT TARGET hotswap::decoder)

--- a/amd/comgr/src/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/decoder/CMakeLists.txt
@@ -58,6 +58,7 @@ endif()
 
 add_library(hotswap-decoder OBJECT
   mc-state.cpp
+  amdgpu-mc-tables.cpp
   amdgpu-formats.cpp
   canonical-op.cpp
   isa-profile.cpp
@@ -167,45 +168,3 @@ target_include_directories(hotswap-decoder PRIVATE
 # private dependencies through $<LINK_ONLY:>.
 target_link_libraries(hotswap-decoder PRIVATE ${HOTSWAP_LLVM_LIBS})
 set_target_properties(hotswap-decoder PROPERTIES INTERFACE_LINK_LIBRARIES "")
-
-# --- Unexported AMDGPU MC tables ----------------------------------------------
-# The decoder calls the named-operand lookup and the opcode-form mappings that
-# AMDGPUBaseInfo.h declares. LLVMAMDGPUUtils defines them and libLLVM.so does
-# not export them, so amd_comgr resolves them only when it links the static
-# component; against the dylib the link fails. amdgpu-mc-tables.cpp
-# instantiates them from the generated header for that case.
-#
-# Keying on amd_comgr's own library set (chosen in the top-level CMakeLists,
-# which runs before this directory is entered) rather than on
-# LLVM_LINK_LLVM_DYLIB tests the condition itself: whichever way that choice is
-# reached, this is on exactly when nothing else supplies the definitions.
-#
-# It is a library of its own rather than another hotswap-decoder source because
-# the definitions must reach that link alone. The hotswap test binaries link
-# the static AMDGPU components (see test-unit/hotswap/CMakeLists.txt), which
-# carry AMDGPUBaseInfo.o and would make these a second definition.
-if(NOT "LLVMAMDGPUUtils" IN_LIST LLVM_LIBS)
-  add_library(hotswap-amdgpu-mc-tables OBJECT amdgpu-mc-tables.cpp)
-  add_library(hotswap::amdgpu-mc-tables ALIAS hotswap-amdgpu-mc-tables)
-
-  llvm_update_compile_flags(hotswap-amdgpu-mc-tables)
-  if(NOT LLVM_ENABLE_RTTI)
-    if(MSVC)
-      target_compile_options(hotswap-amdgpu-mc-tables PRIVATE /GR-)
-    else()
-      target_compile_options(hotswap-amdgpu-mc-tables PRIVATE -fno-rtti)
-    endif()
-  endif()
-  set_target_properties(hotswap-amdgpu-mc-tables PROPERTIES
-    POSITION_INDEPENDENT_CODE ON)
-
-  target_include_directories(hotswap-amdgpu-mc-tables PRIVATE
-    "${HOTSWAP_AMDGPU_SRC_DIR}"
-    "${HOTSWAP_AMDGPU_SRC_DIR}/Utils"
-    "${HOTSWAP_AMDGPU_GEN_DIR}"
-  )
-
-  target_link_libraries(hotswap-amdgpu-mc-tables PRIVATE ${HOTSWAP_LLVM_LIBS})
-  set_target_properties(hotswap-amdgpu-mc-tables PROPERTIES
-    INTERFACE_LINK_LIBRARIES "")
-endif()

--- a/amd/comgr/src/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/decoder/CMakeLists.txt
@@ -167,3 +167,45 @@ target_include_directories(hotswap-decoder PRIVATE
 # private dependencies through $<LINK_ONLY:>.
 target_link_libraries(hotswap-decoder PRIVATE ${HOTSWAP_LLVM_LIBS})
 set_target_properties(hotswap-decoder PROPERTIES INTERFACE_LINK_LIBRARIES "")
+
+# --- Unexported AMDGPU MC tables ----------------------------------------------
+# The decoder calls the named-operand lookup and the opcode-form mappings that
+# AMDGPUBaseInfo.h declares. LLVMAMDGPUUtils defines them and libLLVM.so does
+# not export them, so amd_comgr resolves them only when it links the static
+# component; against the dylib the link fails. amdgpu-mc-tables.cpp
+# instantiates them from the generated header for that case.
+#
+# Keying on amd_comgr's own library set (chosen in the top-level CMakeLists,
+# which runs before this directory is entered) rather than on
+# LLVM_LINK_LLVM_DYLIB tests the condition itself: whichever way that choice is
+# reached, this is on exactly when nothing else supplies the definitions.
+#
+# It is a library of its own rather than another hotswap-decoder source because
+# the definitions must reach that link alone. The hotswap test binaries link
+# the static AMDGPU components (see test-unit/hotswap/CMakeLists.txt), which
+# carry AMDGPUBaseInfo.o and would make these a second definition.
+if(NOT "LLVMAMDGPUUtils" IN_LIST LLVM_LIBS)
+  add_library(hotswap-amdgpu-mc-tables OBJECT amdgpu-mc-tables.cpp)
+  add_library(hotswap::amdgpu-mc-tables ALIAS hotswap-amdgpu-mc-tables)
+
+  llvm_update_compile_flags(hotswap-amdgpu-mc-tables)
+  if(NOT LLVM_ENABLE_RTTI)
+    if(MSVC)
+      target_compile_options(hotswap-amdgpu-mc-tables PRIVATE /GR-)
+    else()
+      target_compile_options(hotswap-amdgpu-mc-tables PRIVATE -fno-rtti)
+    endif()
+  endif()
+  set_target_properties(hotswap-amdgpu-mc-tables PROPERTIES
+    POSITION_INDEPENDENT_CODE ON)
+
+  target_include_directories(hotswap-amdgpu-mc-tables PRIVATE
+    "${HOTSWAP_AMDGPU_SRC_DIR}"
+    "${HOTSWAP_AMDGPU_SRC_DIR}/Utils"
+    "${HOTSWAP_AMDGPU_GEN_DIR}"
+  )
+
+  target_link_libraries(hotswap-amdgpu-mc-tables PRIVATE ${HOTSWAP_LLVM_LIBS})
+  set_target_properties(hotswap-amdgpu-mc-tables PROPERTIES
+    INTERFACE_LINK_LIBRARIES "")
+endif()

--- a/amd/comgr/src/hotswap/decoder/amdgpu-mc-tables.cpp
+++ b/amd/comgr/src/hotswap/decoder/amdgpu-mc-tables.cpp
@@ -1,0 +1,44 @@
+//===- amdgpu-mc-tables.cpp - Hotswap transpiler --------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// AMDGPUBaseInfo.h declares the named-operand lookup and the opcode-form
+// mappings the decoder uses, but libLLVM.so exports neither, so a dylib build
+// of amd_comgr cannot resolve them. Instantiate the tables here from the same
+// generated header AMDGPUBaseInfo.cpp instantiates them from, which keeps them
+// in step with the AMDGPU target the rest of the decoder already builds
+// against.
+//
+// A static build resolves the definitions from LLVMAMDGPUUtils and would
+// reject these as duplicates, so CMakeLists.txt compiles this file only when
+// comgr links the LLVM dylib.
+//
+//===----------------------------------------------------------------------===//
+
+// GET_INSTRINFO_ENUM, for the opcode enumerators the tables are indexed by.
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h"
+// GET_INSTRINFO_OPERAND_ENUM, for the OpName the lookup is keyed by.
+#include "Utils/AMDGPUBaseInfo.h"
+
+#include "llvm/Support/Compiler.h"
+
+#include <cstdint>
+
+#define GET_INSTRINFO_NAMED_OPS
+#define GET_INSTRMAP_INFO
+#include "AMDGPUGenInstrInfo.inc"
+
+namespace llvm::AMDGPU {
+
+// The generated lookup takes the encoding family as `enum Subtarget`, which is
+// declared by the same block that defines the lookup and so cannot be named by
+// a caller. AMDGPUBaseInfo.h declares this unsigned-taking wrapper for them.
+int32_t getMCOpcode(uint32_t Opcode, unsigned Gen) {
+  return getMCOpcodeGen(Opcode, static_cast<Subtarget>(Gen));
+}
+
+} // namespace llvm::AMDGPU

--- a/amd/comgr/src/hotswap/decoder/amdgpu-mc-tables.cpp
+++ b/amd/comgr/src/hotswap/decoder/amdgpu-mc-tables.cpp
@@ -5,40 +5,55 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
-// AMDGPUBaseInfo.h declares the named-operand lookup and the opcode-form
-// mappings the decoder uses, but libLLVM.so exports neither, so a dylib build
-// of amd_comgr cannot resolve them. Instantiate the tables here from the same
-// generated header AMDGPUBaseInfo.cpp instantiates them from, which keeps them
-// in step with the AMDGPU target the rest of the decoder already builds
-// against.
-//
-// A static build resolves the definitions from LLVMAMDGPUUtils and would
-// reject these as duplicates, so CMakeLists.txt compiles this file only when
-// comgr links the LLVM dylib.
-//
-//===----------------------------------------------------------------------===//
 
-// GET_INSTRINFO_ENUM, for the opcode enumerators the tables are indexed by.
+#include "amdgpu-mc-tables.h"
+
+// AMDGPU target-private headers.
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
-// GET_INSTRINFO_OPERAND_ENUM, for the OpName the lookup is keyed by.
 #include "Utils/AMDGPUBaseInfo.h"
-
-#include "llvm/Support/Compiler.h"
 
 #include <cstdint>
 
+namespace COMGR::hotswap {
+
+// Nesting `llvm::AMDGPU` here keeps these definitions distinct from the ones a
+// static build puts on the same link line; the using-directive is what lets the
+// generated code's unqualified lookups still reach the real namespace.
+namespace tables {
+using namespace ::llvm::AMDGPU;
 #define GET_INSTRINFO_NAMED_OPS
 #define GET_INSTRMAP_INFO
 #include "AMDGPUGenInstrInfo.inc"
+} // namespace tables
 
-namespace llvm::AMDGPU {
-
-// The generated lookup takes the encoding family as `enum Subtarget`, which is
-// declared by the same block that defines the lookup and so cannot be named by
-// a caller. AMDGPUBaseInfo.h declares this unsigned-taking wrapper for them.
-int32_t getMCOpcode(uint32_t Opcode, unsigned Gen) {
-  return getMCOpcodeGen(Opcode, static_cast<Subtarget>(Gen));
+int16_t getNamedOperandIdx(uint32_t Opcode, llvm::AMDGPU::OpName Name) {
+  return tables::llvm::AMDGPU::getNamedOperandIdx(Opcode, Name);
 }
 
-} // namespace llvm::AMDGPU
+int32_t getMCOpcode(uint32_t Opcode, unsigned Gen) {
+  using Subtarget = tables::llvm::AMDGPU::Subtarget;
+  return tables::llvm::AMDGPU::getMCOpcodeGen(Opcode,
+                                              static_cast<Subtarget>(Gen));
+}
+
+int32_t getVOPe64(uint32_t Opcode) {
+  return tables::llvm::AMDGPU::getVOPe64(Opcode);
+}
+
+int32_t getDPPOp32(uint32_t Opcode) {
+  return tables::llvm::AMDGPU::getDPPOp32(Opcode);
+}
+
+int32_t getDPPOp64(uint32_t Opcode) {
+  return tables::llvm::AMDGPU::getDPPOp64(Opcode);
+}
+
+int32_t getBasicFromSDWAOp(uint32_t Opcode) {
+  return tables::llvm::AMDGPU::getBasicFromSDWAOp(Opcode);
+}
+
+int32_t getGlobalVaddrOp(uint32_t Opcode) {
+  return tables::llvm::AMDGPU::getGlobalVaddrOp(Opcode);
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/decoder/amdgpu-mc-tables.h
+++ b/amd/comgr/src/hotswap/decoder/amdgpu-mc-tables.h
@@ -1,0 +1,48 @@
+//===- amdgpu-mc-tables.h - Hotswap transpiler ----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The AMDGPU TableGen lookups the decoder needs: the index of a named operand,
+// and the opcode of the other encoding forms of an instruction. Comgr carries
+// its own copy of these tables because libLLVM.so exports none of them.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_AMDGPU_MC_TABLES_H
+#define HOTSWAP_TRANSPILER_AMDGPU_MC_TABLES_H
+
+#include "Utils/AMDGPUBaseInfo.h"
+
+#include <cstdint>
+
+namespace COMGR::hotswap {
+
+/// Index of the operand named `Name` in `Opcode`, or -1 if it has no operand of
+/// that name.
+int16_t getNamedOperandIdx(uint32_t Opcode, llvm::AMDGPU::OpName Name);
+
+/// The opcode `Opcode` encodes as on encoding family `Gen` (an
+/// `AMDGPUEncodingFamily`), or -1 if that family does not encode it.
+int32_t getMCOpcode(uint32_t Opcode, unsigned Gen);
+
+/// The VOP3 form of the VOP1/VOP2/VOPC opcode `Opcode`, or -1 if it has none.
+int32_t getVOPe64(uint32_t Opcode);
+
+/// The DPP form of `Opcode` at the given width, or -1 if it has none.
+int32_t getDPPOp32(uint32_t Opcode);
+int32_t getDPPOp64(uint32_t Opcode);
+
+/// The non-SDWA form of the SDWA opcode `Opcode`, or -1 if it has none.
+int32_t getBasicFromSDWAOp(uint32_t Opcode);
+
+/// The vaddr form of the saddr FLAT/global opcode `Opcode`, or -1 if it has
+/// none.
+int32_t getGlobalVaddrOp(uint32_t Opcode);
+
+} // namespace COMGR::hotswap
+
+#endif // HOTSWAP_TRANSPILER_AMDGPU_MC_TABLES_H

--- a/amd/comgr/src/hotswap/decoder/decode.cpp
+++ b/amd/comgr/src/hotswap/decoder/decode.cpp
@@ -169,7 +169,7 @@ void driftCheckSrcN([[maybe_unused]] const MCState &Mc, DecodedInst &Di,
 // register ids to their canonical pseudo first.
 void classifyImplicitDefs(DecodedInst &Di, const MCInstrDesc &Desc) {
   for (MCPhysReg R : Desc.implicit_defs()) {
-    llvm::MCRegister Reg = AMDGPU::mc2PseudoReg(R);
+    llvm::MCRegister Reg = stripRegEncoding(R);
     switch (Reg) {
     case AMDGPU::SCC:
       Di.setDefsScc(true);

--- a/amd/comgr/src/hotswap/decoder/decode.cpp
+++ b/amd/comgr/src/hotswap/decoder/decode.cpp
@@ -47,20 +47,17 @@ namespace {
 // disassembler could not decode.
 constexpr uint64_t KInstAlignBytes = 4;
 
-// getNamedOperandIdx returns -1 when the opcode has no such operand; index 0
-// is valid. Normalise to an optional operand index so callers compare against
-// unsigned MCInst operand indices without re-testing the sentinel or casting.
+// Operand index of `Name` in `Opc`, or nullopt when the opcode has no such
+// operand.
 std::optional<unsigned> namedOperandIdx(unsigned Opc, AMDGPU::OpName Name) {
   int Idx = AMDGPU::getNamedOperandIdx(Opc, Name);
   return Idx >= 0 ? std::optional<unsigned>(Idx) : std::nullopt;
 }
 
-// Build the logical-source view of an MCInst: SrcMap lists the operand indices
-// that are real sources and ModMap the source-modifier operand paired with each
-// (UINT_MAX when none). A VOP3 source modifier (OPERAND_INPUT_MODS) precedes
-// its source. The DPP/SDWA "old"/"vdst_in" operand is tied to the def but never
-// read in our all-lanes-active model, so it is skipped; other tied inputs (MAC
-// accumulators, atomic read-modify) are real sources and kept.
+// Fill Di.SrcMap with the operand indices that are real sources, and Di.ModMap
+// with the source modifier paired with each (UINT_MAX when none); a modifier
+// operand precedes its source. The "old"/"vdst_in" operand is never read in the
+// all-lanes-active model and is skipped; other tied inputs are kept.
 void buildSrcMap(DecodedInst &Di, const MCInstrDesc &Desc) {
   const MCInst &Inst = Di.Inst;
   unsigned Opc = Inst.getOpcode();
@@ -86,11 +83,9 @@ void buildSrcMap(DecodedInst &Di, const MCInstrDesc &Desc) {
   }
 }
 
-// Assert that every operand tied to a def carries an OpName we have classified.
-// A tied-to-def operand is either a DPP/SDWA inactive-lane fallback (skipped by
-// buildSrcMap) or a real read-modify input (kept); the two are distinguished by
-// OpName, so an unrecognised one means LLVM added a tied input this code does
-// not account for.
+// Assert that every operand tied to a def carries an OpName buildSrcMap
+// classifies. An unrecognised one means a tied input this code does not
+// account for.
 void driftCheckTiedIn(const DecodedInst &Di, const MCInstrDesc &Desc) {
   static constexpr AMDGPU::OpName KKnownTiedIn[] = {
       AMDGPU::OpName::old,     AMDGPU::OpName::vdst_in,
@@ -118,12 +113,10 @@ void driftCheckTiedIn(const DecodedInst &Di, const MCInstrDesc &Desc) {
   }
 }
 
-// Assert that the leading sources and their modifiers agree with LLVM's
-// named-operand table, catching operand-layout changes for the many opcodes
-// that use srcN naming (VALU, VOPC, SOP1/SOP2, ...). Scaled MFMA appends its
-// source modifiers after the sources instead of interleaving them, so the
-// positional walk in buildSrcMap misses them; those are repaired here from the
-// named-operand table.
+// Assert that Di's leading sources and their modifiers agree with the
+// named-operand table, catching operand-layout changes for opcodes using srcN
+// naming. MFMA appends its source modifiers after the sources rather than
+// interleaving them, so Di.ModMap is repaired from the table instead.
 void driftCheckSrcN([[maybe_unused]] const MCState &Mc, DecodedInst &Di,
                     const MCInstrDesc &Desc) {
   static constexpr AMDGPU::OpName KSrcNames[] = {
@@ -134,19 +127,17 @@ void driftCheckSrcN([[maybe_unused]] const MCState &Mc, DecodedInst &Di,
 
   unsigned Opc = Di.Inst.getOpcode();
 
-  // MADMK/FMAMK place the literal between src0 and src1, so buildSrcMap's
-  // positional SrcMap[1] is the literal, not src1. Handlers index by MC operand
-  // order, so skip the strict src1 position check for this known layout.
+  // MADMK/FMAMK place the literal between src0 and src1, so the positional
+  // SrcMap[1] is the literal, not src1; skip the src1 position check.
   std::optional<unsigned> ImmIdx = namedOperandIdx(Opc, AMDGPU::OpName::imm);
   std::optional<unsigned> Src0Idx = namedOperandIdx(Opc, AMDGPU::OpName::src0);
   std::optional<unsigned> Src1Idx = namedOperandIdx(Opc, AMDGPU::OpName::src1);
   bool IsMadmk =
       ImmIdx && Src0Idx && Src1Idx && *Src0Idx < *ImmIdx && *ImmIdx < *Src1Idx;
 
-  // v_movrel{d,sd}_b32 have no real def and place $vdst at operand 0 as an
-  // input, so SrcMap[0] is that vdst-as-source while src0 is at operand 1. Skip
-  // the strict src0 position check for this layout; the handler reads by named
-  // operand index, not SrcMap[0].
+  // v_movrel{d,sd}_b32 have no def and place $vdst at operand 0 as an input, so
+  // SrcMap[0] is that vdst-as-source while src0 is at operand 1; skip the src0
+  // position check.
   bool IsMovrel = namedOperandIdx(Opc, AMDGPU::OpName::vdst) == 0u &&
                   Desc.getNumDefs() == 0;
   assert((!IsMovrel ||
@@ -205,8 +196,6 @@ void classifyImplicitDefs(DecodedInst &Di, const MCInstrDesc &Desc) {
 
 } // namespace
 
-// s_endpgm ends the block with no successor; any other block falls through to
-// NextBlockOffset when a block follows.
 Expected<SmallVector<uint64_t>>
 computeDecodedBlockSuccessors(const DecodedInst &LastInst,
                               std::optional<uint64_t> NextBlockOffset) {

--- a/amd/comgr/src/hotswap/decoder/decode.cpp
+++ b/amd/comgr/src/hotswap/decoder/decode.cpp
@@ -8,6 +8,7 @@
 
 #include "decode.h"
 
+#include "amdgpu-mc-tables.h"
 #include "canonical-op.h"
 #include "decoded-inst.h"
 #include "hotswap/common/hotswap-error.h"
@@ -47,7 +48,7 @@ namespace {
 // Operand index of `Name` in `Opc`, or nullopt when the opcode has no such
 // operand.
 std::optional<unsigned> namedOperandIdx(unsigned Opc, AMDGPU::OpName Name) {
-  int Idx = AMDGPU::getNamedOperandIdx(Opc, Name);
+  int Idx = COMGR::hotswap::getNamedOperandIdx(Opc, Name);
   return Idx >= 0 ? std::optional<unsigned>(Idx) : std::nullopt;
 }
 

--- a/amd/comgr/src/hotswap/decoder/decode.cpp
+++ b/amd/comgr/src/hotswap/decoder/decode.cpp
@@ -156,7 +156,7 @@ void driftCheckSrcN([[maybe_unused]] const MCState &Mc, DecodedInst &Di,
         Di.ModMap[K] == UINT_MAX ? std::nullopt
                                  : std::optional<unsigned>(Di.ModMap[K]);
     if (OurMod != NamedMod) {
-      bool IsMai = Di.TargetSpecificFlags & SIInstrFlags::IsMAI;
+      bool IsMai = SIInstrFlags::isMAI(Desc);
       assert(IsMai && NamedMod && !OurMod &&
              "modMap disagrees with OpName::srcN_modifiers table");
       if (IsMai && NamedMod)

--- a/amd/comgr/src/hotswap/decoder/decode.cpp
+++ b/amd/comgr/src/hotswap/decoder/decode.cpp
@@ -13,23 +13,20 @@
 #include "mc-state.h"
 #include "opcode-map.h"
 
-#include "MCTargetDesc/AMDGPUMCTargetDesc.h" // AMDGPU::EXEC, VCC, SCC, ...
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h"
 #include "SIDefines.h"
 #include "Utils/AMDGPUBaseInfo.h"
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/Twine.h"
 #include "llvm/MC/MCDisassembler/MCDisassembler.h"
-#include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
-#include "llvm/MC/MCInstPrinter.h"
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegister.h"
 #include "llvm/MC/MCSubtargetInfo.h"
-#include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/Format.h"
-#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <cassert>
@@ -38,45 +35,48 @@
 #include <string>
 #include <utility>
 
+#define DEBUG_TYPE "hotswap-decode"
+
 using namespace llvm;
 
 namespace COMGR::hotswap {
 
 namespace {
 
-constexpr unsigned KSoppBranchStrideBytes = 4;
-constexpr int64_t KAddPcI64LiteralAlignmentBytes = 4;
+// AMDGPU instructions occupy whole 4-byte units; step past a word the
+// disassembler could not decode.
+constexpr uint64_t KInstAlignBytes = 4;
 
-// Build the logical-source view of an MCInst. Walks `desc.operands()` and
-// classifies each operand using TableGen-generated metadata only:
-//
-//   * Operand types carrying the AMDGPU-specific `OPERAND_INPUT_MODS`
-//     tag are VOP3 source modifiers (neg/abs/opsel packed as an imm).
-//     They attach to the next logical source via `modMap`.
-//   * DPP/SDWA encodings carry a tied "old" input (fallback value for
-//     inactive lanes, named `$old` or `$vdst_in` in TableGen). In our
-//     all-lanes-active scalar model that slot is never read, so we skip
-//     it. Not every tied-to-def operand is a fallback -- VOP2 MAC forms
-//     (v_fmac_f32, v_mac_f32, v_dot2c_*) tie `$src2` to the dst and
-//     atomics tie `$vdata_in`/`$sdst_in`/`$addr_in`; in those cases the
-//     tied operand is a real accumulator/read-modify input and must stay
-//     in srcMap. We therefore select on the named-operand id rather than
-//     the TIED_TO bit alone.
-//   * Everything else is a logical source recorded in MCInst order.
-Error buildSrcMap(DecodedInst &Di, const MCInstrDesc &Desc) {
+// getNamedOperandIdx returns -1 when the opcode has no such operand; index 0
+// is valid. Normalise to an optional operand index so callers compare against
+// unsigned MCInst operand indices without re-testing the sentinel or casting.
+std::optional<unsigned> namedOperandIdx(unsigned Opc, AMDGPU::OpName Name) {
+  int Idx = AMDGPU::getNamedOperandIdx(Opc, Name);
+  return Idx >= 0 ? std::optional<unsigned>(Idx) : std::nullopt;
+}
+
+// Build the logical-source view of an MCInst: SrcMap lists the operand indices
+// that are real sources and ModMap the source-modifier operand paired with each
+// (UINT_MAX when none). A VOP3 source modifier (OPERAND_INPUT_MODS) precedes
+// its source. The DPP/SDWA "old"/"vdst_in" operand is tied to the def but never
+// read in our all-lanes-active model, so it is skipped; other tied inputs (MAC
+// accumulators, atomic read-modify) are real sources and kept.
+void buildSrcMap(DecodedInst &Di, const MCInstrDesc &Desc) {
   const MCInst &Inst = Di.Inst;
   unsigned Opc = Inst.getOpcode();
-  int OldIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::old);
-  int VdstInIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::vdst_in);
+  std::optional<unsigned> OldIdx = namedOperandIdx(Opc, AMDGPU::OpName::old);
+  std::optional<unsigned> VdstInIdx =
+      namedOperandIdx(Opc, AMDGPU::OpName::vdst_in);
   auto OpInfos = Desc.operands();
+  unsigned NumOps = Inst.getNumOperands();
   unsigned PendingModIdx = UINT_MAX;
-  for (unsigned I = Di.FirstSrcIdx; I < Inst.getNumOperands(); ++I) {
+  for (unsigned I = Di.FirstSrcIdx; I < NumOps; ++I) {
     if (I < OpInfos.size() &&
         OpInfos[I].OperandType == AMDGPU::OPERAND_INPUT_MODS) {
       PendingModIdx = I;
       continue;
     }
-    if (static_cast<int>(I) == OldIdx || static_cast<int>(I) == VdstInIdx) {
+    if (OldIdx == I || VdstInIdx == I) {
       PendingModIdx = UINT_MAX;
       continue;
     }
@@ -84,46 +84,14 @@ Error buildSrcMap(DecodedInst &Di, const MCInstrDesc &Desc) {
     Di.ModMap.push_back(PendingModIdx);
     PendingModIdx = UINT_MAX;
   }
-  return Error::success();
 }
 
-// Drift check A: every tied-to-def operand on this instruction must have
-// an OpName we've explicitly classified. If LLVM introduces a new
-// tied-input OpName we haven't audited (so we don't know whether to skip
-// or keep it), stop and make a human decide. `KKnownTiedIn` is the
-// exhaustive audit as of this commit. Two semantic categories:
-//
-//   skipped-as-fallback (DPP/SDWA inactive-lane value; never read in the
-//                       all-lanes-active scalar model):
-//     `old`, `vdst_in`.
-//
-//   kept-as-real-input (read-modify accumulator, atomic compare, or
-//                      MAC-style third source; the instruction
-//                      semantically reads the prior def value):
-//     `sdst_in`, `vdata_in`, `addr_in`, `srcTiedDef`,
-//     `src0`, `src1`, `src2`,
-//     `src0X`, `src0Y`, `src2X`, `src2Y`,
-//     `vsrc2X`, `vsrc2Y`.
-//
-// CAVEAT: this list reflects whether the *handler* should treat the
-// tied operand as a real read (yes for `sdst_in`/`vdata_in`/etc.; no
-// for `old`/`vdst_in`). It does NOT promise that the AMDGPU
-// disassembler will materialise an MCOperand for that slot -- for
-// SOP1 `sdst_in` (S_BITSET0/1_B{32,64}) and SOP1 `S_CMOV_B{32,64}`
-// the disassembler collapses the tied slot and produces only
-// `(sdst, src0)`, so `srcMap` won't contain an entry for the prior-
-// dst read. Handlers in those cases must fetch the prior value
-// directly via `ctx.Regs.readReg{32,64}(op.dst())`. For
-// `vdata_in` / `addr_in` / `srcTiedDef` (atomics, MAC accumulators)
-// the disassembler does emit a full MCOperand and the handler reads
-// it through the normal `op.src(N)` path.
-//
-// srcN and VOPD variants all appear here because SOPK `S_ADDK_I32`
-// ties `$src0`, SOP2 `sdst,sdst_in` variants may also surface `$src0`,
-// VALU MAC forms tie `$src2`, and VOPD3 FMAC halves tie `$src2X` /
-// `$src2Y` (plus potentially the separate VOPD3 third source).
-Error driftCheckTiedIn(const MCState &Mc, const DecodedInst &Di,
-                       const MCInstrDesc &Desc) {
+// Assert that every operand tied to a def carries an OpName we have classified.
+// A tied-to-def operand is either a DPP/SDWA inactive-lane fallback (skipped by
+// buildSrcMap) or a real read-modify input (kept); the two are distinguished by
+// OpName, so an unrecognised one means LLVM added a tied input this code does
+// not account for.
+void driftCheckTiedIn(const DecodedInst &Di, const MCInstrDesc &Desc) {
   static constexpr AMDGPU::OpName KKnownTiedIn[] = {
       AMDGPU::OpName::old,     AMDGPU::OpName::vdst_in,
       AMDGPU::OpName::sdst_in, AMDGPU::OpName::vdata_in,
@@ -134,174 +102,84 @@ Error driftCheckTiedIn(const MCState &Mc, const DecodedInst &Di,
       AMDGPU::OpName::src2Y,   AMDGPU::OpName::vsrc2X,
       AMDGPU::OpName::vsrc2Y,
   };
-  const MCInst &Inst = Di.Inst;
-  unsigned Opc = Inst.getOpcode();
-  for (unsigned I = 0; I < Inst.getNumOperands(); ++I) {
+  unsigned Opc = Di.Inst.getOpcode();
+  unsigned NumOps = Di.Inst.getNumOperands();
+  for (unsigned I = 0; I < NumOps; ++I) {
     int Tied = Desc.getOperandConstraint(I, MCOI::TIED_TO);
-    if (Tied < 0)
+    // Only defs matter here: use-to-use ties exist but are not fallbacks or
+    // accumulators.
+    if (Tied < 0 || static_cast<unsigned>(Tied) >= Desc.getNumDefs())
       continue;
-    // Only flag operands tied to a def. Use-to-use ties exist in LLVM's
-    // constraint system but are not relevant to the fallback/accumulator
-    // distinction this check protects.
-    if (static_cast<unsigned>(Tied) >= Desc.getNumDefs())
-      continue;
-    bool Known = false;
-    for (AMDGPU::OpName N : KKnownTiedIn) {
-      if (static_cast<int>(I) == AMDGPU::getNamedOperandIdx(Opc, N)) {
-        Known = true;
-        break;
-      }
-    }
-    if (!Known) {
-      std::string Msg;
-      raw_string_ostream Os(Msg);
-      Os << "transpiler: tied-to-def operand has an OpName not in the "
-            "audited set -- classify explicitly (fallback to skip vs. real "
-            "input to keep) before proceeding for "
-         << getMnemonic(Mc, Di.Inst) << " (opcode=" << Opc << "): index=" << I
-         << ", tiedTo=" << Tied << ", numDefs=" << Desc.getNumDefs()
-         << ", numOps=" << Inst.getNumOperands();
-      return createStringError(Msg);
-    }
+    [[maybe_unused]] bool Known =
+        llvm::any_of(KKnownTiedIn, [&](AMDGPU::OpName N) {
+          return namedOperandIdx(Opc, N) == I;
+        });
+    assert(Known && "tied-to-def operand has an unclassified OpName");
   }
-  return Error::success();
 }
 
-// Drift check B: for every opcode that exposes `srcN` / `srcN_modifiers`
-// naming (VALU, VOPC, SOP1/SOP2, a handful of scalar forms), the first
-// N entries of srcMap / modMap must agree with LLVM's named-operand
-// table. Catches operand-layout drift for the large majority of opcodes
-// -- but notably NOT for DS / MUBUF / FLAT / SMEM / image encodings,
-// which don't use srcN naming; those formats are only protected by the
-// walk's correctness and drift check A.
-//
-// Scaled MFMA instructions (ScaledMAIInst in TableGen) append
-// src0_modifiers / src1_modifiers AFTER all source operands, not
-// interleaved as in VOP3. The walk can't discover them because it only
-// looks for OPERAND_INPUT_MODS *before* each source. We repair the
-// modMap from LLVM's authoritative named-operand table here, but ONLY
-// for MAI-format instructions so we don't silently mask future layout
-// drift in other formats.
-Error driftCheckSrcN(const MCState &Mc, DecodedInst &Di,
-                     const MCInstrDesc &Desc) {
+// Assert that the leading sources and their modifiers agree with LLVM's
+// named-operand table, catching operand-layout changes for the many opcodes
+// that use srcN naming (VALU, VOPC, SOP1/SOP2, ...). Scaled MFMA appends its
+// source modifiers after the sources instead of interleaving them, so the
+// positional walk in buildSrcMap misses them; those are repaired here from the
+// named-operand table.
+void driftCheckSrcN([[maybe_unused]] const MCState &Mc, DecodedInst &Di,
+                    const MCInstrDesc &Desc) {
   static constexpr AMDGPU::OpName KSrcNames[] = {
       AMDGPU::OpName::src0, AMDGPU::OpName::src1, AMDGPU::OpName::src2};
   static constexpr AMDGPU::OpName KModNames[] = {
       AMDGPU::OpName::src0_modifiers, AMDGPU::OpName::src1_modifiers,
       AMDGPU::OpName::src2_modifiers};
 
-  auto ReportErr = [&](const Twine &Prefix, int Index, int Ours,
-                       int Expected) -> Error {
-    std::string Msg;
-    raw_string_ostream Os(Msg);
-    Os << Prefix << " for " << getMnemonic(Mc, Di.Inst)
-       << " (opcode=" << Di.Inst.getOpcode() << "): index=" << Index
-       << ", srcMap/modMap=" << Ours << ", named=" << Expected
-       << ", numSrcs=" << Di.SrcMap.size() << ", numDefs=" << Desc.getNumDefs()
-       << ", numOps=" << Di.Inst.getNumOperands();
-    return createStringError(Msg);
-  };
-
   unsigned Opc = Di.Inst.getOpcode();
 
-  // MADMK/FMAMK exception: `v_fmamk_f32` and scalar `s_fmamk_f32`
-  // place the 32-bit literal BETWEEN src0 and src1:
-  //
-  //   VOP_MADMK (VOP2Instructions.td): (src0, K-imm, src1)
-  //   S_FMAMK_F32 (SOPInstructions.td): (src0, KImmFP32, src1)
-  //
-  // The natural positional walk in `buildSrcMap` produces
-  // srcMap = [src0, K-imm, src1], which matches the corresponding handlers'
-  // expectation that logical source order follows MC operand order.
-  //
-  // The strict `srcMap[k] == OpName::srcN` invariant breaks for
-  // this layout because OpName::src1 lives at MCInst index 3, not
-  // srcMap[1] = 2. The drift is INTENTIONAL: handlers index by
-  // MCInst order, not OpName order, and MADMK is a known stable
-  // form. Skip the strict srcN-position check at the AFFECTED
-  // index (k=1, the src1 slot) for this signature; k=0 (src0)
-  // still passes naturally and k=2 returns -1 (no src2) so the
-  // outer loop breaks before reaching it.
-  //
-  // Detection: the opcode exposes both `OpName::imm` and
-  // `OpName::src0` / `OpName::src1`, with the imm operand index
-  // strictly between src0 and src1. (Compare to MADAK/FMAAK forms like
-  // `v_fmaak_f32` / `s_fmaak_f32`, whose layouts are `(src0, src1, K-imm)` --
-  // K trailing -- where the positional walk happens to coincide with OpName
-  // order and the drift check passes naturally.)
-  //
-  // The modifier-map check below remains in force; MADMK has no
-  // src{0,1,2}_modifiers operands, so the loop's modMap branch
-  // simply finds expected=-1 and our=-1, agreement.
-  int ImmIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::imm);
-  int Src0Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::src0);
-  int Src1Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::src1);
-  bool IsMadmk = ImmIdx >= 0 && Src0Idx >= 0 && Src1Idx >= 0 &&
-                 Src0Idx < ImmIdx && ImmIdx < Src1Idx;
+  // MADMK/FMAMK place the literal between src0 and src1, so buildSrcMap's
+  // positional SrcMap[1] is the literal, not src1. Handlers index by MC operand
+  // order, so skip the strict src1 position check for this known layout.
+  std::optional<unsigned> ImmIdx = namedOperandIdx(Opc, AMDGPU::OpName::imm);
+  std::optional<unsigned> Src0Idx = namedOperandIdx(Opc, AMDGPU::OpName::src0);
+  std::optional<unsigned> Src1Idx = namedOperandIdx(Opc, AMDGPU::OpName::src1);
+  bool IsMadmk =
+      ImmIdx && Src0Idx && Src1Idx && *Src0Idx < *ImmIdx && *ImmIdx < *Src1Idx;
 
-  // v_movreld_b32 / v_movrelsd_b32 are the "no true destination" VOP1 forms:
-  // their profile sets HasDst=0 and hacks $vdst into the *inputs* at MC operand
-  // 0 (see VOP_MOVREL in VOP1Instructions.td), so the positional source walk
-  // records SrcMap[0] = that vdst-as-source while OpName::src0 lives at
-  // index 1. That is a legitimate layout, not decoder drift -- like MADMK -- so
-  // skip the strict srcN-position check at k=0 for it. Detect it structurally
-  // from the operand tables (vdst present at operand 0 with zero declared defs)
-  // rather than by mnemonic string. Note there is no MC-level TIED_TO here: the
-  // tied vdst_in described in the ISA is added later by the custom inserter,
-  // not in the MCInstrDesc we see at decode time. v_movrels_b32 has a genuine
-  // def, so its walk matches OpName::src0 naturally and needs no exception. The
-  // v_movrel* handler reads vdst/vsrc by named operand index (not SrcMap[0]),
-  // so it does not depend on the layout skipped here; a data-dependent M0 has
-  // no statically-known index and fails gracefully downstream (stubbed under
-  // HSA_HOTSWAP_STUB_FAILED_KERNELS).
-  int VdstIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::vdst);
-  bool IsMovrel = VdstIdx == 0 && Desc.getNumDefs() == 0;
-  // Cross-check the structural signature against the mnemonic: every op that
-  // matches (vdst-as-source, no declared defs) must be a v_movrel* form. If a
-  // future opcode trips this signature without being a register-relative move,
-  // we would silently skip a genuine srcN drift here -- catch that in asserts
-  // builds rather than let it slip. (One-directional: v_movrels_b32 also starts
-  // with the prefix but has a real def, so it is not expected to match above.)
+  // v_movrel{d,sd}_b32 have no real def and place $vdst at operand 0 as an
+  // input, so SrcMap[0] is that vdst-as-source while src0 is at operand 1. Skip
+  // the strict src0 position check for this layout; the handler reads by named
+  // operand index, not SrcMap[0].
+  bool IsMovrel = namedOperandIdx(Opc, AMDGPU::OpName::vdst) == 0u &&
+                  Desc.getNumDefs() == 0;
   assert((!IsMovrel ||
           StringRef(getMnemonic(Mc, Di.Inst)).starts_with("v_movrel")) &&
          "vdst-at-0/no-defs signature matched a non-movrel opcode");
 
   for (unsigned K = 0; K < 3; ++K) {
-    int NamedSrc = AMDGPU::getNamedOperandIdx(Opc, KSrcNames[K]);
-    if (NamedSrc < 0)
+    std::optional<unsigned> NamedSrc = namedOperandIdx(Opc, KSrcNames[K]);
+    if (!NamedSrc)
       break;
-    int OurSrc = (K < Di.SrcMap.size()) ? static_cast<int>(Di.SrcMap[K]) : -1;
-    // Skip ONLY the genuinely-affected index (k=1) for MADMK. k=0
-    // (src0) still receives the strict check, so a hypothetical
-    // future drift in src0's MCInst position is still caught even
-    // for MADMK opcodes.
+    std::optional<unsigned> OurSrc = K < Di.SrcMap.size()
+                                         ? std::optional<unsigned>(Di.SrcMap[K])
+                                         : std::nullopt;
     bool SkipThis = (IsMadmk && K == 1) || (IsMovrel && K == 0);
-    if (!SkipThis && OurSrc != NamedSrc)
-      return ReportErr("transpiler: srcMap disagrees with OpName::srcN table",
-                       static_cast<int>(K), OurSrc, NamedSrc);
-    int NamedMod = AMDGPU::getNamedOperandIdx(Opc, KModNames[K]);
-    int OurMod =
-        (Di.ModMap[K] == UINT_MAX) ? -1 : static_cast<int>(Di.ModMap[K]);
-    int ExpectedMod = (NamedMod < 0) ? -1 : NamedMod;
-    if (OurMod != ExpectedMod) {
+    assert((SkipThis || OurSrc == NamedSrc) &&
+           "srcMap disagrees with OpName::srcN table");
+
+    std::optional<unsigned> NamedMod = namedOperandIdx(Opc, KModNames[K]);
+    std::optional<unsigned> OurMod =
+        Di.ModMap[K] == UINT_MAX ? std::nullopt
+                                 : std::optional<unsigned>(Di.ModMap[K]);
+    if (OurMod != NamedMod) {
       bool IsMai = Di.TargetSpecificFlags & SIInstrFlags::IsMAI;
-      if (IsMai && NamedMod >= 0 && OurMod == -1) {
-        Di.ModMap[K] = static_cast<unsigned>(NamedMod);
-      } else {
-        return ReportErr(
-            "transpiler: modMap disagrees with OpName::srcN_modifiers table",
-            static_cast<int>(K), OurMod, ExpectedMod);
-      }
+      assert(IsMai && NamedMod && !OurMod &&
+             "modMap disagrees with OpName::srcN_modifiers table");
+      if (IsMai && NamedMod)
+        Di.ModMap[K] = *NamedMod;
     }
   }
-  return Error::success();
 }
 
-// Identify implicit defs of wave-mask / condition-flag registers via
-// identity constants rather than register-name string matches. We
-// normalise through `mc2PseudoReg` first, which strips subtarget
-// suffixes (``_gfxNplus``) and converts aliases to their canonical
-// pseudo-register id -- same pattern used by `parseReg`.
+// Record implicit defs of SCC / VCC / EXEC, normalising subtarget-suffixed
+// register ids to their canonical pseudo first.
 void classifyImplicitDefs(DecodedInst &Di, const MCInstrDesc &Desc) {
   for (MCPhysReg R : Desc.implicit_defs()) {
     llvm::MCRegister Reg = AMDGPU::mc2PseudoReg(R);
@@ -327,9 +205,8 @@ void classifyImplicitDefs(DecodedInst &Di, const MCInstrDesc &Desc) {
 
 } // namespace
 
-// Successor model over decoded block leaders. s_endpgm terminates the block
-// with no successor; everything else falls through to the next linear block.
-// Branch / set-pc successor edges land with control-flow support.
+// s_endpgm ends the block with no successor; any other block falls through to
+// NextBlockOffset when a block follows.
 Expected<SmallVector<uint64_t>>
 computeDecodedBlockSuccessors(const DecodedInst &LastInst,
                               std::optional<uint64_t> NextBlockOffset) {
@@ -345,34 +222,28 @@ bool decodedInstEndsBlock(const DecodedInst &LastInst) {
   return LastInst.CanonOp == CanonicalOp::S_ENDPGM;
 }
 
-Expected<DecodeResult> decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
-                                    ArrayRef<uint8_t> TextBytes,
-                                    uint64_t KernelOffset,
-                                    uint64_t KernelEndOffset,
-                                    std::optional<uint64_t> KernelStartOffset) {
+DecodeResult decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
+                          ArrayRef<uint8_t> TextBytes, uint64_t KernelOffset,
+                          std::optional<uint64_t> KernelEndOffset,
+                          std::optional<uint64_t> KernelStartOffset) {
   DecodeResult Out;
   Out.BlockStarts.insert(KernelOffset);
-  uint64_t KernelStart = KernelStartOffset.value_or(KernelOffset);
+  [[maybe_unused]] uint64_t KernelStart =
+      KernelStartOffset.value_or(KernelOffset);
 
-  if (KernelOffset > 0)
-    errs() << "transpiler: Starting disassembly at kernel offset 0x"
-           << utohexstr(KernelOffset) << "\n";
+  LLVM_DEBUG(if (KernelOffset > 0) dbgs()
+             << "hotswap: starting disassembly at kernel offset 0x"
+             << utohexstr(KernelOffset) << "\n");
 
-  if (KernelOffset > TextBytes.size())
-    return createStringError(
-        "transpiler: kernel decode offset is outside .text contents");
-  if (KernelStart > KernelOffset)
-    return createStringError(
-        "transpiler: kernel decode start follows scan offset");
-  if (KernelEndOffset != 0 && KernelEndOffset < KernelOffset)
-    return createStringError("transpiler: kernel decode end precedes start");
-  if (KernelEndOffset > TextBytes.size())
-    return createStringError(
-        "transpiler: kernel decode end is outside .text contents");
+  assert(KernelOffset <= TextBytes.size() &&
+         "kernel decode offset is outside .text");
+  assert(KernelStart <= KernelOffset && "kernel decode start follows scan");
+  assert((!KernelEndOffset || *KernelEndOffset >= KernelOffset) &&
+         "kernel decode end precedes start");
+  assert((!KernelEndOffset || *KernelEndOffset <= TextBytes.size()) &&
+         "kernel decode end is outside .text");
 
-  const uint64_t TotalSize = KernelEndOffset == 0
-                                 ? static_cast<uint64_t>(TextBytes.size())
-                                 : KernelEndOffset;
+  const uint64_t TotalSize = KernelEndOffset.value_or(TextBytes.size());
   uint64_t Off = KernelOffset;
   while (Off < TotalSize) {
     MCInst Inst;
@@ -380,7 +251,7 @@ Expected<DecodeResult> decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
     auto Status = Mc.Disasm->getInstruction(
         Inst, InstSize, TextBytes.slice(Off, TotalSize - Off), Off, nulls());
     if (Status != MCDisassembler::Success) {
-      Off += 4;
+      Off += KInstAlignBytes;
       continue;
     }
     const MCInstrDesc &Desc = Mc.InstrInfo->get(Inst.getOpcode());
@@ -393,15 +264,12 @@ Expected<DecodeResult> decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
     Di.TargetSpecificFlags = Desc.TSFlags;
     Di.FirstSrcIdx = Desc.getNumDefs();
 
-    if (Error E = buildSrcMap(Di, Desc))
-      return E;
-    if (Error E = driftCheckTiedIn(Mc, Di, Desc))
-      return E;
-    if (Error E = driftCheckSrcN(Mc, Di, Desc))
-      return E;
+    buildSrcMap(Di, Desc);
+    driftCheckTiedIn(Di, Desc);
+    driftCheckSrcN(Mc, Di, Desc);
     classifyImplicitDefs(Di, Desc);
 
-    bool IsEnd = (Di.CanonOp == CanonicalOp::S_ENDPGM);
+    bool IsEnd = decodedInstEndsBlock(Di);
     Out.Insts.push_back(std::move(Di));
     if (IsEnd) {
       // `s_endpgm` may appear mid-binary (early-return path); if there are

--- a/amd/comgr/src/hotswap/decoder/decode.cpp
+++ b/amd/comgr/src/hotswap/decoder/decode.cpp
@@ -10,6 +10,7 @@
 
 #include "canonical-op.h"
 #include "decoded-inst.h"
+#include "hotswap/common/hotswap-error.h"
 #include "mc-state.h"
 #include "opcode-map.h"
 
@@ -42,10 +43,6 @@ using namespace llvm;
 namespace COMGR::hotswap {
 
 namespace {
-
-// AMDGPU instructions occupy whole 4-byte units; step past a word the
-// disassembler could not decode.
-constexpr uint64_t KInstAlignBytes = 4;
 
 // Operand index of `Name` in `Opc`, or nullopt when the opcode has no such
 // operand.
@@ -127,17 +124,16 @@ void driftCheckSrcN([[maybe_unused]] const MCState &Mc, DecodedInst &Di,
 
   unsigned Opc = Di.Inst.getOpcode();
 
-  // MADMK/FMAMK place the literal between src0 and src1, so the positional
-  // SrcMap[1] is the literal, not src1; skip the src1 position check.
+  // MADMK/FMAMK place the literal between src0 and src1, so SrcMap[1] cannot
+  // be checked against the named src1 operand.
   std::optional<unsigned> ImmIdx = namedOperandIdx(Opc, AMDGPU::OpName::imm);
   std::optional<unsigned> Src0Idx = namedOperandIdx(Opc, AMDGPU::OpName::src0);
   std::optional<unsigned> Src1Idx = namedOperandIdx(Opc, AMDGPU::OpName::src1);
   bool IsMadmk =
       ImmIdx && Src0Idx && Src1Idx && *Src0Idx < *ImmIdx && *ImmIdx < *Src1Idx;
 
-  // v_movrel{d,sd}_b32 have no def and place $vdst at operand 0 as an input, so
-  // SrcMap[0] is that vdst-as-source while src0 is at operand 1; skip the src0
-  // position check.
+  // v_movrel{d,sd}_b32 place $vdst at operand 0 as an input, so SrcMap[0]
+  // cannot be checked against the named src0 operand.
   bool IsMovrel = namedOperandIdx(Opc, AMDGPU::OpName::vdst) == 0u &&
                   Desc.getNumDefs() == 0;
   assert((!IsMovrel ||
@@ -211,10 +207,11 @@ bool decodedInstEndsBlock(const DecodedInst &LastInst) {
   return LastInst.CanonOp == CanonicalOp::S_ENDPGM;
 }
 
-DecodeResult decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
-                          ArrayRef<uint8_t> TextBytes, uint64_t KernelOffset,
-                          std::optional<uint64_t> KernelEndOffset,
-                          std::optional<uint64_t> KernelStartOffset) {
+Expected<DecodeResult> decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
+                                    ArrayRef<uint8_t> TextBytes,
+                                    uint64_t KernelOffset,
+                                    std::optional<uint64_t> KernelEndOffset,
+                                    std::optional<uint64_t> KernelStartOffset) {
   DecodeResult Out;
   Out.BlockStarts.insert(KernelOffset);
   [[maybe_unused]] uint64_t KernelStart =
@@ -237,12 +234,15 @@ DecodeResult decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
   while (Off < TotalSize) {
     MCInst Inst;
     uint64_t InstSize = 0;
-    auto Status = Mc.Disasm->getInstruction(
+    MCDisassembler::DecodeStatus Status = Mc.Disasm->getInstruction(
         Inst, InstSize, TextBytes.slice(Off, TotalSize - Off), Off, nulls());
-    if (Status != MCDisassembler::Success) {
-      Off += KInstAlignBytes;
-      continue;
-    }
+    // A failed decode leaves the next instruction boundary unknown, so the
+    // rest of the range cannot be scanned.
+    if (Status != MCDisassembler::Success)
+      return makeHotswapError(
+          "decodeKernel: cannot decode instruction at .text offset 0x" +
+          utohexstr(Off) + " (" +
+          (Status == MCDisassembler::SoftFail ? "soft fail" : "fail") + ")");
     const MCInstrDesc &Desc = Mc.InstrInfo->get(Inst.getOpcode());
     DecodedInst Di;
     Di.Inst = Inst;
@@ -264,7 +264,7 @@ DecodeResult decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
       // `s_endpgm` may appear mid-binary (early-return path); if there are
       // known block starts at later offsets, keep disassembling.
       uint64_t NextOff = Off + InstSize;
-      auto It = Out.BlockStarts.upper_bound(Off);
+      std::set<uint64_t>::const_iterator It = Out.BlockStarts.upper_bound(Off);
       if (It != Out.BlockStarts.end() && *It < TotalSize) {
         Off = NextOff;
         continue;

--- a/amd/comgr/src/hotswap/decoder/decode.cpp
+++ b/amd/comgr/src/hotswap/decoder/decode.cpp
@@ -1,0 +1,423 @@
+//===- decode.cpp - Hotswap transpiler ------------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "decode.h"
+
+#include "canonical-op.h"
+#include "decoded-inst.h"
+#include "mc-state.h"
+#include "opcode-map.h"
+
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h" // AMDGPU::EXEC, VCC, SCC, ...
+#include "SIDefines.h"
+#include "Utils/AMDGPUBaseInfo.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/MC/MCDisassembler/MCDisassembler.h"
+#include "llvm/MC/MCExpr.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegister.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cassert>
+#include <climits>
+#include <optional>
+#include <string>
+#include <utility>
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+namespace {
+
+constexpr unsigned KSoppBranchStrideBytes = 4;
+constexpr int64_t KAddPcI64LiteralAlignmentBytes = 4;
+
+// Build the logical-source view of an MCInst. Walks `desc.operands()` and
+// classifies each operand using TableGen-generated metadata only:
+//
+//   * Operand types carrying the AMDGPU-specific `OPERAND_INPUT_MODS`
+//     tag are VOP3 source modifiers (neg/abs/opsel packed as an imm).
+//     They attach to the next logical source via `modMap`.
+//   * DPP/SDWA encodings carry a tied "old" input (fallback value for
+//     inactive lanes, named `$old` or `$vdst_in` in TableGen). In our
+//     all-lanes-active scalar model that slot is never read, so we skip
+//     it. Not every tied-to-def operand is a fallback -- VOP2 MAC forms
+//     (v_fmac_f32, v_mac_f32, v_dot2c_*) tie `$src2` to the dst and
+//     atomics tie `$vdata_in`/`$sdst_in`/`$addr_in`; in those cases the
+//     tied operand is a real accumulator/read-modify input and must stay
+//     in srcMap. We therefore select on the named-operand id rather than
+//     the TIED_TO bit alone.
+//   * Everything else is a logical source recorded in MCInst order.
+Error buildSrcMap(DecodedInst &Di, const MCInstrDesc &Desc) {
+  const MCInst &Inst = Di.Inst;
+  unsigned Opc = Inst.getOpcode();
+  int OldIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::old);
+  int VdstInIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::vdst_in);
+  auto OpInfos = Desc.operands();
+  unsigned PendingModIdx = UINT_MAX;
+  for (unsigned I = Di.FirstSrcIdx; I < Inst.getNumOperands(); ++I) {
+    if (I < OpInfos.size() &&
+        OpInfos[I].OperandType == AMDGPU::OPERAND_INPUT_MODS) {
+      PendingModIdx = I;
+      continue;
+    }
+    if (static_cast<int>(I) == OldIdx || static_cast<int>(I) == VdstInIdx) {
+      PendingModIdx = UINT_MAX;
+      continue;
+    }
+    Di.SrcMap.push_back(I);
+    Di.ModMap.push_back(PendingModIdx);
+    PendingModIdx = UINT_MAX;
+  }
+  return Error::success();
+}
+
+// Drift check A: every tied-to-def operand on this instruction must have
+// an OpName we've explicitly classified. If LLVM introduces a new
+// tied-input OpName we haven't audited (so we don't know whether to skip
+// or keep it), stop and make a human decide. `KKnownTiedIn` is the
+// exhaustive audit as of this commit. Two semantic categories:
+//
+//   skipped-as-fallback (DPP/SDWA inactive-lane value; never read in the
+//                       all-lanes-active scalar model):
+//     `old`, `vdst_in`.
+//
+//   kept-as-real-input (read-modify accumulator, atomic compare, or
+//                      MAC-style third source; the instruction
+//                      semantically reads the prior def value):
+//     `sdst_in`, `vdata_in`, `addr_in`, `srcTiedDef`,
+//     `src0`, `src1`, `src2`,
+//     `src0X`, `src0Y`, `src2X`, `src2Y`,
+//     `vsrc2X`, `vsrc2Y`.
+//
+// CAVEAT: this list reflects whether the *handler* should treat the
+// tied operand as a real read (yes for `sdst_in`/`vdata_in`/etc.; no
+// for `old`/`vdst_in`). It does NOT promise that the AMDGPU
+// disassembler will materialise an MCOperand for that slot -- for
+// SOP1 `sdst_in` (S_BITSET0/1_B{32,64}) and SOP1 `S_CMOV_B{32,64}`
+// the disassembler collapses the tied slot and produces only
+// `(sdst, src0)`, so `srcMap` won't contain an entry for the prior-
+// dst read. Handlers in those cases must fetch the prior value
+// directly via `ctx.Regs.readReg{32,64}(op.dst())`. For
+// `vdata_in` / `addr_in` / `srcTiedDef` (atomics, MAC accumulators)
+// the disassembler does emit a full MCOperand and the handler reads
+// it through the normal `op.src(N)` path.
+//
+// srcN and VOPD variants all appear here because SOPK `S_ADDK_I32`
+// ties `$src0`, SOP2 `sdst,sdst_in` variants may also surface `$src0`,
+// VALU MAC forms tie `$src2`, and VOPD3 FMAC halves tie `$src2X` /
+// `$src2Y` (plus potentially the separate VOPD3 third source).
+Error driftCheckTiedIn(const MCState &Mc, const DecodedInst &Di,
+                       const MCInstrDesc &Desc) {
+  static constexpr AMDGPU::OpName KKnownTiedIn[] = {
+      AMDGPU::OpName::old,     AMDGPU::OpName::vdst_in,
+      AMDGPU::OpName::sdst_in, AMDGPU::OpName::vdata_in,
+      AMDGPU::OpName::addr_in, AMDGPU::OpName::srcTiedDef,
+      AMDGPU::OpName::src0,    AMDGPU::OpName::src1,
+      AMDGPU::OpName::src2,    AMDGPU::OpName::src0X,
+      AMDGPU::OpName::src0Y,   AMDGPU::OpName::src2X,
+      AMDGPU::OpName::src2Y,   AMDGPU::OpName::vsrc2X,
+      AMDGPU::OpName::vsrc2Y,
+  };
+  const MCInst &Inst = Di.Inst;
+  unsigned Opc = Inst.getOpcode();
+  for (unsigned I = 0; I < Inst.getNumOperands(); ++I) {
+    int Tied = Desc.getOperandConstraint(I, MCOI::TIED_TO);
+    if (Tied < 0)
+      continue;
+    // Only flag operands tied to a def. Use-to-use ties exist in LLVM's
+    // constraint system but are not relevant to the fallback/accumulator
+    // distinction this check protects.
+    if (static_cast<unsigned>(Tied) >= Desc.getNumDefs())
+      continue;
+    bool Known = false;
+    for (AMDGPU::OpName N : KKnownTiedIn) {
+      if (static_cast<int>(I) == AMDGPU::getNamedOperandIdx(Opc, N)) {
+        Known = true;
+        break;
+      }
+    }
+    if (!Known) {
+      std::string Msg;
+      raw_string_ostream Os(Msg);
+      Os << "transpiler: tied-to-def operand has an OpName not in the "
+            "audited set -- classify explicitly (fallback to skip vs. real "
+            "input to keep) before proceeding for "
+         << getMnemonic(Mc, Di.Inst) << " (opcode=" << Opc << "): index=" << I
+         << ", tiedTo=" << Tied << ", numDefs=" << Desc.getNumDefs()
+         << ", numOps=" << Inst.getNumOperands();
+      return createStringError(Msg);
+    }
+  }
+  return Error::success();
+}
+
+// Drift check B: for every opcode that exposes `srcN` / `srcN_modifiers`
+// naming (VALU, VOPC, SOP1/SOP2, a handful of scalar forms), the first
+// N entries of srcMap / modMap must agree with LLVM's named-operand
+// table. Catches operand-layout drift for the large majority of opcodes
+// -- but notably NOT for DS / MUBUF / FLAT / SMEM / image encodings,
+// which don't use srcN naming; those formats are only protected by the
+// walk's correctness and drift check A.
+//
+// Scaled MFMA instructions (ScaledMAIInst in TableGen) append
+// src0_modifiers / src1_modifiers AFTER all source operands, not
+// interleaved as in VOP3. The walk can't discover them because it only
+// looks for OPERAND_INPUT_MODS *before* each source. We repair the
+// modMap from LLVM's authoritative named-operand table here, but ONLY
+// for MAI-format instructions so we don't silently mask future layout
+// drift in other formats.
+Error driftCheckSrcN(const MCState &Mc, DecodedInst &Di,
+                     const MCInstrDesc &Desc) {
+  static constexpr AMDGPU::OpName KSrcNames[] = {
+      AMDGPU::OpName::src0, AMDGPU::OpName::src1, AMDGPU::OpName::src2};
+  static constexpr AMDGPU::OpName KModNames[] = {
+      AMDGPU::OpName::src0_modifiers, AMDGPU::OpName::src1_modifiers,
+      AMDGPU::OpName::src2_modifiers};
+
+  auto ReportErr = [&](const Twine &Prefix, int Index, int Ours,
+                       int Expected) -> Error {
+    std::string Msg;
+    raw_string_ostream Os(Msg);
+    Os << Prefix << " for " << getMnemonic(Mc, Di.Inst)
+       << " (opcode=" << Di.Inst.getOpcode() << "): index=" << Index
+       << ", srcMap/modMap=" << Ours << ", named=" << Expected
+       << ", numSrcs=" << Di.SrcMap.size() << ", numDefs=" << Desc.getNumDefs()
+       << ", numOps=" << Di.Inst.getNumOperands();
+    return createStringError(Msg);
+  };
+
+  unsigned Opc = Di.Inst.getOpcode();
+
+  // MADMK/FMAMK exception: `v_fmamk_f32` and scalar `s_fmamk_f32`
+  // place the 32-bit literal BETWEEN src0 and src1:
+  //
+  //   VOP_MADMK (VOP2Instructions.td): (src0, K-imm, src1)
+  //   S_FMAMK_F32 (SOPInstructions.td): (src0, KImmFP32, src1)
+  //
+  // The natural positional walk in `buildSrcMap` produces
+  // srcMap = [src0, K-imm, src1], which matches the corresponding handlers'
+  // expectation that logical source order follows MC operand order.
+  //
+  // The strict `srcMap[k] == OpName::srcN` invariant breaks for
+  // this layout because OpName::src1 lives at MCInst index 3, not
+  // srcMap[1] = 2. The drift is INTENTIONAL: handlers index by
+  // MCInst order, not OpName order, and MADMK is a known stable
+  // form. Skip the strict srcN-position check at the AFFECTED
+  // index (k=1, the src1 slot) for this signature; k=0 (src0)
+  // still passes naturally and k=2 returns -1 (no src2) so the
+  // outer loop breaks before reaching it.
+  //
+  // Detection: the opcode exposes both `OpName::imm` and
+  // `OpName::src0` / `OpName::src1`, with the imm operand index
+  // strictly between src0 and src1. (Compare to MADAK/FMAAK forms like
+  // `v_fmaak_f32` / `s_fmaak_f32`, whose layouts are `(src0, src1, K-imm)` --
+  // K trailing -- where the positional walk happens to coincide with OpName
+  // order and the drift check passes naturally.)
+  //
+  // The modifier-map check below remains in force; MADMK has no
+  // src{0,1,2}_modifiers operands, so the loop's modMap branch
+  // simply finds expected=-1 and our=-1, agreement.
+  int ImmIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::imm);
+  int Src0Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::src0);
+  int Src1Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::src1);
+  bool IsMadmk = ImmIdx >= 0 && Src0Idx >= 0 && Src1Idx >= 0 &&
+                 Src0Idx < ImmIdx && ImmIdx < Src1Idx;
+
+  // v_movreld_b32 / v_movrelsd_b32 are the "no true destination" VOP1 forms:
+  // their profile sets HasDst=0 and hacks $vdst into the *inputs* at MC operand
+  // 0 (see VOP_MOVREL in VOP1Instructions.td), so the positional source walk
+  // records SrcMap[0] = that vdst-as-source while OpName::src0 lives at
+  // index 1. That is a legitimate layout, not decoder drift -- like MADMK -- so
+  // skip the strict srcN-position check at k=0 for it. Detect it structurally
+  // from the operand tables (vdst present at operand 0 with zero declared defs)
+  // rather than by mnemonic string. Note there is no MC-level TIED_TO here: the
+  // tied vdst_in described in the ISA is added later by the custom inserter,
+  // not in the MCInstrDesc we see at decode time. v_movrels_b32 has a genuine
+  // def, so its walk matches OpName::src0 naturally and needs no exception. The
+  // v_movrel* handler reads vdst/vsrc by named operand index (not SrcMap[0]),
+  // so it does not depend on the layout skipped here; a data-dependent M0 has
+  // no statically-known index and fails gracefully downstream (stubbed under
+  // HSA_HOTSWAP_STUB_FAILED_KERNELS).
+  int VdstIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::vdst);
+  bool IsMovrel = VdstIdx == 0 && Desc.getNumDefs() == 0;
+  // Cross-check the structural signature against the mnemonic: every op that
+  // matches (vdst-as-source, no declared defs) must be a v_movrel* form. If a
+  // future opcode trips this signature without being a register-relative move,
+  // we would silently skip a genuine srcN drift here -- catch that in asserts
+  // builds rather than let it slip. (One-directional: v_movrels_b32 also starts
+  // with the prefix but has a real def, so it is not expected to match above.)
+  assert((!IsMovrel ||
+          StringRef(getMnemonic(Mc, Di.Inst)).starts_with("v_movrel")) &&
+         "vdst-at-0/no-defs signature matched a non-movrel opcode");
+
+  for (unsigned K = 0; K < 3; ++K) {
+    int NamedSrc = AMDGPU::getNamedOperandIdx(Opc, KSrcNames[K]);
+    if (NamedSrc < 0)
+      break;
+    int OurSrc = (K < Di.SrcMap.size()) ? static_cast<int>(Di.SrcMap[K]) : -1;
+    // Skip ONLY the genuinely-affected index (k=1) for MADMK. k=0
+    // (src0) still receives the strict check, so a hypothetical
+    // future drift in src0's MCInst position is still caught even
+    // for MADMK opcodes.
+    bool SkipThis = (IsMadmk && K == 1) || (IsMovrel && K == 0);
+    if (!SkipThis && OurSrc != NamedSrc)
+      return ReportErr("transpiler: srcMap disagrees with OpName::srcN table",
+                       static_cast<int>(K), OurSrc, NamedSrc);
+    int NamedMod = AMDGPU::getNamedOperandIdx(Opc, KModNames[K]);
+    int OurMod =
+        (Di.ModMap[K] == UINT_MAX) ? -1 : static_cast<int>(Di.ModMap[K]);
+    int ExpectedMod = (NamedMod < 0) ? -1 : NamedMod;
+    if (OurMod != ExpectedMod) {
+      bool IsMai = Di.TargetSpecificFlags & SIInstrFlags::IsMAI;
+      if (IsMai && NamedMod >= 0 && OurMod == -1) {
+        Di.ModMap[K] = static_cast<unsigned>(NamedMod);
+      } else {
+        return ReportErr(
+            "transpiler: modMap disagrees with OpName::srcN_modifiers table",
+            static_cast<int>(K), OurMod, ExpectedMod);
+      }
+    }
+  }
+  return Error::success();
+}
+
+// Identify implicit defs of wave-mask / condition-flag registers via
+// identity constants rather than register-name string matches. We
+// normalise through `mc2PseudoReg` first, which strips subtarget
+// suffixes (``_gfxNplus``) and converts aliases to their canonical
+// pseudo-register id -- same pattern used by `parseReg`.
+void classifyImplicitDefs(DecodedInst &Di, const MCInstrDesc &Desc) {
+  for (MCPhysReg R : Desc.implicit_defs()) {
+    llvm::MCRegister Reg = AMDGPU::mc2PseudoReg(R);
+    switch (Reg) {
+    case AMDGPU::SCC:
+      Di.setDefsScc(true);
+      break;
+    case AMDGPU::VCC:
+    case AMDGPU::VCC_LO:
+    case AMDGPU::VCC_HI:
+      Di.setDefsVcc(true);
+      break;
+    case AMDGPU::EXEC:
+    case AMDGPU::EXEC_LO:
+    case AMDGPU::EXEC_HI:
+      Di.setDefsExec(true);
+      break;
+    default:
+      break;
+    }
+  }
+}
+
+} // namespace
+
+// Successor model over decoded block leaders. s_endpgm terminates the block
+// with no successor; everything else falls through to the next linear block.
+// Branch / set-pc successor edges land with control-flow support.
+Expected<SmallVector<uint64_t>>
+computeDecodedBlockSuccessors(const DecodedInst &LastInst,
+                              std::optional<uint64_t> NextBlockOffset) {
+  SmallVector<uint64_t> Result;
+  if (LastInst.CanonOp == CanonicalOp::S_ENDPGM)
+    return Result;
+  if (NextBlockOffset)
+    Result.push_back(*NextBlockOffset);
+  return Result;
+}
+
+bool decodedInstEndsBlock(const DecodedInst &LastInst) {
+  return LastInst.CanonOp == CanonicalOp::S_ENDPGM;
+}
+
+Expected<DecodeResult> decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
+                                    ArrayRef<uint8_t> TextBytes,
+                                    uint64_t KernelOffset,
+                                    uint64_t KernelEndOffset,
+                                    std::optional<uint64_t> KernelStartOffset) {
+  DecodeResult Out;
+  Out.BlockStarts.insert(KernelOffset);
+  uint64_t KernelStart = KernelStartOffset.value_or(KernelOffset);
+
+  if (KernelOffset > 0)
+    errs() << "transpiler: Starting disassembly at kernel offset 0x"
+           << utohexstr(KernelOffset) << "\n";
+
+  if (KernelOffset > TextBytes.size())
+    return createStringError(
+        "transpiler: kernel decode offset is outside .text contents");
+  if (KernelStart > KernelOffset)
+    return createStringError(
+        "transpiler: kernel decode start follows scan offset");
+  if (KernelEndOffset != 0 && KernelEndOffset < KernelOffset)
+    return createStringError("transpiler: kernel decode end precedes start");
+  if (KernelEndOffset > TextBytes.size())
+    return createStringError(
+        "transpiler: kernel decode end is outside .text contents");
+
+  const uint64_t TotalSize = KernelEndOffset == 0
+                                 ? static_cast<uint64_t>(TextBytes.size())
+                                 : KernelEndOffset;
+  uint64_t Off = KernelOffset;
+  while (Off < TotalSize) {
+    MCInst Inst;
+    uint64_t InstSize = 0;
+    auto Status = Mc.Disasm->getInstruction(
+        Inst, InstSize, TextBytes.slice(Off, TotalSize - Off), Off, nulls());
+    if (Status != MCDisassembler::Success) {
+      Off += 4;
+      continue;
+    }
+    const MCInstrDesc &Desc = Mc.InstrInfo->get(Inst.getOpcode());
+    DecodedInst Di;
+    Di.Inst = Inst;
+    Di.CanonOp = OpcMap.lookup(Inst.getOpcode());
+    Di.NumDefs = Desc.getNumDefs();
+    Di.Offset = Off;
+    Di.setSizeInBytes(InstSize);
+    Di.TargetSpecificFlags = Desc.TSFlags;
+    Di.FirstSrcIdx = Desc.getNumDefs();
+
+    if (Error E = buildSrcMap(Di, Desc))
+      return E;
+    if (Error E = driftCheckTiedIn(Mc, Di, Desc))
+      return E;
+    if (Error E = driftCheckSrcN(Mc, Di, Desc))
+      return E;
+    classifyImplicitDefs(Di, Desc);
+
+    bool IsEnd = (Di.CanonOp == CanonicalOp::S_ENDPGM);
+    Out.Insts.push_back(std::move(Di));
+    if (IsEnd) {
+      // `s_endpgm` may appear mid-binary (early-return path); if there are
+      // known block starts at later offsets, keep disassembling.
+      uint64_t NextOff = Off + InstSize;
+      auto It = Out.BlockStarts.upper_bound(Off);
+      if (It != Out.BlockStarts.end() && *It < TotalSize) {
+        Off = NextOff;
+        continue;
+      }
+      break;
+    }
+    Off += InstSize;
+  }
+
+  return Out;
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/decoder/decode.h
+++ b/amd/comgr/src/hotswap/decoder/decode.h
@@ -1,0 +1,87 @@
+//===- decode.h - Hotswap transpiler --------------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_DECODE_H
+#define HOTSWAP_TRANSPILER_DECODE_H
+
+#include "decoded-inst.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Error.h"
+
+#include <cstdint>
+#include <optional>
+#include <set>
+
+namespace COMGR::hotswap {
+
+struct MCState;
+class OpcodeMap;
+
+// Output of the decode phase: a linearised stream of decoded instructions
+// plus the set of basic-block start offsets the CFG recovery discovered.
+//
+// `blockStarts` uses `std::set` because Phase 3 iterates it in ascending
+// order to assign deterministic BB labels and because the decode loop
+// relies on `upper_bound` to decide whether an `s_endpgm` terminates
+// the scan or is an early-return that still has later reachable code.
+//
+// `insts` uses `SmallVector<T, 0>` -- the LLVM-native escape hatch for
+// "I want the SmallVector API but no inline storage because
+// `sizeof(T)` is too large for the default inline budget."
+// `DecodedInst` contains three `std::string`s plus an inline MCInst
+// operand array, which exceeds LLVM's 256-byte default cap; the zero
+// inline capacity explicitly opts out of inline storage while still
+// getting SmallVector's API and move-only guarantees.
+struct DecodeResult {
+  llvm::SmallVector<DecodedInst, 0> Insts;
+  std::set<uint64_t> BlockStarts;
+};
+
+// Decode `textBytes` starting at `kernelOffset` using the caller-owned
+// MC + OpcodeMap. Produces a fully populated `DecodedInst` per MCInst
+// (canonOp, tsFlags, srcMap/modMap, implicit-def classification, branch
+// targets) and the set of block-start offsets.
+//
+// Returns an error for invalid decode extents (offset/start/end outside the
+// .text contents or inconsistent with one another) so callers can surface a
+// diagnostic instead of aborting.
+//
+// Also returns an error on any MC/TableGen invariant violation (unknown
+// tied-to-def OpName, srcMap vs OpName::srcN drift). This is the
+// LLVM-version-drift guard surface -- every check here catches an upstream LLVM
+// change before it can silently corrupt a handler's view of an instruction.
+llvm::Expected<DecodeResult>
+decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
+             llvm::ArrayRef<uint8_t> TextBytes, uint64_t KernelOffset,
+             uint64_t KernelEndOffset = 0,
+             std::optional<uint64_t> KernelStartOffset = std::nullopt);
+
+// Compute the decoded CFG successors for a block ending in LastInst.
+// NextBlockOffset is the linear fallthrough block start, or std::nullopt when
+// no decoded linear fallthrough block exists. The model is intentionally
+// conservative and matches the successor model used by setpc analysis and the
+// raiser's provenance prepasses.
+llvm::Expected<llvm::SmallVector<uint64_t>>
+computeDecodedBlockSuccessors(const DecodedInst &LastInst,
+                              std::optional<uint64_t> NextBlockOffset);
+
+// Compute the absolute byte offset of a SOPP branch target. SOPP branch
+// immediates are signed 16-bit dword offsets from the next instruction
+// (`PC + 4`). Invalid source-offset arithmetic returns an error rather than
+// dropping the edge from CFG recovery.
+
+// True when LastInst terminates the recovered source block. This is separate
+// from successor count: s_swap_pc_i64 ends its block while still having a
+// modeled fallthrough return site.
+bool decodedInstEndsBlock(const DecodedInst &LastInst);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/decoder/decode.h
+++ b/amd/comgr/src/hotswap/decoder/decode.h
@@ -24,62 +24,33 @@ namespace COMGR::hotswap {
 struct MCState;
 class OpcodeMap;
 
-// Output of the decode phase: a linearised stream of decoded instructions
-// plus the set of basic-block start offsets the CFG recovery discovered.
-//
-// `blockStarts` uses `std::set` because Phase 3 iterates it in ascending
-// order to assign deterministic BB labels and because the decode loop
-// relies on `upper_bound` to decide whether an `s_endpgm` terminates
-// the scan or is an early-return that still has later reachable code.
-//
-// `insts` uses `SmallVector<T, 0>` -- the LLVM-native escape hatch for
-// "I want the SmallVector API but no inline storage because
-// `sizeof(T)` is too large for the default inline budget."
-// `DecodedInst` contains three `std::string`s plus an inline MCInst
-// operand array, which exceeds LLVM's 256-byte default cap; the zero
-// inline capacity explicitly opts out of inline storage while still
-// getting SmallVector's API and move-only guarantees.
+// Output of the decode phase: the decoded instructions in program order and
+// the block-start offsets discovered while decoding. BlockStarts is ordered so
+// it can be iterated in offset order and queried with upper_bound.
 struct DecodeResult {
   llvm::SmallVector<DecodedInst, 0> Insts;
   std::set<uint64_t> BlockStarts;
 };
 
-// Decode `textBytes` starting at `kernelOffset` using the caller-owned
-// MC + OpcodeMap. Produces a fully populated `DecodedInst` per MCInst
-// (canonOp, tsFlags, srcMap/modMap, implicit-def classification, branch
-// targets) and the set of block-start offsets.
-//
-// Returns an error for invalid decode extents (offset/start/end outside the
-// .text contents or inconsistent with one another) so callers can surface a
-// diagnostic instead of aborting.
-//
-// Also returns an error on any MC/TableGen invariant violation (unknown
-// tied-to-def OpName, srcMap vs OpName::srcN drift). This is the
-// LLVM-version-drift guard surface -- every check here catches an upstream LLVM
-// change before it can silently corrupt a handler's view of an instruction.
-llvm::Expected<DecodeResult>
+// Decode the kernel in `TextBytes` at `[KernelOffset, KernelEndOffset)` using
+// the caller-owned MC and OpcodeMap, producing a DecodedInst per instruction
+// and the set of block-start offsets. A nullopt `KernelEndOffset` scans to the
+// end of `TextBytes`; `KernelStartOffset` defaults to `KernelOffset`.
+DecodeResult
 decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
              llvm::ArrayRef<uint8_t> TextBytes, uint64_t KernelOffset,
-             uint64_t KernelEndOffset = 0,
+             std::optional<uint64_t> KernelEndOffset = std::nullopt,
              std::optional<uint64_t> KernelStartOffset = std::nullopt);
 
-// Compute the decoded CFG successors for a block ending in LastInst.
-// NextBlockOffset is the linear fallthrough block start, or std::nullopt when
-// no decoded linear fallthrough block exists. The model is intentionally
-// conservative and matches the successor model used by setpc analysis and the
-// raiser's provenance prepasses.
+// Compute the CFG successors of a block whose last instruction is `LastInst`.
+// `NextBlockOffset` is the fall-through successor, or nullopt when no block
+// follows. A block ending in s_endpgm has no successors; any other block falls
+// through.
 llvm::Expected<llvm::SmallVector<uint64_t>>
 computeDecodedBlockSuccessors(const DecodedInst &LastInst,
                               std::optional<uint64_t> NextBlockOffset);
 
-// Compute the absolute byte offset of a SOPP branch target. SOPP branch
-// immediates are signed 16-bit dword offsets from the next instruction
-// (`PC + 4`). Invalid source-offset arithmetic returns an error rather than
-// dropping the edge from CFG recovery.
-
-// True when LastInst terminates the recovered source block. This is separate
-// from successor count: s_swap_pc_i64 ends its block while still having a
-// modeled fallthrough return site.
+// True when `LastInst` terminates its block.
 bool decodedInstEndsBlock(const DecodedInst &LastInst);
 
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/decoder/decode.h
+++ b/amd/comgr/src/hotswap/decoder/decode.h
@@ -35,8 +35,9 @@ struct DecodeResult {
 // Decode the kernel in `TextBytes` at `[KernelOffset, KernelEndOffset)` using
 // the caller-owned MC and OpcodeMap, producing a DecodedInst per instruction
 // and the set of block-start offsets. A nullopt `KernelEndOffset` scans to the
-// end of `TextBytes`; `KernelStartOffset` defaults to `KernelOffset`.
-DecodeResult
+// end of `TextBytes`; `KernelStartOffset` defaults to `KernelOffset`. Returns
+// an error if any bytes in that range do not decode to an instruction.
+llvm::Expected<DecodeResult>
 decodeKernel(const MCState &Mc, const OpcodeMap &OpcMap,
              llvm::ArrayRef<uint8_t> TextBytes, uint64_t KernelOffset,
              std::optional<uint64_t> KernelEndOffset = std::nullopt,

--- a/amd/comgr/src/hotswap/decoder/mc-state.cpp
+++ b/amd/comgr/src/hotswap/decoder/mc-state.cpp
@@ -10,7 +10,7 @@
 #include "comgr.h"
 #include "hotswap/common/hotswap-error.h"
 
-// GET_REGINFO_ENUM, for the register enumerators stripRegEncoding matches on.
+// AMDGPU target-private headers.
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
 
 #include "llvm/ADT/Twine.h"
@@ -137,9 +137,8 @@ std::string strippedMnemonic(const MCState &State, const MCInst &Inst) {
   return stripEncoding(getMnemonic(State, Inst)).str();
 }
 
-// The three variant families, named for the subtargets whose encodings they
-// distinguish. Spelling the enumerators through concatenation keeps a renamed
-// or dropped register a compile error rather than a silent mismatch.
+// Spelling the enumerators through concatenation keeps a renamed or dropped
+// register a compile error rather than a silent mismatch.
 #define CASE_CI_VI(Node)                                                       \
   case AMDGPU::Node##_ci:                                                      \
   case AMDGPU::Node##_vi:                                                      \

--- a/amd/comgr/src/hotswap/decoder/mc-state.cpp
+++ b/amd/comgr/src/hotswap/decoder/mc-state.cpp
@@ -9,6 +9,10 @@
 #include "mc-state.h"
 #include "comgr.h"
 #include "hotswap/common/hotswap-error.h"
+
+// GET_REGINFO_ENUM, for the register enumerators stripRegEncoding matches on.
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h"
+
 #include "llvm/ADT/Twine.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/Support/Error.h"
@@ -132,5 +136,70 @@ StringRef stripEncoding(StringRef Mnemonic) {
 std::string strippedMnemonic(const MCState &State, const MCInst &Inst) {
   return stripEncoding(getMnemonic(State, Inst)).str();
 }
+
+// The three variant families, named for the subtargets whose encodings they
+// distinguish. Spelling the enumerators through concatenation keeps a renamed
+// or dropped register a compile error rather than a silent mismatch.
+#define CASE_CI_VI(Node)                                                       \
+  case AMDGPU::Node##_ci:                                                      \
+  case AMDGPU::Node##_vi:                                                      \
+    return AMDGPU::Node;
+#define CASE_VI_GFX9PLUS(Node)                                                 \
+  case AMDGPU::Node##_vi:                                                      \
+  case AMDGPU::Node##_gfx9plus:                                                \
+    return AMDGPU::Node;
+#define CASE_GFXPRE11_GFX11PLUS(Node)                                          \
+  case AMDGPU::Node##_gfxpre11:                                                \
+  case AMDGPU::Node##_gfx11plus:                                               \
+    return AMDGPU::Node;
+
+MCRegister stripRegEncoding(MCRegister Reg) {
+  switch (Reg.id()) {
+  default:
+    return Reg;
+    CASE_CI_VI(FLAT_SCR)
+    CASE_CI_VI(FLAT_SCR_LO)
+    CASE_CI_VI(FLAT_SCR_HI)
+    CASE_VI_GFX9PLUS(TTMP0)
+    CASE_VI_GFX9PLUS(TTMP1)
+    CASE_VI_GFX9PLUS(TTMP2)
+    CASE_VI_GFX9PLUS(TTMP3)
+    CASE_VI_GFX9PLUS(TTMP4)
+    CASE_VI_GFX9PLUS(TTMP5)
+    CASE_VI_GFX9PLUS(TTMP6)
+    CASE_VI_GFX9PLUS(TTMP7)
+    CASE_VI_GFX9PLUS(TTMP8)
+    CASE_VI_GFX9PLUS(TTMP9)
+    CASE_VI_GFX9PLUS(TTMP10)
+    CASE_VI_GFX9PLUS(TTMP11)
+    CASE_VI_GFX9PLUS(TTMP12)
+    CASE_VI_GFX9PLUS(TTMP13)
+    CASE_VI_GFX9PLUS(TTMP14)
+    CASE_VI_GFX9PLUS(TTMP15)
+    CASE_VI_GFX9PLUS(TTMP0_TTMP1)
+    CASE_VI_GFX9PLUS(TTMP2_TTMP3)
+    CASE_VI_GFX9PLUS(TTMP4_TTMP5)
+    CASE_VI_GFX9PLUS(TTMP6_TTMP7)
+    CASE_VI_GFX9PLUS(TTMP8_TTMP9)
+    CASE_VI_GFX9PLUS(TTMP10_TTMP11)
+    CASE_VI_GFX9PLUS(TTMP12_TTMP13)
+    CASE_VI_GFX9PLUS(TTMP14_TTMP15)
+    CASE_VI_GFX9PLUS(TTMP0_TTMP1_TTMP2_TTMP3)
+    CASE_VI_GFX9PLUS(TTMP4_TTMP5_TTMP6_TTMP7)
+    CASE_VI_GFX9PLUS(TTMP8_TTMP9_TTMP10_TTMP11)
+    CASE_VI_GFX9PLUS(TTMP12_TTMP13_TTMP14_TTMP15)
+    CASE_VI_GFX9PLUS(TTMP0_TTMP1_TTMP2_TTMP3_TTMP4_TTMP5_TTMP6_TTMP7)
+    CASE_VI_GFX9PLUS(TTMP4_TTMP5_TTMP6_TTMP7_TTMP8_TTMP9_TTMP10_TTMP11)
+    CASE_VI_GFX9PLUS(TTMP8_TTMP9_TTMP10_TTMP11_TTMP12_TTMP13_TTMP14_TTMP15)
+    CASE_VI_GFX9PLUS(
+        TTMP0_TTMP1_TTMP2_TTMP3_TTMP4_TTMP5_TTMP6_TTMP7_TTMP8_TTMP9_TTMP10_TTMP11_TTMP12_TTMP13_TTMP14_TTMP15)
+    CASE_GFXPRE11_GFX11PLUS(M0)
+    CASE_GFXPRE11_GFX11PLUS(SGPR_NULL)
+  }
+}
+
+#undef CASE_CI_VI
+#undef CASE_VI_GFX9PLUS
+#undef CASE_GFXPRE11_GFX11PLUS
 
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/decoder/mc-state.h
+++ b/amd/comgr/src/hotswap/decoder/mc-state.h
@@ -83,11 +83,6 @@ llvm::StringRef stripEncoding(llvm::StringRef Mnemonic);
 /// `TTMP0_gfx9plus` both give `TTMP0`), so a handler can match one register id
 /// whichever subtarget the instruction was decoded for. Registers without a
 /// variant are returned unchanged.
-///
-/// Mirrors `AMDGPU::mc2PseudoReg`, which libLLVM.so does not export. The
-/// variant families are declared next to `M0` in SIRegisterInfo.td; a new one
-/// needs a case here, and shows up as a handler failing to match a register it
-/// names.
 llvm::MCRegister stripRegEncoding(llvm::MCRegister Reg);
 
 /// Return the mnemonic of `Inst` with any encoding suffix removed (e.g.

--- a/amd/comgr/src/hotswap/decoder/mc-state.h
+++ b/amd/comgr/src/hotswap/decoder/mc-state.h
@@ -79,6 +79,17 @@ std::string printInst(const MCState &State, const llvm::MCInst &Inst);
 /// `_vi`) from `Mnemonic` if present; otherwise return `Mnemonic` unchanged.
 llvm::StringRef stripEncoding(llvm::StringRef Mnemonic);
 
+/// Drop the subtarget encoding variant from `Reg` (e.g. `TTMP0_vi` and
+/// `TTMP0_gfx9plus` both give `TTMP0`), so a handler can match one register id
+/// whichever subtarget the instruction was decoded for. Registers without a
+/// variant are returned unchanged.
+///
+/// Mirrors `AMDGPU::mc2PseudoReg`, which libLLVM.so does not export. The
+/// variant families are declared next to `M0` in SIRegisterInfo.td; a new one
+/// needs a case here, and shows up as a handler failing to match a register it
+/// names.
+llvm::MCRegister stripRegEncoding(llvm::MCRegister Reg);
+
 /// Return the mnemonic of `Inst` with any encoding suffix removed (e.g.
 /// "v_mov_b32" for `v_mov_b32_e32`), for diagnostics that name the instruction.
 /// The raiser's dispatch identity is `CanonicalOp` (see canonical-op.h), not

--- a/amd/comgr/src/hotswap/decoder/opcode-map.cpp
+++ b/amd/comgr/src/hotswap/decoder/opcode-map.cpp
@@ -8,6 +8,8 @@
 
 #include "opcode-map.h"
 
+#include "amdgpu-mc-tables.h"
+
 #include <cassert>
 #include <optional>
 
@@ -61,7 +63,7 @@ DenseMap<unsigned, unsigned> buildMcToPseudoMap(unsigned NumOpc) {
   DenseMap<unsigned, unsigned> Result;
   for (unsigned P = 0; P < NumOpc; ++P) {
     for (unsigned Gen = 0; Gen < KNumEncodingFamilies; ++Gen) {
-      std::optional<unsigned> Mc = mappedOpcode(AMDGPU::getMCOpcode(P, Gen));
+      std::optional<unsigned> Mc = mappedOpcode(hotswap::getMCOpcode(P, Gen));
       if (Mc && *Mc != P)
         Result.try_emplace(*Mc, P);
     }
@@ -74,9 +76,9 @@ DenseMap<unsigned, unsigned> buildMcToPseudoMap(unsigned NumOpc) {
 DenseMap<unsigned, unsigned> buildDppToBaseMap(unsigned NumOpc) {
   DenseMap<unsigned, unsigned> Result;
   for (unsigned P = 0; P < NumOpc; ++P) {
-    if (std::optional<unsigned> D32 = mappedOpcode(AMDGPU::getDPPOp32(P)))
+    if (std::optional<unsigned> D32 = mappedOpcode(hotswap::getDPPOp32(P)))
       Result.try_emplace(*D32, P);
-    if (std::optional<unsigned> D64 = mappedOpcode(AMDGPU::getDPPOp64(P)))
+    if (std::optional<unsigned> D64 = mappedOpcode(hotswap::getDPPOp64(P)))
       Result.try_emplace(*D64, P);
   }
   return Result;
@@ -97,17 +99,17 @@ unsigned canonicalize(unsigned Mc, const MCInstrInfo &MCII,
     P = DppIt->second;
 
   if (std::optional<unsigned> Base =
-          mappedOpcode(AMDGPU::getBasicFromSDWAOp(P)))
+          mappedOpcode(hotswap::getBasicFromSDWAOp(P)))
     P = *Base;
 
-  if (std::optional<unsigned> E64 = mappedOpcode(AMDGPU::getVOPe64(P)))
+  if (std::optional<unsigned> E64 = mappedOpcode(hotswap::getVOPe64(P)))
     P = *E64;
 
   // Testing the format flag first avoids a table lookup for every non-FLAT
   // opcode.
   if (P < MCII.getNumOpcodes() && SIInstrFlags::isFLAT(MCII, P)) {
     if (std::optional<unsigned> Vaddr =
-            mappedOpcode(AMDGPU::getGlobalVaddrOp(P)))
+            mappedOpcode(hotswap::getGlobalVaddrOp(P)))
       P = *Vaddr;
   }
 

--- a/amd/comgr/src/hotswap/decoder/opcode-map.cpp
+++ b/amd/comgr/src/hotswap/decoder/opcode-map.cpp
@@ -105,8 +105,7 @@ unsigned canonicalize(unsigned Mc, const MCInstrInfo &MCII,
 
   // Testing the format flag first avoids a table lookup for every non-FLAT
   // opcode.
-  if (P < MCII.getNumOpcodes() &&
-      (MCII.get(P).TSFlags & SIInstrFlags::FLAT) != 0) {
+  if (P < MCII.getNumOpcodes() && SIInstrFlags::isFLAT(MCII, P)) {
     if (std::optional<unsigned> Vaddr =
             mappedOpcode(AMDGPU::getGlobalVaddrOp(P)))
       P = *Vaddr;

--- a/amd/comgr/src/hotswap/decoder/opcode-map.cpp
+++ b/amd/comgr/src/hotswap/decoder/opcode-map.cpp
@@ -1,0 +1,456 @@
+//===- opcode-map.cpp - Hotswap transpiler --------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "opcode-map.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+// AMDGPU target-private headers. They expose:
+//   AMDGPU::getMCOpcode           (declared in Utils/AMDGPUBaseInfo.h)
+//   AMDGPU::getVOPe64 / getVOPe32 / getDPPOp32 / getDPPOp64 /
+//   getSDWAOp / getBasicFromSDWAOp / getGlobalVaddrOp
+//                                  (declared in SIInstrInfo.h, implemented
+//                                   in the TableGen-generated
+//                                   AMDGPUGenInstrInfo.inc under
+//                                   `#define GET_INSTRMAP_INFO`, linked from
+//                                   libLLVMAMDGPUUtils.a).
+//
+// SIInstrInfo.h drags in the CodeGen TargetInstrInfo base, which we do not
+// use at runtime, but pulling it in is preferable to hand-rolling forward
+// declarations that would silently go stale if LLVM changes a signature.
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h"
+#include "SIDefines.h"
+#include "SIInstrInfo.h"
+#include "Utils/AMDGPUBaseInfo.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/Support/ErrorHandling.h"
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+namespace {
+
+// Maps a canonical AMDGPU pseudo opcode to the CanonicalOp the raiser
+// dispatches on. The canonical form is what comes out of the canonicalization
+// chain below:
+//   MC opcode -> pseudo
+//   pseudo    -> e64 (if VOP/VOPC has e32/e64 split)
+//   pseudo    -> base (if SDWA/DPP)
+//   pseudo    -> VADDR (if FLAT/GLOBAL SADDR)
+//
+// Using AMDGPU:: enum constants instead of strings gives us compile-time
+// checking: if LLVM renames a pseudo, the build fails here rather than the
+// lookup silently returning CanonicalOp::Unknown at runtime.
+struct Entry {
+  unsigned Opc;
+  CanonicalOp Sem;
+};
+
+#define E(OP, SEM)                                                             \
+  Entry { AMDGPU::OP, CanonicalOp::SEM }
+
+static const Entry kCanonTable[] = {
+    // One row per landed handler; every unlisted MC opcode stays Unknown and
+    // is refused by the raiser's dispatch.
+    E(S_MOV_B32, S_MOV_B32),
+    E(S_ENDPGM, S_ENDPGM),
+};
+
+#undef E
+
+// Iteration bound for SIEncodingFamily: the enum in SIDefines.h is a closed
+// numeric set with GFX13 as the current maximum, so we scan [0, GFX13] when
+// inverting the pseudo -> MC map.  If LLVM adds a new family the next
+// enumerator value appears here automatically and the build still compiles;
+// the static_assert keeps us honest if LLVM ever renames the sentinel we use.
+static_assert(SIEncodingFamily::GFX13 >= SIEncodingFamily::SI,
+              "SIEncodingFamily enum layout changed unexpectedly");
+constexpr unsigned KNumEncodingFamilies =
+    static_cast<unsigned>(SIEncodingFamily::GFX13) + 1;
+
+// Build a reverse map MC-opcode -> canonical pseudo by scanning every pseudo
+// opcode across all subtarget generations. This is ~O(N * 15) work at init
+// time (N ~= 70k AMDGPU opcodes on recent LLVM), which is well under a
+// millisecond on modern hardware and done once per raiser.
+DenseMap<unsigned, unsigned> buildMcToPseudoMap(unsigned NumOpc) {
+  DenseMap<unsigned, unsigned> Result;
+  for (unsigned P = 0; P < NumOpc; ++P) {
+    for (unsigned Gen = 0; Gen < KNumEncodingFamilies; ++Gen) {
+      int Mc = AMDGPU::getMCOpcode(P, Gen);
+      if (Mc > 0 && static_cast<unsigned>(Mc) != P)
+        Result.try_emplace(static_cast<unsigned>(Mc), P);
+    }
+  }
+  return Result;
+}
+
+// Rule predicates: an optional semantic invariant the alias must preserve.
+// Every time an alias step is committed (source pseudo S collapses onto
+// target pseudo T), the firing rule's predicate is evaluated against
+// MCInstrDesc(S) and MCInstrDesc(T). A violation means LLVM renamed or
+// repurposed a pseudo in a way that breaks our naming contract, and is
+// reported as a fatal error at init time rather than silently producing
+// wrong IR at runtime.
+using RulePredicate = bool (*)(const MCInstrDesc &Src, const MCInstrDesc &Tgt);
+
+// `_RTN` collapse: source must be an atomic with a return value; target must
+// be the same atomic without one. The raiser uses `numDefs` as the
+// "publishes old value" signal, so that invariant must also hold.
+static bool atomicRetToNoRet(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
+  constexpr uint64_t KRet = SIInstrFlags::IsAtomicRet;
+  constexpr uint64_t KNoRet = SIInstrFlags::IsAtomicNoRet;
+  return (Src.TSFlags & KRet) && (Tgt.TSFlags & KNoRet) &&
+         Src.getNumDefs() > 0 && Tgt.getNumDefs() == 0;
+}
+
+// `_vgprcd_` / `_mac_` collapse: both source and target must be MFMA
+// (matrix-accumulate) pseudos.
+static bool bothAreMAI(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
+  constexpr uint64_t KMAI = SIInstrFlags::IsMAI;
+  return (Src.TSFlags & KMAI) && (Tgt.TSFlags & KMAI);
+}
+
+// `_nosdst_` collapse: starting with GFX11, VOPC CMPX instructions no longer
+// write a scalar destination register (EXEC receives the mask directly) and
+// LLVM represents this as a `_nosdst_` variant. The non-`_nosdst_` target
+// form keeps the scalar dst (for older subtargets). Both forms share
+// dispatch-relevant TSFlags; the raiser's CMPX handler only writes EXEC and
+// ignores the optional sdst, so collapsing the variant onto the base is
+// safe. The source has one fewer def when the base includes sdst (e64
+// forms) and the same number of defs otherwise (e32, where both lack sdst).
+
+// Bits we require to be identical between source and target for an alias
+// collapse to be considered semantically safe. Deliberately excludes encoding
+// variation flags like `VOP3_OPSEL` (set on `_t16_` op-sel encodings but not
+// on the base `_e64`) and `renamedInGFX9` (set only on the subtarget-specific
+// pseudo). Everything listed below represents *what the handler dispatches
+// on*: instruction family (SOP/VOP/FLAT/DS/...), atomic kind, and MAI.
+static constexpr uint64_t KSemanticShapeMask =
+    // Instruction families.
+    SIInstrFlags::SOP1 | SIInstrFlags::SOP2 | SIInstrFlags::SOPC |
+    SIInstrFlags::SOPK | SIInstrFlags::SOPP | SIInstrFlags::VOP1 |
+    SIInstrFlags::VOP2 | SIInstrFlags::VOPC | SIInstrFlags::VOP3 |
+    SIInstrFlags::VOP3P | SIInstrFlags::SDWA | SIInstrFlags::DPP |
+    SIInstrFlags::MUBUF | SIInstrFlags::MTBUF | SIInstrFlags::SMRD |
+    SIInstrFlags::FLAT | SIInstrFlags::DS | SIInstrFlags::MIMG |
+    // Semantic classification (atomic kind, MAI).
+    SIInstrFlags::IsAtomicRet | SIInstrFlags::IsAtomicNoRet |
+    SIInstrFlags::IsMAI;
+
+// Subtarget-/operand-class variants (`_gfx9`, `_t16_`, `_fake16_`, `_agpr`,
+// etc.) may legitimately toggle encoding flags such as `VOP3_OPSEL` or
+// `renamedInGFX9` between source and target, but they must preserve the
+// instruction's dispatch identity: same family, same atomic kind, same MAI
+// classification, same def arity. A violation means LLVM renamed or
+// repurposed a pseudo in a way our alias map cannot safely collapse.
+static bool sameSemanticShape(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
+  return (Src.TSFlags & KSemanticShapeMask) ==
+             (Tgt.TSFlags & KSemanticShapeMask) &&
+         Src.getNumDefs() == Tgt.getNumDefs();
+}
+
+// `_nosdst_` collapse: same dispatch identity as the base, and the source
+// never has more defs than the target (the scalar dst is either dropped
+// entirely or added back on the target's e64 form).
+static bool nosdstDropsScalarDef(const MCInstrDesc &Src,
+                                 const MCInstrDesc &Tgt) {
+  return (Src.TSFlags & KSemanticShapeMask) ==
+             (Tgt.TSFlags & KSemanticShapeMask) &&
+         Tgt.getNumDefs() >= Src.getNumDefs() &&
+         Tgt.getNumDefs() - Src.getNumDefs() <= 1;
+}
+
+// Build an alias map that collapses "parallel" pseudos LLVM generates for the
+// same semantic instruction into a single canonical pseudo. Examples:
+//   DS_WRITE_B16_gfx9        -> DS_WRITE_B16
+//   V_ADD_F16_t16_e64        -> V_ADD_F16_e64
+//   V_ADD_F16_fake16_e64     -> V_ADD_F16_e64
+// LLVM does not expose a helper for this collapse, so we match on pseudo name
+// at init time. Name lookups are confined to this one-shot scan over
+// `MCII.getNumOpcodes()`; runtime lookups remain pure DenseMap hits.
+DenseMap<unsigned, unsigned> buildPseudoAliasMap(const MCInstrInfo &MCII) {
+  unsigned NumOpc = MCII.getNumOpcodes();
+
+  llvm::StringMap<unsigned> ByName;
+  for (unsigned P = 0; P < NumOpc; ++P)
+    ByName.try_emplace(MCII.getName(P), P);
+
+  struct Rule {
+    llvm::StringRef Needle;
+    bool IsSuffix;
+    // Optional semantic check on (source, target) MCInstrDesc. A null
+    // predicate means "no validation yet" (see the older subtarget/operand
+    // markers below).
+    RulePredicate Pred;
+  };
+  // Subtarget-specific markers ("_gfx9", "_gfx1250", ...) and operand-size
+  // markers ("_t16_", "_fake16_") that LLVM injects into the pseudo name.
+  // A single pseudo can carry multiple markers (e.g.
+  // `V_BITOP3_B16_gfx1250_fake16_e64`), so the outer loop below applies these
+  // rules iteratively until the name stops shrinking.
+  static const Rule Rules[] = {
+      // Subtarget-specific markers. LLVM emits a dedicated pseudo per
+      // subtarget (e.g. `_gfx9`, `_gfx1250`, `_vi_gfx9`) with the same
+      // TableGen class as the base; collapsing them is sound as long as
+      // TSFlags and def arity match.
+      {"_vi_gfx9", true, sameSemanticShape},
+      {"_gfx9", true, sameSemanticShape},
+      {"_gfx1250", true, sameSemanticShape},
+      {"_gfx1250_", false, sameSemanticShape},
+      {"_pseudo_", false, sameSemanticShape},
+      // True16 / Fake16 mark the 16-bit operand encoding variant; LLVM has
+      // no dedicated TSFlag bit for this (the distinction lives in
+      // True16Predicate on the TableGen side), and the t16 encoding toggles
+      // `VOP3_OPSEL`. We cross-check that dispatch-relevant TSFlags and def
+      // arity are preserved, but tolerate encoding-bit drift.
+      {"_t16_", false, sameSemanticShape},
+      {"_fake16_", false, sameSemanticShape},
+      // `_OP_SEL_` infix marks the gfx11+ encoding variant for VOP1 cvt
+      // instructions (e.g. v_cvt_f32_{fp8,bf8}, v_cvt_pk_f32_{fp8,bf8}).
+      // The OP_SEL pseudo carries an extra `byte_sel` immediate operand and
+      // toggles `VOP3_OPSEL`/`maybeAtomic`/`ASYNC_CNT` bits relative to the
+      // base e64 pseudo, but dispatch identity (instruction family + def
+      // arity + atomic/MAI classification) is preserved. Collapsing onto
+      // the base pseudo lets a single CanonicalOp handler service both the
+      // pre-gfx11 SDWA/byte_sel-via-disassembly form and the gfx11+ encoded
+      // byte_sel form; the handler reads the byte_sel from the disassembly
+      // text (`op_sel:`), which is identical for both.
+      {"_OP_SEL_", false, sameSemanticShape},
+      // GFX11+ VOPC CMPX family drops the scalar destination register; the
+      // raiser's CMPX handler only touches EXEC so the `_nosdst_` form
+      // collapses cleanly onto the base pseudo of the same encoding width.
+      {"_nosdst_", false, nosdstDropsScalarDef},
+      // MFMA register-class modifiers.  `_vgprcd_` marks a VGPR destination
+      // variant; `_mac_` marks a multiply-accumulate (tied dst/src2) variant.
+      // Both keep the same TableGen intrinsic and semantic shape, so they
+      // collapse onto the base `_e64` pseudo.
+      {"_vgprcd_", false, bothAreMAI},
+      {"_mac_", false, bothAreMAI},
+      // Atomic return-value variants: LLVM emits distinct `_RTN` pseudos for
+      // the forms that return the pre-modification value, plus `_agpr`
+      // variants that just pick an AGPR destination register class. These
+      // pseudos carry the same TableGen intrinsic and identical semantics;
+      // the only difference is whether the handler should write the result
+      // back, which the raiser already derives from `di.numDefs`
+      // (MCInstrDesc::getNumDefs()). Collapse them onto the non-RTN pseudo
+      // so both forms share a single CanonicalOp.
+      {"_agpr", true, sameSemanticShape},
+      {"_RTN", true, atomicRetToNoRet},
+  };
+
+  // Returns the index of the firing rule or -1 if no rule applies.
+  auto StripOnce = [&](llvm::StringRef Name, std::string &Out) -> int {
+    for (size_t I = 0; I < std::size(Rules); ++I) {
+      const Rule &R = Rules[I];
+      if (R.IsSuffix) {
+        if (!Name.ends_with(R.Needle))
+          continue;
+        Out = Name.drop_back(R.Needle.size()).str();
+        return static_cast<int>(I);
+      }
+      size_t Pos = Name.find(R.Needle);
+      if (Pos == llvm::StringRef::npos)
+        continue;
+      Out = (Name.substr(0, Pos).str() + std::string("_") +
+             Name.substr(Pos + R.Needle.size()).str());
+      return static_cast<int>(I);
+    }
+    return -1;
+  };
+
+  DenseMap<unsigned, unsigned> Alias;
+  for (const auto &Kv : ByName) {
+    std::string Cur = Kv.first().str();
+    unsigned CurOpc = Kv.second;
+    unsigned FinalOpc = Kv.second;
+    while (true) {
+      std::string Next;
+      int RuleIdx = StripOnce(Cur, Next);
+      if (RuleIdx < 0)
+        break;
+      auto It = ByName.find(Next);
+      if (It != ByName.end() && It->second != Kv.second) {
+        const Rule &R = Rules[RuleIdx];
+        if (R.Pred && !R.Pred(MCII.get(CurOpc), MCII.get(It->second))) {
+          report_fatal_error(
+              Twine("opcode_map: alias rule '") + R.Needle +
+              "' broke its semantic invariant while collapsing '" + Cur +
+              "' -> '" + Next +
+              "'. LLVM likely renamed or repurposed a pseudo; update the "
+              "alias rules or the predicate.");
+        }
+        CurOpc = It->second;
+        FinalOpc = CurOpc;
+      }
+      Cur = std::move(Next);
+    }
+    if (FinalOpc != Kv.second)
+      Alias.try_emplace(Kv.second, FinalOpc);
+  }
+  return Alias;
+}
+
+// Build a reverse DPP map: DPP opcode -> base VOP opcode. LLVM only provides
+// forward mappings (base -> DPP32 / DPP64), so we invert by scanning.
+DenseMap<unsigned, unsigned> buildDppToBaseMap(unsigned NumOpc) {
+  DenseMap<unsigned, unsigned> Result;
+  for (unsigned P = 0; P < NumOpc; ++P) {
+    int D32 = AMDGPU::getDPPOp32(P);
+    if (D32 > 0)
+      Result.try_emplace(static_cast<unsigned>(D32), P);
+    int D64 = AMDGPU::getDPPOp64(P);
+    if (D64 > 0)
+      Result.try_emplace(static_cast<unsigned>(D64), P);
+  }
+  return Result;
+}
+
+// Canonicalize any MC opcode `mc` to the pseudo form matched in kCanonTable.
+// The chain is:
+//   MC -> pseudo                (TableGen Subtarget map)
+//   pseudo -> base VOP          (strip DPP / SDWA)
+//   e32 -> e64                  (collapse VOP encoding variants)
+//   SADDR -> VADDR              (FLAT/GLOBAL global-saddr table)
+unsigned canonicalize(unsigned Mc, const MCInstrInfo &MCII,
+                      const DenseMap<unsigned, unsigned> &McToPseudo,
+                      const DenseMap<unsigned, unsigned> &PseudoAlias,
+                      const DenseMap<unsigned, unsigned> &DppToBase) {
+  unsigned P = Mc;
+
+  // MC (subtarget-specific real) -> pseudo.
+  if (auto It = McToPseudo.find(P); It != McToPseudo.end())
+    P = It->second;
+
+  // Parallel-pseudo alias -> base pseudo (strips _gfx9, _t16_, _fake16_).
+  if (auto It = PseudoAlias.find(P); It != PseudoAlias.end())
+    P = It->second;
+
+  // DPP -> base. This handles both VOP2-like _dpp pseudos and VOP3-like
+  // _e64_dpp pseudos; the reverse map was built from both getDPPOp32 and
+  // getDPPOp64.
+  if (auto It = DppToBase.find(P); It != DppToBase.end())
+    P = It->second;
+
+  // SDWA -> base. LLVM provides a forward helper for this direction.
+  int Base = AMDGPU::getBasicFromSDWAOp(P);
+  if (Base > 0)
+    P = static_cast<unsigned>(Base);
+
+  // e32 -> e64.
+  int E64 = AMDGPU::getVOPe64(P);
+  if (E64 > 0)
+    P = static_cast<unsigned>(E64);
+
+  // Re-apply the pseudo-alias step. `getVOPe64` can resolve an `_e32` pseudo
+  // (e.g. `V_LSHLREV_B64_pseudo_e32`) to an `_e64` pseudo with a parallel
+  // variant marker (`V_LSHLREV_B64_pseudo_e64`) that only collapses once
+  // both the `_pseudo_` infix and `_e64` suffix are visible together.
+  if (auto It = PseudoAlias.find(P); It != PseudoAlias.end())
+    P = It->second;
+
+  // FLAT/GLOBAL SADDR -> VADDR. Only applicable to instructions tagged with
+  // the FLAT format flag; the helper returns -1 for non-FLAT opcodes but
+  // checking the flag first avoids the lookup for every non-FLAT opcode.
+  if (P < MCII.getNumOpcodes() &&
+      (MCII.get(P).TSFlags & SIInstrFlags::FLAT) != 0) {
+    int Vaddr = AMDGPU::getGlobalVaddrOp(P);
+    if (Vaddr > 0)
+      P = static_cast<unsigned>(Vaddr);
+  }
+
+  return P;
+}
+
+} // namespace
+
+CanonicalOp OpcodeMap::lookup(unsigned Opcode) const {
+  auto It = Map.find(Opcode);
+  return It != Map.end() ? It->second : CanonicalOp::Unknown;
+}
+
+void OpcodeMap::build(const MCInstrInfo &MCII) {
+  // Flatten the static kCanonTable into a DenseMap for O(1) lookups
+  // during the subsequent scan over every MC opcode.  This flatten
+  // step also serves as a duplicate-key audit for `kCanonTable`: the
+  // earlier implementation used a plain `canonToSem.try_emplace` loop,
+  // which silently keeps the first insertion on key collision.  That
+  // silent-first-wins behaviour is exactly what let S_ADD_U64 get
+  // mapped twice (once as SOP2-block `E(S_ADD_U64, S_ADD_U64)` and
+  // once as gfx12-rename `E(S_ADD_U64, S_ADD_NC_U64)`) with the
+  // second row silently losing the routing race and leaving every
+  // `s_add_u64` lift routed through the wrong CanonicalOp -- see commit
+  // eaee0a0e88 for the repair.  The loop below now returns an error on
+  // duplicate keys so a future add that re-introduces the collision
+  // is caught at transpiler init time instead of quietly miscompiling
+  // everything under the duplicated opcode.
+  //
+  // A returned error (rather than `assert`) keeps the check active in
+  // release builds too -- the cost is a single `try_emplace` per table
+  // row at process start, which is negligible for a ~800-entry table.
+  //
+  // "Same CanonicalOp twice" is also rejected.  In principle a redundant
+  // row that maps the same MC opcode to the same CanonicalOp is just
+  // noise the first-wins rule would swallow harmlessly, but we
+  // refuse it anyway so the `kCanonTable` stays honest -- a
+  // redundant row is always an editing mistake, never an
+  // intentional design, and the abort makes the fix mechanical
+  // (delete one of the two rows).
+  DenseMap<unsigned, CanonicalOp> CanonToSem;
+  CanonToSem.reserve(std::size(kCanonTable));
+  for (const Entry &E : kCanonTable) {
+    auto [existing, inserted] = CanonToSem.try_emplace(E.Opc, E.Sem);
+    if (!inserted) {
+      std::string Msg;
+      raw_string_ostream Os(Msg);
+      Os << "opcode-map.cpp: kCanonTable maps MC opcode '"
+         << MCII.getName(E.Opc) << "' (enum value " << E.Opc
+         << ") to TWO CanonicalOps: " << "first = CanonicalOp::"
+         << canonicalOpName(existing->second)
+         << ", second = CanonicalOp::" << canonicalOpName(E.Sem);
+      if (existing->second == E.Sem) {
+        Os << ".  (Both targets are the same -- the row is redundant; "
+              "remove one.)";
+      } else {
+        Os << ".  `canonToSem.try_emplace` keeps the first insertion, "
+              "so every `"
+           << MCII.getName(E.Opc)
+           << "` lift silently routes through CanonicalOp::"
+           << canonicalOpName(existing->second)
+           << " and the second row is dead.  Pick ONE CanonicalOp target "
+              "and remove the loser row.";
+      }
+      report_fatal_error(Msg.c_str());
+    }
+  }
+
+  const unsigned NumOpc = MCII.getNumOpcodes();
+  const auto McToPseudo = buildMcToPseudoMap(NumOpc);
+  const auto PseudoAlias = buildPseudoAliasMap(MCII);
+  const auto DppToBase = buildDppToBaseMap(NumOpc);
+
+  Map.clear();
+  // Heuristic: roughly a quarter of MC opcodes carry a CanonicalOp in practice;
+  // resizing a few times is fine for a one-shot init.
+  Map.reserve(NumOpc / 4);
+  for (unsigned Mc = 0; Mc < NumOpc; ++Mc) {
+    const unsigned Canon =
+        canonicalize(Mc, MCII, McToPseudo, PseudoAlias, DppToBase);
+    if (auto It = CanonToSem.find(Canon); It != CanonToSem.end())
+      Map[Mc] = It->second;
+    // Every other MC opcode stays Unknown so the raiser's dispatch refuses it.
+  }
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/decoder/opcode-map.cpp
+++ b/amd/comgr/src/hotswap/decoder/opcode-map.cpp
@@ -8,33 +8,22 @@
 
 #include "opcode-map.h"
 
+#include <cassert>
 #include <cstdint>
 #include <optional>
 #include <string>
 
-// AMDGPU target-private headers. They expose:
-//   AMDGPU::getMCOpcode           (declared in Utils/AMDGPUBaseInfo.h)
-//   AMDGPU::getVOPe64 / getVOPe32 / getDPPOp32 / getDPPOp64 /
-//   getSDWAOp / getBasicFromSDWAOp / getGlobalVaddrOp
-//                                  (declared in SIInstrInfo.h, implemented
-//                                   in the TableGen-generated
-//                                   AMDGPUGenInstrInfo.inc under
-//                                   `#define GET_INSTRMAP_INFO`, linked from
-//                                   libLLVMAMDGPUUtils.a).
-//
-// SIInstrInfo.h drags in the CodeGen TargetInstrInfo base, which we do not
-// use at runtime, but pulling it in is preferable to hand-rolling forward
-// declarations that would silently go stale if LLVM changes a signature.
+// AMDGPU target-private headers.
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
 #include "SIDefines.h"
 #include "SIInstrInfo.h"
 #include "Utils/AMDGPUBaseInfo.h"
+
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/Twine.h"
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/MC/MCInstrInfo.h"
-#include "llvm/Support/ErrorHandling.h"
 
 using namespace llvm;
 
@@ -42,17 +31,19 @@ namespace COMGR::hotswap {
 
 namespace {
 
-// Maps a canonical AMDGPU pseudo opcode to the CanonicalOp the raiser
-// dispatches on. The canonical form is what comes out of the canonicalization
-// chain below:
-//   MC opcode -> pseudo
-//   pseudo    -> e64 (if VOP/VOPC has e32/e64 split)
-//   pseudo    -> base (if SDWA/DPP)
-//   pseudo    -> VADDR (if FLAT/GLOBAL SADDR)
-//
-// Using AMDGPU:: enum constants instead of strings gives us compile-time
-// checking: if LLVM renames a pseudo, the build fails here rather than the
-// lookup silently returning CanonicalOp::Unknown at runtime.
+// The AMDGPU InstrMapping helpers (getMCOpcode, getVOPe64, getDPPOp32/64,
+// getBasicFromSDWAOp, getGlobalVaddrOp) return int32_t. They signal "no
+// mapping" two ways: -1 when the opcode is absent from the table, and
+// INSTRUCTION_LIST_END when it is present but the requested column is empty.
+// Normalise both to nullopt so callers get a real opcode or nothing.
+std::optional<unsigned> mappedOpcode(int Result) {
+  if (Result <= 0 || Result >= AMDGPU::INSTRUCTION_LIST_END)
+    return std::nullopt;
+  return Result;
+}
+
+// One kCanonTable row: a canonical AMDGPU pseudo opcode and the CanonicalOp the
+// raiser dispatches on.
 struct Entry {
   unsigned Opc;
   CanonicalOp Sem;
@@ -88,9 +79,8 @@ DenseMap<unsigned, unsigned> buildMcToPseudoMap(unsigned NumOpc) {
   DenseMap<unsigned, unsigned> Result;
   for (unsigned P = 0; P < NumOpc; ++P) {
     for (unsigned Gen = 0; Gen < KNumEncodingFamilies; ++Gen) {
-      int Mc = AMDGPU::getMCOpcode(P, Gen);
-      if (Mc > 0 && static_cast<unsigned>(Mc) != P)
-        Result.try_emplace(static_cast<unsigned>(Mc), P);
+      if (auto Mc = mappedOpcode(AMDGPU::getMCOpcode(P, Gen)); Mc && *Mc != P)
+        Result.try_emplace(*Mc, P);
     }
   }
   return Result;
@@ -105,9 +95,9 @@ DenseMap<unsigned, unsigned> buildMcToPseudoMap(unsigned NumOpc) {
 // wrong IR at runtime.
 using RulePredicate = bool (*)(const MCInstrDesc &Src, const MCInstrDesc &Tgt);
 
-// `_RTN` collapse: source must be an atomic with a return value; target must
-// be the same atomic without one. The raiser uses `numDefs` as the
-// "publishes old value" signal, so that invariant must also hold.
+// Source is an atomic that returns the old value; target is the same atomic
+// without a return. numDefs carries that distinction downstream, so it must
+// differ accordingly.
 static bool atomicRetToNoRet(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
   constexpr uint64_t KRet = SIInstrFlags::IsAtomicRet;
   constexpr uint64_t KNoRet = SIInstrFlags::IsAtomicNoRet;
@@ -115,28 +105,16 @@ static bool atomicRetToNoRet(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
          Src.getNumDefs() > 0 && Tgt.getNumDefs() == 0;
 }
 
-// `_vgprcd_` / `_mac_` collapse: both source and target must be MFMA
-// (matrix-accumulate) pseudos.
+// Both source and target must be MFMA pseudos.
 static bool bothAreMAI(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
   constexpr uint64_t KMAI = SIInstrFlags::IsMAI;
   return (Src.TSFlags & KMAI) && (Tgt.TSFlags & KMAI);
 }
 
-// `_nosdst_` collapse: starting with GFX11, VOPC CMPX instructions no longer
-// write a scalar destination register (EXEC receives the mask directly) and
-// LLVM represents this as a `_nosdst_` variant. The non-`_nosdst_` target
-// form keeps the scalar dst (for older subtargets). Both forms share
-// dispatch-relevant TSFlags; the raiser's CMPX handler only writes EXEC and
-// ignores the optional sdst, so collapsing the variant onto the base is
-// safe. The source has one fewer def when the base includes sdst (e64
-// forms) and the same number of defs otherwise (e32, where both lack sdst).
-
-// Bits we require to be identical between source and target for an alias
-// collapse to be considered semantically safe. Deliberately excludes encoding
-// variation flags like `VOP3_OPSEL` (set on `_t16_` op-sel encodings but not
-// on the base `_e64`) and `renamedInGFX9` (set only on the subtarget-specific
-// pseudo). Everything listed below represents *what the handler dispatches
-// on*: instruction family (SOP/VOP/FLAT/DS/...), atomic kind, and MAI.
+// Flags that must match between source and target for an alias to be
+// semantically safe: instruction family, atomic kind, and MAI. Encoding-only
+// bits such as VOP3_OPSEL are deliberately excluded because operand-size and
+// subtarget variants toggle them.
 static constexpr uint64_t KSemanticShapeMask =
     // Instruction families.
     SIInstrFlags::SOP1 | SIInstrFlags::SOP2 | SIInstrFlags::SOPC |
@@ -187,112 +165,88 @@ DenseMap<unsigned, unsigned> buildPseudoAliasMap(const MCInstrInfo &MCII) {
   for (unsigned P = 0; P < NumOpc; ++P)
     ByName.try_emplace(MCII.getName(P), P);
 
+  // A pseudo-name marker to strip and the invariant the alias must preserve.
   struct Rule {
     llvm::StringRef Needle;
     bool IsSuffix;
-    // Optional semantic check on (source, target) MCInstrDesc. A null
-    // predicate means "no validation yet" (see the older subtarget/operand
-    // markers below).
     RulePredicate Pred;
   };
-  // Subtarget-specific markers ("_gfx9", "_gfx1250", ...) and operand-size
-  // markers ("_t16_", "_fake16_") that LLVM injects into the pseudo name.
-  // A single pseudo can carry multiple markers (e.g.
-  // `V_BITOP3_B16_gfx1250_fake16_e64`), so the outer loop below applies these
-  // rules iteratively until the name stops shrinking.
   static const Rule Rules[] = {
-      // Subtarget-specific markers. LLVM emits a dedicated pseudo per
-      // subtarget (e.g. `_gfx9`, `_gfx1250`, `_vi_gfx9`) with the same
-      // TableGen class as the base; collapsing them is sound as long as
-      // TSFlags and def arity match.
+      // Per-subtarget pseudos (`_gfx9`, `_gfx1250`, `_vi_gfx9`, ...) sharing
+      // the
+      // base's TableGen class.
       {"_vi_gfx9", true, sameSemanticShape},
       {"_gfx9", true, sameSemanticShape},
       {"_gfx1250", true, sameSemanticShape},
       {"_gfx1250_", false, sameSemanticShape},
       {"_pseudo_", false, sameSemanticShape},
-      // True16 / Fake16 mark the 16-bit operand encoding variant; LLVM has
-      // no dedicated TSFlag bit for this (the distinction lives in
-      // True16Predicate on the TableGen side), and the t16 encoding toggles
-      // `VOP3_OPSEL`. We cross-check that dispatch-relevant TSFlags and def
-      // arity are preserved, but tolerate encoding-bit drift.
+      // 16-bit operand encoding variant; toggles VOP3_OPSEL but keeps dispatch
+      // identity.
       {"_t16_", false, sameSemanticShape},
       {"_fake16_", false, sameSemanticShape},
-      // `_OP_SEL_` infix marks the gfx11+ encoding variant for VOP1 cvt
-      // instructions (e.g. v_cvt_f32_{fp8,bf8}, v_cvt_pk_f32_{fp8,bf8}).
-      // The OP_SEL pseudo carries an extra `byte_sel` immediate operand and
-      // toggles `VOP3_OPSEL`/`maybeAtomic`/`ASYNC_CNT` bits relative to the
-      // base e64 pseudo, but dispatch identity (instruction family + def
-      // arity + atomic/MAI classification) is preserved. Collapsing onto
-      // the base pseudo lets a single CanonicalOp handler service both the
-      // pre-gfx11 SDWA/byte_sel-via-disassembly form and the gfx11+ encoded
-      // byte_sel form; the handler reads the byte_sel from the disassembly
-      // text (`op_sel:`), which is identical for both.
+      // gfx11+ encoding variant of the fp8/bf8 cvt ops: adds a byte_sel operand
+      // but keeps dispatch identity.
       {"_OP_SEL_", false, sameSemanticShape},
-      // GFX11+ VOPC CMPX family drops the scalar destination register; the
-      // raiser's CMPX handler only touches EXEC so the `_nosdst_` form
-      // collapses cleanly onto the base pseudo of the same encoding width.
+      // gfx11+ VOPC CMPX drops the scalar dst (writes EXEC only); the handler
+      // ignores it.
       {"_nosdst_", false, nosdstDropsScalarDef},
-      // MFMA register-class modifiers.  `_vgprcd_` marks a VGPR destination
-      // variant; `_mac_` marks a multiply-accumulate (tied dst/src2) variant.
-      // Both keep the same TableGen intrinsic and semantic shape, so they
-      // collapse onto the base `_e64` pseudo.
+      // MFMA VGPR-dest (`_vgprcd_`) and accumulate (`_mac_`) variants.
       {"_vgprcd_", false, bothAreMAI},
       {"_mac_", false, bothAreMAI},
-      // Atomic return-value variants: LLVM emits distinct `_RTN` pseudos for
-      // the forms that return the pre-modification value, plus `_agpr`
-      // variants that just pick an AGPR destination register class. These
-      // pseudos carry the same TableGen intrinsic and identical semantics;
-      // the only difference is whether the handler should write the result
-      // back, which the raiser already derives from `di.numDefs`
-      // (MCInstrDesc::getNumDefs()). Collapse them onto the non-RTN pseudo
-      // so both forms share a single CanonicalOp.
+      // Atomic return-value (`_RTN`) and AGPR-dest (`_agpr`) variants; whether
+      // the old value is written is derived from numDefs downstream.
       {"_agpr", true, sameSemanticShape},
       {"_RTN", true, atomicRetToNoRet},
   };
 
-  // Returns the index of the firing rule or -1 if no rule applies.
-  auto StripOnce = [&](llvm::StringRef Name, std::string &Out) -> int {
+  // Returns the index of the firing rule, or nullopt if no rule applies.
+  auto StripOnce = [&](llvm::StringRef Name,
+                       std::string &Out) -> std::optional<size_t> {
     for (size_t I = 0; I < std::size(Rules); ++I) {
       const Rule &R = Rules[I];
       if (R.IsSuffix) {
         if (!Name.ends_with(R.Needle))
           continue;
         Out = Name.drop_back(R.Needle.size()).str();
-        return static_cast<int>(I);
+        return I;
       }
       size_t Pos = Name.find(R.Needle);
       if (Pos == llvm::StringRef::npos)
         continue;
       Out = (Name.substr(0, Pos).str() + std::string("_") +
              Name.substr(Pos + R.Needle.size()).str());
-      return static_cast<int>(I);
+      return I;
     }
-    return -1;
+    return std::nullopt;
   };
 
   DenseMap<unsigned, unsigned> Alias;
   for (const auto &Kv : ByName) {
-    std::string Cur = Kv.first().str();
+    StringRef Name = Kv.first();
+    // Most pseudos carry no marker, so skip them before any string allocation.
+    if (llvm::none_of(Rules,
+                      [&](const Rule &R) { return Name.contains(R.Needle); }))
+      continue;
+
+    // A pseudo may carry several markers, so strip them one at a time until
+    // none remain, validating each step against the opcode it lands on.
+    std::string Cur = Name.str();
     unsigned CurOpc = Kv.second;
     unsigned FinalOpc = Kv.second;
     while (true) {
       std::string Next;
-      int RuleIdx = StripOnce(Cur, Next);
-      if (RuleIdx < 0)
+      std::optional<size_t> RuleIdx = StripOnce(Cur, Next);
+      if (!RuleIdx)
         break;
       auto It = ByName.find(Next);
       if (It != ByName.end() && It->second != Kv.second) {
-        const Rule &R = Rules[RuleIdx];
-        if (R.Pred && !R.Pred(MCII.get(CurOpc), MCII.get(It->second))) {
-          report_fatal_error(
-              Twine("opcode_map: alias rule '") + R.Needle +
-              "' broke its semantic invariant while collapsing '" + Cur +
-              "' -> '" + Next +
-              "'. LLVM likely renamed or repurposed a pseudo; update the "
-              "alias rules or the predicate.");
+        bool Ok = Rules[*RuleIdx].Pred(MCII.get(CurOpc), MCII.get(It->second));
+        assert(Ok && "alias rule broke its semantic invariant; LLVM likely "
+                     "renamed or repurposed a pseudo");
+        if (Ok) {
+          CurOpc = It->second;
+          FinalOpc = CurOpc;
         }
-        CurOpc = It->second;
-        FinalOpc = CurOpc;
       }
       Cur = std::move(Next);
     }
@@ -307,12 +261,10 @@ DenseMap<unsigned, unsigned> buildPseudoAliasMap(const MCInstrInfo &MCII) {
 DenseMap<unsigned, unsigned> buildDppToBaseMap(unsigned NumOpc) {
   DenseMap<unsigned, unsigned> Result;
   for (unsigned P = 0; P < NumOpc; ++P) {
-    int D32 = AMDGPU::getDPPOp32(P);
-    if (D32 > 0)
-      Result.try_emplace(static_cast<unsigned>(D32), P);
-    int D64 = AMDGPU::getDPPOp64(P);
-    if (D64 > 0)
-      Result.try_emplace(static_cast<unsigned>(D64), P);
+    if (auto D32 = mappedOpcode(AMDGPU::getDPPOp32(P)))
+      Result.try_emplace(*D32, P);
+    if (auto D64 = mappedOpcode(AMDGPU::getDPPOp64(P)))
+      Result.try_emplace(*D64, P);
   }
   return Result;
 }
@@ -333,7 +285,7 @@ unsigned canonicalize(unsigned Mc, const MCInstrInfo &MCII,
   if (auto It = McToPseudo.find(P); It != McToPseudo.end())
     P = It->second;
 
-  // Parallel-pseudo alias -> base pseudo (strips _gfx9, _t16_, _fake16_).
+  // Strip subtarget/operand markers to the base pseudo (_gfx9, _t16_, ...).
   if (auto It = PseudoAlias.find(P); It != PseudoAlias.end())
     P = It->second;
 
@@ -344,19 +296,16 @@ unsigned canonicalize(unsigned Mc, const MCInstrInfo &MCII,
     P = It->second;
 
   // SDWA -> base. LLVM provides a forward helper for this direction.
-  int Base = AMDGPU::getBasicFromSDWAOp(P);
-  if (Base > 0)
-    P = static_cast<unsigned>(Base);
+  if (auto Base = mappedOpcode(AMDGPU::getBasicFromSDWAOp(P)))
+    P = *Base;
 
   // e32 -> e64.
-  int E64 = AMDGPU::getVOPe64(P);
-  if (E64 > 0)
-    P = static_cast<unsigned>(E64);
+  if (auto E64 = mappedOpcode(AMDGPU::getVOPe64(P)))
+    P = *E64;
 
-  // Re-apply the pseudo-alias step. `getVOPe64` can resolve an `_e32` pseudo
-  // (e.g. `V_LSHLREV_B64_pseudo_e32`) to an `_e64` pseudo with a parallel
-  // variant marker (`V_LSHLREV_B64_pseudo_e64`) that only collapses once
-  // both the `_pseudo_` infix and `_e64` suffix are visible together.
+  // Re-run the marker strip: getVOPe64 can expose a marked _e64 pseudo (e.g.
+  // V_LSHLREV_B64_pseudo_e64) that only reduces once the _e64 suffix is
+  // present.
   if (auto It = PseudoAlias.find(P); It != PseudoAlias.end())
     P = It->second;
 
@@ -365,9 +314,8 @@ unsigned canonicalize(unsigned Mc, const MCInstrInfo &MCII,
   // checking the flag first avoids the lookup for every non-FLAT opcode.
   if (P < MCII.getNumOpcodes() &&
       (MCII.get(P).TSFlags & SIInstrFlags::FLAT) != 0) {
-    int Vaddr = AMDGPU::getGlobalVaddrOp(P);
-    if (Vaddr > 0)
-      P = static_cast<unsigned>(Vaddr);
+    if (auto Vaddr = mappedOpcode(AMDGPU::getGlobalVaddrOp(P)))
+      P = *Vaddr;
   }
 
   return P;
@@ -381,58 +329,16 @@ CanonicalOp OpcodeMap::lookup(unsigned Opcode) const {
 }
 
 void OpcodeMap::build(const MCInstrInfo &MCII) {
-  // Flatten the static kCanonTable into a DenseMap for O(1) lookups
-  // during the subsequent scan over every MC opcode.  This flatten
-  // step also serves as a duplicate-key audit for `kCanonTable`: the
-  // earlier implementation used a plain `canonToSem.try_emplace` loop,
-  // which silently keeps the first insertion on key collision.  That
-  // silent-first-wins behaviour is exactly what let S_ADD_U64 get
-  // mapped twice (once as SOP2-block `E(S_ADD_U64, S_ADD_U64)` and
-  // once as gfx12-rename `E(S_ADD_U64, S_ADD_NC_U64)`) with the
-  // second row silently losing the routing race and leaving every
-  // `s_add_u64` lift routed through the wrong CanonicalOp -- see commit
-  // eaee0a0e88 for the repair.  The loop below now returns an error on
-  // duplicate keys so a future add that re-introduces the collision
-  // is caught at transpiler init time instead of quietly miscompiling
-  // everything under the duplicated opcode.
-  //
-  // A returned error (rather than `assert`) keeps the check active in
-  // release builds too -- the cost is a single `try_emplace` per table
-  // row at process start, which is negligible for a ~800-entry table.
-  //
-  // "Same CanonicalOp twice" is also rejected.  In principle a redundant
-  // row that maps the same MC opcode to the same CanonicalOp is just
-  // noise the first-wins rule would swallow harmlessly, but we
-  // refuse it anyway so the `kCanonTable` stays honest -- a
-  // redundant row is always an editing mistake, never an
-  // intentional design, and the abort makes the fix mechanical
-  // (delete one of the two rows).
+  // Flatten kCanonTable into a DenseMap for O(1) lookups during the scan below.
+  // A duplicate MC opcode would silently keep only the first row and route the
+  // rest through the wrong CanonicalOp, so a duplicate key is a table-authoring
+  // bug.
   DenseMap<unsigned, CanonicalOp> CanonToSem;
   CanonToSem.reserve(std::size(kCanonTable));
   for (const Entry &E : kCanonTable) {
-    auto [existing, inserted] = CanonToSem.try_emplace(E.Opc, E.Sem);
-    if (!inserted) {
-      std::string Msg;
-      raw_string_ostream Os(Msg);
-      Os << "opcode-map.cpp: kCanonTable maps MC opcode '"
-         << MCII.getName(E.Opc) << "' (enum value " << E.Opc
-         << ") to TWO CanonicalOps: " << "first = CanonicalOp::"
-         << canonicalOpName(existing->second)
-         << ", second = CanonicalOp::" << canonicalOpName(E.Sem);
-      if (existing->second == E.Sem) {
-        Os << ".  (Both targets are the same -- the row is redundant; "
-              "remove one.)";
-      } else {
-        Os << ".  `canonToSem.try_emplace` keeps the first insertion, "
-              "so every `"
-           << MCII.getName(E.Opc)
-           << "` lift silently routes through CanonicalOp::"
-           << canonicalOpName(existing->second)
-           << " and the second row is dead.  Pick ONE CanonicalOp target "
-              "and remove the loser row.";
-      }
-      report_fatal_error(Msg.c_str());
-    }
+    bool Inserted = CanonToSem.try_emplace(E.Opc, E.Sem).second;
+    assert(Inserted && "kCanonTable maps one MC opcode to two CanonicalOps");
+    (void)Inserted;
   }
 
   const unsigned NumOpc = MCII.getNumOpcodes();

--- a/amd/comgr/src/hotswap/decoder/opcode-map.cpp
+++ b/amd/comgr/src/hotswap/decoder/opcode-map.cpp
@@ -9,9 +9,7 @@
 #include "opcode-map.h"
 
 #include <cassert>
-#include <cstdint>
 #include <optional>
-#include <string>
 
 // AMDGPU target-private headers.
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
@@ -19,9 +17,6 @@
 #include "SIInstrInfo.h"
 #include "Utils/AMDGPUBaseInfo.h"
 
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringMap.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/MC/MCInstrInfo.h"
 
@@ -55,10 +50,8 @@ static const Entry kCanonTable[] = {
 
 #undef E
 
-// Iteration bound for SIEncodingFamily, a closed numeric set whose current
-// maximum is GFX13. The static_assert fails if that sentinel is renamed.
-static_assert(SIEncodingFamily::GFX13 >= SIEncodingFamily::SI,
-              "SIEncodingFamily enum layout changed unexpectedly");
+// Update this bound when SIEncodingFamily gains a new value, otherwise opcodes
+// using that encoding remain unmapped.
 constexpr unsigned KNumEncodingFamilies =
     static_cast<unsigned>(SIEncodingFamily::GFX13) + 1;
 
@@ -68,162 +61,12 @@ DenseMap<unsigned, unsigned> buildMcToPseudoMap(unsigned NumOpc) {
   DenseMap<unsigned, unsigned> Result;
   for (unsigned P = 0; P < NumOpc; ++P) {
     for (unsigned Gen = 0; Gen < KNumEncodingFamilies; ++Gen) {
-      if (auto Mc = mappedOpcode(AMDGPU::getMCOpcode(P, Gen)); Mc && *Mc != P)
+      std::optional<unsigned> Mc = mappedOpcode(AMDGPU::getMCOpcode(P, Gen));
+      if (Mc && *Mc != P)
         Result.try_emplace(*Mc, P);
     }
   }
   return Result;
-}
-
-// Invariant the source pseudo and the target it collapses onto must satisfy
-// for the collapse to be semantically safe.
-using RulePredicate = bool (*)(const MCInstrDesc &Src, const MCInstrDesc &Tgt);
-
-// Source is an atomic that returns the old value and the target is the same
-// atomic without a return, so their def counts differ accordingly.
-static bool atomicRetToNoRet(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
-  constexpr uint64_t KRet = SIInstrFlags::IsAtomicRet;
-  constexpr uint64_t KNoRet = SIInstrFlags::IsAtomicNoRet;
-  return (Src.TSFlags & KRet) && (Tgt.TSFlags & KNoRet) &&
-         Src.getNumDefs() > 0 && Tgt.getNumDefs() == 0;
-}
-
-// Both source and target must be MFMA pseudos.
-static bool bothAreMAI(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
-  constexpr uint64_t KMAI = SIInstrFlags::IsMAI;
-  return (Src.TSFlags & KMAI) && (Tgt.TSFlags & KMAI);
-}
-
-// TSFlags bits that must match between source and target for a collapse to be
-// safe. Encoding-only bits such as VOP3_OPSEL are excluded because
-// operand-size and subtarget variants legitimately toggle them.
-static constexpr uint64_t KSemanticShapeMask =
-    // Instruction families.
-    SIInstrFlags::SOP1 | SIInstrFlags::SOP2 | SIInstrFlags::SOPC |
-    SIInstrFlags::SOPK | SIInstrFlags::SOPP | SIInstrFlags::VOP1 |
-    SIInstrFlags::VOP2 | SIInstrFlags::VOPC | SIInstrFlags::VOP3 |
-    SIInstrFlags::VOP3P | SIInstrFlags::SDWA | SIInstrFlags::DPP |
-    SIInstrFlags::MUBUF | SIInstrFlags::MTBUF | SIInstrFlags::SMRD |
-    SIInstrFlags::FLAT | SIInstrFlags::DS | SIInstrFlags::MIMG |
-    // Semantic classification (atomic kind, MAI).
-    SIInstrFlags::IsAtomicRet | SIInstrFlags::IsAtomicNoRet |
-    SIInstrFlags::IsMAI;
-
-// Source and target agree on every KSemanticShapeMask bit and on def arity.
-static bool sameSemanticShape(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
-  return (Src.TSFlags & KSemanticShapeMask) ==
-             (Tgt.TSFlags & KSemanticShapeMask) &&
-         Src.getNumDefs() == Tgt.getNumDefs();
-}
-
-// Same shape as sameSemanticShape, except the target may carry one more def
-// than the source: the scalar dst the source drops.
-static bool nosdstDropsScalarDef(const MCInstrDesc &Src,
-                                 const MCInstrDesc &Tgt) {
-  return (Src.TSFlags & KSemanticShapeMask) ==
-             (Tgt.TSFlags & KSemanticShapeMask) &&
-         Tgt.getNumDefs() >= Src.getNumDefs() &&
-         Tgt.getNumDefs() - Src.getNumDefs() <= 1;
-}
-
-// Alias map collapsing the several pseudos LLVM generates for one instruction
-// onto a single canonical pseudo, e.g.
-//   DS_WRITE_B16_gfx9        -> DS_WRITE_B16
-//   V_ADD_F16_t16_e64        -> V_ADD_F16_e64
-//   V_ADD_F16_fake16_e64     -> V_ADD_F16_e64
-// No helper exposes this collapse, so it is matched on pseudo name.
-DenseMap<unsigned, unsigned> buildPseudoAliasMap(const MCInstrInfo &MCII) {
-  unsigned NumOpc = MCII.getNumOpcodes();
-
-  llvm::StringMap<unsigned> ByName;
-  for (unsigned P = 0; P < NumOpc; ++P)
-    ByName.try_emplace(MCII.getName(P), P);
-
-  // A pseudo-name marker to strip and the invariant the alias must preserve.
-  struct Rule {
-    llvm::StringRef Needle;
-    bool IsSuffix;
-    RulePredicate Pred;
-  };
-  static const Rule Rules[] = {
-      // Per-subtarget pseudos sharing the base's TableGen class.
-      {"_vi_gfx9", true, sameSemanticShape},
-      {"_gfx9", true, sameSemanticShape},
-      {"_gfx1250", true, sameSemanticShape},
-      {"_gfx1250_", false, sameSemanticShape},
-      {"_pseudo_", false, sameSemanticShape},
-      // 16-bit operand encoding variant; toggles VOP3_OPSEL but keeps dispatch
-      // identity.
-      {"_t16_", false, sameSemanticShape},
-      {"_fake16_", false, sameSemanticShape},
-      // gfx11+ encoding variant of the fp8/bf8 cvt ops: adds a byte_sel operand
-      // but keeps dispatch identity.
-      {"_OP_SEL_", false, sameSemanticShape},
-      // gfx11+ VOPC CMPX drops the scalar dst and writes EXEC only.
-      {"_nosdst_", false, nosdstDropsScalarDef},
-      // MFMA VGPR-dest and accumulate variants.
-      {"_vgprcd_", false, bothAreMAI},
-      {"_mac_", false, bothAreMAI},
-      // AGPR-dest and atomic return-value variants.
-      {"_agpr", true, sameSemanticShape},
-      {"_RTN", true, atomicRetToNoRet},
-  };
-
-  // Returns the index of the firing rule, or nullopt if no rule applies.
-  auto StripOnce = [&](llvm::StringRef Name,
-                       std::string &Out) -> std::optional<size_t> {
-    for (size_t I = 0; I < std::size(Rules); ++I) {
-      const Rule &R = Rules[I];
-      if (R.IsSuffix) {
-        if (!Name.ends_with(R.Needle))
-          continue;
-        Out = Name.drop_back(R.Needle.size()).str();
-        return I;
-      }
-      size_t Pos = Name.find(R.Needle);
-      if (Pos == llvm::StringRef::npos)
-        continue;
-      Out = (Name.substr(0, Pos).str() + std::string("_") +
-             Name.substr(Pos + R.Needle.size()).str());
-      return I;
-    }
-    return std::nullopt;
-  };
-
-  DenseMap<unsigned, unsigned> Alias;
-  for (const auto &Kv : ByName) {
-    StringRef Name = Kv.first();
-    // Most pseudos carry no marker, so skip them before any string allocation.
-    if (llvm::none_of(Rules,
-                      [&](const Rule &R) { return Name.contains(R.Needle); }))
-      continue;
-
-    // A pseudo may carry several markers, so strip them one at a time until
-    // none remain, validating each step against the opcode it lands on.
-    std::string Cur = Name.str();
-    unsigned CurOpc = Kv.second;
-    unsigned FinalOpc = Kv.second;
-    while (true) {
-      std::string Next;
-      std::optional<size_t> RuleIdx = StripOnce(Cur, Next);
-      if (!RuleIdx)
-        break;
-      auto It = ByName.find(Next);
-      if (It != ByName.end() && It->second != Kv.second) {
-        bool Ok = Rules[*RuleIdx].Pred(MCII.get(CurOpc), MCII.get(It->second));
-        assert(Ok && "alias rule broke its semantic invariant; LLVM likely "
-                     "renamed or repurposed a pseudo");
-        if (Ok) {
-          CurOpc = It->second;
-          FinalOpc = CurOpc;
-        }
-      }
-      Cur = std::move(Next);
-    }
-    if (FinalOpc != Kv.second)
-      Alias.try_emplace(Kv.second, FinalOpc);
-  }
-  return Alias;
 }
 
 // Reverse map DPP opcode -> base VOP opcode, built by scanning the first
@@ -231,57 +74,41 @@ DenseMap<unsigned, unsigned> buildPseudoAliasMap(const MCInstrInfo &MCII) {
 DenseMap<unsigned, unsigned> buildDppToBaseMap(unsigned NumOpc) {
   DenseMap<unsigned, unsigned> Result;
   for (unsigned P = 0; P < NumOpc; ++P) {
-    if (auto D32 = mappedOpcode(AMDGPU::getDPPOp32(P)))
+    if (std::optional<unsigned> D32 = mappedOpcode(AMDGPU::getDPPOp32(P)))
       Result.try_emplace(*D32, P);
-    if (auto D64 = mappedOpcode(AMDGPU::getDPPOp64(P)))
+    if (std::optional<unsigned> D64 = mappedOpcode(AMDGPU::getDPPOp64(P)))
       Result.try_emplace(*D64, P);
   }
   return Result;
 }
 
-// Canonicalize any MC opcode `mc` to the pseudo form matched in kCanonTable.
-// The chain is:
-//   MC -> pseudo                (TableGen Subtarget map)
-//   pseudo -> base VOP          (strip DPP / SDWA)
-//   e32 -> e64                  (collapse VOP encoding variants)
-//   SADDR -> VADDR              (FLAT/GLOBAL global-saddr table)
+// Map `Mc` to the canonical pseudo used by kCanonTable.
 unsigned canonicalize(unsigned Mc, const MCInstrInfo &MCII,
                       const DenseMap<unsigned, unsigned> &McToPseudo,
-                      const DenseMap<unsigned, unsigned> &PseudoAlias,
                       const DenseMap<unsigned, unsigned> &DppToBase) {
   unsigned P = Mc;
 
-  // MC (subtarget-specific real) -> pseudo.
-  if (auto It = McToPseudo.find(P); It != McToPseudo.end())
-    P = It->second;
+  DenseMap<unsigned, unsigned>::const_iterator PseudoIt = McToPseudo.find(P);
+  if (PseudoIt != McToPseudo.end())
+    P = PseudoIt->second;
 
-  // Strip subtarget/operand markers to the base pseudo (_gfx9, _t16_, ...).
-  if (auto It = PseudoAlias.find(P); It != PseudoAlias.end())
-    P = It->second;
+  DenseMap<unsigned, unsigned>::const_iterator DppIt = DppToBase.find(P);
+  if (DppIt != DppToBase.end())
+    P = DppIt->second;
 
-  // DPP -> base, for both the _dpp and _e64_dpp pseudos.
-  if (auto It = DppToBase.find(P); It != DppToBase.end())
-    P = It->second;
-
-  // SDWA -> base.
-  if (auto Base = mappedOpcode(AMDGPU::getBasicFromSDWAOp(P)))
+  if (std::optional<unsigned> Base =
+          mappedOpcode(AMDGPU::getBasicFromSDWAOp(P)))
     P = *Base;
 
-  // e32 -> e64.
-  if (auto E64 = mappedOpcode(AMDGPU::getVOPe64(P)))
+  if (std::optional<unsigned> E64 = mappedOpcode(AMDGPU::getVOPe64(P)))
     P = *E64;
 
-  // Re-run the marker strip: getVOPe64 can expose a marked _e64 pseudo (e.g.
-  // V_LSHLREV_B64_pseudo_e64) that only reduces once the _e64 suffix is
-  // present.
-  if (auto It = PseudoAlias.find(P); It != PseudoAlias.end())
-    P = It->second;
-
-  // FLAT/GLOBAL SADDR -> VADDR. Testing the format flag first avoids a table
-  // lookup for every non-FLAT opcode.
+  // Testing the format flag first avoids a table lookup for every non-FLAT
+  // opcode.
   if (P < MCII.getNumOpcodes() &&
       (MCII.get(P).TSFlags & SIInstrFlags::FLAT) != 0) {
-    if (auto Vaddr = mappedOpcode(AMDGPU::getGlobalVaddrOp(P)))
+    if (std::optional<unsigned> Vaddr =
+            mappedOpcode(AMDGPU::getGlobalVaddrOp(P)))
       P = *Vaddr;
   }
 
@@ -291,7 +118,7 @@ unsigned canonicalize(unsigned Mc, const MCInstrInfo &MCII,
 } // namespace
 
 CanonicalOp OpcodeMap::lookup(unsigned Opcode) const {
-  auto It = Map.find(Opcode);
+  DenseMap<unsigned, CanonicalOp>::const_iterator It = Map.find(Opcode);
   return It != Map.end() ? It->second : CanonicalOp::Unknown;
 }
 
@@ -307,17 +134,14 @@ void OpcodeMap::build(const MCInstrInfo &MCII) {
   }
 
   const unsigned NumOpc = MCII.getNumOpcodes();
-  const auto McToPseudo = buildMcToPseudoMap(NumOpc);
-  const auto PseudoAlias = buildPseudoAliasMap(MCII);
-  const auto DppToBase = buildDppToBaseMap(NumOpc);
+  const DenseMap<unsigned, unsigned> McToPseudo = buildMcToPseudoMap(NumOpc);
+  const DenseMap<unsigned, unsigned> DppToBase = buildDppToBaseMap(NumOpc);
 
   Map.clear();
-  // Rough guess at the mapped fraction; a one-shot init tolerates resizes.
-  Map.reserve(NumOpc / 4);
   for (unsigned Mc = 0; Mc < NumOpc; ++Mc) {
-    const unsigned Canon =
-        canonicalize(Mc, MCII, McToPseudo, PseudoAlias, DppToBase);
-    if (auto It = CanonToSem.find(Canon); It != CanonToSem.end())
+    const unsigned Canon = canonicalize(Mc, MCII, McToPseudo, DppToBase);
+    DenseMap<unsigned, CanonicalOp>::const_iterator It = CanonToSem.find(Canon);
+    if (It != CanonToSem.end())
       Map[Mc] = It->second;
   }
 }

--- a/amd/comgr/src/hotswap/decoder/opcode-map.cpp
+++ b/amd/comgr/src/hotswap/decoder/opcode-map.cpp
@@ -31,19 +31,15 @@ namespace COMGR::hotswap {
 
 namespace {
 
-// The AMDGPU InstrMapping helpers (getMCOpcode, getVOPe64, getDPPOp32/64,
-// getBasicFromSDWAOp, getGlobalVaddrOp) return int32_t. They signal "no
-// mapping" two ways: -1 when the opcode is absent from the table, and
-// INSTRUCTION_LIST_END when it is present but the requested column is empty.
-// Normalise both to nullopt so callers get a real opcode or nothing.
+// Opcode named by an AMDGPU InstrMapping helper result, or nullopt for either
+// way the helpers signal "no mapping": -1 and INSTRUCTION_LIST_END.
 std::optional<unsigned> mappedOpcode(int Result) {
   if (Result <= 0 || Result >= AMDGPU::INSTRUCTION_LIST_END)
     return std::nullopt;
   return Result;
 }
 
-// One kCanonTable row: a canonical AMDGPU pseudo opcode and the CanonicalOp the
-// raiser dispatches on.
+// One kCanonTable row: a canonical AMDGPU pseudo opcode and its CanonicalOp.
 struct Entry {
   unsigned Opc;
   CanonicalOp Sem;
@@ -53,28 +49,21 @@ struct Entry {
   Entry { AMDGPU::OP, CanonicalOp::SEM }
 
 static const Entry kCanonTable[] = {
-    // One row per landed handler; every unlisted MC opcode stays Unknown and
-    // is refused by the raiser's dispatch.
     E(S_MOV_B32, S_MOV_B32),
     E(S_ENDPGM, S_ENDPGM),
 };
 
 #undef E
 
-// Iteration bound for SIEncodingFamily: the enum in SIDefines.h is a closed
-// numeric set with GFX13 as the current maximum, so we scan [0, GFX13] when
-// inverting the pseudo -> MC map.  If LLVM adds a new family the next
-// enumerator value appears here automatically and the build still compiles;
-// the static_assert keeps us honest if LLVM ever renames the sentinel we use.
+// Iteration bound for SIEncodingFamily, a closed numeric set whose current
+// maximum is GFX13. The static_assert fails if that sentinel is renamed.
 static_assert(SIEncodingFamily::GFX13 >= SIEncodingFamily::SI,
               "SIEncodingFamily enum layout changed unexpectedly");
 constexpr unsigned KNumEncodingFamilies =
     static_cast<unsigned>(SIEncodingFamily::GFX13) + 1;
 
-// Build a reverse map MC-opcode -> canonical pseudo by scanning every pseudo
-// opcode across all subtarget generations. This is ~O(N * 15) work at init
-// time (N ~= 70k AMDGPU opcodes on recent LLVM), which is well under a
-// millisecond on modern hardware and done once per raiser.
+// Reverse map MC opcode -> canonical pseudo, built by scanning the first
+// `NumOpc` pseudos across every encoding family.
 DenseMap<unsigned, unsigned> buildMcToPseudoMap(unsigned NumOpc) {
   DenseMap<unsigned, unsigned> Result;
   for (unsigned P = 0; P < NumOpc; ++P) {
@@ -86,18 +75,12 @@ DenseMap<unsigned, unsigned> buildMcToPseudoMap(unsigned NumOpc) {
   return Result;
 }
 
-// Rule predicates: an optional semantic invariant the alias must preserve.
-// Every time an alias step is committed (source pseudo S collapses onto
-// target pseudo T), the firing rule's predicate is evaluated against
-// MCInstrDesc(S) and MCInstrDesc(T). A violation means LLVM renamed or
-// repurposed a pseudo in a way that breaks our naming contract, and is
-// reported as a fatal error at init time rather than silently producing
-// wrong IR at runtime.
+// Invariant the source pseudo and the target it collapses onto must satisfy
+// for the collapse to be semantically safe.
 using RulePredicate = bool (*)(const MCInstrDesc &Src, const MCInstrDesc &Tgt);
 
-// Source is an atomic that returns the old value; target is the same atomic
-// without a return. numDefs carries that distinction downstream, so it must
-// differ accordingly.
+// Source is an atomic that returns the old value and the target is the same
+// atomic without a return, so their def counts differ accordingly.
 static bool atomicRetToNoRet(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
   constexpr uint64_t KRet = SIInstrFlags::IsAtomicRet;
   constexpr uint64_t KNoRet = SIInstrFlags::IsAtomicNoRet;
@@ -111,10 +94,9 @@ static bool bothAreMAI(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
   return (Src.TSFlags & KMAI) && (Tgt.TSFlags & KMAI);
 }
 
-// Flags that must match between source and target for an alias to be
-// semantically safe: instruction family, atomic kind, and MAI. Encoding-only
-// bits such as VOP3_OPSEL are deliberately excluded because operand-size and
-// subtarget variants toggle them.
+// TSFlags bits that must match between source and target for a collapse to be
+// safe. Encoding-only bits such as VOP3_OPSEL are excluded because
+// operand-size and subtarget variants legitimately toggle them.
 static constexpr uint64_t KSemanticShapeMask =
     // Instruction families.
     SIInstrFlags::SOP1 | SIInstrFlags::SOP2 | SIInstrFlags::SOPC |
@@ -127,21 +109,15 @@ static constexpr uint64_t KSemanticShapeMask =
     SIInstrFlags::IsAtomicRet | SIInstrFlags::IsAtomicNoRet |
     SIInstrFlags::IsMAI;
 
-// Subtarget-/operand-class variants (`_gfx9`, `_t16_`, `_fake16_`, `_agpr`,
-// etc.) may legitimately toggle encoding flags such as `VOP3_OPSEL` or
-// `renamedInGFX9` between source and target, but they must preserve the
-// instruction's dispatch identity: same family, same atomic kind, same MAI
-// classification, same def arity. A violation means LLVM renamed or
-// repurposed a pseudo in a way our alias map cannot safely collapse.
+// Source and target agree on every KSemanticShapeMask bit and on def arity.
 static bool sameSemanticShape(const MCInstrDesc &Src, const MCInstrDesc &Tgt) {
   return (Src.TSFlags & KSemanticShapeMask) ==
              (Tgt.TSFlags & KSemanticShapeMask) &&
          Src.getNumDefs() == Tgt.getNumDefs();
 }
 
-// `_nosdst_` collapse: same dispatch identity as the base, and the source
-// never has more defs than the target (the scalar dst is either dropped
-// entirely or added back on the target's e64 form).
+// Same shape as sameSemanticShape, except the target may carry one more def
+// than the source: the scalar dst the source drops.
 static bool nosdstDropsScalarDef(const MCInstrDesc &Src,
                                  const MCInstrDesc &Tgt) {
   return (Src.TSFlags & KSemanticShapeMask) ==
@@ -150,14 +126,12 @@ static bool nosdstDropsScalarDef(const MCInstrDesc &Src,
          Tgt.getNumDefs() - Src.getNumDefs() <= 1;
 }
 
-// Build an alias map that collapses "parallel" pseudos LLVM generates for the
-// same semantic instruction into a single canonical pseudo. Examples:
+// Alias map collapsing the several pseudos LLVM generates for one instruction
+// onto a single canonical pseudo, e.g.
 //   DS_WRITE_B16_gfx9        -> DS_WRITE_B16
 //   V_ADD_F16_t16_e64        -> V_ADD_F16_e64
 //   V_ADD_F16_fake16_e64     -> V_ADD_F16_e64
-// LLVM does not expose a helper for this collapse, so we match on pseudo name
-// at init time. Name lookups are confined to this one-shot scan over
-// `MCII.getNumOpcodes()`; runtime lookups remain pure DenseMap hits.
+// No helper exposes this collapse, so it is matched on pseudo name.
 DenseMap<unsigned, unsigned> buildPseudoAliasMap(const MCInstrInfo &MCII) {
   unsigned NumOpc = MCII.getNumOpcodes();
 
@@ -172,9 +146,7 @@ DenseMap<unsigned, unsigned> buildPseudoAliasMap(const MCInstrInfo &MCII) {
     RulePredicate Pred;
   };
   static const Rule Rules[] = {
-      // Per-subtarget pseudos (`_gfx9`, `_gfx1250`, `_vi_gfx9`, ...) sharing
-      // the
-      // base's TableGen class.
+      // Per-subtarget pseudos sharing the base's TableGen class.
       {"_vi_gfx9", true, sameSemanticShape},
       {"_gfx9", true, sameSemanticShape},
       {"_gfx1250", true, sameSemanticShape},
@@ -187,14 +159,12 @@ DenseMap<unsigned, unsigned> buildPseudoAliasMap(const MCInstrInfo &MCII) {
       // gfx11+ encoding variant of the fp8/bf8 cvt ops: adds a byte_sel operand
       // but keeps dispatch identity.
       {"_OP_SEL_", false, sameSemanticShape},
-      // gfx11+ VOPC CMPX drops the scalar dst (writes EXEC only); the handler
-      // ignores it.
+      // gfx11+ VOPC CMPX drops the scalar dst and writes EXEC only.
       {"_nosdst_", false, nosdstDropsScalarDef},
-      // MFMA VGPR-dest (`_vgprcd_`) and accumulate (`_mac_`) variants.
+      // MFMA VGPR-dest and accumulate variants.
       {"_vgprcd_", false, bothAreMAI},
       {"_mac_", false, bothAreMAI},
-      // Atomic return-value (`_RTN`) and AGPR-dest (`_agpr`) variants; whether
-      // the old value is written is derived from numDefs downstream.
+      // AGPR-dest and atomic return-value variants.
       {"_agpr", true, sameSemanticShape},
       {"_RTN", true, atomicRetToNoRet},
   };
@@ -256,8 +226,8 @@ DenseMap<unsigned, unsigned> buildPseudoAliasMap(const MCInstrInfo &MCII) {
   return Alias;
 }
 
-// Build a reverse DPP map: DPP opcode -> base VOP opcode. LLVM only provides
-// forward mappings (base -> DPP32 / DPP64), so we invert by scanning.
+// Reverse map DPP opcode -> base VOP opcode, built by scanning the first
+// `NumOpc` opcodes because only the forward mappings are exposed.
 DenseMap<unsigned, unsigned> buildDppToBaseMap(unsigned NumOpc) {
   DenseMap<unsigned, unsigned> Result;
   for (unsigned P = 0; P < NumOpc; ++P) {
@@ -289,13 +259,11 @@ unsigned canonicalize(unsigned Mc, const MCInstrInfo &MCII,
   if (auto It = PseudoAlias.find(P); It != PseudoAlias.end())
     P = It->second;
 
-  // DPP -> base. This handles both VOP2-like _dpp pseudos and VOP3-like
-  // _e64_dpp pseudos; the reverse map was built from both getDPPOp32 and
-  // getDPPOp64.
+  // DPP -> base, for both the _dpp and _e64_dpp pseudos.
   if (auto It = DppToBase.find(P); It != DppToBase.end())
     P = It->second;
 
-  // SDWA -> base. LLVM provides a forward helper for this direction.
+  // SDWA -> base.
   if (auto Base = mappedOpcode(AMDGPU::getBasicFromSDWAOp(P)))
     P = *Base;
 
@@ -309,9 +277,8 @@ unsigned canonicalize(unsigned Mc, const MCInstrInfo &MCII,
   if (auto It = PseudoAlias.find(P); It != PseudoAlias.end())
     P = It->second;
 
-  // FLAT/GLOBAL SADDR -> VADDR. Only applicable to instructions tagged with
-  // the FLAT format flag; the helper returns -1 for non-FLAT opcodes but
-  // checking the flag first avoids the lookup for every non-FLAT opcode.
+  // FLAT/GLOBAL SADDR -> VADDR. Testing the format flag first avoids a table
+  // lookup for every non-FLAT opcode.
   if (P < MCII.getNumOpcodes() &&
       (MCII.get(P).TSFlags & SIInstrFlags::FLAT) != 0) {
     if (auto Vaddr = mappedOpcode(AMDGPU::getGlobalVaddrOp(P)))
@@ -329,10 +296,8 @@ CanonicalOp OpcodeMap::lookup(unsigned Opcode) const {
 }
 
 void OpcodeMap::build(const MCInstrInfo &MCII) {
-  // Flatten kCanonTable into a DenseMap for O(1) lookups during the scan below.
-  // A duplicate MC opcode would silently keep only the first row and route the
-  // rest through the wrong CanonicalOp, so a duplicate key is a table-authoring
-  // bug.
+  // A duplicate opcode would silently keep only the first row and route the
+  // rest through the wrong CanonicalOp, so it is a table-authoring bug.
   DenseMap<unsigned, CanonicalOp> CanonToSem;
   CanonToSem.reserve(std::size(kCanonTable));
   for (const Entry &E : kCanonTable) {
@@ -347,15 +312,13 @@ void OpcodeMap::build(const MCInstrInfo &MCII) {
   const auto DppToBase = buildDppToBaseMap(NumOpc);
 
   Map.clear();
-  // Heuristic: roughly a quarter of MC opcodes carry a CanonicalOp in practice;
-  // resizing a few times is fine for a one-shot init.
+  // Rough guess at the mapped fraction; a one-shot init tolerates resizes.
   Map.reserve(NumOpc / 4);
   for (unsigned Mc = 0; Mc < NumOpc; ++Mc) {
     const unsigned Canon =
         canonicalize(Mc, MCII, McToPseudo, PseudoAlias, DppToBase);
     if (auto It = CanonToSem.find(Canon); It != CanonToSem.end())
       Map[Mc] = It->second;
-    // Every other MC opcode stays Unknown so the raiser's dispatch refuses it.
   }
 }
 

--- a/amd/comgr/src/hotswap/decoder/opcode-map.h
+++ b/amd/comgr/src/hotswap/decoder/opcode-map.h
@@ -1,0 +1,44 @@
+//===- opcode-map.h - Hotswap transpiler ----------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_OPCODE_MAP_H
+#define HOTSWAP_TRANSPILER_OPCODE_MAP_H
+
+#include "canonical-op.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/MC/MCInstrInfo.h"
+
+#include <cstdint>
+
+namespace COMGR::hotswap {
+
+// Maps raw LLVM MC opcodes emitted by the AMDGPU disassembler to
+// architecture-neutral CanonicalOp tags that the raiser dispatches on.
+//
+// The map is built once at raiser-initialization time from MCInstrInfo and
+// TableGen-generated AMDGPU instruction tables. Almost no string parsing is
+// involved: encoding variants (e32/e64/DPP/SDWA/subtarget-specific real
+// encodings) are folded onto their canonical pseudo via the
+// AMDGPU::InstrMapping helpers, and the resulting canonical pseudo is matched
+// against a compile-time table of AMDGPU::<opcode> enum constants that grows
+// one row per landed handler. Every other opcode maps to Unknown.
+class OpcodeMap {
+public:
+  // Lookup is hot-path: called once per decoded instruction.
+  CanonicalOp lookup(unsigned Opcode) const;
+
+  // Build is one-shot: called during raiser initialization.
+  void build(const llvm::MCInstrInfo &MCII);
+
+private:
+  llvm::DenseMap<unsigned, CanonicalOp> Map;
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/decoder/opcode-map.h
+++ b/amd/comgr/src/hotswap/decoder/opcode-map.h
@@ -17,22 +17,16 @@
 
 namespace COMGR::hotswap {
 
-// Maps raw LLVM MC opcodes emitted by the AMDGPU disassembler to
-// architecture-neutral CanonicalOp tags that the raiser dispatches on.
-//
-// The map is built once at raiser-initialization time from MCInstrInfo and
-// TableGen-generated AMDGPU instruction tables. Almost no string parsing is
-// involved: encoding variants (e32/e64/DPP/SDWA/subtarget-specific real
-// encodings) are folded onto their canonical pseudo via the
-// AMDGPU::InstrMapping helpers, and the resulting canonical pseudo is matched
-// against a compile-time table of AMDGPU::<opcode> enum constants that grows
-// one row per landed handler. Every other opcode maps to Unknown.
+// Maps raw AMDGPU MC opcodes to architecture-neutral CanonicalOp tags.
+// Encoding variants (e32/e64/DPP/SDWA/subtarget-specific real encodings) fold
+// onto a single canonical pseudo, so they share one tag; an opcode with no tag
+// maps to Unknown.
 class OpcodeMap {
 public:
-  // Lookup is hot-path: called once per decoded instruction.
+  // Tag for `Opcode`, or Unknown when it has none.
   CanonicalOp lookup(unsigned Opcode) const;
 
-  // Build is one-shot: called during raiser initialization.
+  // Populate the map from `MCII`. Must run before any lookup.
   void build(const llvm::MCInstrInfo &MCII);
 
 private:

--- a/amd/comgr/src/hotswap/decoder/opcode-map.h
+++ b/amd/comgr/src/hotswap/decoder/opcode-map.h
@@ -17,13 +17,11 @@
 
 namespace COMGR::hotswap {
 
-// Maps raw AMDGPU MC opcodes to architecture-neutral CanonicalOp tags.
-// Encoding variants (e32/e64/DPP/SDWA/subtarget-specific real encodings) fold
-// onto a single canonical pseudo, so they share one tag; an opcode with no tag
-// maps to Unknown.
+// Maps AMDGPU MC opcodes to CanonicalOp values. Opcodes without a mapping
+// return CanonicalOp::Unknown.
 class OpcodeMap {
 public:
-  // Tag for `Opcode`, or Unknown when it has none.
+  // CanonicalOp for `Opcode`, or Unknown when it has no mapping.
   CanonicalOp lookup(unsigned Opcode) const;
 
   // Populate the map from `MCII`. Must run before any lookup.

--- a/amd/comgr/test-unit/hotswap/decoder/DecoderTest.cpp
+++ b/amd/comgr/test-unit/hotswap/decoder/DecoderTest.cpp
@@ -23,6 +23,8 @@
 #include "hotswap/decoder/opcode-map.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCDisassembler/MCDisassembler.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
@@ -164,6 +166,33 @@ TEST(StripEncoding, DropsKnownSuffixes) {
 TEST(StripEncoding, LeavesUnsuffixedUnchanged) {
   EXPECT_EQ(stripEncoding("s_mov_b32"), "s_mov_b32");
   EXPECT_EQ(stripEncoding("s_endpgm"), "s_endpgm");
+}
+
+// A variant is named for the register it collapses onto plus the suffix naming
+// its subtarget, so checking the two names against each other catches a row
+// that maps to the wrong base without this test restating the table.
+TEST_F(DecoderTest, StripRegEncodingDropsOnlyTheVariantSuffix) {
+  static constexpr llvm::StringRef KSuffixes[] = {"_ci", "_vi", "_gfx9plus",
+                                                  "_gfx11plus", "_gfxpre11"};
+  const llvm::MCRegisterInfo &MRI = *State.RegInfo;
+  unsigned Stripped = 0;
+  for (unsigned Reg = 1; Reg < MRI.getNumRegs(); ++Reg) {
+    llvm::MCRegister Base = stripRegEncoding(Reg);
+    EXPECT_EQ(stripRegEncoding(Base), Base) << MRI.getName(Reg);
+    if (Base == Reg)
+      continue;
+    ++Stripped;
+    llvm::StringRef Name = MRI.getName(Reg);
+    llvm::StringRef BaseName = MRI.getName(Base);
+    ASSERT_TRUE(Name.starts_with(BaseName))
+        << Name << " does not name a variant of " << BaseName;
+    EXPECT_TRUE(llvm::is_contained(KSuffixes, Name.substr(BaseName.size())))
+        << Name << " does not name a variant of " << BaseName;
+  }
+  // Two variants each of the 37 registers that have them: FLAT_SCR and its two
+  // halves, the 16 TTMPs and their 16 tuples, M0, and SGPR_NULL. A register
+  // gaining or losing a variant lands here first.
+  EXPECT_EQ(Stripped, 74u);
 }
 
 // -- isa-profile --------------------------------------------------------------

--- a/amd/comgr/test-unit/hotswap/decoder/DecoderTest.cpp
+++ b/amd/comgr/test-unit/hotswap/decoder/DecoderTest.cpp
@@ -185,9 +185,9 @@ TEST_F(DecoderTest, StripRegEncodingDropsOnlyTheVariantSuffix) {
     llvm::StringRef Name = MRI.getName(Reg);
     llvm::StringRef BaseName = MRI.getName(Base);
     ASSERT_TRUE(Name.starts_with(BaseName))
-        << Name << " does not name a variant of " << BaseName;
+        << Name.str() << " does not name a variant of " << BaseName.str();
     EXPECT_TRUE(llvm::is_contained(KSuffixes, Name.substr(BaseName.size())))
-        << Name << " does not name a variant of " << BaseName;
+        << Name.str() << " does not name a variant of " << BaseName.str();
   }
   // Two variants each of the 37 registers that have them: FLAT_SCR and its two
   // halves, the 16 TTMPs and their 16 tuples, M0, and SGPR_NULL. A register

--- a/amd/comgr/test-unit/hotswap/decoder/DecoderTest.cpp
+++ b/amd/comgr/test-unit/hotswap/decoder/DecoderTest.cpp
@@ -8,17 +8,21 @@
 //
 // Unit tests for the decoder library: the AMDGPU MC stack (mc-state), the
 // architecture-neutral instruction identity (canonical-op), the per-subtarget
-// capability queries (isa-profile), and the decoded-instruction model
-// (decoded-inst). Each exercises the piece directly, without a code object or
+// capability queries (isa-profile), the decoded-instruction model
+// (decoded-inst), the MC-opcode to CanonicalOp map (opcode-map), and the .text
+// scan (decode). Each exercises the piece directly, without a code object or
 // the raiser, so the coverage matches what the decoder alone provides.
 //
 //===----------------------------------------------------------------------===//
 
 #include "hotswap/decoder/canonical-op.h"
+#include "hotswap/decoder/decode.h"
 #include "hotswap/decoder/decoded-inst.h"
 #include "hotswap/decoder/isa-profile.h"
 #include "hotswap/decoder/mc-state.h"
+#include "hotswap/decoder/opcode-map.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/MC/MCDisassembler/MCDisassembler.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
@@ -29,7 +33,10 @@
 #include "gtest/gtest.h"
 
 #include <cstdint>
+#include <initializer_list>
 #include <mutex>
+#include <set>
+#include <vector>
 
 using namespace COMGR::hotswap;
 
@@ -181,6 +188,112 @@ TEST_F(DecoderTest, ISAProfileGfx1250) {
   EXPECT_TRUE(Profile.hasValidWaveSize());
   EXPECT_FALSE(Profile.hasAgpr());
   EXPECT_TRUE(Profile.hasGfx125UserSgprCountField());
+}
+
+// -- opcode-map ---------------------------------------------------------------
+
+// Resolve an MC opcode through the disassembler so the map is queried with the
+// same opcode a real .text scan produces.
+unsigned opcodeOf(MCState &State, llvm::ArrayRef<uint8_t> Bytes) {
+  llvm::MCInst Inst;
+  uint64_t Size = 0;
+  EXPECT_EQ(State.Disasm->getInstruction(Inst, Size, Bytes, /*Address=*/0,
+                                         llvm::nulls()),
+            llvm::MCDisassembler::Success);
+  return Inst.getOpcode();
+}
+
+TEST_F(DecoderTest, OpcodeMapTagsTableEntries) {
+  OpcodeMap Map;
+  Map.build(*State.InstrInfo);
+  EXPECT_EQ(Map.lookup(opcodeOf(State, SMovB32Bytes)), CanonicalOp::S_MOV_B32);
+  EXPECT_EQ(Map.lookup(opcodeOf(State, SEndpgmBytes)), CanonicalOp::S_ENDPGM);
+}
+
+TEST_F(DecoderTest, OpcodeMapReturnsUnknownForUnmappedOpcode) {
+  OpcodeMap Map;
+  Map.build(*State.InstrInfo);
+  // v_mov_b32 has no kCanonTable row, so it stays Unknown.
+  EXPECT_EQ(Map.lookup(opcodeOf(State, VMovB32Bytes)), CanonicalOp::Unknown);
+  EXPECT_EQ(Map.lookup(State.InstrInfo->getNumOpcodes()), CanonicalOp::Unknown);
+}
+
+// -- decode -------------------------------------------------------------------
+
+// Concatenate instruction encodings into one .text image.
+std::vector<uint8_t>
+textOf(std::initializer_list<llvm::ArrayRef<uint8_t>> Insts) {
+  std::vector<uint8_t> Bytes;
+  for (llvm::ArrayRef<uint8_t> Inst : Insts)
+    Bytes.insert(Bytes.end(), Inst.begin(), Inst.end());
+  return Bytes;
+}
+
+TEST_F(DecoderTest, DecodeKernelWalksToProgramEnd) {
+  OpcodeMap Map;
+  Map.build(*State.InstrInfo);
+  std::vector<uint8_t> Text =
+      textOf({SMovB32Bytes, VMovB32Bytes, SEndpgmBytes});
+
+  llvm::Expected<DecodeResult> ResultOrErr =
+      decodeKernel(State, Map, Text, /*KernelOffset=*/0);
+  ASSERT_TRUE(static_cast<bool>(ResultOrErr))
+      << llvm::toString(ResultOrErr.takeError());
+
+  ASSERT_EQ(ResultOrErr->Insts.size(), 3u);
+  EXPECT_EQ(ResultOrErr->Insts[0].CanonOp, CanonicalOp::S_MOV_B32);
+  EXPECT_EQ(ResultOrErr->Insts[1].CanonOp, CanonicalOp::Unknown);
+  EXPECT_EQ(ResultOrErr->Insts[2].CanonOp, CanonicalOp::S_ENDPGM);
+  EXPECT_EQ(ResultOrErr->Insts[0].Offset, 0u);
+  EXPECT_EQ(ResultOrErr->Insts[1].Offset, 4u);
+  EXPECT_EQ(ResultOrErr->Insts[2].Offset, 8u);
+  EXPECT_EQ(ResultOrErr->Insts[0].sizeInBytes(), 4u);
+  EXPECT_EQ(ResultOrErr->BlockStarts, (std::set<uint64_t>{0}));
+}
+
+TEST_F(DecoderTest, DecodeKernelStopsAtProgramEnd) {
+  OpcodeMap Map;
+  Map.build(*State.InstrInfo);
+  // Bytes after the terminator belong to the next kernel, not this one.
+  std::vector<uint8_t> Text = textOf({SEndpgmBytes, SMovB32Bytes});
+
+  llvm::Expected<DecodeResult> ResultOrErr =
+      decodeKernel(State, Map, Text, /*KernelOffset=*/0);
+  ASSERT_TRUE(static_cast<bool>(ResultOrErr))
+      << llvm::toString(ResultOrErr.takeError());
+  ASSERT_EQ(ResultOrErr->Insts.size(), 1u);
+  EXPECT_EQ(ResultOrErr->Insts[0].CanonOp, CanonicalOp::S_ENDPGM);
+}
+
+TEST_F(DecoderTest, DecodeKernelHonoursOffsetAndEnd) {
+  OpcodeMap Map;
+  Map.build(*State.InstrInfo);
+  std::vector<uint8_t> Text =
+      textOf({SEndpgmBytes, SMovB32Bytes, SEndpgmBytes});
+
+  llvm::Expected<DecodeResult> ResultOrErr =
+      decodeKernel(State, Map, Text, /*KernelOffset=*/4, /*KernelEndOffset=*/8);
+  ASSERT_TRUE(static_cast<bool>(ResultOrErr))
+      << llvm::toString(ResultOrErr.takeError());
+  ASSERT_EQ(ResultOrErr->Insts.size(), 1u);
+  EXPECT_EQ(ResultOrErr->Insts[0].CanonOp, CanonicalOp::S_MOV_B32);
+  EXPECT_EQ(ResultOrErr->Insts[0].Offset, 4u);
+  EXPECT_EQ(ResultOrErr->BlockStarts, (std::set<uint64_t>{4}));
+}
+
+TEST_F(DecoderTest, DecodeKernelRejectsTruncatedInstruction) {
+  OpcodeMap Map;
+  Map.build(*State.InstrInfo);
+  // A whole s_mov_b32 followed by half an s_endpgm.
+  std::vector<uint8_t> Text = textOf({SMovB32Bytes, SEndpgmBytes});
+  Text.resize(6);
+
+  llvm::Expected<DecodeResult> ResultOrErr =
+      decodeKernel(State, Map, Text, /*KernelOffset=*/0);
+  ASSERT_FALSE(static_cast<bool>(ResultOrErr));
+  EXPECT_EQ(llvm::toString(ResultOrErr.takeError()),
+            "hotswap: decodeKernel: cannot decode instruction at .text offset "
+            "0x4 (fail)");
 }
 
 // -- decoded-inst bitfields ---------------------------------------------------

--- a/amd/comgr/test-unit/hotswap/decoder/DecoderTest.cpp
+++ b/amd/comgr/test-unit/hotswap/decoder/DecoderTest.cpp
@@ -168,9 +168,6 @@ TEST(StripEncoding, LeavesUnsuffixedUnchanged) {
   EXPECT_EQ(stripEncoding("s_endpgm"), "s_endpgm");
 }
 
-// A variant is named for the register it collapses onto plus the suffix naming
-// its subtarget, so checking the two names against each other catches a row
-// that maps to the wrong base without this test restating the table.
 TEST_F(DecoderTest, StripRegEncodingDropsOnlyTheVariantSuffix) {
   static constexpr llvm::StringRef KSuffixes[] = {"_ci", "_vi", "_gfx9plus",
                                                   "_gfx11plus", "_gfxpre11"};
@@ -189,9 +186,7 @@ TEST_F(DecoderTest, StripRegEncodingDropsOnlyTheVariantSuffix) {
     EXPECT_TRUE(llvm::is_contained(KSuffixes, Name.substr(BaseName.size())))
         << Name.str() << " does not name a variant of " << BaseName.str();
   }
-  // Two variants each of the 37 registers that have them: FLAT_SCR and its two
-  // halves, the 16 TTMPs and their 16 tuples, M0, and SGPR_NULL. A register
-  // gaining or losing a variant lands here first.
+  // Pinned so a register gaining or losing a variant fails here.
   EXPECT_EQ(Stripped, 74u);
 }
 


### PR DESCRIPTION
opcode-map folds the MC opcodes the AMDGPU disassembler emits (across e32/e64/
DPP/SDWA and subtarget encodings) onto canonical ops via LLVM's InstrMapping
helpers, keyed by a table that grows one row per landed handler; unlisted
opcodes stay Unknown. decode walks a kernel's .text with the MC disassembler
and produces a DecodedInst per instruction plus the recovered block starts,
returning an llvm::Error on any decode-extent or TableGen-invariant violation
rather than silently corrupting a handler's view. Branch and set-pc control
flow recovery lands with control-flow support; a branchless kernel needs only
the linear scan and the s_endpgm terminator.
