### PR TITLE
[Comgr][hotswap] Add the wave projection

### DIFF
--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -15,15 +15,16 @@
 # mixes component archives with libLLVM.so under LLVM_LINK_LLVM_DYLIB. Targets
 # that link these libraries directly name their own LLVM libs.
 add_subdirectory(rewriter)
-add_subdirectory(raiser)
 
-# The loader and decoder consume AMDGPU target-private headers an
-# install-tree-only build does not expose, so the transpile-path libraries are
-# entered only when the transpile entry point is on.
+# The raiser, loader, and decoder consume AMDGPU target-private headers an
+# install-tree-only build does not expose, and the raiser links the decoder, so
+# the transpile-path libraries are entered only when the transpile entry point
+# is on.
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   add_subdirectory(common)
   add_subdirectory(loader)
   add_subdirectory(decoder)
+  add_subdirectory(raiser)
 endif()
 
 # The OBJECT libraries amd_comgr links, exported to the parent scope so the

--- a/amd/comgr/src/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/raiser/CMakeLists.txt
@@ -30,6 +30,7 @@ add_definitions(${LLVM_DEFINITIONS})
 # or a separate static archive.
 add_library(hotswap-raiser OBJECT
   raiser.cpp
+  wave-projection.cpp
 )
 
 if(NOT TARGET hotswap::raiser)
@@ -58,11 +59,82 @@ else()
   set(hotswap_raiser_llvm_libs LLVMCore LLVMSupport LLVMTargetParser)
 endif()
 
+# The wave projection lowers decoded instructions to IR, so it links the decoder
+# OBJECT library and inherits its curated LLVM component set (the AMDGPU MC/Desc/
+# Utils libraries the projection's register queries need).
 # PRIVATE keeps these out of the link interface, but CMake still records them as
 # $<LINK_ONLY:> for an OBJECT library; clear the interface so consumers get the
 # objects only (see ../CMakeLists.txt).
 target_link_libraries(hotswap-raiser
   PRIVATE
+    hotswap::decoder
     ${hotswap_raiser_llvm_libs}
 )
 set_target_properties(hotswap-raiser PROPERTIES INTERFACE_LINK_LIBRARIES "")
+
+# The wave projection consumes AMDGPU target-private headers (AMDGPUMCTargetDesc.h,
+# AMDGPUBaseInfo.h). SIDefines.h and its siblings are hand-written headers that
+# live only in the LLVM source tree; the TableGen-generated AMDGPUGen*.inc they
+# transitively include live only in the LLVM build tree. Neither is exposed by an
+# install tree, so locate both.
+#
+# Source: an in-tree monorepo build exposes it as LLVM_MAIN_SRC_DIR, a
+# find_package(LLVM) consumer as LLVM_BUILD_MAIN_SRC_DIR, and the ROCm superbuild
+# sets neither but keeps amd/comgr next to llvm/ under a shared root. Probe for
+# the header rather than trust one variable, so a wrong or empty root fails the
+# configure loudly.
+set(HOTSWAP_AMDGPU_SRC_DIR "")
+foreach(HotswapLLVMRoot
+    "${LLVM_MAIN_SRC_DIR}"
+    "${LLVM_BUILD_MAIN_SRC_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../llvm")
+  if(HotswapLLVMRoot AND
+     EXISTS "${HotswapLLVMRoot}/lib/Target/AMDGPU/SIDefines.h")
+    get_filename_component(HOTSWAP_AMDGPU_SRC_DIR
+      "${HotswapLLVMRoot}/lib/Target/AMDGPU" ABSOLUTE)
+    break()
+  endif()
+endforeach()
+if(NOT HOTSWAP_AMDGPU_SRC_DIR)
+  message(FATAL_ERROR
+    "hotswap-raiser: cannot find the LLVM AMDGPU target sources "
+    "(SIDefines.h); set LLVM_MAIN_SRC_DIR to the llvm source directory.")
+endif()
+# Generated headers: the TableGen-generated AMDGPUGen*.inc live in the LLVM build
+# tree, never an install prefix, so in an installed LLVMConfig.cmake
+# LLVM_BINARY_DIR (the install prefix) carries none of them. Probe, in order:
+#   1. LLVM_BUILD_BINARY_DIR, if a consumer points us straight at its LLVM build;
+#   2. LLVM_BINARY_DIR, correct for an in-tree monorepo build;
+#   3. the ROCm/TheRock superbuild layout, where comgr consumes the installed
+#      LLVM under <root>/dist/lib/llvm while the producing build sits beside it
+#      at <root>/build (LLVM_BINARY_DIR is .../dist/lib/llvm there).
+# Validate every header the projection pulls in so an unrecognised layout fails
+# the configure loudly.
+set(HOTSWAP_AMDGPU_GEN_DIR "")
+foreach(HotswapLLVMBuild
+    "${LLVM_BUILD_BINARY_DIR}"
+    "${LLVM_BINARY_DIR}"
+    "${LLVM_BINARY_DIR}/../../../build")
+  if(HotswapLLVMBuild AND
+     EXISTS "${HotswapLLVMBuild}/lib/Target/AMDGPU/AMDGPUGenInstrInfo.inc")
+    get_filename_component(HOTSWAP_AMDGPU_GEN_DIR
+      "${HotswapLLVMBuild}/lib/Target/AMDGPU" ABSOLUTE)
+    break()
+  endif()
+endforeach()
+foreach(HotswapGenInc
+    AMDGPUGenInstrInfo.inc
+    AMDGPUGenRegisterInfo.inc
+    AMDGPUGenSubtargetInfo.inc)
+  if(NOT EXISTS "${HOTSWAP_AMDGPU_GEN_DIR}/${HotswapGenInc}")
+    message(FATAL_ERROR
+      "hotswap-raiser: cannot find the generated AMDGPU headers "
+      "(${HotswapGenInc}); pass -DLLVM_BUILD_BINARY_DIR=<llvm build dir>.")
+  endif()
+endforeach()
+
+target_include_directories(hotswap-raiser PRIVATE
+  "${HOTSWAP_AMDGPU_SRC_DIR}"
+  "${HOTSWAP_AMDGPU_SRC_DIR}/Utils"
+  "${HOTSWAP_AMDGPU_GEN_DIR}"
+)

