### PR TITLE
[Comgr][hotswap] Add the raise-failure error type and register file

### DIFF
--- a/amd/comgr/src/hotswap/decoder/parsed-reg.h
+++ b/amd/comgr/src/hotswap/decoder/parsed-reg.h
@@ -14,7 +14,7 @@
 
 namespace COMGR::hotswap {
 
-struct ISAProfile; // forward declaration
+class ISAProfile;
 
 struct ParsedReg {
   // Compact-predicate "source-only" registers (SIRegisterInfo.td:198-200):

--- a/amd/comgr/src/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/raiser/CMakeLists.txt
@@ -30,6 +30,8 @@ add_definitions(${LLVM_DEFINITIONS})
 # or a separate static archive.
 add_library(hotswap-raiser OBJECT
   raiser.cpp
+  raise_failure.cpp
+  reg-file.cpp
   wave-projection.cpp
 )
 

--- a/amd/comgr/src/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/raiser/CMakeLists.txt
@@ -44,6 +44,16 @@ endif()
 # RTTI-on TUs with RTTI-off LLVM libs produces undefined-reference errors
 # for `typeinfo` symbols on any class with a virtual method.
 llvm_update_compile_flags(hotswap-raiser)
+# llvm_update_compile_flags does not reliably carry LLVM's -fno-rtti to a
+# standalone find_package(LLVM) consumer. RaiseFailure derives from
+# llvm::ErrorInfo, so mirror LLVM_ENABLE_RTTI explicitly.
+if(NOT LLVM_ENABLE_RTTI)
+  if(MSVC)
+    target_compile_options(hotswap-raiser PRIVATE /GR-)
+  else()
+    target_compile_options(hotswap-raiser PRIVATE -fno-rtti)
+  endif()
+endif()
 
 set_target_properties(hotswap-raiser PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/amd/comgr/src/hotswap/raiser/raise_failure.cpp
+++ b/amd/comgr/src/hotswap/raiser/raise_failure.cpp
@@ -1,0 +1,106 @@
+//===- raise_failure.cpp - Structured raise-failure values ----------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "raise_failure.h"
+
+#include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace COMGR::hotswap {
+
+char RaiseFailure::ID = 0;
+
+void RaiseFailure::log(llvm::raw_ostream &OS) const {
+  OS << reasonString(Reason);
+  if (!Mnemonic.empty())
+    OS << ": " << Mnemonic;
+  if (Format)
+    OS << " [" << *Format << "]";
+  if (Offset) {
+    OS << " @offset=0x";
+    OS.write_hex(*Offset);
+  }
+  if (!Detail.empty())
+    OS << " :: " << Detail;
+}
+
+// Stable diagnostic token for each structured raise-failure category.
+llvm::StringRef reasonString(RaiseFailureReason R) {
+  switch (R) {
+  case RaiseFailureReason::None:
+    return "None";
+  case RaiseFailureReason::BadInput:
+    return "BadInput";
+  case RaiseFailureReason::InternalError:
+    return "internal-raise-failure";
+  case RaiseFailureReason::UnsupportedOpcode:
+    return "UnsupportedOpcode";
+  case RaiseFailureReason::UnsupportedInstructionForm:
+    return "unsupported-instruction-form";
+  case RaiseFailureReason::UnsupportedSourceHiddenArg:
+    return "unsupported-source-hidden-arg";
+  case RaiseFailureReason::SPEUnsafeExecWriter:
+    return "SPE-unmodeled-EXEC-writer";
+  case RaiseFailureReason::TargetMachineCreationFailed:
+    return "TargetMachineCreationFailed";
+  case RaiseFailureReason::IRVerificationFailed:
+    return "IRVerificationFailed";
+  case RaiseFailureReason::KernelBoundaryViolation:
+    return "kernel-boundary-violation";
+  case RaiseFailureReason::DeviceLibraryLinkFailed:
+    return "device-library-link-failed";
+  case RaiseFailureReason::CrossWaveLaneIdLeak:
+    return "cross-wave-lane-id-leak";
+  case RaiseFailureReason::CrossWaveUnrewritableShuffle:
+    return "cross-wave-unrewritable-shuffle";
+  case RaiseFailureReason::CrossWaveShuffleRewritePending:
+    return "cross-wave-shuffle-rewrite-pending";
+  case RaiseFailureReason::CrossWaveReplicaRace:
+    return "cross-wave-replica-race";
+  case RaiseFailureReason::CrossWaveLanePredicatedExec:
+    return "cross-wave-lane-predicated-exec";
+  case RaiseFailureReason::CrossWavePredicateChain:
+    return "cross-wave-predicate-chain";
+  case RaiseFailureReason::StrictUnsafeLowering:
+    return "strict-unsafe-lowering";
+  case RaiseFailureReason::MissingKernelDescriptor:
+    return "missing-kernel-descriptor";
+  case RaiseFailureReason::UserSgprLayoutMismatch:
+    return "user-sgpr-layout-mismatch";
+  case RaiseFailureReason::UnsupportedSourceClusterDims:
+    return "unsupported-source-cluster-dims";
+  }
+  llvm_unreachable("unhandled RaiseFailureReason");
+}
+
+llvm::Error RaiseFailure::atInstruction(RaiseFailureReason Reason,
+                                        llvm::StringRef Mnemonic,
+                                        uint64_t Offset, llvm::StringRef Format,
+                                        const llvm::Twine &Detail) {
+  return llvm::make_error<RaiseFailure>(
+      Reason, Mnemonic.str(), std::optional<std::string>(Format.str()),
+      std::optional<uint64_t>(Offset), Detail.str());
+}
+
+llvm::Error RaiseFailure::inKernel(RaiseFailureReason Reason,
+                                   llvm::StringRef KernelName,
+                                   const llvm::Twine &Detail) {
+  return llvm::make_error<RaiseFailure>(
+      Reason, std::string(), std::optional<std::string>(std::nullopt),
+      std::optional<uint64_t>(std::nullopt),
+      ("kernel '" + KernelName + "': " + Detail).str());
+}
+
+llvm::Error RaiseFailure::general(RaiseFailureReason Reason,
+                                  const llvm::Twine &Detail) {
+  return llvm::make_error<RaiseFailure>(
+      Reason, std::string(), std::optional<std::string>(std::nullopt),
+      std::optional<uint64_t>(std::nullopt), Detail.str());
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/raise_failure.h
+++ b/amd/comgr/src/hotswap/raiser/raise_failure.h
@@ -9,25 +9,148 @@
 #ifndef HOTSWAP_TRANSPILER_RAISE_FAILURE_H
 #define HOTSWAP_TRANSPILER_RAISE_FAILURE_H
 
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/Error.h"
+
 #include <cstdint>
+#include <optional>
 #include <string>
+
+namespace llvm {
+class raw_ostream;
+} // namespace llvm
 
 namespace COMGR::hotswap {
 
-// Lives in its own header so the handler layer can depend on failure
-// values without pulling in the rest of the top-level `raiser.h`
-// interface.
+// Structured reason for a raise failure.
 enum class RaiseFailureReason : uint16_t {
   None = 0,
+  // Caller-supplied input was rejected before any IR was built (e.g. an empty
+  // or non-AMDGPU source ISA string). `detail()` carries the offending input.
   BadInput,
+  // Internal contract violation: a failure return path was reached with no
+  // structured failure to explain it. A Hotswap bug, not a source-kernel
+  // property.
+  InternalError,
+  // The instruction's opcode is not lifted.
+  UnsupportedOpcode,
+  // The instruction's opcode is lifted, but this operand shape or encoding
+  // variant is not. `detail()` carries shape-specific context when available.
+  UnsupportedInstructionForm,
+  // A source hidden kernarg was identified, but no synthesis exists for its
+  // `.value_kind` yet. Narrower than `UnsupportedInstructionForm`: only that
+  // hidden-argument kind is unsupported.
+  UnsupportedSourceHiddenArg,
+  // An instruction writes EXEC through a path the lift does not model.
+  SPEUnsafeExecWriter,
+  // `createTargetMachine` returned null.
+  TargetMachineCreationFailed,
+  // `verifyModule` rejected the emitted IR.
+  IRVerificationFailed,
+  // Control flow targets an offset outside the selected kernel symbol, or an
+  // in-extent target could not be decoded. Crossing the boundary would inspect
+  // neighboring symbols.
+  KernelBoundaryViolation,
+  // A helper or device-library bitcode link step failed. Distinct from a
+  // verifier failure: the module is intentionally incomplete until the linked
+  // body is inlined.
+  DeviceLibraryLinkFailed,
+  // Wave-size-obstruction refusals, split one enumerator per refusal so
+  // diagnostics can bucket them without parsing the message text.
+  CrossWaveLaneIdLeak,
+  CrossWaveUnrewritableShuffle,
+  CrossWaveShuffleRewritePending,
+  CrossWaveReplicaRace,
+  CrossWaveLanePredicatedExec,
+  // A lane-position value gates a side effect without being masked to the
+  // source wave width.
+  CrossWavePredicateChain,
+  // `HSA_HOTSWAP_STRICT=1` refusal: a lowering that would otherwise warn and
+  // continue is rejected as potentially miscompiling.
+  StrictUnsafeLowering,
+  // The kernel descriptor could not be read from `.rodata` via the `<name>.kd`
+  // symbol, so the user-SGPR layout cannot be derived.
+  MissingKernelDescriptor,
+  // The descriptor's USER_SGPR_COUNT disagrees with the layout implied by
+  // kernel_code_properties and kernarg preload for the source ISA.
+  UserSgprLayoutMismatch,
+  // The source object declares non-disabled workgroup cluster dimensions, so
+  // TTMP6 carries per-cluster state the Hotswap ABI model does not reconstruct.
+  UnsupportedSourceClusterDims,
 };
 
-struct RaiseFailure {
-  RaiseFailureReason Reason = RaiseFailureReason::None;
-  // Optional human-readable context.
-  std::string Detail;
+// Human-readable name for a `RaiseFailureReason`. Stable enough for
+// diagnostics and tests to bucket on.
+llvm::StringRef reasonString(RaiseFailureReason R);
 
-  bool hasFailed() const { return Reason != RaiseFailureReason::None; }
+// Payload of the `llvm::Error` the raiser produces on a refusal. Build one
+// through the shape factories below, which return the `llvm::Error` directly;
+// the constructor is exposed only because `make_error` needs it. The data
+// members are private, so a failure is always fully formed and cannot be
+// mutated field by field.
+struct RaiseFailure : public llvm::ErrorInfo<RaiseFailure> {
+  static char ID;
+
+  RaiseFailure(RaiseFailureReason Reason, std::string Mnemonic,
+               std::optional<std::string> Format,
+               std::optional<uint64_t> Offset, std::string Detail)
+      : Reason(Reason), Mnemonic(std::move(Mnemonic)),
+        Format(std::move(Format)), Offset(Offset), Detail(std::move(Detail)) {}
+
+  RaiseFailureReason reason() const { return Reason; }
+
+  // Offending instruction mnemonic (e.g. `global_store_dwordx4`); empty for a
+  // failure not tied to a decoded instruction.
+  llvm::StringRef mnemonic() const { return Mnemonic; }
+
+  // Encoding-format category of the offending instruction (e.g. `VALU`,
+  // `FLAT`); absent for a failure not tied to a decoded instruction. This is
+  // the instruction's format, distinct from the failure reason, which is
+  // `reason()`.
+  std::optional<llvm::StringRef> format() const {
+    if (Format)
+      return llvm::StringRef(*Format);
+    return std::nullopt;
+  }
+
+  // Byte offset of the offending instruction into the disassembled text
+  // section; absent for a failure not tied to a decoded instruction.
+  std::optional<uint64_t> offset() const { return Offset; }
+
+  // Optional human-readable context.
+  llvm::StringRef detail() const { return Detail; }
+
+  void log(llvm::raw_ostream &OS) const override;
+
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+
+  // Failure tied to a decoded instruction, located by `Mnemonic` and `Offset`.
+  // `Format` is the encoding-format category of the offending instruction.
+  static llvm::Error atInstruction(RaiseFailureReason Reason,
+                                   llvm::StringRef Mnemonic, uint64_t Offset,
+                                   llvm::StringRef Format,
+                                   const llvm::Twine &Detail = {});
+
+  // Failure scoped to a whole kernel rather than one instruction. The rendered
+  // message is `kernel '<KernelName>': <Detail>`.
+  static llvm::Error inKernel(RaiseFailureReason Reason,
+                              llvm::StringRef KernelName,
+                              const llvm::Twine &Detail);
+
+  // Pipeline-level failure carrying only a detail string, with no instruction
+  // or kernel context.
+  static llvm::Error general(RaiseFailureReason Reason,
+                             const llvm::Twine &Detail);
+
+private:
+  RaiseFailureReason Reason;
+  std::string Mnemonic;
+  std::optional<std::string> Format;
+  std::optional<uint64_t> Offset;
+  std::string Detail;
 };
 
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/raiser.cpp
+++ b/amd/comgr/src/hotswap/raiser/raiser.cpp
@@ -8,6 +8,8 @@
 
 #include "raiser.h"
 
+#include "raise_failure.h"
+
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -31,50 +33,42 @@ constexpr llvm::StringLiteral AMDGPUTriple = "amdgcn-amd-amdhsa";
 // currently lives behind the comgr-metadata layer in `src/comgr.cpp` and
 // is not reachable from the hotswap subproject. As a stop-gap, validate
 // the AMDGPU processor name through `llvm::AMDGPU::parseArchAMDGCN`.
-RaiseFailure validateInputs(llvm::StringRef SourceISA,
-                            llvm::StringRef KernelName) {
-  RaiseFailure F;
-  if (SourceISA.empty()) {
-    F.Reason = RaiseFailureReason::BadInput;
-    F.Detail = "source ISA string is empty";
-    return F;
-  }
+llvm::Error validateInputs(llvm::StringRef SourceISA,
+                           llvm::StringRef KernelName) {
+  if (SourceISA.empty())
+    return RaiseFailure::general(RaiseFailureReason::BadInput,
+                                 "source ISA string is empty");
   // The disassembler-facing identifier is `<arch>-<vendor>-<os>-<env>-<gfx>`;
   // `parseArchAMDGCN` inspects the trailing component.
   llvm::StringRef GfxName = SourceISA.rsplit('-').second;
   if (GfxName.empty()) {
     GfxName = SourceISA;
   }
-  if (llvm::AMDGPU::parseArchAMDGCN(GfxName) == llvm::AMDGPU::GK_NONE) {
-    F.Reason = RaiseFailureReason::BadInput;
-    F.Detail =
-        ("source ISA '" + SourceISA + "' does not name an AMDGPU GPU").str();
-    return F;
-  }
-  if (KernelName.empty()) {
-    F.Reason = RaiseFailureReason::BadInput;
-    F.Detail = "kernel name is empty";
-    return F;
-  }
-  return F;
+  if (llvm::AMDGPU::parseArchAMDGCN(GfxName) == llvm::AMDGPU::GK_NONE)
+    return RaiseFailure::general(RaiseFailureReason::BadInput,
+                                 "source ISA '" + SourceISA +
+                                     "' does not name an AMDGPU GPU");
+  if (KernelName.empty())
+    return RaiseFailure::general(RaiseFailureReason::BadInput,
+                                 "kernel name is empty");
+  return llvm::Error::success();
 }
 
 } // namespace
 
-RaiseResult raiseToIR(llvm::StringRef SourceISA, llvm::StringRef KernelName,
-                      const KernelMeta &Meta) {
+llvm::Expected<RaiseResult> raiseToIR(llvm::StringRef SourceISA,
+                                      llvm::StringRef KernelName,
+                                      const KernelMeta &Meta) {
   using namespace llvm;
 
   // Meta becomes load-bearing once the decoder reconstructs the kernel
   // signature and ABI from it; the scaffolding only echoes the kernel name.
   (void)Meta;
 
-  RaiseResult Result;
-  Result.Failure = validateInputs(SourceISA, KernelName);
-  if (Result.Failure.hasFailed()) {
-    return Result;
-  }
+  if (Error E = validateInputs(SourceISA, KernelName))
+    return std::move(E);
 
+  RaiseResult Result;
   Result.Ctx = std::make_unique<LLVMContext>();
   LLVMContext &C = *Result.Ctx;
   Result.Module = std::make_unique<Module>("transpiler_module", C);
@@ -91,7 +85,6 @@ RaiseResult raiseToIR(llvm::StringRef SourceISA, llvm::StringRef KernelName,
   IRBuilder<> B(Entry);
   B.CreateRetVoid();
 
-  Result.Success = true;
   return Result;
 }
 

--- a/amd/comgr/src/hotswap/raiser/raiser.h
+++ b/amd/comgr/src/hotswap/raiser/raiser.h
@@ -10,9 +10,9 @@
 #define HOTSWAP_TRANSPILER_RAISER_H
 
 #include "hotswap/common/kernel-meta.h"
-#include "raise_failure.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
 
 #include <memory>
 
@@ -26,9 +26,6 @@ namespace COMGR::hotswap {
 struct RaiseResult {
   std::unique_ptr<llvm::LLVMContext> Ctx;
   std::unique_ptr<llvm::Module> Module;
-  // Structured failure description. `failure.reason == None` iff `success`.
-  RaiseFailure Failure;
-  bool Success = false;
 };
 
 // Raise a kernel named `KernelName` whose source ISA is `SourceISA`. `Meta`
@@ -39,8 +36,9 @@ struct RaiseResult {
 // `llvm::AMDGPU::parseArchAMDGCN`. The kernel-text bytes, kernel offset, and
 // compilation-target ISA become real parameters once the decoder is wired
 // in (subsequent commit).
-RaiseResult raiseToIR(llvm::StringRef SourceISA, llvm::StringRef KernelName,
-                      const KernelMeta &Meta);
+llvm::Expected<RaiseResult> raiseToIR(llvm::StringRef SourceISA,
+                                      llvm::StringRef KernelName,
+                                      const KernelMeta &Meta);
 
 } // namespace COMGR::hotswap
 

--- a/amd/comgr/src/hotswap/raiser/reg-file.cpp
+++ b/amd/comgr/src/hotswap/raiser/reg-file.cpp
@@ -1,0 +1,673 @@
+//===- reg-file.cpp - Hotswap transpiler ----------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "reg-file.h"
+
+#include "hotswap/decoder/isa-profile.h"
+#include "wave-projection.h"
+
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/Support/AMDGPUAddrSpace.h"
+#include "llvm/Support/ErrorHandling.h"
+
+#include <cassert>
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+namespace {
+
+// Human-readable name for a ParsedReg::Kind, used only in fatal-error messages.
+StringRef kindName(ParsedReg::Kind K) {
+  switch (K) {
+  case ParsedReg::SGPR:
+    return "SGPR";
+  case ParsedReg::VGPR:
+    return "VGPR";
+  case ParsedReg::AGPR:
+    return "AGPR";
+  case ParsedReg::VCC:
+    return "VCC";
+  case ParsedReg::EXEC:
+    return "EXEC";
+  case ParsedReg::SCC:
+    return "SCC";
+  case ParsedReg::MODE:
+    return "MODE";
+  case ParsedReg::M0:
+    return "M0";
+  case ParsedReg::FLAT_SCR:
+    return "FLAT_SCR";
+  case ParsedReg::TTMP:
+    return "TTMP";
+  case ParsedReg::LDS_DIRECT:
+    return "LDS_DIRECT";
+  case ParsedReg::SRC_VCCZ:
+    return "SRC_VCCZ";
+  case ParsedReg::SRC_EXECZ:
+    return "SRC_EXECZ";
+  case ParsedReg::SRC_SCC:
+    return "SRC_SCC";
+  case ParsedReg::VCC_HI_SCRATCH:
+    return "VCC_HI_SCRATCH";
+  case ParsedReg::EXEC_HI_SCRATCH:
+    return "EXEC_HI_SCRATCH";
+  case ParsedReg::NOREG:
+    return "NOREG";
+  case ParsedReg::OTHER:
+    return "OTHER";
+  }
+  return "<invalid>";
+}
+
+// The base register index an indexed register kind requires. An absent index
+// reaching an indexed kind is a raiser bug.
+unsigned requireIndex(const ParsedReg &Pr) {
+  assert(Pr.BaseIdx && "indexed register kind requires a base register index; "
+                       "raiser produced an invalid ParsedReg");
+  return *Pr.BaseIdx;
+}
+
+[[noreturn]] void failUnhandledKind(StringRef Fn, ParsedReg Pr) {
+  report_fatal_error(
+      Twine("transpiler: ") + Fn + ": unhandled ParsedReg Kind " +
+      kindName(Pr.RegKind) +
+      " (baseIdx=" + (Pr.BaseIdx ? Twine(*Pr.BaseIdx) : Twine("none")) +
+      ", width=" + Twine(Pr.WidthInDwords) +
+      "). Caller must handle NOREG / OTHER / MODE before "
+      "dispatching through the reg-file read/write paths.");
+}
+
+// A reg-file index reaching a per-class helper out of range means the caller
+// produced an invalid ParsedReg, which is always a raiser bug.
+template <typename BankT>
+void assertInBank([[maybe_unused]] const BankT &Bank,
+                  [[maybe_unused]] unsigned Idx) {
+  assert(Idx < Bank.size() && Bank[Idx] &&
+         "reg-file access out of range; raiser produced an invalid ParsedReg");
+}
+
+// 64-bit accesses touch idx and idx+1; both must be in range.
+template <typename BankT>
+void assertPairInBank([[maybe_unused]] const BankT &Bank,
+                      [[maybe_unused]] unsigned Idx) {
+  assert(Idx + 1 < Bank.size() && Bank[Idx] && Bank[Idx + 1] &&
+         "reg-file pair access out of range; raiser produced an invalid "
+         "ParsedReg");
+}
+
+// Reinterpret a value as i32 for a 32-bit register slot. The value must
+// already be 32 bits wide; only its type is changed.
+Value *asI32(IRBuilder<> &B, Value *V) {
+  Type *I32Ty = B.getInt32Ty();
+  if (V->getType() == I32Ty)
+    return V;
+  assert(V->getType()->getPrimitiveSizeInBits() == 32 &&
+         "32-bit register store expects a 32-bit value");
+  return B.CreateBitCast(V, I32Ty);
+}
+
+// Coerce an arbitrary scalar or pointer to i32 for a VGPR slot: pointers are
+// narrowed with ptrtoint, wider values truncated, equal-width values bitcast.
+Value *coerceToI32(IRBuilder<> &B, Value *V) {
+  Type *I32Ty = B.getInt32Ty();
+  if (V->getType() == I32Ty)
+    return V;
+  if (V->getType()->isPointerTy())
+    V = B.CreatePtrToInt(V, B.getInt64Ty());
+  unsigned Bits = V->getType()->getPrimitiveSizeInBits();
+  if (Bits == 32)
+    return B.CreateBitCast(V, I32Ty);
+  assert(Bits > 32 && "cannot widen a sub-32-bit value to a 32-bit slot");
+  return B.CreateTrunc(V, I32Ty);
+}
+
+// Coerce a 64-bit value or pointer to i64 for splitting into a register pair.
+Value *asI64(IRBuilder<> &B, Value *V) {
+  Type *I64Ty = B.getInt64Ty();
+  if (V->getType() == I64Ty)
+    return V;
+  if (V->getType()->isPointerTy())
+    return B.CreatePtrToInt(V, I64Ty);
+  assert(V->getType()->getPrimitiveSizeInBits() == 64 &&
+         "64-bit register store expects a 64-bit value");
+  return B.CreateBitCast(V, I64Ty);
+}
+
+// Store a 64-bit value as two i32 halves at Bank[Idx] and Bank[Idx + 1].
+void storeLoHi(IRBuilder<> &B, ArrayRef<AllocaInst *> Bank, unsigned Idx,
+               Value *V) {
+  Type *I32Ty = B.getInt32Ty();
+  V = asI64(B, V);
+  B.CreateStore(B.CreateTrunc(V, I32Ty), Bank[Idx]);
+  B.CreateStore(B.CreateTrunc(B.CreateLShr(V, 32), I32Ty), Bank[Idx + 1]);
+}
+
+// Combine two adjacent i32 halves at Bank[Idx] and Bank[Idx + 1] into an i64.
+Value *loadLoHi(IRBuilder<> &B, ArrayRef<AllocaInst *> Bank, unsigned Idx) {
+  Type *I32Ty = B.getInt32Ty();
+  Type *I64Ty = B.getInt64Ty();
+  Value *Lo = B.CreateZExt(B.CreateLoad(I32Ty, Bank[Idx]), I64Ty);
+  Value *Hi = B.CreateZExt(B.CreateLoad(I32Ty, Bank[Idx + 1]), I64Ty);
+  return B.CreateOr(Lo, B.CreateShl(Hi, 32));
+}
+
+} // namespace
+
+void AllocaRegFile::init(IRBuilder<> &B, Type *I32Ty, Type *I1Ty,
+                         const ISAProfile &Isa, const MCRegisterInfo &MRI,
+                         const WaveProjection &Proj) {
+  Projection = &Proj;
+
+  const unsigned NSgpr =
+      MRI.getRegClass(AMDGPU::SGPR_32RegClassID).getNumRegs();
+  Sgpr.assign(NSgpr, nullptr);
+  for (unsigned I = 0; I < NSgpr; ++I)
+    Sgpr[I] = B.CreateAlloca(I32Ty, nullptr, "Sgpr" + Twine(I));
+
+  // VGPR storage is oversized relative to TableGen's VGPR_32 class (see
+  // `KVGPRCap`). AGPR storage mirrors the VGPR size because AGPRs share
+  // the same index space under MFMA encoding conventions.
+  Vgpr.assign(KVGPRCap, nullptr);
+  for (unsigned I = 0; I < KVGPRCap; ++I)
+    Vgpr[I] = B.CreateAlloca(I32Ty, nullptr, "Vgpr" + Twine(I));
+
+  if (Isa.hasAgpr()) {
+    Agpr.assign(KVGPRCap, nullptr);
+    for (unsigned I = 0; I < KVGPRCap; ++I)
+      Agpr[I] = B.CreateAlloca(I32Ty, nullptr, "Agpr" + Twine(I));
+  }
+
+  // Condition-carrying scalar registers are zero-initialised so that a
+  // read-before-write yields a deterministic "false / inactive" value rather
+  // than poison, which would silently destroy predication.
+  Vcc = B.CreateAlloca(I1Ty, nullptr, "Vcc");
+  B.CreateStore(ConstantInt::getFalse(I1Ty), Vcc);
+  VccHiScratch = B.CreateAlloca(I32Ty, nullptr, "VccHiScratch");
+  B.CreateStore(ConstantInt::get(I32Ty, 0), VccHiScratch);
+  ExecHiScratch = B.CreateAlloca(I32Ty, nullptr, "ExecHiScratch");
+  B.CreateStore(ConstantInt::get(I32Ty, 0), ExecHiScratch);
+  Scc = B.CreateAlloca(I1Ty, nullptr, "Scc");
+  B.CreateStore(ConstantInt::getFalse(I1Ty), Scc);
+  // EXEC storage width and initial value are both chosen by the projection.
+  Exec = B.CreateAlloca(Proj.execStorageTy(), nullptr, "exec");
+  B.CreateStore(Proj.emitInitialExec(B), Exec);
+  M0 = B.CreateAlloca(I32Ty, nullptr, "M0");
+  B.CreateStore(ConstantInt::get(I32Ty, 0), M0);
+  FlatScr[0] = B.CreateAlloca(I32Ty, nullptr, "flat_scr_lo");
+  FlatScr[1] = B.CreateAlloca(I32Ty, nullptr, "flat_scr_hi");
+
+  const unsigned NTtmp =
+      MRI.getRegClass(AMDGPU::TTMP_32RegClassID).getNumRegs();
+  Ttmp.assign(NTtmp, nullptr);
+  for (unsigned I = 0; I < NTtmp; ++I)
+    Ttmp[I] = B.CreateAlloca(I32Ty, nullptr, "ttmp" + Twine(I));
+}
+
+void AllocaRegFile::storeSGPR32(IRBuilder<> &B, unsigned Idx, Value *V) {
+  assertInBank(Sgpr, Idx);
+  B.CreateStore(asI32(B, V), Sgpr[Idx]);
+  // Notify the per-SGPR write hook, if installed.
+  if (OnSgprWritten)
+    OnSgprWritten(Idx);
+}
+
+Value *AllocaRegFile::loadSGPR32(IRBuilder<> &B, unsigned Idx) {
+  assertInBank(Sgpr, Idx);
+  return B.CreateLoad(B.getInt32Ty(), Sgpr[Idx]);
+}
+
+void AllocaRegFile::storeSGPR64(IRBuilder<> &B, unsigned Idx, Value *V) {
+  assertPairInBank(Sgpr, Idx);
+  storeLoHi(B, Sgpr, Idx, V);
+  // A pair write touches both halves, so notify the hook for each.
+  if (OnSgprWritten) {
+    OnSgprWritten(Idx);
+    OnSgprWritten(Idx + 1);
+  }
+}
+
+Value *AllocaRegFile::loadSGPR64(IRBuilder<> &B, unsigned Idx) {
+  assertPairInBank(Sgpr, Idx);
+  return loadLoHi(B, Sgpr, Idx);
+}
+
+void AllocaRegFile::storeVGPR32(IRBuilder<> &B, unsigned Idx, Value *V) {
+  assertInBank(Vgpr, Idx);
+  B.CreateStore(coerceToI32(B, V), Vgpr[Idx]);
+}
+
+Value *AllocaRegFile::loadVGPR32(IRBuilder<> &B, unsigned Idx) {
+  assertInBank(Vgpr, Idx);
+  return B.CreateLoad(B.getInt32Ty(), Vgpr[Idx]);
+}
+
+void AllocaRegFile::storeVGPR64(IRBuilder<> &B, unsigned Idx, Value *V) {
+  assertPairInBank(Vgpr, Idx);
+  storeLoHi(B, Vgpr, Idx, V);
+}
+
+Value *AllocaRegFile::loadVGPR64(IRBuilder<> &B, unsigned Idx) {
+  assertPairInBank(Vgpr, Idx);
+  return loadLoHi(B, Vgpr, Idx);
+}
+
+void AllocaRegFile::storeAGPR32(IRBuilder<> &B, unsigned Idx, Value *V) {
+  assertInBank(Agpr, Idx);
+  B.CreateStore(asI32(B, V), Agpr[Idx]);
+}
+
+Value *AllocaRegFile::loadAGPR32(IRBuilder<> &B, unsigned Idx) {
+  assertInBank(Agpr, Idx);
+  return B.CreateLoad(B.getInt32Ty(), Agpr[Idx]);
+}
+
+void AllocaRegFile::storeVCC(IRBuilder<> &B, Value *V) {
+  if (V->getType() != B.getInt1Ty())
+    V = B.CreateICmpNE(V, Constant::getNullValue(V->getType()));
+  B.CreateStore(V, Vcc);
+}
+
+Value *AllocaRegFile::loadVCC(IRBuilder<> &B) {
+  return B.CreateLoad(B.getInt1Ty(), Vcc);
+}
+
+void AllocaRegFile::storeSCC(IRBuilder<> &B, Value *V) {
+  if (V->getType() != B.getInt1Ty())
+    V = B.CreateICmpNE(V, Constant::getNullValue(V->getType()));
+  B.CreateStore(V, Scc);
+}
+
+Value *AllocaRegFile::loadSCC(IRBuilder<> &B) {
+  return B.CreateLoad(B.getInt1Ty(), Scc);
+}
+
+Value *AllocaRegFile::loadExec(IRBuilder<> &B) {
+  return B.CreateLoad(Exec->getAllocatedType(), Exec, "exec_val");
+}
+
+void AllocaRegFile::storeExec(IRBuilder<> &B, Value *V) {
+  Type *ExecTy = Exec->getAllocatedType();
+  if (V->getType() != ExecTy)
+    V = B.CreateBitOrPointerCast(V, ExecTy);
+  B.CreateStore(V, Exec);
+  if (OnExecWritten)
+    OnExecWritten();
+}
+
+Value *AllocaRegFile::readVCCAsWaveMask(IRBuilder<> &B, Type *ResultTy) {
+  assert(Projection && "readVCCAsWaveMask requires a WaveProjection -- "
+                       "call init() before using this reg-file");
+  return Projection->ballotI1ToWidth(B, loadVCC(B), ResultTy, "vcc_ballot");
+}
+
+Value *AllocaRegFile::readReg32(IRBuilder<> &B, ParsedReg Pr) {
+  if (Pr.RegKind == ParsedReg::SGPR)
+    return loadSGPR32(B, requireIndex(Pr));
+  if (Pr.RegKind == ParsedReg::VGPR)
+    return loadVGPR32(B, requireIndex(Pr));
+  if (Pr.RegKind == ParsedReg::AGPR)
+    return loadAGPR32(B, requireIndex(Pr));
+  if (Pr.RegKind == ParsedReg::VCC_HI_SCRATCH)
+    return B.CreateLoad(B.getInt32Ty(), VccHiScratch, "vcc_hi_scratch");
+  if (Pr.RegKind == ParsedReg::EXEC_HI_SCRATCH)
+    return B.CreateLoad(B.getInt32Ty(), ExecHiScratch, "exec_hi_scratch");
+  // VCC read as a scalar goes through the wave-mask ballot, not a
+  // sign-extension of the local i1; callers wanting a per-lane i1 call
+  // `loadVCC` directly.
+  if (Pr.RegKind == ParsedReg::VCC)
+    return readVCCAsWaveMask(B, B.getInt32Ty());
+  if (Pr.RegKind == ParsedReg::EXEC) {
+    Value *V = loadExec(B);
+    Type *I32Ty = B.getInt32Ty();
+    if (V->getType() == I32Ty)
+      return V;
+    // wave64 EXEC is i64; pick the correct half when reading a 32-bit slice.
+    if (Pr.WidthInDwords >= 2)
+      return B.CreateTrunc(V, I32Ty, "exec_lo");
+    // A narrow read names EXEC_LO (index 0) or EXEC_HI (index 1); an absent
+    // index reads the low half.
+    unsigned Half = Pr.BaseIdx.value_or(0);
+    if (Half == 1)
+      V = B.CreateLShr(V, 32, "exec_hi_shr");
+    return B.CreateTrunc(V, I32Ty, Half == 1 ? "exec_hi" : "exec_lo");
+  }
+  if (Pr.RegKind == ParsedReg::SCC)
+    return B.CreateZExt(loadSCC(B), B.getInt32Ty());
+  if (Pr.RegKind == ParsedReg::M0)
+    return B.CreateLoad(B.getInt32Ty(), M0, "m0_val");
+  if (Pr.RegKind == ParsedReg::FLAT_SCR)
+    return B.CreateLoad(B.getInt32Ty(), FlatScr[0], "fscr_val");
+  if (Pr.RegKind == ParsedReg::TTMP && Pr.BaseIdx && *Pr.BaseIdx < Ttmp.size())
+    return B.CreateLoad(B.getInt32Ty(), Ttmp[*Pr.BaseIdx], "ttmp_val");
+  // GFX9 src_lds_direct (encoding 254) reads one dword from LDS at the byte
+  // address in M0; M0 is not auto-incremented, so the kernel manages it
+  // explicitly between reads.
+  if (Pr.RegKind == ParsedReg::LDS_DIRECT) {
+    Type *I32Ty = B.getInt32Ty();
+    Value *Addr = B.CreateLoad(I32Ty, M0, "m0_lds_off");
+    PointerType *LdsPtr =
+        PointerType::get(I32Ty->getContext(), AMDGPUAS::LOCAL_ADDRESS);
+    Value *Ptr = B.CreateIntToPtr(Addr, LdsPtr, "lds_direct_ptr");
+    return B.CreateLoad(I32Ty, Ptr, "lds_direct_val");
+  }
+  failUnhandledKind("readReg32", Pr);
+}
+
+Value *AllocaRegFile::readReg64(IRBuilder<> &B, ParsedReg Pr) {
+  if (Pr.RegKind == ParsedReg::SGPR)
+    return loadSGPR64(B, requireIndex(Pr));
+  if (Pr.RegKind == ParsedReg::VGPR)
+    return loadVGPR64(B, requireIndex(Pr));
+  if (Pr.RegKind == ParsedReg::VCC_HI_SCRATCH)
+    return B.CreateZExt(B.CreateLoad(B.getInt32Ty(), VccHiScratch),
+                        B.getInt64Ty());
+  if (Pr.RegKind == ParsedReg::EXEC_HI_SCRATCH)
+    return B.CreateZExt(B.CreateLoad(B.getInt32Ty(), ExecHiScratch),
+                        B.getInt64Ty());
+  // VCC read as a scalar routes through the wave-mask ballot: sign-extending
+  // the local i1 would replicate this lane's VCC bit across all bits, a silent
+  // lie when the consumer expects a wave-level mask (e.g. `s_and_b64 vcc, exec,
+  // vcc`).
+  if (Pr.RegKind == ParsedReg::VCC)
+    return readVCCAsWaveMask(B, B.getInt64Ty());
+  if (Pr.RegKind == ParsedReg::EXEC) {
+    Value *V = loadExec(B);
+    if (V->getType() != B.getInt64Ty())
+      V = B.CreateZExt(V, B.getInt64Ty(), "exec_ext");
+    return V;
+  }
+  if (Pr.RegKind == ParsedReg::M0)
+    return B.CreateZExt(B.CreateLoad(B.getInt32Ty(), M0, "m0_val"),
+                        B.getInt64Ty());
+  if (Pr.RegKind == ParsedReg::FLAT_SCR)
+    return loadLoHi(B, FlatScr, 0);
+  // TTMP pair read as i64, combining the two adjacent i32 lanes.
+  if (Pr.RegKind == ParsedReg::TTMP && Pr.BaseIdx &&
+      *Pr.BaseIdx + 1 < Ttmp.size())
+    return loadLoHi(B, Ttmp, *Pr.BaseIdx);
+  failUnhandledKind("readReg64", Pr);
+}
+
+Value *AllocaRegFile::readExecWidth(IRBuilder<> &B) { return loadExec(B); }
+
+void AllocaRegFile::writeExecWidth(IRBuilder<> &B, Value *V) {
+  storeExec(B, V);
+}
+
+void AllocaRegFile::writeReg32(IRBuilder<> &B, ParsedReg Pr, Value *V) {
+  if (Pr.RegKind == ParsedReg::SGPR) {
+    storeSGPR32(B, requireIndex(Pr), V);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::VGPR) {
+    storeVGPR32(B, requireIndex(Pr), V);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::AGPR) {
+    storeAGPR32(B, requireIndex(Pr), V);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::VCC_HI_SCRATCH ||
+      Pr.RegKind == ParsedReg::EXEC_HI_SCRATCH) {
+    // Wave32-source VCC_HI / EXEC_HI are plain 32-bit data scalars, never
+    // pointers (only address/control registers carry those). Coerce any
+    // non-i32 scalar width to i32.
+    assert(!V->getType()->isPointerTy() &&
+           "VCC_HI_SCRATCH/EXEC_HI_SCRATCH is a data scalar; pointer writes "
+           "are a raiser bug");
+    B.CreateStore(coerceToI32(B, V), Pr.RegKind == ParsedReg::VCC_HI_SCRATCH
+                                         ? VccHiScratch
+                                         : ExecHiScratch);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::EXEC) {
+    Type *I32Ty = B.getInt32Ty();
+    Type *ExecTy = Exec->getAllocatedType();
+    // Coerce the incoming value to i32; storeExec matches it to the EXEC
+    // storage width. For wave64-native EXEC (ExecTy == i64) a 32-bit write
+    // addresses a single half and is reconciled below.
+    V = coerceToI32(B, V);
+    if (ExecTy == I32Ty || Pr.WidthInDwords >= 2) {
+      storeExec(B, V);
+      return;
+    }
+    // ExecTy is i64 and the write is a single EXEC_LO (index 0) or EXEC_HI
+    // (index 1) half. When the projection broadcasts a narrow EXEC_LO write,
+    // the whole-wave mask is replicated into both halves; otherwise the other
+    // half is preserved.
+    unsigned Half = requireIndex(Pr);
+    Value *V64 = B.CreateZExt(V, ExecTy);
+    if (Projection && Projection->broadcastNarrowExecLoWrite() && Half == 0) {
+      Value *Hi = B.CreateShl(V64, 32);
+      Value *Merged = B.CreateOr(V64, Hi, "exec_lo_broadcast");
+      storeExec(B, Merged);
+      return;
+    }
+    Value *Cur = loadExec(B);
+    Value *Merged;
+    if (Half == 1) {
+      Value *Mask = ConstantInt::get(ExecTy, 0xFFFFFFFFULL);
+      Merged = B.CreateOr(B.CreateAnd(Cur, Mask), B.CreateShl(V64, 32),
+                          "exec_hi_write");
+    } else {
+      Value *Mask = ConstantInt::get(ExecTy, 0xFFFFFFFF00000000ULL);
+      Merged = B.CreateOr(B.CreateAnd(Cur, Mask), V64, "exec_lo_write");
+    }
+    storeExec(B, Merged);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::VCC) {
+    assert(Projection && "writeReg32(VCC) requires a WaveProjection");
+    storeVCC(B, Projection->extractLaneBitFromWaveMask(B, V));
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::M0) {
+    V = asI32(B, V);
+    B.CreateStore(V, M0);
+    if (OnM0Written)
+      OnM0Written(V);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::FLAT_SCR) {
+    B.CreateStore(asI32(B, V), FlatScr[0]);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::TTMP && Pr.BaseIdx &&
+      *Pr.BaseIdx < Ttmp.size()) {
+    B.CreateStore(asI32(B, V), Ttmp[*Pr.BaseIdx]);
+    return;
+  }
+  failUnhandledKind("writeReg32", Pr);
+}
+
+void AllocaRegFile::writeReg64(IRBuilder<> &B, ParsedReg Pr, Value *V) {
+  if (Pr.RegKind == ParsedReg::SGPR) {
+    storeSGPR64(B, requireIndex(Pr), V);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::VGPR) {
+    storeVGPR64(B, requireIndex(Pr), V);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::VCC) {
+    assert(Projection && "writeReg64(VCC) requires a WaveProjection");
+    storeVCC(B, Projection->extractLaneBitFromWaveMask(B, V));
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::EXEC) {
+    storeExec(B, V);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::FLAT_SCR) {
+    storeLoHi(B, FlatScr, 0, V);
+    return;
+  }
+  // Trap-handler kernels materialise a 64-bit address into a TTMP pair before
+  // invoking the trap; split it into two i32 stores at Idx and Idx+1.
+  if (Pr.RegKind == ParsedReg::TTMP && Pr.BaseIdx &&
+      *Pr.BaseIdx + 1 < Ttmp.size()) {
+    storeLoHi(B, Ttmp, *Pr.BaseIdx, V);
+    return;
+  }
+  failUnhandledKind("writeReg64", Pr);
+}
+
+void AllocaRegFile::writeRegExecWidth(IRBuilder<> &B, ParsedReg Pr, Value *V) {
+  if (Pr.RegKind == ParsedReg::SGPR) {
+    unsigned Idx = requireIndex(Pr);
+    // Under wave-native widening the EXEC storage is the wider target mask
+    // while a source-named SGPR stays at the source width, so narrow the
+    // incoming EXEC-width value to the source width before storing.
+    Type *SourceWidthTy =
+        (Projection && Projection->sourceWaveScopedLaneOps() &&
+         Pr.WidthInDwords >= 2)
+            ? B.getInt64Ty()
+            : (Projection ? Projection->sourceWaveMaskTy()
+                          : Exec->getAllocatedType());
+    if (V->getType() != SourceWidthTy) {
+      unsigned Have = V->getType()->getPrimitiveSizeInBits();
+      unsigned Want = SourceWidthTy->getPrimitiveSizeInBits();
+      if (Have > Want)
+        V = B.CreateTrunc(V, SourceWidthTy, "wn_exec_to_src_mask");
+      else if (Have < Want)
+        V = B.CreateZExt(V, SourceWidthTy, "wn_exec_to_src_mask");
+    }
+    if (SourceWidthTy == B.getInt32Ty())
+      storeSGPR32(B, Idx, V);
+    else
+      storeSGPR64(B, Idx, V);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::VCC_HI_SCRATCH ||
+      Pr.RegKind == ParsedReg::EXEC_HI_SCRATCH) {
+    // Wave32 vcc_hi / exec_hi are scratch scalars, not the wave mask.
+    writeReg32(B, Pr, V);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::VCC) {
+    assert(Projection && "writeRegExecWidth(VCC) requires a WaveProjection");
+    storeVCC(B, Projection->extractLaneBitFromWaveMask(B, V));
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::EXEC) {
+    storeExec(B, V);
+    return;
+  }
+  failUnhandledKind("writeRegExecWidth", Pr);
+}
+
+Value *AllocaRegFile::readRegVec(IRBuilder<> &B, ParsedReg Pr, Type *VecTy) {
+  FixedVectorType *VecT = dyn_cast<FixedVectorType>(VecTy);
+  unsigned N = VecT ? VecT->getNumElements() : 1;
+  Type *ElemTy = VecT ? VecT->getElementType() : VecTy;
+
+  if (N == 1 && !VecT && VecTy->getPrimitiveSizeInBits() <= 32) {
+    Value *V = readReg32(B, Pr);
+    if (V->getType() != VecTy)
+      V = B.CreateBitCast(V, VecTy);
+    return V;
+  }
+
+  unsigned TotalDwords = 0;
+  if (ElemTy->isFloatTy())
+    TotalDwords = N;
+  else if (ElemTy->isIntegerTy(32))
+    TotalDwords = N;
+  else if (ElemTy->isHalfTy())
+    TotalDwords = (N + 1) / 2;
+  else
+    TotalDwords = (N * ElemTy->getPrimitiveSizeInBits() + 31) / 32;
+
+  const unsigned Base = requireIndex(Pr);
+  SmallVector<Value *> Dwords;
+  for (unsigned I = 0; I < TotalDwords; ++I) {
+    ParsedReg Sub = Pr;
+    Sub.BaseIdx = Base + I;
+    Sub.WidthInDwords = 1;
+    Dwords.push_back(readReg32(B, Sub));
+  }
+
+  unsigned TotalBits = TotalDwords * 32;
+  Type *IntTy = Type::getIntNTy(B.getContext(), TotalBits);
+
+  Value *Packed = ConstantInt::get(IntTy, 0);
+  for (unsigned I = 0; I < TotalDwords; ++I) {
+    Value *Ext = B.CreateZExt(Dwords[I], IntTy);
+    if (I > 0)
+      Ext = B.CreateShl(Ext, I * 32);
+    Packed = B.CreateOr(Packed, Ext);
+  }
+  return B.CreateBitCast(Packed, VecTy);
+}
+
+void AllocaRegFile::writeRegVec(IRBuilder<> &B, ParsedReg Pr, Value *V) {
+  Type *Ty = V->getType();
+  unsigned TotalBits = Ty->getPrimitiveSizeInBits();
+  unsigned TotalDwords = (TotalBits + 31) / 32;
+
+  Type *IntTy = Type::getIntNTy(B.getContext(), TotalDwords * 32);
+  Type *I32Ty = B.getInt32Ty();
+  Value *Packed = B.CreateBitCast(V, IntTy);
+
+  const unsigned Base = requireIndex(Pr);
+  for (unsigned I = 0; I < TotalDwords; ++I) {
+    Value *Dw;
+    if (I == 0)
+      Dw = B.CreateTrunc(Packed, I32Ty);
+    else
+      Dw = B.CreateTrunc(B.CreateLShr(Packed, I * 32), I32Ty);
+    ParsedReg Sub = Pr;
+    Sub.BaseIdx = Base + I;
+    Sub.WidthInDwords = 1;
+    writeReg32(B, Sub, Dw);
+  }
+}
+
+void AllocaRegFile::collectAllocas(SmallVectorImpl<AllocaInst *> &Out) {
+  for (AllocaInst *A : Sgpr)
+    Out.push_back(A);
+  for (AllocaInst *A : Vgpr)
+    Out.push_back(A);
+  for (AllocaInst *A : Agpr)
+    Out.push_back(A);
+  if (Vcc)
+    Out.push_back(Vcc);
+  // VccHiScratch must be promoted too: a surviving private alloca would be
+  // moved to LDS by the AMDGPU backend, where it could alias the kernel's
+  // own LDS and be clobbered.
+  if (VccHiScratch)
+    Out.push_back(VccHiScratch);
+  // ExecHiScratch is promoted for the same reason as VccHiScratch.
+  if (ExecHiScratch)
+    Out.push_back(ExecHiScratch);
+  if (Scc)
+    Out.push_back(Scc);
+  if (Exec)
+    Out.push_back(Exec);
+  if (M0)
+    Out.push_back(M0);
+  for (AllocaInst *A : FlatScr)
+    if (A)
+      Out.push_back(A);
+  // ttmps must be promoted too: a surviving private alloca is moved to
+  // LDS by the AMDGPU backend, which re-enables dispatch_ptr and lets the
+  // register allocator reuse s[0:1], corrupting preloaded pointers.
+  for (AllocaInst *A : Ttmp)
+    Out.push_back(A);
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/reg-file.h
+++ b/amd/comgr/src/hotswap/raiser/reg-file.h
@@ -1,0 +1,130 @@
+//===- reg-file.h - Hotswap transpiler ------------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_REG_FILE_H
+#define HOTSWAP_TRANSPILER_REG_FILE_H
+
+#include "hotswap/decoder/parsed-reg.h"
+
+#include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Type.h"
+#include "llvm/IR/Value.h"
+
+#include <array>
+
+namespace llvm {
+class MCRegisterInfo;
+} // namespace llvm
+
+namespace COMGR::hotswap {
+
+class ISAProfile;
+class WaveProjection;
+
+// Per-register alloca-based representation of the AMDGPU register file. Every
+// architectural register gets its own alloca (i32, or i1 for VCC/SCC, i32/i64
+// for EXEC depending on wave width). Callers emit straight-line loads/stores;
+// the raiser later runs `PromoteMemToReg` to lift the allocas to SSA. Storage
+// is sized at `init()` time from the live subtarget's register classes, except
+// the VGPR/AGPR banks (see `KVGPRCap`).
+struct AllocaRegFile {
+  // VGPR/AGPR bank size. Not taken from the VGPR_32 register class: gfx1250
+  // S_SET_VGPR_MSB extends the addressable VGPR index range to 1024 (an 8-bit
+  // base plus a 2-bit MSB pair contributing value*256, so 255 + 3*256 = 1023),
+  // and the raiser needs storage for every reachable index.
+  static constexpr unsigned KVGPRCap = 1024;
+
+  llvm::SmallVector<llvm::AllocaInst *> Sgpr;
+  llvm::SmallVector<llvm::AllocaInst *> Vgpr;
+  llvm::SmallVector<llvm::AllocaInst *> Agpr;
+  llvm::SmallVector<llvm::AllocaInst *> Ttmp;
+  llvm::AllocaInst *Vcc = nullptr;
+  // Wave32-source scratch slot for VCC_HI. On a wave32 source VCC_HI is a free
+  // scalar; on a wave64 source it is a real half of the VCC mask and routes
+  // through Vcc.
+  llvm::AllocaInst *VccHiScratch = nullptr;
+  // Wave32-source scratch slot for EXEC_HI, symmetric with VccHiScratch.
+  llvm::AllocaInst *ExecHiScratch = nullptr;
+  llvm::AllocaInst *Scc = nullptr;
+  llvm::AllocaInst *Exec = nullptr;
+  llvm::AllocaInst *M0 = nullptr;
+  std::array<llvm::AllocaInst *, 2> FlatScr = {};
+
+  // Non-owning cross-wave projection policy, used by the VCC read/write paths
+  // (ballot for per-lane-i1 -> wave-mask and the inverse). Null when the reg
+  // file is used without a projection (e.g. unit tests); the VCC wave-mask
+  // paths are then unreachable.
+  const WaveProjection *Projection = nullptr;
+
+  // Invalidation hook fired on every EXEC-mutating store.
+  llvm::unique_function<void()> OnExecWritten;
+
+  // Invalidation hook fired on every per-SGPR store, once per 32-bit half.
+  llvm::unique_function<void(int)> OnSgprWritten;
+
+  // Tracking hook fired on every M0 store, passing the stored value.
+  llvm::unique_function<void(llvm::Value *)> OnM0Written;
+
+  // Initialise storage. `MRI` supplies the architectural SGPR_32 / TTMP_32
+  // register-class sizes; `Isa.hasAgpr()` selects whether to allocate AGPR
+  // slots; `Proj` is retained as a non-owning pointer for the VCC read/write
+  // paths.
+  void init(llvm::IRBuilder<> &B, llvm::Type *I32Ty, llvm::Type *I1Ty,
+            const ISAProfile &Isa, const llvm::MCRegisterInfo &MRI,
+            const WaveProjection &Proj);
+
+  // Direct per-class store/load helpers. `Idx` must be in range for the
+  // corresponding class; an out-of-range index is a raiser bug and
+  // fatal-errors.
+  void storeSGPR32(llvm::IRBuilder<> &B, unsigned Idx, llvm::Value *V);
+  llvm::Value *loadSGPR32(llvm::IRBuilder<> &B, unsigned Idx);
+  void storeSGPR64(llvm::IRBuilder<> &B, unsigned Idx, llvm::Value *V);
+  llvm::Value *loadSGPR64(llvm::IRBuilder<> &B, unsigned Idx);
+  void storeVGPR32(llvm::IRBuilder<> &B, unsigned Idx, llvm::Value *V);
+  llvm::Value *loadVGPR32(llvm::IRBuilder<> &B, unsigned Idx);
+  void storeVGPR64(llvm::IRBuilder<> &B, unsigned Idx, llvm::Value *V);
+  llvm::Value *loadVGPR64(llvm::IRBuilder<> &B, unsigned Idx);
+  void storeAGPR32(llvm::IRBuilder<> &B, unsigned Idx, llvm::Value *V);
+  llvm::Value *loadAGPR32(llvm::IRBuilder<> &B, unsigned Idx);
+
+  void storeVCC(llvm::IRBuilder<> &B, llvm::Value *V);
+  llvm::Value *loadVCC(llvm::IRBuilder<> &B);
+  void storeSCC(llvm::IRBuilder<> &B, llvm::Value *V);
+  llvm::Value *loadSCC(llvm::IRBuilder<> &B);
+  llvm::Value *loadExec(llvm::IRBuilder<> &B);
+  void storeExec(llvm::IRBuilder<> &B, llvm::Value *V);
+
+  // Read VCC as a wave-level bit-mask of width `ResultTy` through the wave
+  // projection. Requires `init()` to have supplied a projection.
+  llvm::Value *readVCCAsWaveMask(llvm::IRBuilder<> &B, llvm::Type *ResultTy);
+
+  // Generic read/write by ParsedReg.
+  llvm::Value *readReg32(llvm::IRBuilder<> &B, ParsedReg Pr);
+  llvm::Value *readReg64(llvm::IRBuilder<> &B, ParsedReg Pr);
+  llvm::Value *readExecWidth(llvm::IRBuilder<> &B);
+  void writeExecWidth(llvm::IRBuilder<> &B, llvm::Value *V);
+  void writeReg32(llvm::IRBuilder<> &B, ParsedReg Pr, llvm::Value *V);
+  void writeReg64(llvm::IRBuilder<> &B, ParsedReg Pr, llvm::Value *V);
+  void writeRegExecWidth(llvm::IRBuilder<> &B, ParsedReg Pr, llvm::Value *V);
+
+  // Read/write N dwords as a vector from contiguous VGPRs/AGPRs.
+  llvm::Value *readRegVec(llvm::IRBuilder<> &B, ParsedReg Pr,
+                          llvm::Type *VecTy);
+  void writeRegVec(llvm::IRBuilder<> &B, ParsedReg Pr, llvm::Value *V);
+
+  // Populate `Out` with every alloca the raiser emitted, for feeding
+  // into `PromoteMemToReg`.
+  void collectAllocas(llvm::SmallVectorImpl<llvm::AllocaInst *> &Out);
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/raiser/wave-projection.cpp
+++ b/amd/comgr/src/hotswap/raiser/wave-projection.cpp
@@ -66,7 +66,7 @@ Value *WaveProjection::emitLaneIdx(IRBuilder<> &B) const {
   Value *AllOnes = ConstantInt::getSigned(I32Ty, -1);
   Value *Zero32 = ConstantInt::get(I32Ty, 0);
   Value *LaneId = EB.CreateCall(MbcntLo, {AllOnes, Zero32}, "lane_lo");
-  if (WaveMaskTy != I32Ty) {
+  if (waveMaskTy() != I32Ty) {
     Function *MbcntHi =
         Intrinsic::getOrInsertDeclaration(M, Intrinsic::amdgcn_mbcnt_hi);
     LaneId = EB.CreateCall(MbcntHi, {AllOnes, LaneId}, "lane_id");
@@ -242,7 +242,7 @@ Value *ReplicationProjection::ballotI1ToWidth(IRBuilder<> &B, Value *Pred,
       M, Intrinsic::amdgcn_ballot, {waveMaskTy()});
   Value *WaveMask = B.CreateCall(Ballot, {Pred}, Name);
   unsigned WantedBits = ResultTy->getPrimitiveSizeInBits();
-  unsigned WaveBits = WaveMaskTy->getPrimitiveSizeInBits();
+  unsigned WaveBits = waveMaskTy()->getPrimitiveSizeInBits();
   assert(WantedBits <= WaveBits &&
          "ballotI1ToWidth: wantedBits > waveBits (wave64 source on wave32 "
          "target) has no replication projection; this direction needs "
@@ -267,7 +267,7 @@ Value *ReplicationProjection::extractLaneBitFromWaveMask(IRBuilder<> &B,
   Type *I64Ty = B.getInt64Ty();
   if (V->getType()->isPointerTy())
     V = B.CreatePtrToInt(V, I64Ty);
-  Type *TargetTy = WaveMaskTy;
+  Type *TargetTy = waveMaskTy();
   unsigned SrcBits = V->getType()->getPrimitiveSizeInBits();
   unsigned DstBits = TargetTy->getPrimitiveSizeInBits();
   if (SrcBits < DstBits) {
@@ -350,8 +350,8 @@ Value *ReplicationDoubledDispatchProjection::emitPackedWorkitemId(
 // ----------------------------------------------------------------------------
 // WaveNativeProjection -- widening (wave32 -> wave64).
 //
-// The target is wave64, so WaveMaskTy is i64; this projection uses it for both
-// the EXEC alloca storage and the ballot/lane-active arithmetic.
+// The target is wave64, so waveMaskTy() is i64; this projection uses it for
+// both the EXEC alloca storage and the ballot/lane-active arithmetic.
 // ----------------------------------------------------------------------------
 
 WaveNativeProjection::WaveNativeProjection(const ISAProfile &SrcIsa,
@@ -370,7 +370,7 @@ WaveNativeProjection::WaveNativeProjection(const ISAProfile &SrcIsa,
   // EXEC=-1 kernel-wide, so mbcnt-derived EXEC writes project into independent
   // target-width masks and a narrow EXEC_LO write broadcasts across both
   // halves.
-  ExecStorageTy = WaveMaskTy;
+  ExecStorageTy = waveMaskTy();
   NumSourceWavesPerTarget = 2;
   BroadcastNarrowExecLoWrite = true;
   ProvidesFullWaveExecInvariant = true;
@@ -389,17 +389,17 @@ Value *WaveNativeProjection::emitInitialExec(IRBuilder<> &B) const {
       Intrinsic::getOrInsertDeclaration(M, Intrinsic::amdgcn_init_whole_wave);
   Value *OriginalActive = B.CreateCall(InitWw, {}, "orig_active");
   // Ballot the per-lane i1 into a wave-width mask via the projection's own
-  // ballot so the result type matches WaveMaskTy.
-  return ballotI1ToWidth(B, OriginalActive, WaveMaskTy, "saved_exec");
+  // ballot so the result type matches waveMaskTy().
+  return ballotI1ToWidth(B, OriginalActive, waveMaskTy(), "saved_exec");
 }
 
 Value *WaveNativeProjection::emitLaneActiveBit(IRBuilder<> &B,
                                                Value *ExecVal) const {
-  // Target lane L is active iff bit L of the widened EXEC (WaveMaskTy) is set;
-  // the shift index is the full target lane id, with no modulo fold.
+  // Target lane L is active iff bit L of the widened EXEC (waveMaskTy()) is
+  // set; the shift index is the full target lane id, with no modulo fold.
   Value *LaneId = emitLaneIdx(B);
   Type *ExecTy = ExecVal->getType();
-  assert(ExecTy == WaveMaskTy &&
+  assert(ExecTy == waveMaskTy() &&
          "WaveNativeProjection requires EXEC storage to match the "
          "target wave mask width; caller must size the alloca via "
          "execStorageTy()");
@@ -419,7 +419,7 @@ Value *WaveNativeProjection::ballotI1ToWidth(IRBuilder<> &B, Value *Pred,
       M, Intrinsic::amdgcn_ballot, {waveMaskTy()});
   Value *WaveMask = B.CreateCall(Ballot, {Pred}, Name);
   unsigned WantedBits = ResultTy->getPrimitiveSizeInBits();
-  unsigned WaveBits = WaveMaskTy->getPrimitiveSizeInBits();
+  unsigned WaveBits = waveMaskTy()->getPrimitiveSizeInBits();
   assert(WantedBits <= WaveBits &&
          "WaveNativeProjection::ballotI1ToWidth: wantedBits > waveBits "
          "is not defined for wave32 source -> wave64 target cross-"
@@ -443,7 +443,7 @@ Value *WaveNativeProjection::extractLaneBitFromWaveMask(IRBuilder<> &B,
   Type *I64Ty = B.getInt64Ty();
   if (V->getType()->isPointerTy())
     V = B.CreatePtrToInt(V, I64Ty);
-  Type *TargetTy = WaveMaskTy;
+  Type *TargetTy = waveMaskTy();
   unsigned SrcBits = V->getType()->getPrimitiveSizeInBits();
   unsigned DstBits = TargetTy->getPrimitiveSizeInBits();
   if (SrcBits < DstBits) {
@@ -509,7 +509,7 @@ ThreadLoopProjection::ThreadLoopProjection(const ISAProfile &SrcIsa,
          "ThreadLoopProjection requires target wave size to be an integer "
          "multiple of source wave size");
 
-  ExecStorageTy = WaveMaskTy;
+  ExecStorageTy = waveMaskTy();
   NumSourceWavesPerTarget = TgtIsa.waveSize() / SrcIsa.waveSize();
   SourceWaveScopedLaneOps = true;
 }
@@ -559,7 +559,7 @@ Value *ThreadLoopProjection::ballotI1ToWidth(IRBuilder<> &B, Value *Pred,
       M, Intrinsic::amdgcn_ballot, {waveMaskTy()});
   Value *WaveMask = B.CreateCall(Ballot, {Pred}, Name);
   const unsigned WantedBits = ResultTy->getPrimitiveSizeInBits();
-  const unsigned WaveBits = WaveMaskTy->getPrimitiveSizeInBits();
+  const unsigned WaveBits = waveMaskTy()->getPrimitiveSizeInBits();
   assert(WantedBits <= WaveBits &&
          "ThreadLoopProjection::ballotI1ToWidth requires resultTy <= target "
          "wave mask width");
@@ -574,7 +574,7 @@ Value *ThreadLoopProjection::extractLaneBitFromWaveMask(IRBuilder<> &B,
     return V;
   Type *TargetTy = V->getType()->getPrimitiveSizeInBits() >
                            sourceWaveMaskTy()->getPrimitiveSizeInBits()
-                       ? WaveMaskTy
+                       ? waveMaskTy()
                        : sourceWaveMaskTy();
   unsigned SrcBits = V->getType()->getPrimitiveSizeInBits();
   unsigned DstBits = TargetTy->getPrimitiveSizeInBits();
@@ -589,7 +589,7 @@ Value *ThreadLoopProjection::extractLaneBitFromWaveMask(IRBuilder<> &B,
   Value *LaneIdxExt =
       B.CreateZExtOrTrunc(LaneIdx, TargetTy, "tl_mask_lane_idx");
   Value *ShiftIdx =
-      (TargetTy == WaveMaskTy)
+      (TargetTy == waveMaskTy())
           ? LaneIdxExt
           : B.CreateAnd(LaneIdxExt, ConstantInt::get(TargetTy, DstBits - 1),
                         "tl_mask_lane_mod");

--- a/amd/comgr/src/hotswap/raiser/wave-projection.h
+++ b/amd/comgr/src/hotswap/raiser/wave-projection.h
@@ -36,7 +36,6 @@ public:
   WaveProjection(const ISAProfile &SrcIsa, const ISAProfile &TgtIsa,
                  llvm::Type *I32Ty, llvm::Type *I64Ty)
       : Src(SrcIsa), Tgt(TgtIsa), I32Ty(I32Ty), I64Ty(I64Ty),
-        WaveMaskTy(TgtIsa.isWave32() ? I32Ty : I64Ty),
         ExecStorageTy(SrcIsa.isWave32() ? I32Ty : I64Ty) {}
 
   virtual ~WaveProjection() = default;
@@ -51,7 +50,7 @@ public:
   // Hardware-width wave mask (i32 on wave32 target, i64 on wave64 target).
   // Distinct from the EXEC alloca storage width returned by
   // `execStorageTy()`.
-  llvm::Type *waveMaskTy() const { return WaveMaskTy; }
+  llvm::Type *waveMaskTy() const { return Tgt.isWave32() ? I32Ty : I64Ty; }
 
   // Wave mask at the source ISA's width (i32 on wave32 source, i64 on wave64):
   // the width the source observes when reading or writing EXEC and SGPR wave
@@ -184,13 +183,12 @@ protected:
 
   ISAProfile Src;
   ISAProfile Tgt;
-  // Retained on the base so `sourceWaveMaskTy()` / `execStorageTy()` can
-  // return the canonical i32/i64 IR types without re-deriving them from the
-  // current IRBuilder's context (subclasses are constructed once per kernel
-  // and outlive any particular builder).
+  // Retained on the base so `waveMaskTy()` / `sourceWaveMaskTy()` /
+  // `execStorageTy()` can return the canonical i32/i64 IR types without
+  // re-deriving them from the current IRBuilder's context (subclasses are
+  // constructed once per kernel and outlive any particular builder).
   llvm::Type *I32Ty;
   llvm::Type *I64Ty;
-  llvm::Type *WaveMaskTy;
 
   // Per-projection configuration, read through the like-named accessors
   // above. The defaults describe the same-wave / replication policy;

--- a/amd/comgr/test-unit/hotswap/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/CMakeLists.txt
@@ -6,7 +6,8 @@ if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   add_subdirectory(raiser)
   add_subdirectory(decoder)
   list(APPEND COMGR_HOTSWAP_TEST_TARGETS
-    RaiserScaffoldingTests WaveProjectionTests DecoderTests)
+    RaiserScaffoldingTests WaveProjectionTests RaiseFailureTests RegFileTests
+    DecoderTests)
 endif()
 
 # The test binaries above, exported to the parent scope so the top-level

--- a/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
@@ -58,3 +58,57 @@ target_include_directories(WaveProjectionTests PRIVATE
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
 
 comgr_configure_test_target(WaveProjectionTests)
+
+# -- RaiseFailureTests --------------------------------------------------------
+#
+# Pins the RaiseFailure value type: the shape factories, the optional
+# format/offset accessors, and the stable reasonString / log diagnostic text.
+
+add_executable(RaiseFailureTests
+  RaiseFailureTest.cpp)
+
+# RaiseFailure lives in hotswap::raiser. That OBJECT library also carries the
+# reg file and wave projection, which reach into hotswap::decoder, so link both.
+target_link_libraries(RaiseFailureTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  hotswap::raiser
+  hotswap::decoder
+  hotswap::common
+  ${LLVM_PTHREAD_LIB})
+
+target_include_directories(RaiseFailureTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+
+comgr_configure_test_target(RaiseFailureTests)
+
+# -- RegFileTests -------------------------------------------------------------
+#
+# Round-trips values through AllocaRegFile's ParsedReg dispatch, then promotes
+# the allocas to SSA and constant-folds to confirm the value survives. Needs
+# TransformUtils (PromoteMemToReg) and Analysis (constant folding) on top of the
+# component set hotswap::decoder carries.
+
+add_executable(RegFileTests
+  RegFileTest.cpp)
+
+llvm_map_components_to_libnames(COMGR_TEST_UNIT_REGFILE_LIBS
+  Analysis TransformUtils)
+
+target_link_libraries(RegFileTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  hotswap::raiser
+  hotswap::decoder
+  hotswap::common
+  ${COMGR_TEST_UNIT_REGFILE_LIBS}
+  ${LLVM_PTHREAD_LIB})
+
+target_include_directories(RegFileTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+
+comgr_configure_test_target(RegFileTests)

--- a/amd/comgr/test-unit/hotswap/raiser/RaiseFailureTest.cpp
+++ b/amd/comgr/test-unit/hotswap/raiser/RaiseFailureTest.cpp
@@ -1,0 +1,130 @@
+//===- RaiseFailureTest.cpp - structured raise-failure unit tests ---------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Unit tests for the RaiseFailure error payload: the three shape factories
+// return an llvm::Error carrying a RaiseFailure, and these tests inspect the
+// payload's reason, the optional format/offset accessors, and the stable
+// reasonString / log diagnostic text.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hotswap/raiser/raise_failure.h"
+
+#include "llvm/Support/Error.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "gtest/gtest.h"
+
+#include <mutex>
+
+// Linking hotswap::raiser drags in the sibling objects (the reg file and wave
+// projection), whose decoder dependency calls COMGR::ensureLLVMInitialized. Its
+// production definition lives in libamd_comgr; provide the registration here so
+// the test binary links without pulling in the full Comgr.
+namespace COMGR {
+void ensureLLVMInitialized() {
+  static std::once_flag Once;
+  std::call_once(Once, [] {
+    LLVMInitializeAMDGPUTargetInfo();
+    LLVMInitializeAMDGPUTargetMC();
+    LLVMInitializeAMDGPUDisassembler();
+    LLVMInitializeAMDGPUAsmParser();
+    LLVMInitializeAMDGPUAsmPrinter();
+    LLVMInitializeAMDGPUTarget();
+  });
+}
+} // namespace COMGR
+
+using COMGR::hotswap::RaiseFailure;
+using COMGR::hotswap::RaiseFailureReason;
+using COMGR::hotswap::reasonString;
+
+namespace {
+
+std::string toLog(const RaiseFailure &F) {
+  std::string S;
+  llvm::raw_string_ostream OS(S);
+  F.log(OS);
+  return S;
+}
+
+// Run Check on the single RaiseFailure the factory returns, asserting the error
+// is exactly one RaiseFailure.
+template <typename FnT> void inspect(llvm::Error E, FnT Check) {
+  ASSERT_TRUE(static_cast<bool>(E));
+  unsigned Handled = 0;
+  llvm::handleAllErrors(std::move(E), [&](const RaiseFailure &F) {
+    ++Handled;
+    Check(F);
+  });
+  EXPECT_EQ(Handled, 1u);
+}
+
+TEST(RaiseFailure, GeneralCarriesOnlyReasonAndDetail) {
+  inspect(RaiseFailure::general(RaiseFailureReason::BadInput,
+                                "source ISA string is empty"),
+          [](const RaiseFailure &F) {
+            EXPECT_EQ(F.reason(), RaiseFailureReason::BadInput);
+            EXPECT_EQ(F.detail().str(), "source ISA string is empty");
+            EXPECT_TRUE(F.mnemonic().empty());
+            EXPECT_FALSE(F.offset().has_value());
+            EXPECT_FALSE(F.format().has_value());
+            EXPECT_EQ(toLog(F), "BadInput :: source ISA string is empty");
+          });
+}
+
+TEST(RaiseFailure, AtInstructionLocatesTheInstruction) {
+  inspect(RaiseFailure::atInstruction(RaiseFailureReason::UnsupportedOpcode,
+                                      "v_foo_e32", 0x2c, "VALU",
+                                      "operand shape not modelled"),
+          [](const RaiseFailure &F) {
+            EXPECT_EQ(F.reason(), RaiseFailureReason::UnsupportedOpcode);
+            EXPECT_EQ(F.mnemonic().str(), "v_foo_e32");
+            ASSERT_TRUE(F.offset().has_value());
+            EXPECT_EQ(*F.offset(), 0x2cu);
+            ASSERT_TRUE(F.format().has_value());
+            EXPECT_EQ(F.format()->str(), "VALU");
+            EXPECT_EQ(toLog(F),
+                      "UnsupportedOpcode: v_foo_e32 [VALU] @offset=0x2c "
+                      ":: operand shape not modelled");
+          });
+}
+
+TEST(RaiseFailure, AtInstructionAllowsAnEmptyDetail) {
+  inspect(RaiseFailure::atInstruction(RaiseFailureReason::UnsupportedOpcode,
+                                      "s_bar", 0, "SOP1"),
+          [](const RaiseFailure &F) {
+            EXPECT_TRUE(F.detail().empty());
+            EXPECT_EQ(toLog(F), "UnsupportedOpcode: s_bar [SOP1] @offset=0x0");
+          });
+}
+
+TEST(RaiseFailure, InKernelFormatsTheKernelScopedMessage) {
+  inspect(RaiseFailure::inKernel(RaiseFailureReason::MissingKernelDescriptor,
+                                 "my_kernel", ".kd symbol not parsed"),
+          [](const RaiseFailure &F) {
+            EXPECT_EQ(F.reason(), RaiseFailureReason::MissingKernelDescriptor);
+            EXPECT_TRUE(F.mnemonic().empty());
+            EXPECT_FALSE(F.offset().has_value());
+            EXPECT_FALSE(F.format().has_value());
+            EXPECT_EQ(F.detail().str(),
+                      "kernel 'my_kernel': .kd symbol not parsed");
+          });
+}
+
+TEST(RaiseFailure, ReasonStringTokensAreStable) {
+  EXPECT_EQ(reasonString(RaiseFailureReason::None), "None");
+  EXPECT_EQ(reasonString(RaiseFailureReason::BadInput), "BadInput");
+  EXPECT_EQ(reasonString(RaiseFailureReason::UnsupportedInstructionForm),
+            "unsupported-instruction-form");
+  EXPECT_EQ(reasonString(RaiseFailureReason::CrossWaveLaneIdLeak),
+            "cross-wave-lane-id-leak");
+}
+
+} // namespace

--- a/amd/comgr/test-unit/hotswap/raiser/RaiserScaffoldingTest.cpp
+++ b/amd/comgr/test-unit/hotswap/raiser/RaiserScaffoldingTest.cpp
@@ -9,13 +9,16 @@
 // Pins the scaffolding contract `raiseToIR` advertises: an empty input
 // produces a well-formed `llvm::Module` containing one `AMDGPU_KERNEL`
 // function whose body is exactly `ret void`, with the AMDGPU triple set.
-// Empty inputs succeed; malformed ISA inputs are rejected with a structured
-// failure. Descriptor presence is enforced upstream by the code-object loader,
-// so it is no longer a raiser precondition.
+// Empty inputs succeed; malformed ISA inputs are rejected with a BadInput
+// RaiseFailure carried in the returned `llvm::Error`. Descriptor presence is
+// enforced upstream by the code-object loader, so it is no longer a raiser
+// precondition.
 //
 //===----------------------------------------------------------------------===//
 
 #include "hotswap/raiser/raiser.h"
+
+#include "hotswap/raiser/raise_failure.h"
 
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/CallingConv.h"
@@ -23,6 +26,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -49,47 +53,59 @@ void ensureLLVMInitialized() {
 }
 } // namespace COMGR
 
+using COMGR::hotswap::KernelMeta;
+using COMGR::hotswap::RaiseFailure;
+using COMGR::hotswap::RaiseFailureReason;
+using COMGR::hotswap::RaiseResult;
+using COMGR::hotswap::raiseToIR;
+
 namespace {
 
-COMGR::hotswap::KernelMeta makeKernelMeta(llvm::StringRef Name) {
-  COMGR::hotswap::KernelMeta Meta;
+KernelMeta makeKernelMeta(llvm::StringRef Name) {
+  KernelMeta Meta;
   Meta.Name = Name.str();
   return Meta;
+}
+
+// The RaiseFailureReason a refused raise reports, or None if the error was not
+// a RaiseFailure.
+RaiseFailureReason refusalReason(llvm::Error E) {
+  RaiseFailureReason Reason = RaiseFailureReason::None;
+  llvm::handleAllErrors(std::move(E),
+                        [&](const RaiseFailure &F) { Reason = F.reason(); });
+  return Reason;
 }
 
 } // namespace
 
 TEST(RaiserScaffolding, EmptyInputProducesValidModule) {
-  COMGR::hotswap::KernelMeta Meta = makeKernelMeta("kernel");
-  COMGR::hotswap::RaiseResult Result =
-      COMGR::hotswap::raiseToIR("gfx942", "kernel", Meta);
+  KernelMeta Meta = makeKernelMeta("kernel");
+  llvm::Expected<RaiseResult> Result = raiseToIR("gfx942", "kernel", Meta);
 
-  ASSERT_TRUE(Result.Success);
-  ASSERT_NE(Result.Ctx, nullptr);
-  ASSERT_NE(Result.Module, nullptr);
+  ASSERT_TRUE(static_cast<bool>(Result)) << llvm::toString(Result.takeError());
+  ASSERT_NE(Result->Ctx, nullptr);
+  ASSERT_NE(Result->Module, nullptr);
 
   std::string Err;
   llvm::raw_string_ostream ErrStream(Err);
-  EXPECT_FALSE(llvm::verifyModule(*Result.Module, &ErrStream)) << Err;
+  EXPECT_FALSE(llvm::verifyModule(*Result->Module, &ErrStream)) << Err;
 }
 
 TEST(RaiserScaffolding, ModuleAdvertisesAMDGPUTriple) {
-  COMGR::hotswap::KernelMeta Meta = makeKernelMeta("kernel");
-  COMGR::hotswap::RaiseResult Result =
-      COMGR::hotswap::raiseToIR("gfx942", "kernel", Meta);
+  KernelMeta Meta = makeKernelMeta("kernel");
+  llvm::Expected<RaiseResult> Result = raiseToIR("gfx942", "kernel", Meta);
 
-  ASSERT_TRUE(Result.Success);
-  ASSERT_NE(Result.Module, nullptr);
-  EXPECT_EQ(Result.Module->getTargetTriple().str(), "amdgcn-amd-amdhsa");
+  ASSERT_TRUE(static_cast<bool>(Result)) << llvm::toString(Result.takeError());
+  ASSERT_NE(Result->Module, nullptr);
+  EXPECT_EQ(Result->Module->getTargetTriple().str(), "amdgcn-amd-amdhsa");
 }
 
 TEST(RaiserScaffolding, KernelFunctionIsAMDGPUKernelWithRetVoid) {
-  COMGR::hotswap::KernelMeta Meta = makeKernelMeta("kernel");
-  COMGR::hotswap::RaiseResult Result =
-      COMGR::hotswap::raiseToIR("gfx942", "kernel", Meta);
+  KernelMeta Meta = makeKernelMeta("kernel");
+  llvm::Expected<RaiseResult> Result = raiseToIR("gfx942", "kernel", Meta);
 
-  ASSERT_TRUE(Result.Success);
-  llvm::Function *Fn = Result.Module->getFunction("kernel");
+  ASSERT_TRUE(static_cast<bool>(Result)) << llvm::toString(Result.takeError());
+  llvm::Function *Fn = Result->Module->getFunction("kernel");
   ASSERT_NE(Fn, nullptr);
   EXPECT_EQ(Fn->getCallingConv(), llvm::CallingConv::AMDGPU_KERNEL);
   ASSERT_EQ(Fn->size(), 1u);
@@ -99,19 +115,18 @@ TEST(RaiserScaffolding, KernelFunctionIsAMDGPUKernelWithRetVoid) {
 }
 
 TEST(RaiserScaffolding, EmptyTargetIsaIsRejected) {
-  COMGR::hotswap::KernelMeta Meta = makeKernelMeta("kernel");
-  COMGR::hotswap::RaiseResult Result =
-      COMGR::hotswap::raiseToIR("", "kernel", Meta);
+  KernelMeta Meta = makeKernelMeta("kernel");
+  llvm::Expected<RaiseResult> Result = raiseToIR("", "kernel", Meta);
 
-  EXPECT_FALSE(Result.Success);
-  EXPECT_TRUE(Result.Failure.hasFailed());
+  ASSERT_FALSE(static_cast<bool>(Result));
+  EXPECT_EQ(refusalReason(Result.takeError()), RaiseFailureReason::BadInput);
 }
 
 TEST(RaiserScaffolding, MalformedTargetIsaIsRejected) {
-  COMGR::hotswap::KernelMeta Meta = makeKernelMeta("kernel");
-  COMGR::hotswap::RaiseResult Result =
-      COMGR::hotswap::raiseToIR("not-a-real-isa", "kernel", Meta);
+  KernelMeta Meta = makeKernelMeta("kernel");
+  llvm::Expected<RaiseResult> Result =
+      raiseToIR("not-a-real-isa", "kernel", Meta);
 
-  EXPECT_FALSE(Result.Success);
-  EXPECT_TRUE(Result.Failure.hasFailed());
+  ASSERT_FALSE(static_cast<bool>(Result));
+  EXPECT_EQ(refusalReason(Result.takeError()), RaiseFailureReason::BadInput);
 }

--- a/amd/comgr/test-unit/hotswap/raiser/RegFileTest.cpp
+++ b/amd/comgr/test-unit/hotswap/raiser/RegFileTest.cpp
@@ -1,0 +1,267 @@
+//===- RegFileTest.cpp - alloca register-file unit tests ------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Unit tests for AllocaRegFile. The reg file exists to be written and read
+// with straight-line stores/loads and then lifted to SSA by PromoteMemToReg,
+// so the tests write a constant through the generic ParsedReg dispatch, read it
+// back, promote, constant-fold, and check the value survives the round trip. A
+// structural test pins that every emitted alloca is promotable and the module
+// verifies.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hotswap/raiser/reg-file.h"
+
+#include "hotswap/decoder/isa-profile.h"
+#include "hotswap/decoder/mc-state.h"
+#include "hotswap/raiser/wave-projection.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Analysis/ConstantFolding.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Dominators.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/PromoteMemToReg.h"
+
+#include "gtest/gtest.h"
+
+#include <mutex>
+
+// AllocaRegFile links the hotswap::decoder MC stack, whose initMCState calls
+// COMGR::ensureLLVMInitialized; its production definition lives in
+// libamd_comgr. Provide the registration here so the test binary stays minimal.
+namespace COMGR {
+void ensureLLVMInitialized() {
+  static std::once_flag Once;
+  std::call_once(Once, [] {
+    LLVMInitializeAMDGPUTargetInfo();
+    LLVMInitializeAMDGPUTargetMC();
+    LLVMInitializeAMDGPUDisassembler();
+    LLVMInitializeAMDGPUAsmParser();
+    LLVMInitializeAMDGPUAsmPrinter();
+    LLVMInitializeAMDGPUTarget();
+  });
+}
+} // namespace COMGR
+
+using namespace llvm;
+using COMGR::hotswap::AllocaRegFile;
+using COMGR::hotswap::initMCState;
+using COMGR::hotswap::ISAProfile;
+using COMGR::hotswap::MCState;
+using COMGR::hotswap::ParsedReg;
+using COMGR::hotswap::ReplicationProjection;
+
+namespace {
+
+// gfx942 is a wave64 CDNA ISA (it has AGPRs), so a same-ISA replication
+// projection gives a self-consistent register file that exercises the AGPR
+// bank and the i64 EXEC storage width.
+class RegFileTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    Expected<MCState> S = initMCState("gfx942");
+    ASSERT_TRUE(static_cast<bool>(S)) << toString(S.takeError());
+    Mc = std::move(*S);
+  }
+
+  ISAProfile srcIsa() const {
+    return ISAProfile::fromSubtarget(*Mc.SubtargetInfo);
+  }
+
+  MCState Mc;
+};
+
+// Owns a module and an initialised register file. `begin` starts a function
+// returning RetTy and initialises the reg file in its entry block, leaving the
+// builder positioned to append register traffic.
+struct RegFileFixture {
+  LLVMContext Ctx;
+  std::unique_ptr<Module> M;
+  ISAProfile Isa;
+  ReplicationProjection Proj;
+  const MCRegisterInfo &MRI;
+  IRBuilder<> B;
+  AllocaRegFile RF;
+  Function *F = nullptr;
+
+  RegFileFixture(const ISAProfile &SrcIsa, const MCRegisterInfo &Mri)
+      : M(std::make_unique<Module>("regfile_test", Ctx)), Isa(SrcIsa),
+        Proj(Isa, Isa, Type::getInt32Ty(Ctx), Type::getInt64Ty(Ctx)), MRI(Mri),
+        B(Ctx) {}
+
+  void begin(Type *RetTy) {
+    FunctionType *FT = FunctionType::get(RetTy, /*isVarArg=*/false);
+    F = Function::Create(FT, Function::ExternalLinkage, "f", M.get());
+    BasicBlock *BB = BasicBlock::Create(Ctx, "entry", F);
+    B.SetInsertPoint(BB);
+    RF.init(B, Type::getInt32Ty(Ctx), Type::getInt1Ty(Ctx), Isa, MRI, Proj);
+  }
+};
+
+// Promote the register file's allocas to SSA and constant-fold the result, then
+// return the value the function returns. With a constant written in, the read
+// chain folds back to that constant.
+Value *promoteAndFold(RegFileFixture &Fx) {
+  SmallVector<AllocaInst *> Allocas;
+  Fx.RF.collectAllocas(Allocas);
+  DominatorTree DT(*Fx.F);
+  PromoteMemToReg(Allocas, DT);
+
+  const DataLayout &DL = Fx.M->getDataLayout();
+  bool Changed = true;
+  while (Changed) {
+    Changed = false;
+    for (BasicBlock &BB : *Fx.F)
+      for (Instruction &I : make_early_inc_range(BB)) {
+        if (I.isTerminator())
+          continue;
+        if (Constant *C = ConstantFoldInstruction(&I, DL)) {
+          I.replaceAllUsesWith(C);
+          I.eraseFromParent();
+          Changed = true;
+        }
+      }
+  }
+  return cast<ReturnInst>(Fx.F->back().getTerminator())->getReturnValue();
+}
+
+ParsedReg reg(ParsedReg::Kind Kind, unsigned Idx, uint8_t Width) {
+  ParsedReg R;
+  R.RegKind = Kind;
+  R.BaseIdx = Idx;
+  R.WidthInDwords = Width;
+  return R;
+}
+
+TEST_F(RegFileTest, SGPR32RoundTrip) {
+  RegFileFixture Fx(srcIsa(), *Mc.RegInfo);
+  Fx.begin(Type::getInt32Ty(Fx.Ctx));
+  ParsedReg R = reg(ParsedReg::SGPR, 5, 1);
+  Fx.RF.writeReg32(Fx.B, R, ConstantInt::get(Type::getInt32Ty(Fx.Ctx), 0x1234));
+  Fx.B.CreateRet(Fx.RF.readReg32(Fx.B, R));
+
+  auto *CI = dyn_cast_or_null<ConstantInt>(promoteAndFold(Fx));
+  ASSERT_NE(CI, nullptr);
+  EXPECT_EQ(CI->getZExtValue(), 0x1234u);
+}
+
+TEST_F(RegFileTest, VGPR32RoundTrip) {
+  RegFileFixture Fx(srcIsa(), *Mc.RegInfo);
+  Fx.begin(Type::getInt32Ty(Fx.Ctx));
+  ParsedReg R = reg(ParsedReg::VGPR, 7, 1);
+  Fx.RF.writeReg32(Fx.B, R, ConstantInt::get(Type::getInt32Ty(Fx.Ctx), 0xABCD));
+  Fx.B.CreateRet(Fx.RF.readReg32(Fx.B, R));
+
+  auto *CI = dyn_cast_or_null<ConstantInt>(promoteAndFold(Fx));
+  ASSERT_NE(CI, nullptr);
+  EXPECT_EQ(CI->getZExtValue(), 0xABCDu);
+}
+
+TEST_F(RegFileTest, M0RoundTrip) {
+  RegFileFixture Fx(srcIsa(), *Mc.RegInfo);
+  Fx.begin(Type::getInt32Ty(Fx.Ctx));
+  ParsedReg R = reg(ParsedReg::M0, 0, 1);
+  Fx.RF.writeReg32(Fx.B, R, ConstantInt::get(Type::getInt32Ty(Fx.Ctx), 0x55));
+  Fx.B.CreateRet(Fx.RF.readReg32(Fx.B, R));
+
+  auto *CI = dyn_cast_or_null<ConstantInt>(promoteAndFold(Fx));
+  ASSERT_NE(CI, nullptr);
+  EXPECT_EQ(CI->getZExtValue(), 0x55u);
+}
+
+TEST_F(RegFileTest, SGPR64RoundTripSplitsAndRecombines) {
+  RegFileFixture Fx(srcIsa(), *Mc.RegInfo);
+  Fx.begin(Type::getInt64Ty(Fx.Ctx));
+  ParsedReg R = reg(ParsedReg::SGPR, 4, 2);
+  Constant *C =
+      ConstantInt::get(Type::getInt64Ty(Fx.Ctx), 0x1122334455667788ULL);
+  Fx.RF.writeReg64(Fx.B, R, C);
+  Fx.B.CreateRet(Fx.RF.readReg64(Fx.B, R));
+
+  auto *CI = dyn_cast_or_null<ConstantInt>(promoteAndFold(Fx));
+  ASSERT_NE(CI, nullptr);
+  EXPECT_EQ(CI->getZExtValue(), 0x1122334455667788ULL);
+}
+
+TEST_F(RegFileTest, SccI1RoundTrip) {
+  RegFileFixture Fx(srcIsa(), *Mc.RegInfo);
+  Fx.begin(Type::getInt1Ty(Fx.Ctx));
+  Fx.RF.storeSCC(Fx.B, ConstantInt::getTrue(Fx.Ctx));
+  Fx.B.CreateRet(Fx.RF.loadSCC(Fx.B));
+
+  auto *CI = dyn_cast_or_null<ConstantInt>(promoteAndFold(Fx));
+  ASSERT_NE(CI, nullptr);
+  EXPECT_TRUE(CI->isOne());
+}
+
+TEST_F(RegFileTest, VectorRoundTripAcrossContiguousVgprs) {
+  RegFileFixture Fx(srcIsa(), *Mc.RegInfo);
+  auto *VecTy = FixedVectorType::get(Type::getInt32Ty(Fx.Ctx), 4);
+  Fx.begin(VecTy);
+  ParsedReg R = reg(ParsedReg::VGPR, 8, 4);
+  Constant *Vec =
+      ConstantDataVector::get(Fx.Ctx, ArrayRef<uint32_t>{1, 2, 3, 4});
+  Fx.RF.writeRegVec(Fx.B, R, Vec);
+  Fx.B.CreateRet(Fx.RF.readRegVec(Fx.B, R, VecTy));
+
+  // Constants are uniqued, so a correct round trip folds back to the same
+  // constant object.
+  EXPECT_EQ(promoteAndFold(Fx), Vec);
+}
+
+TEST_F(RegFileTest, InitProducesPromotableAllocasAndVerifies) {
+  RegFileFixture Fx(srcIsa(), *Mc.RegInfo);
+  Fx.begin(Type::getVoidTy(Fx.Ctx));
+  Fx.RF.writeReg32(Fx.B, reg(ParsedReg::SGPR, 0, 1),
+                   ConstantInt::get(Type::getInt32Ty(Fx.Ctx), 7));
+  Fx.RF.writeReg64(Fx.B, reg(ParsedReg::VGPR, 2, 2),
+                   ConstantInt::get(Type::getInt64Ty(Fx.Ctx), 9));
+  Fx.B.CreateRetVoid();
+
+  SmallVector<AllocaInst *> Allocas;
+  Fx.RF.collectAllocas(Allocas);
+  EXPECT_FALSE(Allocas.empty());
+
+  DominatorTree DT(*Fx.F);
+  PromoteMemToReg(Allocas, DT);
+
+  unsigned RemainingAllocas = 0;
+  for (Instruction &I : Fx.F->getEntryBlock())
+    if (isa<AllocaInst>(I))
+      ++RemainingAllocas;
+  EXPECT_EQ(RemainingAllocas, 0u);
+
+  std::string Err;
+  raw_string_ostream OS(Err);
+  EXPECT_FALSE(verifyModule(*Fx.M, &OS)) << Err;
+}
+
+#if GTEST_HAS_DEATH_TEST && !defined(NDEBUG)
+TEST_F(RegFileTest, AbsentIndexOnIndexedKindAborts) {
+  RegFileFixture Fx(srcIsa(), *Mc.RegInfo);
+  Fx.begin(Type::getInt32Ty(Fx.Ctx));
+  ParsedReg R;
+  R.RegKind = ParsedReg::SGPR;
+  R.WidthInDwords = 1; // BaseIdx left absent.
+  EXPECT_DEATH((void)Fx.RF.readReg32(Fx.B, R), "base register index");
+}
+#endif
+
+} // namespace


### PR DESCRIPTION
RaiseFailure is the structured llvm::Error the raiser returns: a reason code
plus the offending mnemonic/format/offset, so a refusal names the instruction
class rather than aborting. AllocaRegFile models the source SGPR/VGPR/EXEC/VCC/
SCC/M0 register file as entry allocas that PromoteMemToReg later lifts to SSA,
which is how the handlers read and write registers without threading explicit
dataflow.