--- a/amd/comgr/src/hotswap/raiser/wave-projection.cpp
+++ b/amd/comgr/src/hotswap/raiser/wave-projection.cpp
@@ -1,0 +1,673 @@
+//===- wave-projection.cpp - Hotswap transpiler ---------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "wave-projection.h"
+
+#include "hotswap/decoder/decoded-inst.h"
+#include "hotswap/decoder/mc-state.h"
+
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/IR/Module.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegister.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "wave-projection"
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+// ----------------------------------------------------------------------------
+// WaveProjection base: lane-id derivation is shared across every projection
+// that keeps each target lane mapped 1:1 to a hardware lane.
+// ----------------------------------------------------------------------------
+
+Value *WaveProjection::emitLaneIdx(IRBuilder<> &B) const {
+  // Lane id (mbcnt vs all-ones, base 0) is EXEC-independent and
+  // function-invariant: emit it once at a point that dominates the whole
+  // function and reuse it everywhere. If nothing consumes it, DCE drops it.
+  //
+  // The cache is keyed by the function it was emitted into, the kernel boundary
+  // this class can observe: a projection reused across kernels re-emits per
+  // function instead of returning a value that belongs to a different one.
+  Function *F = B.GetInsertBlock()->getParent();
+  if (CachedLaneIdx && CachedLaneIdxFunc == F)
+    return CachedLaneIdx;
+
+  // Emit in the entry block, after any leading allocas. The allocas must stay
+  // at the top of the entry block or mem2reg/SROA may decline to promote them,
+  // so insert at the first non-alloca instruction rather than the block start.
+  BasicBlock &Entry = F->getEntryBlock();
+  IRBuilder<> EB(&Entry, Entry.getFirstNonPHIOrDbgOrAlloca());
+
+  Module *M = Entry.getModule();
+  Type *I32Ty = EB.getInt32Ty();
+  Function *MbcntLo =
+      Intrinsic::getOrInsertDeclaration(M, Intrinsic::amdgcn_mbcnt_lo);
+  Value *AllOnes = ConstantInt::getSigned(I32Ty, -1);
+  Value *Zero32 = ConstantInt::get(I32Ty, 0);
+  Value *LaneId = EB.CreateCall(MbcntLo, {AllOnes, Zero32}, "lane_lo");
+  if (WaveMaskTy != I32Ty) {
+    Function *MbcntHi =
+        Intrinsic::getOrInsertDeclaration(M, Intrinsic::amdgcn_mbcnt_hi);
+    LaneId = EB.CreateCall(MbcntHi, {AllOnes, LaneId}, "lane_id");
+  }
+  CachedLaneIdxFunc = F;
+  CachedLaneIdx = LaneId;
+  return LaneId;
+}
+
+Value *WaveProjection::emitWorkitemIdX(IRBuilder<> &B) const {
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *Fn =
+      Intrinsic::getOrInsertDeclaration(M, Intrinsic::amdgcn_workitem_id_x);
+  return B.CreateCall(Fn, {}, "tid");
+}
+
+Value *ReplicationProjection::emitWorkitemIdX(IRBuilder<> &B) const {
+  Value *Raw = WaveProjection::emitWorkitemIdX(B);
+  // When the target wave is wider than the source workgroup, the upper target
+  // lanes [MaxFlatWG, WaveSize) carry no source workitem, so their raw workitem
+  // id is just the hardware lane index. Clamp those lanes to workitem 0 so they
+  // replicate lane 0's in-bounds addressing; real lanes are unchanged and every
+  // committed result is identical.
+  if (Tgt.waveSize() > Src.waveSize() && MaxFlatWG > 0 &&
+      MaxFlatWG < Tgt.waveSize()) {
+    // The "real lane" test is the flat local id, not workitem.id.x. Under
+    // replication the target lane index is the flat local id (lanes are
+    // laid out in flat order), so a lane is real iff its index is below the
+    // flattened workgroup size. Comparing workitem.id.x against MaxFlatWG would
+    // only be correct for 1D workgroups, where tid.x == flat local id; for a
+    // multidimensional workgroup tid.x is just the X coordinate while MaxFlatWG
+    // is the flattened total.
+    Value *Limit = ConstantInt::get(I32Ty, MaxFlatWG);
+    Value *FlatLaneId = emitLaneIdx(B);
+    Value *IsRealLane = B.CreateICmpULT(FlatLaneId, Limit, "tid_is_real_lane");
+    Raw = B.CreateSelect(IsRealLane, Raw, ConstantInt::get(I32Ty, 0),
+                         "tid_phantom_clamp");
+  }
+  return Raw;
+}
+
+// Bit offsets of the Y/Z fields in the packed kernel-entry v0 workitem id
+// (x[0:9] | y[10:19] | z[20:29])
+static constexpr unsigned WorkitemIdYBitOffset = 10;
+static constexpr unsigned WorkitemIdZBitOffset = 20;
+
+Value *WaveProjection::packWorkitemId(IRBuilder<> &B, Value *X,
+                                      unsigned NumDims) const {
+  if (NumDims < 2)
+    return X;
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *FnY =
+      Intrinsic::getOrInsertDeclaration(M, Intrinsic::amdgcn_workitem_id_y);
+  Value *Y = B.CreateCall(FnY, {}, "tid_y");
+  Value *Packed =
+      B.CreateOr(X,
+                 B.CreateShl(Y, ConstantInt::get(I32Ty, WorkitemIdYBitOffset),
+                             "tid_y_shl"),
+                 "tid_xy");
+  if (NumDims < 3)
+    return Packed;
+  Function *FnZ =
+      Intrinsic::getOrInsertDeclaration(M, Intrinsic::amdgcn_workitem_id_z);
+  Value *Z = B.CreateCall(FnZ, {}, "tid_z");
+  return B.CreateOr(Packed,
+                    B.CreateShl(Z,
+                                ConstantInt::get(I32Ty, WorkitemIdZBitOffset),
+                                "tid_z_shl"),
+                    "tid_xyz");
+}
+
+Value *WaveProjection::emitPackedWorkitemId(IRBuilder<> &B,
+                                            unsigned NumDims) const {
+  return packWorkitemId(B, emitWorkitemIdX(B), NumDims);
+}
+
+Value *WaveProjection::emitCurrentSourceWaveMask(IRBuilder<> &B, Value *Mask,
+                                                 const Twine &Name) const {
+  Type *SourceTy = sourceWaveMaskTy();
+  assert(Mask->getType()->isIntegerTy() &&
+         "emitCurrentSourceWaveMask expects an integer mask");
+  if (Mask->getType() == SourceTy)
+    return Mask;
+  return B.CreateZExtOrTrunc(Mask, SourceTy, Name);
+}
+
+Value *ReplicationProjection::emitPackedWorkitemId(IRBuilder<> &B,
+                                                   unsigned NumDims) const {
+  // 1-D: identical to the (already phantom-clamped) X-only seed.
+  if (NumDims < 2)
+    return emitWorkitemIdX(B);
+  // Build from the unclamped x so the phantom-lane clamp applies once to the
+  // whole packed id; otherwise a clamped-to-0 x OR'd with a non-zero Y/Z would
+  // leave phantom lanes with a stray id instead of replicating lane 0.
+  Value *Raw = packWorkitemId(B, WaveProjection::emitWorkitemIdX(B), NumDims);
+  if (Tgt.waveSize() > Src.waveSize() && MaxFlatWG > 0 &&
+      MaxFlatWG < Tgt.waveSize()) {
+    Value *Limit = ConstantInt::get(I32Ty, MaxFlatWG);
+    Value *FlatLaneId = emitLaneIdx(B);
+    Value *IsRealLane = B.CreateICmpULT(FlatLaneId, Limit, "tid_is_real_lane");
+    // Clamp phantom upper lanes to the literal packed 0 (local id (0, 0, 0));
+    // this copies nothing from lane 0. They stay hardware inactive and cannot
+    // commit source-visible memory, so 0 is only an in-bounds address floor for
+    // any address still computed for them.
+    Raw = B.CreateSelect(IsRealLane, Raw, ConstantInt::get(I32Ty, 0),
+                         "tid_phantom_clamp");
+  }
+  return Raw;
+}
+
+Value *WaveProjection::emitInitialExec(IRBuilder<> &B) const {
+  // The architectural boot state of a dispatched wave is "every source lane
+  // active", i.e. all-ones in the source-width EXEC storage. A projection that
+  // decouples the modeled EXEC from the hardware EXEC overrides this hook.
+  return ConstantInt::getSigned(execStorageTy(), -1);
+}
+
+Value *WaveProjection::wrapAsWWMValue(IRBuilder<> &B, Value *V,
+                                      const Twine &Name) const {
+  if (providesFullWaveExecInvariant())
+    return V;
+  // strict.wwm is declared llvm_any_ty, but the backend lowers only integer
+  // and floating-point scalars and fixed vectors thereof. Assert on that
+  // subset so an unsupported type fails here rather than at lowering.
+  Type *T = V->getType();
+  Type *ElemTy =
+      T->isVectorTy() ? cast<FixedVectorType>(T)->getElementType() : T;
+  (void)ElemTy;
+  assert((ElemTy->isIntegerTy() || ElemTy->isFloatingPointTy()) &&
+         "wrapAsWWMValue supports only integer / floating-point scalars "
+         "and fixed-length vectors thereof");
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *WwmFn =
+      Intrinsic::getOrInsertDeclaration(M, Intrinsic::amdgcn_strict_wwm, {T});
+  return B.CreateCall(WwmFn, {V}, Name);
+}
+
+// ----------------------------------------------------------------------------
+// ReplicationProjection.
+// ----------------------------------------------------------------------------
+
+Value *ReplicationProjection::emitLaneActiveBit(IRBuilder<> &B,
+                                                Value *ExecVal) const {
+  // Project the target-lane id onto the source EXEC mask under
+  // replication: target lane L is active iff bit `L mod W_src` of
+  // the source EXEC mask is set. Same-wave and narrowing cases collapse
+  // to the identity because `lane_id < source_wave_bits` already; the
+  // modulo is a no-op and the shift happens at source width.
+  //
+  // Shifting at source width also sidesteps the LLVM-IR poison rule that
+  // `lshr iN, M` is poison for M >= N: the pre-modulo clamps the shift
+  // into [0, execBits).
+  Value *LaneId = emitLaneIdx(B);
+  Type *ExecTy = ExecVal->getType();
+  unsigned ExecBits = ExecTy->getPrimitiveSizeInBits();
+  Value *LaneIdInExec = B.CreateZExtOrTrunc(LaneId, ExecTy, "spe_lane_idx");
+  // execBits is a power of two (32 or 64), so modulo is bitwise AND.
+  Value *LaneMod = B.CreateAnd(
+      LaneIdInExec, ConstantInt::get(ExecTy, ExecBits - 1), "spe_lane_mod");
+  Value *Shifted = B.CreateLShr(ExecVal, LaneMod, "spe_exec_at_lane");
+  Value *Bit =
+      B.CreateAnd(Shifted, ConstantInt::get(ExecTy, 1), "spe_exec_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(ExecTy, 0), "spe_lane_active");
+}
+
+Value *ReplicationProjection::ballotI1ToWidth(IRBuilder<> &B, Value *Pred,
+                                              Type *ResultTy,
+                                              const Twine &Name) const {
+  assert(Pred->getType() == B.getInt1Ty() &&
+         "ballotI1ToWidth requires an i1 predicate");
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *Ballot = Intrinsic::getOrInsertDeclaration(
+      M, Intrinsic::amdgcn_ballot, {waveMaskTy()});
+  Value *WaveMask = B.CreateCall(Ballot, {Pred}, Name);
+  unsigned WantedBits = ResultTy->getPrimitiveSizeInBits();
+  unsigned WaveBits = WaveMaskTy->getPrimitiveSizeInBits();
+  assert(WantedBits <= WaveBits &&
+         "ballotI1ToWidth: wantedBits > waveBits (wave64 source on wave32 "
+         "target) has no replication projection; this direction needs "
+         "an explicit policy decision before use");
+  if (WantedBits == WaveBits)
+    return WaveMask;
+  if (WantedBits < WaveBits)
+    // Truncation is the replication projection of the target ballot
+    // onto the source wave width.
+    return B.CreateTrunc(WaveMask, ResultTy, Name + "_trunc");
+  // `wantedBits > waveBits`: wave64 source on wave32 target. No correct
+  // replication projection exists (the wider source wave has lanes
+  // that do not exist in the narrower target), so zero-extending would
+  // invent bits; fall through without returning so this direction is not
+  // silently miscompiled.
+}
+
+Value *ReplicationProjection::extractLaneBitFromWaveMask(IRBuilder<> &B,
+                                                         Value *V) const {
+  if (V->getType() == B.getInt1Ty())
+    return V;
+  Type *I64Ty = B.getInt64Ty();
+  if (V->getType()->isPointerTy())
+    V = B.CreatePtrToInt(V, I64Ty);
+  Type *TargetTy = WaveMaskTy;
+  unsigned SrcBits = V->getType()->getPrimitiveSizeInBits();
+  unsigned DstBits = TargetTy->getPrimitiveSizeInBits();
+  if (SrcBits < DstBits) {
+    // A narrow source-wave-width mask must be widened to the target
+    // wave-mask width before the per-lane shift extracts a single bit.
+    // Replicate the narrow mask into the upper half rather than zero-
+    // extending: replication's contract is that target lane L reads
+    // bit `L mod W_src` of the source mask, so a zext would make lanes in
+    // the upper half always read 0.
+    Value *Zext = B.CreateZExt(V, TargetTy);
+    Value *Shifted = B.CreateShl(Zext, ConstantInt::get(TargetTy, SrcBits),
+                                 "mask_widen_shl");
+    V = B.CreateOr(Zext, Shifted, "mask_widen_replicate");
+  } else if (SrcBits > DstBits) {
+    V = B.CreateTrunc(V, TargetTy);
+  } else if (V->getType() != TargetTy) {
+    V = B.CreateBitCast(V, TargetTy);
+  }
+  Value *LaneIdx = emitLaneIdx(B);
+  // Neutral `mask_*` names: this helper reads any wave mask as a per-lane
+  // predicate, not only VCC, so a `vcc_` prefix would mislabel SGPR sources.
+  Value *LaneIdxExt = B.CreateZExtOrTrunc(LaneIdx, TargetTy, "mask_lane_idx");
+  Value *Shifted = B.CreateLShr(V, LaneIdxExt, "mask_at_lane");
+  Value *Bit =
+      B.CreateAnd(Shifted, ConstantInt::get(TargetTy, 1), "mask_lane_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(TargetTy, 0), "mask_lane_i1");
+}
+
+// ----------------------------------------------------------------------------
+// ReplicationDoubledDispatchProjection.
+//
+// Remaps the hardware workitem-id.x of a doubled-dispatch launch back onto the
+// logical source id, so hardware lane `W_s + i` (a replica) sees the same
+// logical thread as hardware lane `i`. Everything else is inherited from
+// ReplicationProjection.
+// ----------------------------------------------------------------------------
+
+// logical_x = ((x_hw & ~(W_t-1)) >> log2(W_t/W_s)) | (x_hw & (W_s-1))
+//
+// The first term recovers the hardware wave index and rescales it to source
+// lanes; the second term is the source lane within the wave (identical for a
+// lane and its replica). For wave32->wave64 this is
+// `((x_hw & ~63) >> 1) | (x_hw & 31)`.
+static Value *emitDoubledDispatchLogicalX(IRBuilder<> &B, Value *RawX,
+                                          unsigned SrcWaveSize,
+                                          unsigned TgtWaveSize) {
+  assert(TgtWaveSize > SrcWaveSize && (TgtWaveSize % SrcWaveSize) == 0 &&
+         "doubled-dispatch remap requires widening with an integer "
+         "wave-size ratio");
+  Type *Ty = RawX->getType();
+  const unsigned Ratio = TgtWaveSize / SrcWaveSize;
+  const unsigned RatioLog2 = llvm::Log2_32(Ratio);
+  Value *WaveAligned = B.CreateAnd(
+      RawX, ConstantInt::get(Ty, ~static_cast<uint64_t>(TgtWaveSize - 1u)),
+      "dd_wave_aligned");
+  Value *WaveScaled = B.CreateLShr(WaveAligned, ConstantInt::get(Ty, RatioLog2),
+                                   "dd_wave_base");
+  Value *SrcLane =
+      B.CreateAnd(RawX, ConstantInt::get(Ty, SrcWaveSize - 1u), "dd_src_lane");
+  return B.CreateOr(WaveScaled, SrcLane, "dd_logical_x");
+}
+
+Value *
+ReplicationDoubledDispatchProjection::emitWorkitemIdX(IRBuilder<> &B) const {
+  // Deliberately bypass ReplicationProjection::emitWorkitemIdX (the
+  // phantom-lane clamp): a doubled dispatch has no phantom lanes, every
+  // hardware lane is a real source thread or an exact replica of one.
+  Value *Raw = WaveProjection::emitWorkitemIdX(B);
+  return emitDoubledDispatchLogicalX(B, Raw, Src.waveSize(), Tgt.waveSize());
+}
+
+Value *ReplicationDoubledDispatchProjection::emitPackedWorkitemId(
+    IRBuilder<> &B, unsigned NumDims) const {
+  // Remapped x OR'd with the source's raw y/z fields. y/z are per-thread
+  // correct as launched and become wave-uniform once x is doubled, so no
+  // remap or clamp is applied to them.
+  return packWorkitemId(B, emitWorkitemIdX(B), NumDims);
+}
+
+// ----------------------------------------------------------------------------
+// WaveNativeProjection -- widening (wave32 -> wave64).
+//
+// The target is wave64, so WaveMaskTy is i64; this projection uses it for both
+// the EXEC alloca storage and the ballot/lane-active arithmetic.
+// ----------------------------------------------------------------------------
+
+WaveNativeProjection::WaveNativeProjection(const ISAProfile &SrcIsa,
+                                           const ISAProfile &TgtIsa,
+                                           Type *I32Ty, Type *I64Ty)
+    : WaveProjection(SrcIsa, TgtIsa, I32Ty, I64Ty) {
+  // Restrict to the one direction where the widened-EXEC invariants are
+  // well-defined: same-wave needs no widening, and narrowing loses lanes
+  // regardless of policy.
+  assert((SrcIsa.isWave32() && !TgtIsa.isWave32()) &&
+         "WaveNativeProjection is defined only for wave32 source -> "
+         "wave64 target widening");
+
+  // Widen EXEC storage to the target hardware mask and treat each half of the
+  // target wave as a distinct source wave. `emitInitialExec` forces HW
+  // EXEC=-1 kernel-wide, so mbcnt-derived EXEC writes project into independent
+  // target-width masks and a narrow EXEC_LO write broadcasts across both
+  // halves.
+  ExecStorageTy = WaveMaskTy;
+  NumSourceWavesPerTarget = 2;
+  BroadcastNarrowExecLoWrite = true;
+  ProvidesFullWaveExecInvariant = true;
+  PreservesMbcntDerivedExec = true;
+}
+
+Value *WaveNativeProjection::emitInitialExec(IRBuilder<> &B) const {
+  // Call `@llvm.amdgcn.init_whole_wave` to set hardware EXEC = -1 (all target
+  // lanes active) and capture the original per-lane active bit; ballot the
+  // captured bit into a wave-width mask to seed the EXEC alloca. This keeps the
+  // modeled source EXEC (read by emitUnderExec) separate from the hardware
+  // EXEC, so the kernel body runs with all lanes hardware-active while stores
+  // still honour the original mask.
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *InitWw =
+      Intrinsic::getOrInsertDeclaration(M, Intrinsic::amdgcn_init_whole_wave);
+  Value *OriginalActive = B.CreateCall(InitWw, {}, "orig_active");
+  // Ballot the per-lane i1 into a wave-width mask via the projection's own
+  // ballot so the result type matches WaveMaskTy.
+  return ballotI1ToWidth(B, OriginalActive, WaveMaskTy, "saved_exec");
+}
+
+Value *WaveNativeProjection::emitLaneActiveBit(IRBuilder<> &B,
+                                               Value *ExecVal) const {
+  // Target lane L is active iff bit L of the widened EXEC (WaveMaskTy) is set;
+  // the shift index is the full target lane id, with no modulo fold.
+  Value *LaneId = emitLaneIdx(B);
+  Type *ExecTy = ExecVal->getType();
+  assert(ExecTy == WaveMaskTy &&
+         "WaveNativeProjection requires EXEC storage to match the "
+         "target wave mask width; caller must size the alloca via "
+         "execStorageTy()");
+  Value *LaneIdInExec = B.CreateZExtOrTrunc(LaneId, ExecTy, "wn_lane_idx");
+  Value *Shifted = B.CreateLShr(ExecVal, LaneIdInExec, "wn_exec_at_lane");
+  Value *Bit = B.CreateAnd(Shifted, ConstantInt::get(ExecTy, 1), "wn_exec_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(ExecTy, 0), "wn_lane_active");
+}
+
+Value *WaveNativeProjection::ballotI1ToWidth(IRBuilder<> &B, Value *Pred,
+                                             Type *ResultTy,
+                                             const Twine &Name) const {
+  assert(Pred->getType() == B.getInt1Ty() &&
+         "ballotI1ToWidth requires an i1 predicate");
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *Ballot = Intrinsic::getOrInsertDeclaration(
+      M, Intrinsic::amdgcn_ballot, {waveMaskTy()});
+  Value *WaveMask = B.CreateCall(Ballot, {Pred}, Name);
+  unsigned WantedBits = ResultTy->getPrimitiveSizeInBits();
+  unsigned WaveBits = WaveMaskTy->getPrimitiveSizeInBits();
+  assert(WantedBits <= WaveBits &&
+         "WaveNativeProjection::ballotI1ToWidth: wantedBits > waveBits "
+         "is not defined for wave32 source -> wave64 target cross-"
+         "widening; caller must request resultTy <= waveMaskTy");
+  if (WantedBits == WaveBits)
+    return WaveMask;
+  if (WantedBits < WaveBits)
+    // Narrowing the full target ballot to a source-width scalar loses the
+    // upper half (target lanes 32..63): a source instruction naming a single
+    // 32-bit SGPR destination cannot hold a 64-bit mask.
+    return B.CreateTrunc(WaveMask, ResultTy, Name + "_trunc");
+  // `wantedBits > waveBits` cannot occur for the wave32 -> wave64 direction
+  // this projection handles, so fall through without returning rather than
+  // zero-extending, which would invent bits the source wave does not have.
+}
+
+Value *WaveNativeProjection::extractLaneBitFromWaveMask(IRBuilder<> &B,
+                                                        Value *V) const {
+  if (V->getType() == B.getInt1Ty())
+    return V;
+  Type *I64Ty = B.getInt64Ty();
+  if (V->getType()->isPointerTy())
+    V = B.CreatePtrToInt(V, I64Ty);
+  Type *TargetTy = WaveMaskTy;
+  unsigned SrcBits = V->getType()->getPrimitiveSizeInBits();
+  unsigned DstBits = TargetTy->getPrimitiveSizeInBits();
+  if (SrcBits < DstBits) {
+    // Widen a source-width mask back to target width by replication, so target
+    // lane K and K+W_src read the same bit. A zero-extend would leave the upper
+    // half always reading 0, deactivating target lanes 32..63 whenever EXEC is
+    // restored through a source-width SGPR.
+    Value *Zext = B.CreateZExt(V, TargetTy);
+    Value *Shifted = B.CreateShl(Zext, SrcBits);
+    V = B.CreateOr(Zext, Shifted, "wn_mask_widen");
+  } else if (SrcBits > DstBits) {
+    V = B.CreateTrunc(V, TargetTy);
+  } else if (V->getType() != TargetTy) {
+    V = B.CreateBitCast(V, TargetTy);
+  }
+  Value *LaneIdx = emitLaneIdx(B);
+  // Neutral `mask_*` names: this helper reads any wave mask as a per-lane
+  // predicate, not only VCC, so a `vcc_` prefix would mislabel SGPR sources.
+  Value *LaneIdxExt =
+      B.CreateZExtOrTrunc(LaneIdx, TargetTy, "wn_mask_lane_idx");
+  Value *Shifted = B.CreateLShr(V, LaneIdxExt, "wn_mask_at_lane");
+  Value *Bit =
+      B.CreateAnd(Shifted, ConstantInt::get(TargetTy, 1), "wn_mask_lane_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(TargetTy, 0), "wn_mask_lane_i1");
+}
+
+Value *
+WaveNativeProjection::emitCurrentSourceWaveMask(IRBuilder<> &B, Value *Mask,
+                                                const Twine &Name) const {
+  assert(Mask->getType()->isIntegerTy() &&
+         "emitCurrentSourceWaveMask expects an "
+         "integer mask");
+
+  Type *SourceTy = sourceWaveMaskTy();
+  unsigned SourceBits = SourceTy->getPrimitiveSizeInBits();
+  unsigned MaskBits = Mask->getType()->getPrimitiveSizeInBits();
+  if (MaskBits <= SourceBits)
+    return B.CreateZExtOrTrunc(Mask, SourceTy, Name);
+
+  Value *LaneId = emitLaneIdx(B);
+  Value *SourceWaveBase = B.CreateAnd(
+      LaneId, B.getInt32(~(static_cast<uint32_t>(Src.waveSize()) - 1u)),
+      Name + "_base");
+  Value *Shift =
+      B.CreateZExtOrTrunc(SourceWaveBase, Mask->getType(), Name + "_shift");
+  Value *AtSourceWave = B.CreateLShr(Mask, Shift, Name + "_at_srcwave");
+  return B.CreateTrunc(AtSourceWave, SourceTy, Name);
+}
+
+// ----------------------------------------------------------------------------
+// ThreadLoopProjection.
+// ----------------------------------------------------------------------------
+
+ThreadLoopProjection::ThreadLoopProjection(const ISAProfile &SrcIsa,
+                                           const ISAProfile &TgtIsa,
+                                           Type *I32Ty, Type *I64Ty)
+    : WaveProjection(SrcIsa, TgtIsa, I32Ty, I64Ty) {
+  assert(TgtIsa.waveSize() > SrcIsa.waveSize() &&
+         "ThreadLoopProjection is defined only for widening "
+         "(target wave > source wave)");
+
+  assert((TgtIsa.waveSize() % SrcIsa.waveSize()) == 0 &&
+         "ThreadLoopProjection requires target wave size to be an integer "
+         "multiple of source wave size");
+
+  ExecStorageTy = WaveMaskTy;
+  NumSourceWavesPerTarget = TgtIsa.waveSize() / SrcIsa.waveSize();
+  SourceWaveScopedLaneOps = true;
+}
+
+Value *ThreadLoopProjection::emitWorkitemIdX(IRBuilder<> &B) const {
+  assert(IterationAlloca &&
+         "ThreadLoopProjection::emitWorkitemIdX requires an iteration alloca; "
+         "raiser must call setIterationAlloca before emitting source workitem "
+         "ids");
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *Fn =
+      Intrinsic::getOrInsertDeclaration(M, Intrinsic::amdgcn_workitem_id_x);
+  Value *Tid = B.CreateCall(Fn, {}, "tl_hw_tid");
+  Value *LaneId = emitLaneIdx(B);
+  const unsigned SrcBits = Src.waveSize();
+  const unsigned TgtBits = Tgt.waveSize();
+  Value *Iter = B.CreateLoad(B.getInt32Ty(), IterationAlloca, "tl_iter");
+  Value *Base = B.CreateAnd(Tid, B.getInt32(~(TgtBits - 1u)), "tl_tid_base");
+  Value *SourceLane =
+      B.CreateAnd(LaneId, B.getInt32(SrcBits - 1u), "tl_source_lane");
+  Value *WaveOffset =
+      B.CreateMul(Iter, B.getInt32(SrcBits), "tl_source_wave_off");
+  return B.CreateAdd(B.CreateAdd(Base, WaveOffset, "tl_tid_wave_base"),
+                     SourceLane, "tl_tid");
+}
+
+Value *ThreadLoopProjection::emitLaneActiveBit(IRBuilder<> &B,
+                                               Value *ExecVal) const {
+  Value *LaneId = emitLaneIdx(B);
+  Type *ExecTy = ExecVal->getType();
+  const unsigned SourceBits = sourceWaveMaskTy()->getPrimitiveSizeInBits();
+  Value *LaneIdInExec = B.CreateZExtOrTrunc(LaneId, ExecTy, "tl_lane_idx");
+  Value *LaneMod = B.CreateAnd(
+      LaneIdInExec, ConstantInt::get(ExecTy, SourceBits - 1), "tl_lane_mod");
+  Value *Shifted = B.CreateLShr(ExecVal, LaneMod, "tl_exec_at_lane");
+  Value *Bit = B.CreateAnd(Shifted, ConstantInt::get(ExecTy, 1), "tl_exec_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(ExecTy, 0), "tl_lane_active");
+}
+
+Value *ThreadLoopProjection::ballotI1ToWidth(IRBuilder<> &B, Value *Pred,
+                                             Type *ResultTy,
+                                             const Twine &Name) const {
+  assert(Pred->getType() == B.getInt1Ty() &&
+         "ballotI1ToWidth requires an i1 predicate");
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *Ballot = Intrinsic::getOrInsertDeclaration(
+      M, Intrinsic::amdgcn_ballot, {waveMaskTy()});
+  Value *WaveMask = B.CreateCall(Ballot, {Pred}, Name);
+  const unsigned WantedBits = ResultTy->getPrimitiveSizeInBits();
+  const unsigned WaveBits = WaveMaskTy->getPrimitiveSizeInBits();
+  assert(WantedBits <= WaveBits &&
+         "ThreadLoopProjection::ballotI1ToWidth requires resultTy <= target "
+         "wave mask width");
+  if (WantedBits == WaveBits)
+    return WaveMask;
+  return B.CreateTrunc(WaveMask, ResultTy, Name + "_trunc");
+}
+
+Value *ThreadLoopProjection::extractLaneBitFromWaveMask(IRBuilder<> &B,
+                                                        Value *V) const {
+  if (V->getType() == B.getInt1Ty())
+    return V;
+  Type *TargetTy = V->getType()->getPrimitiveSizeInBits() >
+                           sourceWaveMaskTy()->getPrimitiveSizeInBits()
+                       ? WaveMaskTy
+                       : sourceWaveMaskTy();
+  unsigned SrcBits = V->getType()->getPrimitiveSizeInBits();
+  unsigned DstBits = TargetTy->getPrimitiveSizeInBits();
+  if (SrcBits < DstBits) {
+    V = B.CreateZExt(V, TargetTy);
+  } else if (SrcBits > DstBits) {
+    V = B.CreateTrunc(V, TargetTy);
+  } else if (V->getType() != TargetTy) {
+    V = B.CreateBitCast(V, TargetTy);
+  }
+  Value *LaneIdx = emitLaneIdx(B);
+  Value *LaneIdxExt =
+      B.CreateZExtOrTrunc(LaneIdx, TargetTy, "tl_mask_lane_idx");
+  Value *ShiftIdx =
+      (TargetTy == WaveMaskTy)
+          ? LaneIdxExt
+          : B.CreateAnd(LaneIdxExt, ConstantInt::get(TargetTy, DstBits - 1),
+                        "tl_mask_lane_mod");
+  Value *Shifted = B.CreateLShr(V, ShiftIdx, "tl_mask_at_lane");
+  Value *Bit =
+      B.CreateAnd(Shifted, ConstantInt::get(TargetTy, 1), "tl_mask_lane_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(TargetTy, 0), "tl_mask_lane_i1");
+}
+
+// ----------------------------------------------------------------------------
+// EXEC-writer detection.
+// ----------------------------------------------------------------------------
+
+bool instructionWritesEXEC(const DecodedInst &Di, const MCState &Mc) {
+  if (Di.defsExec())
+    return true;
+  // On a wave32 source, hardware EXEC is 32-bit (== EXEC_LO) and EXEC_HI is a
+  // free scratch scalar, so an explicit def of EXEC_HI alone is a scratch
+  // write, not an EXEC write.
+  const bool SourceIsWave32 =
+      Mc.SubtargetInfo->hasFeature(AMDGPU::FeatureWavefrontSize32);
+  const MCInstrDesc &Desc = Mc.InstrInfo->get(Di.Inst.getOpcode());
+  for (unsigned I = 0; I < Desc.getNumDefs() && I < Di.Inst.getNumOperands();
+       ++I) {
+    const MCOperand &Mop = Di.Inst.getOperand(I);
+    if (!Mop.isReg() || !Mop.getReg())
+      continue;
+    // EXEC has no subtarget-specific MC aliases, so the raw MC register already
+    // matches the pseudo-register id; no mc2PseudoReg normalization is needed.
+    MCRegister Reg = Mop.getReg();
+    if (Reg == AMDGPU::EXEC || Reg == AMDGPU::EXEC_LO)
+      return true;
+    if (Reg == AMDGPU::EXEC_HI && !SourceIsWave32)
+      return true;
+  }
+  return false;
+}
+
+// ----------------------------------------------------------------------------
+// Cross-wave warning.
+// ----------------------------------------------------------------------------
+
+bool emitCrossWaveWarning(const WaveProjection &Proj, const MCState &Mc,
+                          ArrayRef<DecodedInst> Insts, StringRef SourceIsa,
+                          StringRef TargetIsa) {
+  if (Proj.sourceIsa().waveSize() == Proj.targetIsa().waveSize())
+    return false;
+
+  const DecodedInst *FirstExecWriter = nullptr;
+  for (const DecodedInst &Di : Insts) {
+    if (instructionWritesEXEC(Di, Mc)) {
+      FirstExecWriter = &Di;
+      break;
+    }
+  }
+  if (!FirstExecWriter)
+    return false;
+
+  // Emit a warn-only diagnostic under -debug-only=wave-projection.
+  LLVM_DEBUG({
+    dbgs() << "transpiler: WARNING: cross-wave translation of an "
+              "EXEC-manipulating kernel relies on replication, "
+              "which is not provably correct in general.\n"
+           << "  source ISA wave size: " << Proj.sourceIsa().waveSize() << " ("
+           << SourceIsa << ")\n"
+           << "  target ISA wave size: " << Proj.targetIsa().waveSize() << " ("
+           << (TargetIsa.empty() ? SourceIsa : TargetIsa) << ")\n"
+           << "  first EXEC-writer: " << getMnemonic(Mc, FirstExecWriter->Inst)
+           << " at offset 0x"
+           << format_hex_no_prefix(FirstExecWriter->Offset, 4) << "\n"
+           << "  rationale: the kernel manipulates EXEC; replicating it "
+              "across wave halves will double per-lane side effects in a "
+              "way the source author did not specify. Empirically this is "
+              "correct for kernels whose EXEC writers are lane-position-"
+              "independent (pointwise ops with bounds checks against a "
+              "uniform >= target_wave_bits).\n";
+  });
+  return true;
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/wave-projection.h
+++ b/amd/comgr/src/hotswap/raiser/wave-projection.h
@@ -1,0 +1,389 @@
+//===- wave-projection.h - Hotswap transpiler -----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_WAVE_PROJECTION_H
+#define HOTSWAP_TRANSPILER_WAVE_PROJECTION_H
+
+#include "hotswap/decoder/decoded-inst.h"
+#include "hotswap/decoder/isa-profile.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Type.h"
+#include "llvm/IR/Value.h"
+
+namespace COMGR::hotswap {
+
+struct MCState;
+
+// ============================================================================
+// WaveProjection -- the cross-wave translation policy surface.
+//
+// A projection maps a source-ISA wavefront onto a target-ISA wavefront when
+// the two wave widths differ. This is an abstract base; each concrete
+// projection is a subclass and the choice is made once when the raiser
+// constructs it.
+class WaveProjection {
+public:
+  WaveProjection(const ISAProfile &SrcIsa, const ISAProfile &TgtIsa,
+                 llvm::Type *I32Ty, llvm::Type *I64Ty)
+      : Src(SrcIsa), Tgt(TgtIsa), I32Ty(I32Ty), I64Ty(I64Ty),
+        WaveMaskTy(TgtIsa.isWave32() ? I32Ty : I64Ty),
+        ExecStorageTy(SrcIsa.isWave32() ? I32Ty : I64Ty) {}
+
+  virtual ~WaveProjection() = default;
+
+  const ISAProfile &sourceIsa() const { return Src; }
+  const ISAProfile &targetIsa() const { return Tgt; }
+
+  // Source kernel's max_flat_workgroup_size (threads per workgroup), set by
+  // the raiser after construction. Used to clamp the workitem id of the
+  // undispatched upper target lanes.
+  void setMaxFlatWorkgroupSize(unsigned N) { MaxFlatWG = N; }
+  // Hardware-width wave mask (i32 on wave32 target, i64 on wave64 target).
+  // Distinct from the EXEC alloca storage width returned by
+  // `execStorageTy()`.
+  llvm::Type *waveMaskTy() const { return WaveMaskTy; }
+
+  // Wave mask at the source ISA's width (i32 on wave32 source, i64 on wave64):
+  // the width the source observes when reading or writing EXEC and SGPR wave
+  // masks through 32/64-bit scalar operations.
+  llvm::Type *sourceWaveMaskTy() const {
+    return Src.isWave32() ? I32Ty : I64Ty;
+  }
+
+  // EXEC alloca storage width chosen by the projection; the base uses the
+  // source wave-mask width. A subclass may widen it (e.g. to the target mask)
+  // in its constructor.
+  llvm::Type *execStorageTy() const { return ExecStorageTy; }
+
+  // Emit the initial value to store into the EXEC alloca at kernel entry.
+  // Default is all-ones (every source lane active on entry). Projections that
+  // decouple the hardware EXEC from the modeled source EXEC override this to
+  // capture the hardware EXEC into the alloca while forcing hardware EXEC to
+  // all-ones.
+  virtual llvm::Value *emitInitialExec(llvm::IRBuilder<> &B) const;
+
+  // True iff a 32-bit write to EXEC_LO means "replicate across the full widened
+  // EXEC" rather than the architectural "replace the low half, keep the high
+  // half". A projection that models each target lane as an independent source
+  // thread sets this, so a whole-wave EXEC_LO write fans out to both halves.
+  bool broadcastNarrowExecLoWrite() const { return BroadcastNarrowExecLoWrite; }
+
+  // Emit the current lane's linear index within the wavefront (i32). Wave size
+  // follows the target ISA, since the lane id is a property of the hardware the
+  // raised IR runs on, not of the source ISA. Non-virtual: every projection
+  // derives the lane id the same way.
+  llvm::Value *emitLaneIdx(llvm::IRBuilder<> &B) const;
+
+  // Emit the workitem-id-x value source-ISA code should observe under this
+  // projection. The base returns the target hardware value; a projection that
+  // splits or re-maps source waves overrides it.
+  virtual llvm::Value *emitWorkitemIdX(llvm::IRBuilder<> &B) const;
+
+  // Emit the full packed kernel-entry `v0` workitem id under this projection.
+  // amdgpu packs the workitem id as x[0:9] | y[10:19] | z[20:29]; `NumDims`
+  // (1..3, derived from the source descriptor's ENABLE_VGPR_WORKITEM_ID) says
+  // how many fields the source enabled, so a 1-D kernel reduces to exactly
+  // `emitWorkitemIdX` (no Y/Z math).
+  virtual llvm::Value *emitPackedWorkitemId(llvm::IRBuilder<> &B,
+                                            unsigned NumDims) const;
+
+  // Given the current EXEC alloca value, return an i1 true iff the current lane
+  // is active. Each concrete projection defines what "active" means.
+  virtual llvm::Value *emitLaneActiveBit(llvm::IRBuilder<> &B,
+                                         llvm::Value *ExecVal) const = 0;
+
+  // Collect a per-lane i1 predicate into a wave-level bit-mask of width
+  // `ResultTy`. The ballot itself must be at the target wave width (the AMDGPU
+  // backend only selects ballot.i32 on wave32 and ballot.i64 on wave64) and
+  // must be emitted in outer / full-EXEC control flow so inactive lanes do not
+  // contribute 0. How a `ResultTy` narrower than the wave width is reconciled
+  // is projection-specific.
+  virtual llvm::Value *
+  ballotI1ToWidth(llvm::IRBuilder<> &B, llvm::Value *Pred, llvm::Type *ResultTy,
+                  const llvm::Twine &Name = "ballot") const = 0;
+
+  // Project a wave-level bit-mask back onto the current lane's bit (i1).
+  // Inverse direction of the ballot. Per-lane i1 inputs short-circuit
+  // to a direct pass-through (some callers already produce the final
+  // per-lane i1 and route through writeReg*(VCC, i1)); those must not
+  // be reinterpreted as a one-bit wave mask.
+  virtual llvm::Value *extractLaneBitFromWaveMask(llvm::IRBuilder<> &B,
+                                                  llvm::Value *V) const = 0;
+
+  // Return the source-wave slice of a wave mask, e.g. for `v_mbcnt_lo`.
+  virtual llvm::Value *
+  emitCurrentSourceWaveMask(llvm::IRBuilder<> &B, llvm::Value *Mask,
+                            const llvm::Twine &Name = "source_wave_mask") const;
+
+  // True iff this projection guarantees hardware EXEC = -1 between
+  // `emitUnderExec` diamonds kernel-wide, so cross-lane collectives can run
+  // without additional EXEC scaffolding.
+  bool providesFullWaveExecInvariant() const {
+    return ProvidesFullWaveExecInvariant;
+  }
+
+  // True iff handlers should lower source-ISA lane-indexed primitives
+  // (`readlane`, `writelane`, `readfirstlane`) as source-wave-scoped
+  // operations instead of target-wave-native AMDGPU intrinsics. Needed when a
+  // target wave packs multiple source-wave instances, which a native
+  // target-wave `readlane` / `readfirstlane` would collapse together.
+  bool sourceWaveScopedLaneOps() const { return SourceWaveScopedLaneOps; }
+
+  // True iff mbcnt-derived EXEC writes -- the vector `v_cmpx` and its scalar
+  // `s_*_saveexec_b32` sibling -- can be projected into an independent
+  // target-width EXEC mask per packed source wave. Requires an injective
+  // source-wave mapping.
+  bool preservesMbcntDerivedExec() const { return PreservesMbcntDerivedExec; }
+
+  // True iff this projection expects the runtime to launch the block with a
+  // `W_t / W_s`-scaled extent along `doubledDispatchDim()`, so each target wave
+  // hosts one source wave in its low `W_s` lanes with the rest as replicas.
+  // Equivalent to a scale factor above 1.
+  bool usesDoubledDispatch() const { return DoubledDispatchFactor > 1; }
+
+  // The block dimension (0=x, 1=y, 2=z) the runtime doubles when
+  // `usesDoubledDispatch()` is true. Always the fastest wave-carrying
+  // dimension (x) for the wave32->wave64 case; the higher dims that carry the
+  // divergent predicate become wave-uniform once x is doubled. Meaningless
+  // unless `usesDoubledDispatch()`.
+  unsigned doubledDispatchDim() const { return DoubledDispatchDim; }
+
+  // The integer factor by which the dispatch is scaled along
+  // `doubledDispatchDim()` (`W_t / W_s`, i.e. 2 for wave32->wave64).
+  // Meaningless unless `usesDoubledDispatch()`.
+  unsigned doubledDispatchFactor() const { return DoubledDispatchFactor; }
+
+  // Number of source waves whose per-lane fragment data is present in each
+  // target wave under this projection's mapping. Callers that synthesise
+  // per-source-wave passes iterate one pass per source wave.
+  unsigned numSourceWavesPerTarget() const { return NumSourceWavesPerTarget; }
+
+  // Return `v` wrapped in `@llvm.amdgcn.strict.wwm` iff the current projection
+  // does not already guarantee HW EXEC=-1 kernel-wide; otherwise return `v`
+  // unchanged. Accepts any type strict.wwm's overload set covers (integer /
+  // floating-point scalars and fixed vectors thereof).
+  llvm::Value *wrapAsWWMValue(llvm::IRBuilder<> &B, llvm::Value *V,
+                              const llvm::Twine &Name = "wwm") const;
+
+protected:
+  // Combine an already-projected workitem-id-x value with the native Y/Z
+  // workitem-id fields into AMDGPU's packed `v0` layout
+  // (x | y<<10 | z<<20). `NumDims` selects how many fields to fold in.
+  llvm::Value *packWorkitemId(llvm::IRBuilder<> &B, llvm::Value *X,
+                              unsigned NumDims) const;
+
+  ISAProfile Src;
+  ISAProfile Tgt;
+  // Retained on the base so `sourceWaveMaskTy()` / `execStorageTy()` can
+  // return the canonical i32/i64 IR types without re-deriving them from the
+  // current IRBuilder's context (subclasses are constructed once per kernel
+  // and outlive any particular builder).
+  llvm::Type *I32Ty;
+  llvm::Type *I64Ty;
+  llvm::Type *WaveMaskTy;
+
+  // Per-projection configuration, read through the like-named accessors
+  // above. The defaults describe the same-wave / replication policy;
+  // the widening projections set the ones they change in their constructors,
+  // so a projection's behaviour is declared in one place rather than spread
+  // across virtual overrides.
+  llvm::Type *ExecStorageTy;
+  unsigned NumSourceWavesPerTarget = 1;
+  unsigned DoubledDispatchDim = 0;
+  unsigned DoubledDispatchFactor = 1;
+  bool BroadcastNarrowExecLoWrite = false;
+  bool ProvidesFullWaveExecInvariant = false;
+  bool SourceWaveScopedLaneOps = false;
+  bool PreservesMbcntDerivedExec = false;
+
+  // Source max_flat_workgroup_size; 0 until the raiser sets it.
+  unsigned MaxFlatWG = 0;
+  // Cache for the function-invariant lane id, keyed by the function it was
+  // emitted into so a projection reused across kernels re-emits per function
+  // rather than returning a value from another one. See `emitLaneIdx`.
+  mutable llvm::Function *CachedLaneIdxFunc = nullptr;
+  mutable llvm::Value *CachedLaneIdx = nullptr;
+};
+
+// ============================================================================
+// ReplicationProjection.
+//
+// Target lane L reads bit `L mod W_src` of the source EXEC mask; a target
+// ballot is truncated to source width, taking the lower `W_src` lanes as
+// canonical; a wave-level mask projected back onto a per-lane bit indexes by
+// `lane_id mod W_src`. This is a translation policy, not a hardware fact.
+class ReplicationProjection : public WaveProjection {
+public:
+  using WaveProjection::WaveProjection;
+
+  llvm::Value *emitLaneActiveBit(llvm::IRBuilder<> &B,
+                                 llvm::Value *ExecVal) const override;
+  llvm::Value *
+  ballotI1ToWidth(llvm::IRBuilder<> &B, llvm::Value *Pred, llvm::Type *ResultTy,
+                  const llvm::Twine &Name = "ballot") const override;
+  llvm::Value *extractLaneBitFromWaveMask(llvm::IRBuilder<> &B,
+                                          llvm::Value *V) const override;
+
+  // Clamp the workitem id of undispatched upper target lanes so they replicate
+  // a real lane's in-bounds addressing when the target wave is wider than the
+  // source workgroup.
+  llvm::Value *emitWorkitemIdX(llvm::IRBuilder<> &B) const override;
+
+  // Apply the same phantom-lane clamp as `emitWorkitemIdX`, but to the whole
+  // packed id, so undispatched upper target lanes replicate lane 0 (packed 0)
+  // rather than getting a stray non-zero Y/Z.
+  llvm::Value *emitPackedWorkitemId(llvm::IRBuilder<> &B,
+                                    unsigned NumDims) const override;
+
+  // Both the phantom-lane widening regime and same-wave instantiations carry
+  // exactly one source wave per target wave, which is the base default
+  // (`NumSourceWavesPerTarget == 1`), so no constructor override is needed.
+};
+
+// ============================================================================
+// ReplicationDoubledDispatchProjection -- replication backed by a doubled
+// dispatch.
+//
+// The runtime launches the block with a `W_t / W_s`-scaled extent along the
+// wave-carrying dimension x, so each target wave hosts one source wave in lanes
+// `0..W_s-1` and exact replicas in `W_s..W_t-1`. For wave32->wave64:
+//
+//   * the runtime doubles blockDim.x (grid unchanged);
+//   * the raised kernel maps hardware workitem-id.x back to the logical source
+//     id so hardware lane `W_s + i` sees the same logical thread as lane `i`;
+//   * the raiser halves the in-kernel workgroup/grid-size query along x so
+//     loops and reduction bounds still observe the source block size.
+//
+// A lane and its replica compute identically, so they share every predicate
+// and cross-lane ops read valid duplicate data from the upper half. All of the
+// per-source-wave cross-lane machinery is inherited; this class overrides only
+// the workitem-id mapping. Utilisation is ~50%, so it is a correctness
+// fallback, not the fast path.
+class ReplicationDoubledDispatchProjection final
+    : public ReplicationProjection {
+public:
+  ReplicationDoubledDispatchProjection(const ISAProfile &SrcIsa,
+                                       const ISAProfile &TgtIsa,
+                                       llvm::Type *I32Ty, llvm::Type *I64Ty)
+      : ReplicationProjection(SrcIsa, TgtIsa, I32Ty, I64Ty) {
+    // Doubled dispatch along x (the wave-carrying dimension); dim stays 0.
+    DoubledDispatchFactor = TgtIsa.waveSize() / SrcIsa.waveSize();
+  }
+
+  // Remap hardware workitem-id.x to the logical source id so replica lanes
+  // alias their originals. No phantom-lane clamp: under a doubled dispatch
+  // every hardware lane maps to a valid logical thread (real or replica).
+  llvm::Value *emitWorkitemIdX(llvm::IRBuilder<> &B) const override;
+
+  // Pack the remapped x with the source's raw y/z fields (which are already
+  // per-thread correct and become wave-uniform once x is doubled). Bypasses
+  // the base replication phantom-lane clamp.
+  llvm::Value *emitPackedWorkitemId(llvm::IRBuilder<> &B,
+                                    unsigned NumDims) const override;
+};
+
+// ============================================================================
+// WaveNativeProjection -- widening (wave32 -> wave64) projection
+// that preserves the full target-hardware EXEC mask.
+//
+// The EXEC alloca is sized to the target hardware wave-mask width, and each
+// target lane is treated as an independent source-thread equivalent, so a
+// data-dependent `v_cmpx` that differs on target lanes 0..31 vs 32..63 keeps
+// both halves distinct through the ballot/AND/store round trip.
+//
+// Source-width EXEC writes (`s_mov_b32 exec_lo, v`) are replicated into both
+// halves of the widened EXEC; narrowing reads take the low half. This is
+// lossless as long as the source never observes the upper half of EXEC
+// independently, which wave32 source ISAs cannot express.
+//
+// Correct only for wave32 -> wave64 widening; the constructor asserts on
+// other directions.
+class WaveNativeProjection final : public WaveProjection {
+public:
+  // The constructor sets the projection configuration: target-width EXEC
+  // storage, full-wave-EXEC invariant (its `emitInitialExec` forces HW
+  // EXEC=-1), broadcast-on-narrow-EXEC-write, preserved mbcnt-derived EXEC,
+  // and two source waves per target wave (lanes 0..31 and 32..63).
+  WaveNativeProjection(const ISAProfile &SrcIsa, const ISAProfile &TgtIsa,
+                       llvm::Type *I32Ty, llvm::Type *I64Ty);
+
+  llvm::Value *emitInitialExec(llvm::IRBuilder<> &B) const override;
+  llvm::Value *emitLaneActiveBit(llvm::IRBuilder<> &B,
+                                 llvm::Value *ExecVal) const override;
+  llvm::Value *
+  ballotI1ToWidth(llvm::IRBuilder<> &B, llvm::Value *Pred, llvm::Type *ResultTy,
+                  const llvm::Twine &Name = "ballot") const override;
+  llvm::Value *extractLaneBitFromWaveMask(llvm::IRBuilder<> &B,
+                                          llvm::Value *V) const override;
+  llvm::Value *emitCurrentSourceWaveMask(
+      llvm::IRBuilder<> &B, llvm::Value *Mask,
+      const llvm::Twine &Name = "source_wave_mask") const override;
+};
+
+// ============================================================================
+// ThreadLoopProjection -- source-wave-scoped execution for widening.
+//
+// Banks source-wave predicate masks in target-width storage and emits a
+// virtual workitem id through one projection hook, so equality predicates keep
+// the packed source waves distinct. The projection surface:
+//   * target-width EXEC storage for per-source-wave predicate masks;
+//   * source-wave-scoped lane ops;
+//   * target ballots narrowed only when the destination is source-width;
+// and reports `W_t / W_s` source waves per target wave.
+//
+// Opt-in: selected only by an explicit fallback path in the raiser.
+class ThreadLoopProjection final : public WaveProjection {
+public:
+  // The constructor sets the projection configuration: target-width EXEC
+  // storage, source-wave-scoped lane ops, and `W_t / W_s` source waves per
+  // target wave.
+  ThreadLoopProjection(const ISAProfile &SrcIsa, const ISAProfile &TgtIsa,
+                       llvm::Type *I32Ty, llvm::Type *I64Ty);
+
+  void setIterationAlloca(llvm::AllocaInst *Iter) { IterationAlloca = Iter; }
+  llvm::Value *emitWorkitemIdX(llvm::IRBuilder<> &B) const override;
+
+  llvm::Value *emitLaneActiveBit(llvm::IRBuilder<> &B,
+                                 llvm::Value *ExecVal) const override;
+  llvm::Value *
+  ballotI1ToWidth(llvm::IRBuilder<> &B, llvm::Value *Pred, llvm::Type *ResultTy,
+                  const llvm::Twine &Name = "ballot") const override;
+  llvm::Value *extractLaneBitFromWaveMask(llvm::IRBuilder<> &B,
+                                          llvm::Value *V) const override;
+
+private:
+  llvm::AllocaInst *IterationAlloca = nullptr;
+};
+
+// ============================================================================
+// EXEC-writer detection.
+// ============================================================================
+
+// True iff Di writes EXEC (EXEC/EXEC_LO, or EXEC_HI on a wave64 source),
+// whether as an implicit def or an explicit destination operand.
+bool instructionWritesEXEC(const DecodedInst &Di, const MCState &Mc);
+
+// ============================================================================
+// Cross-wave safety warning.
+// ============================================================================
+
+// Emit a warn-only diagnostic (through LLVM_DEBUG) when a cross-wave
+// translation relies on replication of an EXEC-manipulating kernel.
+// Returns true iff a diagnostic was emitted.
+bool emitCrossWaveWarning(const WaveProjection &Proj, const MCState &Mc,
+                          llvm::ArrayRef<DecodedInst> Insts,
+                          llvm::StringRef SourceIsa, llvm::StringRef TargetIsa);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -133,18 +133,19 @@ add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapElfTests>
   COMMAND $<TARGET_FILE:HotswapMCTests>
   COMMAND $<TARGET_FILE:HotswapProfileTests>
-  COMMAND $<TARGET_FILE:RaiserScaffoldingTests>
   COMMAND $<TARGET_FILE:DemangleSymbolNameTest>
   COMMAND $<TARGET_FILE:LoggerTests>)
 add_dependencies(test-unit HotswapElfTests HotswapMCTests HotswapProfileTests
-  RaiserScaffoldingTests DemangleSymbolNameTest LoggerTests)
+  DemangleSymbolNameTest LoggerTests)
 
-# DecoderTests builds only when the hotswap decoder library is present
-# (COMGR_ENABLE_HOTSWAP_TRANSPILE); run it under test-unit when it does.
-if(TARGET DecoderTests)
+# The transpile-path test binaries, exported by hotswap/CMakeLists.txt in
+# COMGR_HOTSWAP_TEST_TARGETS (empty unless COMGR_ENABLE_HOTSWAP_TRANSPILE is on).
+# Adding a hotswap test updates that list, not this file.
+foreach(HotswapTest ${COMGR_HOTSWAP_TEST_TARGETS})
   add_custom_command(TARGET test-unit POST_BUILD
-    COMMAND $<TARGET_FILE:DecoderTests>)
-  add_dependencies(test-unit DecoderTests)
+    COMMAND $<TARGET_FILE:${HotswapTest}>)
+endforeach()
+if(COMGR_HOTSWAP_TEST_TARGETS)
+  add_dependencies(test-unit ${COMGR_HOTSWAP_TEST_TARGETS})
 endif()
-
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/hotswap/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/CMakeLists.txt
@@ -1,8 +1,15 @@
 add_subdirectory(rewriter)
-add_subdirectory(raiser)
 
-# The decoder unit tests link the hotswap::decoder library, which only exists
-# when COMGR_ENABLE_HOTSWAP_TRANSPILE is on; skip them otherwise.
-if(TARGET hotswap::decoder)
+# The raiser and decoder unit tests link the transpile-path OBJECT libraries,
+# entered only under COMGR_ENABLE_HOTSWAP_TRANSPILE; skip them otherwise.
+if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
+  add_subdirectory(raiser)
   add_subdirectory(decoder)
+  list(APPEND COMGR_HOTSWAP_TEST_TARGETS
+    RaiserScaffoldingTests WaveProjectionTests DecoderTests)
 endif()
+
+# The test binaries above, exported to the parent scope so the top-level
+# test-unit target runs them without naming each one. Adding a hotswap test
+# target updates this list, not test-unit/CMakeLists.txt.
+set(COMGR_HOTSWAP_TEST_TARGETS "${COMGR_HOTSWAP_TEST_TARGETS}" PARENT_SCOPE)

--- a/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
@@ -10,13 +10,17 @@
 add_executable(RaiserScaffoldingTests
   RaiserScaffoldingTest.cpp)
 
-# hotswap::raiser keeps its LLVM dependencies PRIVATE, so name them here.
+# hotswap::raiser keeps its LLVM dependencies PRIVATE, so name them here. It also
+# carries the wave-projection objects, which call into hotswap::decoder; link it
+# too and inherit its curated LLVM component set.
 llvm_map_components_to_libnames(COMGR_TEST_UNIT_RAISER_LIBS
   Core Support TargetParser)
 
 target_link_libraries(RaiserScaffoldingTests PRIVATE
   ${COMGR_GTEST_LIBS}
   hotswap::raiser
+  hotswap::decoder
+  hotswap::common
   ${COMGR_TEST_UNIT_RAISER_LIBS}
   ${LLVM_PTHREAD_LIB})
 
@@ -27,3 +31,30 @@ target_include_directories(RaiserScaffoldingTests PRIVATE
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
 
 comgr_configure_test_target(RaiserScaffoldingTests)
+
+# -- WaveProjectionTests ------------------------------------------------------
+#
+# Pins the per-projection contract on WaveProjection and its subclasses (EXEC
+# storage width, source waves per target wave, doubled-dispatch factor, the
+# exec/mbcnt predicates) and the wrapAsWWMValue emission behaviour.
+
+add_executable(WaveProjectionTests
+  WaveProjectionTest.cpp)
+
+# The wave projection lives in hotswap::raiser and calls into hotswap::decoder
+# (ISAProfile and the AMDGPU register queries); link both. hotswap::decoder
+# carries the curated LLVM component set the projection needs.
+target_link_libraries(WaveProjectionTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  hotswap::raiser
+  hotswap::decoder
+  hotswap::common
+  ${LLVM_PTHREAD_LIB})
+
+target_include_directories(WaveProjectionTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+
+comgr_configure_test_target(WaveProjectionTests)

--- a/amd/comgr/test-unit/hotswap/raiser/RaiserScaffoldingTest.cpp
+++ b/amd/comgr/test-unit/hotswap/raiser/RaiserScaffoldingTest.cpp
@@ -23,9 +23,31 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
+#include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "gtest/gtest.h"
+
+#include <mutex>
+
+// hotswap::raiser also carries the wave-projection objects, which link the
+// hotswap::decoder MC stack; its initMCState calls
+// COMGR::ensureLLVMInitialized, whose production definition lives in
+// libamd_comgr. Provide the registration here so the test binary stays minimal
+// instead of linking the full Comgr.
+namespace COMGR {
+void ensureLLVMInitialized() {
+  static std::once_flag Once;
+  std::call_once(Once, [] {
+    LLVMInitializeAMDGPUTargetInfo();
+    LLVMInitializeAMDGPUTargetMC();
+    LLVMInitializeAMDGPUDisassembler();
+    LLVMInitializeAMDGPUAsmParser();
+    LLVMInitializeAMDGPUAsmPrinter();
+    LLVMInitializeAMDGPUTarget();
+  });
+}
+} // namespace COMGR
 
 namespace {
 

--- a/amd/comgr/test-unit/hotswap/raiser/WaveProjectionTest.cpp
+++ b/amd/comgr/test-unit/hotswap/raiser/WaveProjectionTest.cpp
@@ -1,0 +1,345 @@
+//===- WaveProjectionTest.cpp - wave projection unit tests ----------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Unit tests for the per-projection contract on WaveProjection and its
+// subclasses. Each projection fixes its policy (EXEC storage width, source
+// waves per target wave, doubled-dispatch factor, and the exec/mbcnt
+// predicates) in its constructor, and the raiser and its passes branch on
+// those values through a WaveProjection reference. These tests pin the value
+// each projection reports, so a constructor that forgets to set a flag, or a
+// change that flips a default, is caught here rather than downstream.
+//
+// The IR-emitting side of the interface (wrapAsWWMValue) is exercised on a
+// small synthetic function.
+
+#include "hotswap/raiser/wave-projection.h"
+
+#include "hotswap/decoder/isa-profile.h"
+#include "hotswap/decoder/mc-state.h"
+
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
+#include "llvm/Support/TargetSelect.h"
+
+#include "gtest/gtest.h"
+
+#include <mutex>
+
+// The wave-projection objects link the hotswap::decoder MC stack, whose
+// initMCState calls COMGR::ensureLLVMInitialized; its production definition
+// lives in libamd_comgr. Provide the registration here so the test binary stays
+// minimal instead of linking the full Comgr.
+namespace COMGR {
+void ensureLLVMInitialized() {
+  static std::once_flag Once;
+  std::call_once(Once, [] {
+    LLVMInitializeAMDGPUTargetInfo();
+    LLVMInitializeAMDGPUTargetMC();
+    LLVMInitializeAMDGPUDisassembler();
+    LLVMInitializeAMDGPUAsmParser();
+    LLVMInitializeAMDGPUAsmPrinter();
+    LLVMInitializeAMDGPUTarget();
+  });
+}
+} // namespace COMGR
+
+using namespace llvm;
+using COMGR::hotswap::initMCState;
+using COMGR::hotswap::ISAProfile;
+using COMGR::hotswap::MCState;
+using COMGR::hotswap::ReplicationDoubledDispatchProjection;
+using COMGR::hotswap::ReplicationProjection;
+using COMGR::hotswap::ThreadLoopProjection;
+using COMGR::hotswap::WaveNativeProjection;
+using COMGR::hotswap::WaveProjection;
+
+namespace {
+
+// Every projection here covers the widening direction: a wave32 source
+// (gfx1250) onto a wave64 target (gfx942). The projections consult only the
+// wave size, but ISAProfile reads it from a live MCSubtargetInfo, so the
+// fixture stands up the real AMDGPU MC stack for both ISAs and hands out
+// profiles that reference it.
+class WaveProjectionContract : public ::testing::Test {
+protected:
+  void SetUp() override {
+    Expected<MCState> SrcState = initMCState("gfx1250");
+    ASSERT_TRUE(static_cast<bool>(SrcState)) << toString(SrcState.takeError());
+    SrcMc = std::move(*SrcState);
+
+    Expected<MCState> TgtState = initMCState("gfx942");
+    ASSERT_TRUE(static_cast<bool>(TgtState)) << toString(TgtState.takeError());
+    TgtMc = std::move(*TgtState);
+  }
+
+  ISAProfile srcIsa() const {
+    return ISAProfile::fromSubtarget(*SrcMc.SubtargetInfo);
+  }
+  ISAProfile tgtIsa() const {
+    return ISAProfile::fromSubtarget(*TgtMc.SubtargetInfo);
+  }
+
+  MCState SrcMc;
+  MCState TgtMc;
+};
+
+} // namespace
+
+// ----------------------------------------------------------------------------
+// providesFullWaveExecInvariant: only WaveNative decouples hardware EXEC from
+// the modeled source mask (via init_whole_wave), so only it reports true.
+// Cross-lane collective lowerings gate on this before running.
+// ----------------------------------------------------------------------------
+TEST_F(WaveProjectionContract, ReplicationDoesNotProvideFullWaveExec) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = srcIsa();
+  ISAProfile Tgt = tgtIsa();
+
+  ReplicationProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_FALSE(Proj.providesFullWaveExecInvariant());
+
+  // Read through a base reference too: the value lives in the base subobject
+  // the constructor set, so the non-virtual accessor resolves it correctly.
+  const WaveProjection &Base = Proj;
+  EXPECT_FALSE(Base.providesFullWaveExecInvariant());
+}
+
+TEST_F(WaveProjectionContract, WaveNativeProvidesFullWaveExec) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  // The constructor asserts a wave32 -> wave64 direction.
+  ISAProfile Src = srcIsa();
+  ISAProfile Tgt = tgtIsa();
+
+  WaveNativeProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_TRUE(Proj.providesFullWaveExecInvariant());
+  EXPECT_EQ(Proj.execStorageTy(), I64Ty);
+  EXPECT_TRUE(Proj.broadcastNarrowExecLoWrite());
+  EXPECT_TRUE(Proj.preservesMbcntDerivedExec());
+
+  const WaveProjection &Base = Proj;
+  EXPECT_TRUE(Base.providesFullWaveExecInvariant());
+}
+
+// A minimal concrete projection that implements only the pure virtuals, used
+// to pin the base-class defaults for the constructor-set configuration.
+namespace {
+class DefaultTestProjection final : public WaveProjection {
+public:
+  using WaveProjection::WaveProjection;
+  llvm::Value *emitLaneActiveBit(llvm::IRBuilder<> &,
+                                 llvm::Value *) const override {
+    return nullptr;
+  }
+  llvm::Value *ballotI1ToWidth(llvm::IRBuilder<> &, llvm::Value *, llvm::Type *,
+                               const llvm::Twine &) const override {
+    return nullptr;
+  }
+  llvm::Value *extractLaneBitFromWaveMask(llvm::IRBuilder<> &,
+                                          llvm::Value *) const override {
+    return nullptr;
+  }
+};
+} // namespace
+
+TEST_F(WaveProjectionContract, BaseDefaults) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = srcIsa();
+  ISAProfile Tgt = tgtIsa();
+
+  DefaultTestProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_FALSE(Proj.providesFullWaveExecInvariant());
+  EXPECT_FALSE(Proj.usesDoubledDispatch());
+  EXPECT_EQ(Proj.numSourceWavesPerTarget(), 1u);
+}
+
+TEST_F(WaveProjectionContract, ThreadLoop) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = srcIsa();
+  ISAProfile Tgt = tgtIsa();
+
+  ThreadLoopProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_FALSE(Proj.providesFullWaveExecInvariant());
+  EXPECT_TRUE(Proj.sourceWaveScopedLaneOps());
+  EXPECT_EQ(Proj.execStorageTy(), I64Ty);
+
+  const WaveProjection &Base = Proj;
+  EXPECT_FALSE(Base.providesFullWaveExecInvariant());
+}
+
+// ----------------------------------------------------------------------------
+// numSourceWavesPerTarget: the per-source-wave pass count. A wrong value makes
+// callers synthesise the wrong number of passes (a bogus second-wave pass for
+// replication, or a skipped second wave for the widening projections).
+// ----------------------------------------------------------------------------
+TEST_F(WaveProjectionContract, ReplicationHasOneSourceWavePerTarget) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = srcIsa();
+  ISAProfile Tgt = tgtIsa();
+
+  ReplicationProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_EQ(Proj.numSourceWavesPerTarget(), 1u);
+}
+
+TEST_F(WaveProjectionContract, WaveNativeHasTwoSourceWavesPerTarget) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = srcIsa();
+  ISAProfile Tgt = tgtIsa();
+
+  WaveNativeProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_EQ(Proj.numSourceWavesPerTarget(), 2u);
+}
+
+TEST_F(WaveProjectionContract, ThreadLoopReportsSourceWavesPerTargetRatio) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = srcIsa();
+  ISAProfile Tgt = tgtIsa();
+
+  ThreadLoopProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_EQ(Proj.numSourceWavesPerTarget(), 2u);
+}
+
+// ----------------------------------------------------------------------------
+// Doubled dispatch: ReplicationDoubledDispatchProjection is the only projection
+// that asks the runtime to scale the block's x extent. The factor is W_t / W_s.
+// ----------------------------------------------------------------------------
+TEST_F(WaveProjectionContract, ReplicationDoubledDispatch) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = srcIsa();
+  ISAProfile Tgt = tgtIsa();
+
+  ReplicationDoubledDispatchProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_TRUE(Proj.usesDoubledDispatch());
+  EXPECT_EQ(Proj.doubledDispatchFactor(), 2u);
+  EXPECT_EQ(Proj.doubledDispatchDim(), 0u);
+  // Doubled dispatch is replication underneath: one source wave per
+  // target wave, upper lanes are replicas.
+  EXPECT_EQ(Proj.numSourceWavesPerTarget(), 1u);
+
+  // Plain replication must not report a doubled dispatch.
+  ReplicationProjection Plain(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_FALSE(Plain.usesDoubledDispatch());
+}
+
+// ----------------------------------------------------------------------------
+// wrapAsWWMValue: an identity no-op on projections that already guarantee
+// hardware EXEC=-1 kernel-wide (WaveNative), and a single strict.wwm wrapper on
+// those that do not (Replication). The WMMA lowering relies on both behaviours.
+// ----------------------------------------------------------------------------
+namespace {
+struct IRScaffold {
+  LLVMContext Ctx;
+  std::unique_ptr<Module> M;
+  Function *F;
+  BasicBlock *BB;
+  Argument *Arg;
+  IRBuilder<> B;
+
+  IRScaffold() : Ctx(), M(std::make_unique<Module>("t", Ctx)), B(Ctx) {
+    auto *I32Ty = Type::getInt32Ty(Ctx);
+    auto *FnTy = FunctionType::get(Type::getVoidTy(Ctx), {I32Ty}, false);
+    F = Function::Create(FnTy, Function::ExternalLinkage, "f", M.get());
+    BB = BasicBlock::Create(Ctx, "entry", F);
+    Arg = F->getArg(0);
+    B.SetInsertPoint(BB);
+  }
+};
+} // namespace
+
+TEST_F(WaveProjectionContract, WrapAsWWMValueIsNoOpOnWaveNative) {
+  IRScaffold S;
+  auto *I32Ty = Type::getInt32Ty(S.Ctx);
+  auto *I64Ty = Type::getInt64Ty(S.Ctx);
+
+  ISAProfile Src = srcIsa();
+  ISAProfile Tgt = tgtIsa();
+  WaveNativeProjection Proj(Src, Tgt, I32Ty, I64Ty);
+
+  Value *Result = Proj.wrapAsWWMValue(S.B, S.Arg);
+  EXPECT_EQ(Result, S.Arg);
+  EXPECT_TRUE(S.BB->empty());
+}
+
+TEST_F(WaveProjectionContract, WrapAsWWMValueEmitsStrictWWMOnReplication) {
+  IRScaffold S;
+  auto *I32Ty = Type::getInt32Ty(S.Ctx);
+  auto *I64Ty = Type::getInt64Ty(S.Ctx);
+
+  ISAProfile Src = srcIsa();
+  ISAProfile Tgt = tgtIsa();
+  ReplicationProjection Proj(Src, Tgt, I32Ty, I64Ty);
+
+  Value *Result = Proj.wrapAsWWMValue(S.B, S.Arg);
+  EXPECT_NE(Result, S.Arg);
+  auto *Cb = dyn_cast<CallInst>(Result);
+  ASSERT_NE(Cb, nullptr);
+  Function *Callee = Cb->getCalledFunction();
+  ASSERT_NE(Callee, nullptr);
+  EXPECT_EQ(Callee->getIntrinsicID(), Intrinsic::amdgcn_strict_wwm);
+  ASSERT_EQ(Cb->arg_size(), 1u);
+  EXPECT_EQ(Cb->getArgOperand(0), S.Arg);
+  EXPECT_EQ(Cb->getType(), I32Ty);
+  EXPECT_EQ(S.BB->size(), 1u);
+}
+
+// wmma-lowering wraps both i32 (result dwords) and <4 x float> (MFMA outputs),
+// so cover the vector overload too.
+TEST_F(WaveProjectionContract, WrapAsWWMValueHandlesVectorFloatOverload) {
+  IRScaffold S;
+  auto *I32Ty = Type::getInt32Ty(S.Ctx);
+  auto *I64Ty = Type::getInt64Ty(S.Ctx);
+  auto *F32Ty = Type::getFloatTy(S.Ctx);
+  auto *V4f32Ty = FixedVectorType::get(F32Ty, 4);
+
+  ISAProfile Src = srcIsa();
+  ISAProfile Tgt = tgtIsa();
+  ReplicationProjection Proj(Src, Tgt, I32Ty, I64Ty);
+
+  Value *Vec = PoisonValue::get(V4f32Ty);
+  Value *Result = Proj.wrapAsWWMValue(S.B, Vec);
+
+  auto *Cb = dyn_cast<CallInst>(Result);
+  ASSERT_NE(Cb, nullptr);
+  Function *Callee = Cb->getCalledFunction();
+  ASSERT_NE(Callee, nullptr);
+  EXPECT_EQ(Callee->getIntrinsicID(), Intrinsic::amdgcn_strict_wwm);
+  EXPECT_EQ(Cb->getType(), V4f32Ty);
+  ASSERT_EQ(Cb->arg_size(), 1u);
+  EXPECT_EQ(Cb->getArgOperand(0)->getType(), V4f32Ty);
+}


### PR DESCRIPTION
WaveProjection models the relationship between the source and target wave
widths and how source lanes map onto target lanes. Same-wave translation (the
first milestone's gfx942 to gfx942 path) uses ModuloReplicationProjection; the
cross-widening projections are carried here too and select in later milestones.
The register file and the per-kernel context build on this in the following
patches.
