### PR TITLE
[Comgr][hotswap] Derive the source kernel-argument ABI layouts

### DIFF
--- a/amd/comgr/src/hotswap/decoder/isa-profile.cpp
+++ b/amd/comgr/src/hotswap/decoder/isa-profile.cpp
@@ -40,4 +40,16 @@ bool ISAProfile::hasGfx125UserSgprCountField() const {
   return STI->hasFeature(llvm::AMDGPU::FeatureGFX1250Insts);
 }
 
+unsigned ISAProfile::maxUserSgprs() const {
+  return STI->hasFeature(llvm::AMDGPU::FeatureGFX1250Insts) ? 32 : 16;
+}
+
+bool ISAProfile::hasKernargPreload() const {
+  return STI->hasFeature(llvm::AMDGPU::FeatureKernargPreload);
+}
+
+bool ISAProfile::hasArchitectedSgprs() const {
+  return STI->hasFeature(llvm::AMDGPU::FeatureArchitectedSGPRs);
+}
+
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/decoder/isa-profile.h
+++ b/amd/comgr/src/hotswap/decoder/isa-profile.h
@@ -38,6 +38,15 @@ public:
   // rather than the older 5-bit field.
   bool hasGfx125UserSgprCountField() const;
 
+  // Maximum USER_SGPR_COUNT supported by the source ISA.
+  unsigned maxUserSgprs() const;
+
+  // Whether the source ISA supports kernarg preloading.
+  bool hasKernargPreload() const;
+
+  // Whether the source ISA uses architected SGPRs.
+  bool hasArchitectedSgprs() const;
+
 private:
   explicit ISAProfile(const llvm::MCSubtargetInfo &STI) : STI(&STI) {}
 

--- a/amd/comgr/src/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/raiser/CMakeLists.txt
@@ -33,6 +33,9 @@ add_library(hotswap-raiser OBJECT
   raise_failure.cpp
   reg-file.cpp
   wave-projection.cpp
+  kernarg-layout.cpp
+  user-sgpr-layout.cpp
+  source-hidden-args.cpp
 )
 
 if(NOT TARGET hotswap::raiser)

--- a/amd/comgr/src/hotswap/raiser/kernarg-layout.cpp
+++ b/amd/comgr/src/hotswap/raiser/kernarg-layout.cpp
@@ -1,0 +1,74 @@
+//===- kernarg-layout.cpp - Hotswap transpiler ----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "kernarg-layout.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
+
+#include <cstdint>
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+std::optional<SourceHiddenArgByte>
+classifySourceHiddenArgByte(ArrayRef<KernelArgMeta> Args, uint64_t ByteOffset) {
+  for (const KernelArgMeta &Arg : Args) {
+    uint64_t ArgEnd = static_cast<uint64_t>(Arg.Offset) + Arg.Size;
+    if (ByteOffset < Arg.Offset || ByteOffset >= ArgEnd)
+      continue;
+
+    StringRef Kind(Arg.ValueKind);
+    SourceHiddenArgByte Result;
+    Result.ArgOffset = Arg.Offset;
+    Result.ByteOffset = ByteOffset;
+    Result.Kind =
+        StringSwitch<SourceHiddenArgKind>(Kind)
+            .Case("hidden_block_count_x",
+                  SourceHiddenArgKind::HiddenBlockCountX)
+            .Case("hidden_block_count_y",
+                  SourceHiddenArgKind::HiddenBlockCountY)
+            .Case("hidden_block_count_z",
+                  SourceHiddenArgKind::HiddenBlockCountZ)
+            .Case("hidden_group_size_x", SourceHiddenArgKind::HiddenGroupSizeX)
+            .Case("hidden_group_size_y", SourceHiddenArgKind::HiddenGroupSizeY)
+            .Case("hidden_group_size_z", SourceHiddenArgKind::HiddenGroupSizeZ)
+            .Case("hidden_remainder_x", SourceHiddenArgKind::HiddenRemainderX)
+            .Case("hidden_remainder_y", SourceHiddenArgKind::HiddenRemainderY)
+            .Case("hidden_remainder_z", SourceHiddenArgKind::HiddenRemainderZ)
+            .Case("hidden_grid_dims", SourceHiddenArgKind::HiddenGridDims)
+            .Case("hidden_global_offset_x",
+                  SourceHiddenArgKind::HiddenGlobalOffsetX)
+            .Case("hidden_global_offset_y",
+                  SourceHiddenArgKind::HiddenGlobalOffsetY)
+            .Case("hidden_global_offset_z",
+                  SourceHiddenArgKind::HiddenGlobalOffsetZ)
+            .Case("hidden_private_base", SourceHiddenArgKind::HiddenPrivateBase)
+            .Case("hidden_shared_base", SourceHiddenArgKind::HiddenSharedBase)
+            .Case("hidden_default_queue",
+                  SourceHiddenArgKind::HiddenDefaultQueue)
+            .Case("hidden_completion_action",
+                  SourceHiddenArgKind::HiddenCompletionAction)
+            .Case("hidden_multigrid_sync_arg",
+                  SourceHiddenArgKind::HiddenMultigridSyncArg)
+            .Case("hidden_hostcall_buffer",
+                  SourceHiddenArgKind::HiddenHostcallBuffer)
+            .Case("hidden_heap_v1", SourceHiddenArgKind::HiddenHeapV1)
+            .Default(Kind.starts_with("hidden_")
+                         ? SourceHiddenArgKind::UnsupportedHidden
+                         : SourceHiddenArgKind::None);
+    // A non-hidden kernarg occupying this byte is not a hidden-arg match.
+    if (Result.Kind == SourceHiddenArgKind::None)
+      return std::nullopt;
+    return Result;
+  }
+  return std::nullopt;
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/kernarg-layout.cpp
+++ b/amd/comgr/src/hotswap/raiser/kernarg-layout.cpp
@@ -17,6 +17,35 @@ using namespace llvm;
 
 namespace COMGR::hotswap {
 
+SourceHiddenArgKind classifySourceHiddenArgKind(StringRef ValueKind) {
+  return StringSwitch<SourceHiddenArgKind>(ValueKind)
+      .Case("hidden_block_count_x", SourceHiddenArgKind::HiddenBlockCountX)
+      .Case("hidden_block_count_y", SourceHiddenArgKind::HiddenBlockCountY)
+      .Case("hidden_block_count_z", SourceHiddenArgKind::HiddenBlockCountZ)
+      .Case("hidden_group_size_x", SourceHiddenArgKind::HiddenGroupSizeX)
+      .Case("hidden_group_size_y", SourceHiddenArgKind::HiddenGroupSizeY)
+      .Case("hidden_group_size_z", SourceHiddenArgKind::HiddenGroupSizeZ)
+      .Case("hidden_remainder_x", SourceHiddenArgKind::HiddenRemainderX)
+      .Case("hidden_remainder_y", SourceHiddenArgKind::HiddenRemainderY)
+      .Case("hidden_remainder_z", SourceHiddenArgKind::HiddenRemainderZ)
+      .Case("hidden_grid_dims", SourceHiddenArgKind::HiddenGridDims)
+      .Case("hidden_global_offset_x", SourceHiddenArgKind::HiddenGlobalOffsetX)
+      .Case("hidden_global_offset_y", SourceHiddenArgKind::HiddenGlobalOffsetY)
+      .Case("hidden_global_offset_z", SourceHiddenArgKind::HiddenGlobalOffsetZ)
+      .Case("hidden_private_base", SourceHiddenArgKind::HiddenPrivateBase)
+      .Case("hidden_shared_base", SourceHiddenArgKind::HiddenSharedBase)
+      .Case("hidden_default_queue", SourceHiddenArgKind::HiddenDefaultQueue)
+      .Case("hidden_completion_action",
+            SourceHiddenArgKind::HiddenCompletionAction)
+      .Case("hidden_multigrid_sync_arg",
+            SourceHiddenArgKind::HiddenMultigridSyncArg)
+      .Case("hidden_hostcall_buffer", SourceHiddenArgKind::HiddenHostcallBuffer)
+      .Case("hidden_heap_v1", SourceHiddenArgKind::HiddenHeapV1)
+      .Default(ValueKind.starts_with("hidden_")
+                   ? SourceHiddenArgKind::UnsupportedHidden
+                   : SourceHiddenArgKind::None);
+}
+
 std::optional<SourceHiddenArgByte>
 classifySourceHiddenArgByte(ArrayRef<KernelArgMeta> Args, uint64_t ByteOffset) {
   for (const KernelArgMeta &Arg : Args) {
@@ -24,45 +53,10 @@ classifySourceHiddenArgByte(ArrayRef<KernelArgMeta> Args, uint64_t ByteOffset) {
     if (ByteOffset < Arg.Offset || ByteOffset >= ArgEnd)
       continue;
 
-    StringRef Kind(Arg.ValueKind);
     SourceHiddenArgByte Result;
     Result.ArgOffset = Arg.Offset;
     Result.ByteOffset = ByteOffset;
-    Result.Kind =
-        StringSwitch<SourceHiddenArgKind>(Kind)
-            .Case("hidden_block_count_x",
-                  SourceHiddenArgKind::HiddenBlockCountX)
-            .Case("hidden_block_count_y",
-                  SourceHiddenArgKind::HiddenBlockCountY)
-            .Case("hidden_block_count_z",
-                  SourceHiddenArgKind::HiddenBlockCountZ)
-            .Case("hidden_group_size_x", SourceHiddenArgKind::HiddenGroupSizeX)
-            .Case("hidden_group_size_y", SourceHiddenArgKind::HiddenGroupSizeY)
-            .Case("hidden_group_size_z", SourceHiddenArgKind::HiddenGroupSizeZ)
-            .Case("hidden_remainder_x", SourceHiddenArgKind::HiddenRemainderX)
-            .Case("hidden_remainder_y", SourceHiddenArgKind::HiddenRemainderY)
-            .Case("hidden_remainder_z", SourceHiddenArgKind::HiddenRemainderZ)
-            .Case("hidden_grid_dims", SourceHiddenArgKind::HiddenGridDims)
-            .Case("hidden_global_offset_x",
-                  SourceHiddenArgKind::HiddenGlobalOffsetX)
-            .Case("hidden_global_offset_y",
-                  SourceHiddenArgKind::HiddenGlobalOffsetY)
-            .Case("hidden_global_offset_z",
-                  SourceHiddenArgKind::HiddenGlobalOffsetZ)
-            .Case("hidden_private_base", SourceHiddenArgKind::HiddenPrivateBase)
-            .Case("hidden_shared_base", SourceHiddenArgKind::HiddenSharedBase)
-            .Case("hidden_default_queue",
-                  SourceHiddenArgKind::HiddenDefaultQueue)
-            .Case("hidden_completion_action",
-                  SourceHiddenArgKind::HiddenCompletionAction)
-            .Case("hidden_multigrid_sync_arg",
-                  SourceHiddenArgKind::HiddenMultigridSyncArg)
-            .Case("hidden_hostcall_buffer",
-                  SourceHiddenArgKind::HiddenHostcallBuffer)
-            .Case("hidden_heap_v1", SourceHiddenArgKind::HiddenHeapV1)
-            .Default(Kind.starts_with("hidden_")
-                         ? SourceHiddenArgKind::UnsupportedHidden
-                         : SourceHiddenArgKind::None);
+    Result.Kind = classifySourceHiddenArgKind(Arg.ValueKind);
     // A non-hidden kernarg occupying this byte is not a hidden-arg match.
     if (Result.Kind == SourceHiddenArgKind::None)
       return std::nullopt;

--- a/amd/comgr/src/hotswap/raiser/kernarg-layout.h
+++ b/amd/comgr/src/hotswap/raiser/kernarg-layout.h
@@ -11,6 +11,7 @@
 
 #include "hotswap/common/kernel-meta.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
 
 #include <cstdint>
 #include <optional>
@@ -65,6 +66,10 @@ struct SourceHiddenArgByte {
 
   uint64_t byteIndexInArg() const { return ByteOffset - ArgOffset; }
 };
+
+// Classify an AMDHSA metadata value kind. Non-hidden kinds map to None and
+// unknown hidden kinds map to UnsupportedHidden.
+SourceHiddenArgKind classifySourceHiddenArgKind(llvm::StringRef ValueKind);
 
 // Resolve a byte offset in the source ABI's flat kernarg/hidden-arg metadata
 // view. Returns nullopt when the offset does not land in a hidden_* argument;

--- a/amd/comgr/src/hotswap/raiser/kernarg-layout.h
+++ b/amd/comgr/src/hotswap/raiser/kernarg-layout.h
@@ -1,0 +1,78 @@
+//===- kernarg-layout.h - Hotswap transpiler ------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_KERNARG_LAYOUT_H
+#define HOTSWAP_TRANSPILER_KERNARG_LAYOUT_H
+
+#include "hotswap/common/kernel-meta.h"
+#include "llvm/ADT/ArrayRef.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace COMGR::hotswap {
+
+// Source-kernel kernarg-segment metadata needed without reading the segment.
+struct KernargLayout {
+  // Source ABI byte offset where the implicit-arg block begins. Loads at or
+  // above this offset are rebased through `amdgcn_implicitarg_ptr`.
+  uint64_t ImplicitArgsBase = 0;
+  // Source metadata argument layout, including hidden_* entries.
+  llvm::ArrayRef<KernelArgMeta> Args;
+  // Total kernarg segment size in bytes, copied from the kernel
+  // descriptor's `.kernarg_segment_size`. Informational; the lifted
+  // kernel's `Function` parameter list drives the backend's
+  // `kernarg_segment_size` calculation in the output kernel descriptor.
+  uint64_t KernargSegmentSize = 0;
+};
+
+// Source metadata hidden_* argument kinds with source-ABI synthesis support.
+enum class SourceHiddenArgKind {
+  None,
+  HiddenBlockCountX,
+  HiddenBlockCountY,
+  HiddenBlockCountZ,
+  HiddenGroupSizeX,
+  HiddenGroupSizeY,
+  HiddenGroupSizeZ,
+  HiddenRemainderX,
+  HiddenRemainderY,
+  HiddenRemainderZ,
+  HiddenGridDims,
+  HiddenGlobalOffsetX,
+  HiddenGlobalOffsetY,
+  HiddenGlobalOffsetZ,
+  HiddenPrivateBase,
+  HiddenSharedBase,
+  HiddenDefaultQueue,
+  HiddenCompletionAction,
+  HiddenMultigridSyncArg,
+  HiddenHostcallBuffer,
+  HiddenHeapV1,
+  UnsupportedHidden,
+};
+
+// Metadata match for one byte in a source hidden_* argument.
+struct SourceHiddenArgByte {
+  SourceHiddenArgKind Kind = SourceHiddenArgKind::None;
+  uint64_t ArgOffset = 0;
+  uint64_t ByteOffset = 0;
+
+  uint64_t byteIndexInArg() const { return ByteOffset - ArgOffset; }
+};
+
+// Resolve a byte offset in the source ABI's flat kernarg/hidden-arg metadata
+// view. Returns nullopt when the offset does not land in a hidden_* argument;
+// unsupported hidden args are reported with Kind == UnsupportedHidden.
+std::optional<SourceHiddenArgByte>
+classifySourceHiddenArgByte(llvm::ArrayRef<KernelArgMeta> Args,
+                            uint64_t ByteOffset);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/raiser/raise_failure.h
+++ b/amd/comgr/src/hotswap/raiser/raise_failure.h
@@ -38,9 +38,8 @@ enum class RaiseFailureReason : uint16_t {
   // The instruction's opcode is lifted, but this operand shape or encoding
   // variant is not. `detail()` carries shape-specific context when available.
   UnsupportedInstructionForm,
-  // A source hidden kernarg was identified, but no synthesis exists for its
-  // `.value_kind` yet. Narrower than `UnsupportedInstructionForm`: only that
-  // hidden-argument kind is unsupported.
+  // A source hidden kernarg cannot be synthesized safely from its metadata or
+  // requested load range.
   UnsupportedSourceHiddenArg,
   // An instruction writes EXEC through a path the lift does not model.
   SPEUnsafeExecWriter,
@@ -72,8 +71,8 @@ enum class RaiseFailureReason : uint16_t {
   // The kernel descriptor could not be read from `.rodata` via the `<name>.kd`
   // symbol, so the user-SGPR layout cannot be derived.
   MissingKernelDescriptor,
-  // The descriptor's USER_SGPR_COUNT disagrees with the layout implied by
-  // kernel_code_properties and kernarg preload for the source ISA.
+  // Source descriptor fields do not describe a valid, self-consistent user
+  // SGPR layout.
   UserSgprLayoutMismatch,
   // The source object declares non-disabled workgroup cluster dimensions, so
   // TTMP6 carries per-cluster state the Hotswap ABI model does not reconstruct.

--- a/amd/comgr/src/hotswap/raiser/source-hidden-args.cpp
+++ b/amd/comgr/src/hotswap/raiser/source-hidden-args.cpp
@@ -18,7 +18,9 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MathExtras.h"
 
+#include <cassert>
 #include <optional>
+#include <utility>
 
 using namespace llvm;
 
@@ -126,6 +128,8 @@ Value *loadTargetHiddenPointer(SourceHiddenArgContext &Ctx,
 Value *virtualizeScaledReplicationSize(SourceHiddenArgContext &Ctx,
                                        unsigned Dim, Value *Size,
                                        const Twine &Name) {
+  assert(llvm::isPowerOf2_32(Ctx.ScaledReplicationFactor) &&
+         "scaled replication factor must be a nonzero power of two");
   if (Dim != 0 || Ctx.ScaledReplicationFactor <= 1)
     return Size;
   unsigned ShiftBy = llvm::Log2_32(Ctx.ScaledReplicationFactor);
@@ -182,6 +186,55 @@ Error unsupportedHiddenKind(uint64_t ByteOffset, StringRef Kind) {
        "'; add explicit source-ABI synthesis instead of falling back to "
        "target implicitarg layout")
           .str());
+}
+
+std::optional<unsigned> expectedHiddenArgSize(SourceHiddenArgKind Kind) {
+  switch (Kind) {
+  case SourceHiddenArgKind::HiddenBlockCountX:
+  case SourceHiddenArgKind::HiddenBlockCountY:
+  case SourceHiddenArgKind::HiddenBlockCountZ:
+  case SourceHiddenArgKind::HiddenPrivateBase:
+  case SourceHiddenArgKind::HiddenSharedBase:
+    return 4;
+  case SourceHiddenArgKind::HiddenGroupSizeX:
+  case SourceHiddenArgKind::HiddenGroupSizeY:
+  case SourceHiddenArgKind::HiddenGroupSizeZ:
+  case SourceHiddenArgKind::HiddenRemainderX:
+  case SourceHiddenArgKind::HiddenRemainderY:
+  case SourceHiddenArgKind::HiddenRemainderZ:
+  case SourceHiddenArgKind::HiddenGridDims:
+    return 2;
+  case SourceHiddenArgKind::HiddenGlobalOffsetX:
+  case SourceHiddenArgKind::HiddenGlobalOffsetY:
+  case SourceHiddenArgKind::HiddenGlobalOffsetZ:
+  case SourceHiddenArgKind::HiddenDefaultQueue:
+  case SourceHiddenArgKind::HiddenCompletionAction:
+  case SourceHiddenArgKind::HiddenMultigridSyncArg:
+  case SourceHiddenArgKind::HiddenHostcallBuffer:
+  case SourceHiddenArgKind::HiddenHeapV1:
+    return 8;
+  case SourceHiddenArgKind::None:
+  case SourceHiddenArgKind::UnsupportedHidden:
+    return std::nullopt;
+  }
+  llvm_unreachable("unhandled SourceHiddenArgKind");
+}
+
+Error validateHiddenArgSizes(ArrayRef<KernelArgMeta> Args) {
+  for (const KernelArgMeta &Arg : Args) {
+    const SourceHiddenArgKind Kind = classifySourceHiddenArgKind(Arg.ValueKind);
+    const std::optional<unsigned> ExpectedSize = expectedHiddenArgSize(Kind);
+    if (!ExpectedSize || Arg.Size == *ExpectedSize)
+      continue;
+    return RaiseFailure::atInstruction(
+        RaiseFailureReason::UnsupportedSourceHiddenArg, "<source-hidden-arg>",
+        Arg.Offset, "hidden-arg",
+        formatv("source hidden argument at byte offset {0} has size {1}, "
+                "expected {2}",
+                Arg.Offset, Arg.Size, *ExpectedSize)
+            .str());
+  }
+  return Error::success();
 }
 
 // Emit the full source hidden argument value for one metadata kind, or an Error
@@ -295,24 +348,32 @@ Expected<Value *> emitSourceHiddenInteger(SourceHiddenArgContext &Ctx,
         formatv("unsupported source hidden integer byte width {0}", ByteWidth)
             .str());
 
+  if (Error E = validateHiddenArgSizes(Ctx.Args))
+    return std::move(E);
+
+  const bool StartsInHiddenArg =
+      classifySourceHiddenArgByte(Ctx.Args, ByteOffset).has_value();
+  for (unsigned I = 1; I < ByteWidth; ++I) {
+    const bool IsInHiddenArg =
+        classifySourceHiddenArgByte(Ctx.Args, ByteOffset + I).has_value();
+    if (IsInHiddenArg != StartsInHiddenArg)
+      return RaiseFailure::atInstruction(
+          RaiseFailureReason::UnsupportedSourceHiddenArg, "<source-hidden-arg>",
+          ByteOffset, "hidden-arg",
+          formatv("source integer at byte offset {0} spans hidden and "
+                  "non-hidden bytes",
+                  ByteOffset)
+              .str());
+  }
+  if (!StartsInHiddenArg)
+    return nullptr;
+
   Value *Acc = Ctx.B.getInt32(0);
   for (unsigned I = 0; I < ByteWidth; ++I) {
     Expected<Value *> Byte = emitSourceHiddenByte(Ctx, ByteOffset + I);
     if (!Byte)
       return Byte.takeError();
-    // The first byte decides whether this offset is a hidden arg at all; a
-    // subsequent unmatched byte means the field straddles non-hidden memory.
-    if (!*Byte) {
-      if (I == 0)
-        return nullptr;
-      return RaiseFailure::atInstruction(
-          RaiseFailureReason::UnsupportedSourceHiddenArg, "<source-hidden-arg>",
-          ByteOffset, "hidden-arg",
-          formatv("source hidden dword at byte offset {0} spans non-hidden "
-                  "byte {1}",
-                  ByteOffset, ByteOffset + I)
-              .str());
-    }
+    assert(*Byte && "hidden range must contain only hidden argument bytes");
 
     Value *Part = Ctx.B.CreateZExt(*Byte, Ctx.I32Ty, "source_hidden_byte_zext");
     if (I != 0)

--- a/amd/comgr/src/hotswap/raiser/source-hidden-args.cpp
+++ b/amd/comgr/src/hotswap/raiser/source-hidden-args.cpp
@@ -1,0 +1,338 @@
+//===- source-hidden-args.cpp - Hotswap transpiler ------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "source-hidden-args.h"
+#include "raise_failure.h"
+
+#include "SIDefines.h"
+#include "Utils/AMDGPUBaseInfo.h"
+
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/MathExtras.h"
+
+#include <optional>
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+namespace {
+
+// Offsets in the HSA AQL `hsa_kernel_dispatch_packet_t` as defined by the
+// public HSA runtime header.  Do not use SI::KernelInputOffsets here: those are
+// LLVM's kernel-input/implicit-buffer offsets (`NGROUPS`, `LOCAL_SIZE`), not
+// the AQL dispatch-packet layout addressed by `llvm.amdgcn.dispatch.ptr`.
+namespace DispatchPacket {
+constexpr unsigned SetupOffset = 2;
+constexpr unsigned SetupDimensionsMask = 0x3;
+constexpr unsigned WorkgroupSizeXOffset = 4;
+constexpr unsigned WorkgroupSizeYOffset = 6;
+constexpr unsigned WorkgroupSizeZOffset = 8;
+constexpr unsigned GridSizeXOffset = 12;
+constexpr unsigned GridSizeYOffset = 16;
+constexpr unsigned GridSizeZOffset = 20;
+
+// Return the AQL dispatch-packet workgroup-size field offset for a dimension.
+unsigned dispatchWorkgroupSizeOffset(unsigned Dim) {
+  switch (Dim) {
+  case 0:
+    return WorkgroupSizeXOffset;
+  case 1:
+    return WorkgroupSizeYOffset;
+  case 2:
+    return WorkgroupSizeZOffset;
+  default:
+    llvm_unreachable("invalid source hidden workgroup-size dimension");
+  }
+}
+
+// Return the AQL dispatch-packet grid-size field offset for a dimension.
+unsigned dispatchGridSizeOffset(unsigned Dim) {
+  switch (Dim) {
+  case 0:
+    return GridSizeXOffset;
+  case 1:
+    return GridSizeYOffset;
+  case 2:
+    return GridSizeZOffset;
+  default:
+    llvm_unreachable("invalid source hidden grid-size dimension");
+  }
+}
+} // namespace DispatchPacket
+
+// Emit llvm.amdgcn.dispatch.ptr for AQL packet-backed hidden args.
+Value *dispatchPtr(SourceHiddenArgContext &Ctx) {
+  Function *DispatchPtrFn =
+      Intrinsic::getOrInsertDeclaration(&Ctx.M, Intrinsic::amdgcn_dispatch_ptr);
+  return Ctx.B.CreateCall(DispatchPtrFn, {}, "dispatch_ptr");
+}
+
+// Load a zero-extended 16-bit field from the AQL dispatch packet.
+Value *loadDispatchU16(SourceHiddenArgContext &Ctx, unsigned ByteOffset,
+                       const Twine &Name) {
+  Value *Ptr =
+      Ctx.B.CreateConstInBoundsGEP1_32(Ctx.I8Ty, dispatchPtr(Ctx), ByteOffset);
+  return Ctx.B.CreateZExt(Ctx.B.CreateLoad(Type::getInt16Ty(Ctx.C), Ptr, Name),
+                          Ctx.I32Ty, Name + "_zext");
+}
+
+// Load a 32-bit field from the AQL dispatch packet.
+Value *loadDispatchU32(SourceHiddenArgContext &Ctx, unsigned ByteOffset,
+                       const Twine &Name) {
+  Value *Ptr =
+      Ctx.B.CreateConstInBoundsGEP1_32(Ctx.I8Ty, dispatchPtr(Ctx), ByteOffset);
+  return Ctx.B.CreateLoad(Ctx.I32Ty, Ptr, Name);
+}
+
+// The target backend initially gets "amdgpu-no-*" attrs for every hidden field
+// so it does not invent unused target ABI inputs. When a source hidden arg has
+// the same semantic value on the target ABI, remove only the attributes needed
+// to make the target runtime populate that target ABI field.
+void requireTargetImplicitArg(SourceHiddenArgContext &Ctx,
+                              StringRef FieldNoAttr) {
+  Ctx.Fn.removeFnAttr("amdgpu-no-implicitarg-ptr");
+  Ctx.Fn.removeFnAttr(FieldNoAttr);
+}
+
+// Emit a pointer-sized source hidden argument by reading the corresponding
+// target ABI field. Offsets are relative to llvm.amdgcn.implicitarg.ptr in the
+// target code-object version; source metadata offsets are deliberately ignored.
+Value *loadTargetHiddenPointer(SourceHiddenArgContext &Ctx,
+                               unsigned TargetByteOffset, StringRef FieldNoAttr,
+                               const Twine &Name) {
+  requireTargetImplicitArg(Ctx, FieldNoAttr);
+  Function *FnImplicitArgPtr = Intrinsic::getOrInsertDeclaration(
+      &Ctx.M, Intrinsic::amdgcn_implicitarg_ptr);
+  Value *Ptr = Ctx.B.CreateCall(FnImplicitArgPtr, {}, "target_implicitarg_ptr");
+  if (TargetByteOffset != 0)
+    Ptr = Ctx.B.CreateConstInBoundsGEP1_32(Ctx.I8Ty, Ptr, TargetByteOffset,
+                                           Name + "_ptr");
+  return Ctx.B.CreateAlignedLoad(Ctx.I64Ty, Ptr, Align(8), Name);
+}
+
+// Divide an x-dimension size read by the scaled-replication factor so the
+// source kernel observes the un-scaled (logical) size. The hardware size is an
+// exact multiple of the factor (the runtime scales it), so an unsigned shift is
+// exact. No-op for non-x dimensions and for non-replicated kernels. The factor
+// is a power of two.
+Value *virtualizeScaledReplicationSize(SourceHiddenArgContext &Ctx,
+                                       unsigned Dim, Value *Size,
+                                       const Twine &Name) {
+  if (Dim != 0 || Ctx.ScaledReplicationFactor <= 1)
+    return Size;
+  unsigned ShiftBy = llvm::Log2_32(Ctx.ScaledReplicationFactor);
+  return Ctx.B.CreateLShr(Size, ConstantInt::get(Size->getType(), ShiftBy),
+                          Name + "_descaled");
+}
+
+// Emit source hidden_group_size_{x,y,z}.
+Value *emitDispatchWorkgroupSize(SourceHiddenArgContext &Ctx, unsigned Dim) {
+  Value *Size =
+      loadDispatchU16(Ctx, DispatchPacket::dispatchWorkgroupSizeOffset(Dim),
+                      Twine("source_hidden_wg_size_") + Twine(Dim));
+  return virtualizeScaledReplicationSize(
+      Ctx, Dim, Size, Twine("source_hidden_wg_size_") + Twine(Dim));
+}
+
+// Emit source grid size for hidden block-count/remainder calculations.
+Value *emitDispatchGridSize(SourceHiddenArgContext &Ctx, unsigned Dim) {
+  Value *Size =
+      loadDispatchU32(Ctx, DispatchPacket::dispatchGridSizeOffset(Dim),
+                      Twine("source_hidden_grid_size_") + Twine(Dim));
+  return virtualizeScaledReplicationSize(
+      Ctx, Dim, Size, Twine("source_hidden_grid_size_") + Twine(Dim));
+}
+
+// Emit source hidden_block_count_{x,y,z}.
+Value *emitHiddenBlockCount(SourceHiddenArgContext &Ctx, unsigned Dim) {
+  return Ctx.B.CreateUDiv(emitDispatchGridSize(Ctx, Dim),
+                          emitDispatchWorkgroupSize(Ctx, Dim),
+                          Twine("source_hidden_block_count_") + Twine(Dim));
+}
+
+// Emit source hidden_remainder_{x,y,z}.
+Value *emitHiddenRemainder(SourceHiddenArgContext &Ctx, unsigned Dim) {
+  return Ctx.B.CreateURem(emitDispatchGridSize(Ctx, Dim),
+                          emitDispatchWorkgroupSize(Ctx, Dim),
+                          Twine("source_hidden_remainder_") + Twine(Dim));
+}
+
+// Emit source hidden_grid_dims from the AQL setup field.
+Value *emitGridDims(SourceHiddenArgContext &Ctx) {
+  return Ctx.B.CreateAnd(
+      loadDispatchU16(Ctx, DispatchPacket::SetupOffset, "dispatch_setup"),
+      Ctx.B.getInt32(DispatchPacket::SetupDimensionsMask),
+      "source_hidden_grid_dims");
+}
+
+// Build the failure for a hidden kind that lacks source-ABI synthesis.
+Error unsupportedHiddenKind(uint64_t ByteOffset, StringRef Kind) {
+  return RaiseFailure::atInstruction(
+      RaiseFailureReason::UnsupportedSourceHiddenArg, "<source-hidden-arg>",
+      ByteOffset, "hidden-arg",
+      ("unsupported source hidden argument kind '" + Kind +
+       "'; add explicit source-ABI synthesis instead of falling back to "
+       "target implicitarg layout")
+          .str());
+}
+
+// Emit the full source hidden argument value for one metadata kind, or an Error
+// when that kind has no source-side synthesis. `ByteOffset` locates the field
+// for diagnostics.
+Expected<Value *> emitHiddenArgValue(SourceHiddenArgContext &Ctx,
+                                     SourceHiddenArgKind Kind,
+                                     uint64_t ByteOffset) {
+  switch (Kind) {
+  case SourceHiddenArgKind::HiddenBlockCountX:
+    return emitHiddenBlockCount(Ctx, 0);
+  case SourceHiddenArgKind::HiddenBlockCountY:
+    return emitHiddenBlockCount(Ctx, 1);
+  case SourceHiddenArgKind::HiddenBlockCountZ:
+    return emitHiddenBlockCount(Ctx, 2);
+  case SourceHiddenArgKind::HiddenGroupSizeX:
+    return emitDispatchWorkgroupSize(Ctx, 0);
+  case SourceHiddenArgKind::HiddenGroupSizeY:
+    return emitDispatchWorkgroupSize(Ctx, 1);
+  case SourceHiddenArgKind::HiddenGroupSizeZ:
+    return emitDispatchWorkgroupSize(Ctx, 2);
+  case SourceHiddenArgKind::HiddenRemainderX:
+    return emitHiddenRemainder(Ctx, 0);
+  case SourceHiddenArgKind::HiddenRemainderY:
+    return emitHiddenRemainder(Ctx, 1);
+  case SourceHiddenArgKind::HiddenRemainderZ:
+    return emitHiddenRemainder(Ctx, 2);
+  case SourceHiddenArgKind::HiddenGridDims:
+    return emitGridDims(Ctx);
+  case SourceHiddenArgKind::HiddenGlobalOffsetX:
+  case SourceHiddenArgKind::HiddenGlobalOffsetY:
+  case SourceHiddenArgKind::HiddenGlobalOffsetZ:
+    if (!Ctx.AssumeHipGlobalOffsetZero)
+      return unsupportedHiddenKind(ByteOffset, "hidden_global_offset_{x,y,z}");
+    // The HotSwap runtime path intercepts HIP-launched kernels. HIP's launch
+    // APIs do not expose a non-zero HSA grid-global offset, so the source ABI's
+    // hidden_global_offset fields are the all-zero 64-bit value.
+    return Ctx.B.getInt64(0);
+  case SourceHiddenArgKind::HiddenPrivateBase:
+    // Private/shared bases are real aperture state. Do not synthesize them
+    // until the translator has a target-capability proof that the source read
+    // is either unused or exactly reconstructed elsewhere.
+    return unsupportedHiddenKind(ByteOffset, "hidden_private_base");
+  case SourceHiddenArgKind::HiddenSharedBase:
+    return unsupportedHiddenKind(ByteOffset, "hidden_shared_base");
+  case SourceHiddenArgKind::HiddenDefaultQueue:
+    return loadTargetHiddenPointer(
+        Ctx,
+        AMDGPU::getDefaultQueueImplicitArgPosition(Ctx.TargetCodeObjectVersion),
+        "amdgpu-no-default-queue", "source_hidden_default_queue");
+  case SourceHiddenArgKind::HiddenCompletionAction:
+    return loadTargetHiddenPointer(
+        Ctx,
+        AMDGPU::getCompletionActionImplicitArgPosition(
+            Ctx.TargetCodeObjectVersion),
+        "amdgpu-no-completion-action", "source_hidden_completion_action");
+  case SourceHiddenArgKind::HiddenMultigridSyncArg:
+    return loadTargetHiddenPointer(
+        Ctx,
+        AMDGPU::getMultigridSyncArgImplicitArgPosition(
+            Ctx.TargetCodeObjectVersion),
+        "amdgpu-no-multigrid-sync-arg", "source_hidden_multigrid_sync_arg");
+  case SourceHiddenArgKind::HiddenHostcallBuffer:
+    return loadTargetHiddenPointer(
+        Ctx,
+        AMDGPU::getHostcallImplicitArgPosition(Ctx.TargetCodeObjectVersion),
+        "amdgpu-no-hostcall-ptr", "source_hidden_hostcall_buffer");
+  case SourceHiddenArgKind::HiddenHeapV1:
+    if (Ctx.TargetCodeObjectVersion < AMDGPU::AMDHSA_COV5)
+      return unsupportedHiddenKind(ByteOffset, "hidden_heap_v1");
+    return loadTargetHiddenPointer(Ctx, AMDGPU::ImplicitArg::HEAP_PTR_OFFSET,
+                                   "amdgpu-no-heap-ptr",
+                                   "source_hidden_heap_v1");
+  case SourceHiddenArgKind::None:
+  case SourceHiddenArgKind::UnsupportedHidden:
+    return unsupportedHiddenKind(ByteOffset, "<unknown>");
+  }
+  llvm_unreachable("unhandled SourceHiddenArgKind");
+}
+
+// Emit one byte from the source hidden-argument metadata view. Returns a null
+// Value when the offset is not a source hidden argument.
+Expected<Value *> emitSourceHiddenByte(SourceHiddenArgContext &Ctx,
+                                       uint64_t ByteOffset) {
+  std::optional<SourceHiddenArgByte> Byte =
+      classifySourceHiddenArgByte(Ctx.Args, ByteOffset);
+  if (!Byte)
+    return nullptr;
+
+  Expected<Value *> Whole = emitHiddenArgValue(Ctx, Byte->Kind, ByteOffset);
+  if (!Whole)
+    return Whole.takeError();
+
+  Value *Wide = Ctx.B.CreateZExtOrTrunc(*Whole, Ctx.I64Ty, "hidden_wide");
+  uint64_t ByteInArg = Byte->byteIndexInArg();
+  if (ByteInArg != 0)
+    Wide = Ctx.B.CreateLShr(Wide, Ctx.B.getInt64(ByteInArg * 8),
+                            "hidden_byte_shift");
+  return Ctx.B.CreateTrunc(Wide, Ctx.I8Ty, "source_hidden_byte");
+}
+
+} // namespace
+
+Expected<Value *> emitSourceHiddenInteger(SourceHiddenArgContext &Ctx,
+                                          uint64_t ByteOffset,
+                                          unsigned ByteWidth, bool IsSigned) {
+  if (ByteWidth != 1 && ByteWidth != 2 && ByteWidth != 4)
+    return RaiseFailure::atInstruction(
+        RaiseFailureReason::UnsupportedSourceHiddenArg, "<source-hidden-arg>",
+        ByteOffset, "hidden-arg",
+        formatv("unsupported source hidden integer byte width {0}", ByteWidth)
+            .str());
+
+  Value *Acc = Ctx.B.getInt32(0);
+  for (unsigned I = 0; I < ByteWidth; ++I) {
+    Expected<Value *> Byte = emitSourceHiddenByte(Ctx, ByteOffset + I);
+    if (!Byte)
+      return Byte.takeError();
+    // The first byte decides whether this offset is a hidden arg at all; a
+    // subsequent unmatched byte means the field straddles non-hidden memory.
+    if (!*Byte) {
+      if (I == 0)
+        return nullptr;
+      return RaiseFailure::atInstruction(
+          RaiseFailureReason::UnsupportedSourceHiddenArg, "<source-hidden-arg>",
+          ByteOffset, "hidden-arg",
+          formatv("source hidden dword at byte offset {0} spans non-hidden "
+                  "byte {1}",
+                  ByteOffset, ByteOffset + I)
+              .str());
+    }
+
+    Value *Part = Ctx.B.CreateZExt(*Byte, Ctx.I32Ty, "source_hidden_byte_zext");
+    if (I != 0)
+      Part = Ctx.B.CreateShl(Part, Ctx.B.getInt32(I * 8),
+                             "source_hidden_byte_place");
+    Acc = Ctx.B.CreateOr(Acc, Part, "source_hidden_dword");
+  }
+  if (IsSigned && ByteWidth < 4) {
+    Type *NarrowTy = Type::getIntNTy(Ctx.C, ByteWidth * 8);
+    return Ctx.B.CreateSExt(
+        Ctx.B.CreateTrunc(Acc, NarrowTy, "source_hidden_narrow"), Ctx.I32Ty,
+        "source_hidden_sext");
+  }
+  return Acc;
+}
+
+Expected<Value *> emitSourceHiddenDword(SourceHiddenArgContext &Ctx,
+                                        uint64_t ByteOffset) {
+  return emitSourceHiddenInteger(Ctx, ByteOffset, /*ByteWidth=*/4,
+                                 /*IsSigned=*/false);
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/source-hidden-args.h
+++ b/amd/comgr/src/hotswap/raiser/source-hidden-args.h
@@ -1,0 +1,70 @@
+//===- source-hidden-args.h - Hotswap transpiler --------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_SOURCE_HIDDEN_ARGS_H
+#define HOTSWAP_TRANSPILER_SOURCE_HIDDEN_ARGS_H
+
+#include "hotswap/common/kernel-meta.h"
+#include "kernarg-layout.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Error.h"
+
+#include <cstdint>
+
+namespace llvm {
+class Function;
+class IRBuilderBase;
+class LLVMContext;
+class Module;
+class Type;
+class Value;
+} // namespace llvm
+
+namespace COMGR::hotswap {
+
+// Inputs needed to synthesize source-ABI hidden argument values in IR.
+struct SourceHiddenArgContext {
+  llvm::LLVMContext &C;
+  llvm::Module &M;
+  llvm::IRBuilderBase &B;
+  llvm::Function &Fn;
+  // The i8/i32/i64 types are cached here rather than re-fetched from the
+  // builder at every use: the emit helpers below reference them densely and
+  // the cached handles keep those expressions terse.
+  llvm::Type *I8Ty;
+  llvm::Type *I32Ty;
+  llvm::Type *I64Ty;
+  llvm::ArrayRef<KernelArgMeta> Args;
+  bool AssumeHipGlobalOffsetZero = false;
+  unsigned TargetCodeObjectVersion = 6;
+  // Scaled replication factor along the x dimension. The runtime
+  // launches such a block with an x extent scaled up by this factor, so the
+  // source kernel's loops and reduction bounds must still observe the
+  // un-scaled block size: the synthesized `hidden_group_size_x` and x grid-size
+  // reads are divided by the factor. Derived hidden args (block_count =
+  // grid/group, remainder = grid%group) stay correct because the factor
+  // cancels in the ratio. A factor of 1 disables the adjustment.
+  unsigned ScaledReplicationFactor = 1;
+};
+
+// Synthesize a 32-bit source hidden argument value at ByteOffset. Returns a
+// null Value when the offset is not a source hidden argument (the caller then
+// falls back to a plain kernarg load); returns an Error when the offset is a
+// hidden argument with no supported source-side synthesis.
+llvm::Expected<llvm::Value *> emitSourceHiddenDword(SourceHiddenArgContext &Ctx,
+                                                    uint64_t ByteOffset);
+// Synthesize a 1-, 2-, or 4-byte source hidden integer at ByteOffset, with the
+// same null-Value / Error contract as emitSourceHiddenDword.
+llvm::Expected<llvm::Value *>
+emitSourceHiddenInteger(SourceHiddenArgContext &Ctx, uint64_t ByteOffset,
+                        unsigned ByteWidth, bool IsSigned);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/raiser/user-sgpr-layout.cpp
+++ b/amd/comgr/src/hotswap/raiser/user-sgpr-layout.cpp
@@ -1,0 +1,291 @@
+//===- user-sgpr-layout.cpp - Hotswap transpiler --------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "user-sgpr-layout.h"
+#include "raise_failure.h"
+
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/AMDHSAKernelDescriptor.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace COMGR::hotswap {
+
+namespace {
+
+// Append one Entry row per dword the source occupies. Returns the SGPR index of
+// the first (low) dword, which the caller stores into the convenience `*Sgpr`
+// field for the corresponding source.
+unsigned appendSource(llvm::SmallVectorImpl<UserSgprLayout::Entry> &Entries,
+                      UserSgprLayout::Source Src) {
+  unsigned FirstIdx = Entries.size();
+  for (unsigned I = 0, E = UserSgprLayout::dwordCount(Src); I < E; ++I) {
+    UserSgprLayout::Entry Row;
+    Row.SrcKind = Src;
+    Row.SubDword = static_cast<uint8_t>(I);
+    Entries.push_back(Row);
+  }
+  return FirstIdx;
+}
+
+llvm::StringRef sourceName(UserSgprLayout::Source S) {
+  switch (S) {
+  case UserSgprLayout::Source::Unset:
+    return "Unset";
+  case UserSgprLayout::Source::PrivateSegmentBuffer:
+    return "PrivateSegmentBuffer";
+  case UserSgprLayout::Source::DispatchPtr:
+    return "DispatchPtr";
+  case UserSgprLayout::Source::QueuePtr:
+    return "QueuePtr";
+  case UserSgprLayout::Source::KernargSegmentPtr:
+    return "KernargSegmentPtr";
+  case UserSgprLayout::Source::DispatchId:
+    return "DispatchId";
+  case UserSgprLayout::Source::FlatScratchInit:
+    return "FlatScratchInit";
+  case UserSgprLayout::Source::PrivateSegmentSize:
+    return "PrivateSegmentSize";
+  case UserSgprLayout::Source::PreloadedKernarg:
+    return "PreloadedKernarg";
+  case UserSgprLayout::Source::WorkgroupIdX:
+    return "WorkgroupIdX";
+  case UserSgprLayout::Source::WorkgroupIdY:
+    return "WorkgroupIdY";
+  case UserSgprLayout::Source::WorkgroupIdZ:
+    return "WorkgroupIdZ";
+  case UserSgprLayout::Source::WorkgroupInfo:
+    return "WorkgroupInfo";
+  }
+  return "<invalid>";
+}
+
+unsigned userSgprCountFieldWidth(const ISAProfile &SourceProfile) {
+  using namespace llvm::amdhsa;
+  return SourceProfile.hasGfx125UserSgprCountField()
+             ? COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT_WIDTH
+             : COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_WIDTH;
+}
+
+unsigned decodeUserSgprCount(uint32_t ComputePgmRsrc2,
+                             const ISAProfile &SourceProfile) {
+  using namespace llvm::amdhsa;
+  return SourceProfile.hasGfx125UserSgprCountField()
+             ? AMDHSA_BITS_GET(ComputePgmRsrc2,
+                               COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT)
+             : AMDHSA_BITS_GET(ComputePgmRsrc2,
+                               COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT);
+}
+
+void formatMetadataMismatch(llvm::raw_ostream &Os, const KernelMeta &Meta,
+                            llvm::StringRef SourceIsa,
+                            const UserSgprLayout &Layout,
+                            unsigned DecodedUserSgprCount,
+                            unsigned UserSgprCountWidth, unsigned PreloadLen,
+                            unsigned PreloadOffsetDwords) {
+  using namespace llvm::amdhsa;
+
+  Os << "transpiler: UserSgprLayout::fromKernelMeta: kernel '" << Meta.Name
+     << "' has compute_pgm_rsrc2.USER_SGPR_COUNT=" << DecodedUserSgprCount
+     << " (decoded as " << UserSgprCountWidth << "-bit field for source ISA '"
+     << SourceIsa << "') but kernel_code_properties + kernarg_preload imply "
+     << static_cast<unsigned>(Layout.UserSgprCount)
+     << ". Kernel descriptor is inconsistent -- refusing to guess the layout. "
+        "Raw descriptor fields:"
+     << " compute_pgm_rsrc1=0x" << llvm::utohexstr(Meta.ComputePgmRsrc1)
+     << " compute_pgm_rsrc2=0x" << llvm::utohexstr(Meta.ComputePgmRsrc2)
+     << " kernel_code_properties=0x"
+     << llvm::utohexstr(static_cast<unsigned>(Meta.KernelCodeProperties))
+     << " kernarg_preload=0x"
+     << llvm::utohexstr(static_cast<unsigned>(Meta.KernargPreload))
+     << " kernarg_preload_length=" << PreloadLen
+     << " kernarg_preload_offset_dwords=" << PreloadOffsetDwords
+     << " kernarg_segment_size=" << Meta.KernargSegmentSize
+     << " enabled_user_sgprs=[";
+
+  bool First = true;
+  auto Append = [&](llvm::StringRef Name, unsigned Count) {
+    if (!First)
+      Os << ",";
+    First = false;
+    Os << Name << ":" << Count;
+  };
+
+  using Source = UserSgprLayout::Source;
+  const uint16_t Kcp = Meta.KernelCodeProperties;
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_PRIVATE_SEGMENT_BUFFER)
+    Append("private_segment_buffer",
+           UserSgprLayout::dwordCount(Source::PrivateSegmentBuffer));
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_DISPATCH_PTR)
+    Append("dispatch_ptr", UserSgprLayout::dwordCount(Source::DispatchPtr));
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_QUEUE_PTR)
+    Append("queue_ptr", UserSgprLayout::dwordCount(Source::QueuePtr));
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR)
+    Append("kernarg_segment_ptr",
+           UserSgprLayout::dwordCount(Source::KernargSegmentPtr));
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_DISPATCH_ID)
+    Append("dispatch_id", UserSgprLayout::dwordCount(Source::DispatchId));
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_FLAT_SCRATCH_INIT)
+    Append("flat_scratch_init",
+           UserSgprLayout::dwordCount(Source::FlatScratchInit));
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_PRIVATE_SEGMENT_SIZE)
+    Append("private_segment_size",
+           UserSgprLayout::dwordCount(Source::PrivateSegmentSize));
+  if (PreloadLen > 0)
+    Append("kernarg_preload", PreloadLen);
+
+  Os << "] system_sgprs=[";
+  First = true;
+  auto AppendSystem = [&](llvm::StringRef Name) {
+    if (!First)
+      Os << ",";
+    First = false;
+    Os << Name;
+  };
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_X)
+    AppendSystem("workgroup_id_x");
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Y)
+    AppendSystem("workgroup_id_y");
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Z)
+    AppendSystem("workgroup_id_z");
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_INFO)
+    AppendSystem("workgroup_info");
+  Os << "]";
+}
+
+} // namespace
+
+unsigned UserSgprLayout::dwordCount(Source Src) {
+  switch (Src) {
+  case Source::PrivateSegmentBuffer:
+    return 4;
+  case Source::DispatchPtr:
+  case Source::QueuePtr:
+  case Source::KernargSegmentPtr:
+  case Source::DispatchId:
+  case Source::FlatScratchInit:
+    return 2;
+  case Source::PrivateSegmentSize:
+  case Source::PreloadedKernarg:
+  case Source::WorkgroupIdX:
+  case Source::WorkgroupIdY:
+  case Source::WorkgroupIdZ:
+  case Source::WorkgroupInfo:
+    return 1;
+  case Source::Unset:
+    return 0;
+  }
+  llvm_unreachable("unhandled UserSgprLayout::Source");
+}
+
+llvm::Error UserSgprLayout::tryFromKernelMeta(const KernelMeta &Meta,
+                                              const ISAProfile &SourceProfile,
+                                              llvm::StringRef SourceIsa,
+                                              UserSgprLayout &Layout) {
+  Layout = UserSgprLayout();
+
+  using namespace llvm::amdhsa;
+
+  const uint16_t Kcp = Meta.KernelCodeProperties;
+
+  // The ABI assigns user SGPRs in ascending kernel-code-property bit order.
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_PRIVATE_SEGMENT_BUFFER)
+    Layout.PrivateSegmentBufferSgpr =
+        appendSource(Layout.Entries, Source::PrivateSegmentBuffer);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_DISPATCH_PTR)
+    Layout.DispatchPtrSgpr = appendSource(Layout.Entries, Source::DispatchPtr);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_QUEUE_PTR)
+    Layout.QueuePtrSgpr = appendSource(Layout.Entries, Source::QueuePtr);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR)
+    Layout.KernargSegmentPtrSgpr =
+        appendSource(Layout.Entries, Source::KernargSegmentPtr);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_DISPATCH_ID)
+    Layout.DispatchIdSgpr = appendSource(Layout.Entries, Source::DispatchId);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_FLAT_SCRATCH_INIT)
+    Layout.FlatScratchInitSgpr =
+        appendSource(Layout.Entries, Source::FlatScratchInit);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_PRIVATE_SEGMENT_SIZE)
+    Layout.PrivateSegmentSizeSgpr =
+        appendSource(Layout.Entries, Source::PrivateSegmentSize);
+
+  // Kernarg preload (gfx1250+): N dwords from kernarg memory at byte
+  // offset (preloadOffset * 4) get loaded into the user SGPRs immediately
+  // above the enable_sgpr_*-selected ones, before kernel entry. The
+  // sequence is little-endian dword-aligned: dword i goes into
+  // s[user_sgpr_count_so_far + i] and corresponds to kernarg bytes
+  // [(offset+i)*4 .. (offset+i+1)*4 - 1].
+  const uint8_t PreloadLen = static_cast<uint8_t>(
+      AMDHSA_BITS_GET(Meta.KernargPreload, KERNARG_PRELOAD_SPEC_LENGTH));
+  const uint16_t PreloadOffsetDwords = static_cast<uint16_t>(
+      AMDHSA_BITS_GET(Meta.KernargPreload, KERNARG_PRELOAD_SPEC_OFFSET));
+  Layout.PreloadedKernargLength = PreloadLen;
+  Layout.PreloadedKernargByteOffset =
+      static_cast<uint16_t>(PreloadOffsetDwords * 4);
+  if (PreloadLen > 0) {
+    Layout.FirstPreloadedKernargSgpr = Layout.Entries.size();
+    for (unsigned I = 0; I < PreloadLen; ++I) {
+      Entry Row;
+      Row.SrcKind = Source::PreloadedKernarg;
+      // Each preloaded dword is its own independent SGPR: the byte offset alone
+      // identifies which kernarg slice it carries, so it is not bundled as a
+      // multi-dword source. SubDword stays 0 for every preload entry.
+      Row.SubDword = 0;
+      Row.KernargByteOffset =
+          static_cast<uint16_t>((PreloadOffsetDwords + I) * 4);
+      Layout.Entries.push_back(Row);
+    }
+  }
+
+  Layout.UserSgprCount = static_cast<uint8_t>(Layout.Entries.size());
+
+  // Sanity-check against compute_pgm_rsrc2.USER_SGPR_COUNT. gfx125 widens
+  // this field to 6 bits; using the older 5-bit decode would read a valid
+  // count of 32 as zero and falsely reject Triton gfx1250 kernels.
+  const unsigned UserSgprCountWidth = userSgprCountFieldWidth(SourceProfile);
+  const unsigned PgmRsrc2UserSgprCount =
+      decodeUserSgprCount(Meta.ComputePgmRsrc2, SourceProfile);
+  if (PgmRsrc2UserSgprCount != Layout.UserSgprCount) {
+    std::string Detail;
+    llvm::raw_string_ostream Os(Detail);
+    formatMetadataMismatch(Os, Meta, SourceIsa, Layout, PgmRsrc2UserSgprCount,
+                           UserSgprCountWidth, PreloadLen, PreloadOffsetDwords);
+    return RaiseFailure::inKernel(RaiseFailureReason::UserSgprLayoutMismatch,
+                                  Meta.Name, Detail);
+  }
+
+  // Workgroup ID SGPRs sit immediately above the user-SGPR region.
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_X)
+    Layout.WorkgroupIdXSgpr =
+        appendSource(Layout.Entries, Source::WorkgroupIdX);
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Y)
+    Layout.WorkgroupIdYSgpr =
+        appendSource(Layout.Entries, Source::WorkgroupIdY);
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Z)
+    Layout.WorkgroupIdZSgpr =
+        appendSource(Layout.Entries, Source::WorkgroupIdZ);
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_INFO)
+    Layout.WorkgroupInfoSgpr =
+        appendSource(Layout.Entries, Source::WorkgroupInfo);
+
+  return llvm::Error::success();
+}
+
+void UserSgprLayout::print(llvm::raw_ostream &OS) const {
+  OS << "user_sgpr_count=" << static_cast<int>(UserSgprCount);
+  for (size_t I = 0; I < Entries.size(); ++I) {
+    const Entry &E = Entries[I];
+    OS << " s[" << I << "]=" << sourceName(E.SrcKind);
+    if (E.SrcKind == Source::PreloadedKernarg)
+      OS << "(off=" << E.KernargByteOffset << ")";
+    else if (E.SubDword > 0)
+      OS << "[" << static_cast<int>(E.SubDword) << "]";
+  }
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/user-sgpr-layout.cpp
+++ b/amd/comgr/src/hotswap/raiser/user-sgpr-layout.cpp
@@ -214,20 +214,30 @@ llvm::Error UserSgprLayout::tryFromKernelMeta(const KernelMeta &Meta,
     Layout.PrivateSegmentSizeSgpr =
         appendSource(Layout.Entries, Source::PrivateSegmentSize);
 
-  // Kernarg preload (gfx1250+): N dwords from kernarg memory at byte
-  // offset (preloadOffset * 4) get loaded into the user SGPRs immediately
-  // above the enable_sgpr_*-selected ones, before kernel entry. The
-  // sequence is little-endian dword-aligned: dword i goes into
-  // s[user_sgpr_count_so_far + i] and corresponds to kernarg bytes
-  // [(offset+i)*4 .. (offset+i+1)*4 - 1].
+  // Preloaded dwords follow the enable_sgpr_*-selected entries in the source
+  // ABI.
   const uint8_t PreloadLen = static_cast<uint8_t>(
       AMDHSA_BITS_GET(Meta.KernargPreload, KERNARG_PRELOAD_SPEC_LENGTH));
   const uint16_t PreloadOffsetDwords = static_cast<uint16_t>(
       AMDHSA_BITS_GET(Meta.KernargPreload, KERNARG_PRELOAD_SPEC_OFFSET));
+  if (Meta.KernargPreload != 0 && !SourceProfile.hasKernargPreload())
+    return RaiseFailure::inKernel(RaiseFailureReason::UserSgprLayoutMismatch,
+                                  Meta.Name,
+                                  llvm::Twine("source ISA '") + SourceIsa +
+                                      "' does not support kernarg preloading");
   Layout.PreloadedKernargLength = PreloadLen;
   Layout.PreloadedKernargByteOffset =
       static_cast<uint16_t>(PreloadOffsetDwords * 4);
   if (PreloadLen > 0) {
+    const uint64_t PreloadEnd =
+        (static_cast<uint64_t>(PreloadOffsetDwords) + PreloadLen) * 4;
+    if (PreloadEnd > Meta.KernargSegmentSize)
+      return RaiseFailure::inKernel(
+          RaiseFailureReason::UserSgprLayoutMismatch, Meta.Name,
+          llvm::Twine("kernarg preload ends at byte ") +
+              llvm::Twine(PreloadEnd) + " beyond kernarg segment size " +
+              llvm::Twine(Meta.KernargSegmentSize));
+
     Layout.FirstPreloadedKernargSgpr = Layout.Entries.size();
     for (unsigned I = 0; I < PreloadLen; ++I) {
       Entry Row;
@@ -242,15 +252,21 @@ llvm::Error UserSgprLayout::tryFromKernelMeta(const KernelMeta &Meta,
     }
   }
 
-  Layout.UserSgprCount = static_cast<uint8_t>(Layout.Entries.size());
+  const unsigned ImpliedUserSgprCount = Layout.Entries.size();
+  Layout.UserSgprCount = static_cast<uint8_t>(ImpliedUserSgprCount);
 
-  // Sanity-check against compute_pgm_rsrc2.USER_SGPR_COUNT. gfx125 widens
-  // this field to 6 bits; using the older 5-bit decode would read a valid
-  // count of 32 as zero and falsely reject Triton gfx1250 kernels.
+  // USER_SGPR_COUNT is 6 bits on gfx1250, where 32 is a valid count.
   const unsigned UserSgprCountWidth = userSgprCountFieldWidth(SourceProfile);
   const unsigned PgmRsrc2UserSgprCount =
       decodeUserSgprCount(Meta.ComputePgmRsrc2, SourceProfile);
-  if (PgmRsrc2UserSgprCount != Layout.UserSgprCount) {
+  if (PgmRsrc2UserSgprCount > SourceProfile.maxUserSgprs())
+    return RaiseFailure::inKernel(
+        RaiseFailureReason::UserSgprLayoutMismatch, Meta.Name,
+        llvm::Twine("compute_pgm_rsrc2.USER_SGPR_COUNT=") +
+            llvm::Twine(PgmRsrc2UserSgprCount) + " exceeds source ISA '" +
+            SourceIsa + "' maximum of " +
+            llvm::Twine(SourceProfile.maxUserSgprs()));
+  if (PgmRsrc2UserSgprCount < ImpliedUserSgprCount) {
     std::string Detail;
     llvm::raw_string_ostream Os(Detail);
     formatMetadataMismatch(Os, Meta, SourceIsa, Layout, PgmRsrc2UserSgprCount,
@@ -259,14 +275,20 @@ llvm::Error UserSgprLayout::tryFromKernelMeta(const KernelMeta &Meta,
                                   Meta.Name, Detail);
   }
 
-  // Workgroup ID SGPRs sit immediately above the user-SGPR region.
-  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_X)
+  Layout.Entries.resize(PgmRsrc2UserSgprCount);
+  Layout.UserSgprCount = static_cast<uint8_t>(PgmRsrc2UserSgprCount);
+
+  // Architected workgroup IDs do not consume sequential SGPRs.
+  if (!SourceProfile.hasArchitectedSgprs() &&
+      Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_X)
     Layout.WorkgroupIdXSgpr =
         appendSource(Layout.Entries, Source::WorkgroupIdX);
-  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Y)
+  if (!SourceProfile.hasArchitectedSgprs() &&
+      Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Y)
     Layout.WorkgroupIdYSgpr =
         appendSource(Layout.Entries, Source::WorkgroupIdY);
-  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Z)
+  if (!SourceProfile.hasArchitectedSgprs() &&
+      Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Z)
     Layout.WorkgroupIdZSgpr =
         appendSource(Layout.Entries, Source::WorkgroupIdZ);
   if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_INFO)

--- a/amd/comgr/src/hotswap/raiser/user-sgpr-layout.h
+++ b/amd/comgr/src/hotswap/raiser/user-sgpr-layout.h
@@ -1,0 +1,149 @@
+//===- user-sgpr-layout.h - Hotswap transpiler ----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_USER_SGPR_LAYOUT_H
+#define HOTSWAP_TRANSPILER_USER_SGPR_LAYOUT_H
+
+#include "hotswap/common/kernel-meta.h"
+#include "hotswap/decoder/isa-profile.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace llvm {
+class raw_ostream;
+} // namespace llvm
+
+namespace COMGR::hotswap {
+
+// What each SGPR contains at function entry on the source ISA, derived from the
+// kernel descriptor (KernelMeta's KernelCodeProperties, KernargPreload,
+// ComputePgmRsrc2). This is the single source of truth for the source-ISA SGPR
+// ABI inside the raiser: the layout depends on kernarg-preload and
+// kernel_code_properties, so handlers must consult it rather than assuming
+// fixed SGPR indices.
+//
+// Entries is indexed by SGPR index, so Entries[i] describes the contents of
+// SGPR i at kernel entry. The convenience `*Sgpr()` accessors return the SGPR
+// index of the first dword of the corresponding source, or no value when the
+// source is disabled, so handlers can identify a source by comparison rather
+// than walking Entries.
+//
+// tryFromKernelMeta reports an inconsistent descriptor through llvm::Error; it
+// never falls back to a hardcoded layout.
+struct UserSgprLayout {
+  enum class Source : uint8_t {
+    Unset,
+    PrivateSegmentBuffer, // 4 dwords (s[i:i+3]) -- shader resource descriptor
+    DispatchPtr,          // 2 dwords -- pointer to the AQL dispatch packet
+    QueuePtr,             // 2 dwords -- pointer to the HSA queue object
+    KernargSegmentPtr,    // 2 dwords -- pointer to the kernarg segment
+    DispatchId,           // 2 dwords -- dispatch identifier
+    FlatScratchInit,      // 2 dwords -- flat scratch base/size init
+    PrivateSegmentSize,   // 1 dword  -- size of private segment per work-item
+    PreloadedKernarg,     // 1 dword  -- preloaded kernarg dword (gfx1250 ABI)
+    WorkgroupIdX,         // 1 dword  -- system SGPR (compute_pgm_rsrc2 bit 7)
+    WorkgroupIdY,         // 1 dword  -- system SGPR (compute_pgm_rsrc2 bit 8)
+    WorkgroupIdZ,         // 1 dword  -- system SGPR (compute_pgm_rsrc2 bit 9)
+    WorkgroupInfo,        // 1 dword  -- system SGPR (compute_pgm_rsrc2 bit 10)
+  };
+
+  // Number of consecutive SGPRs the source occupies.
+  static unsigned dwordCount(Source Src);
+
+  struct Entry {
+    Source SrcKind = Source::Unset;
+    // For multi-dword sources (DispatchPtr, KernargSegmentPtr, ...) this is
+    // the dword index within the source: 0 = lo, 1 = hi for 2-dword
+    // sources, 0..3 for the 4-dword private segment buffer descriptor.
+    uint8_t SubDword = 0;
+    // For PreloadedKernarg only: the byte offset within the kernarg segment
+    // that this dword originated from. Computed as
+    // `(kernarg_preload_offset + i) * 4` per the gfx1250 ABI. Used by the
+    // raiser to look up the matching kernarg parameter and extract the
+    // appropriate dword from it.
+    uint16_t KernargByteOffset = 0;
+  };
+
+  llvm::SmallVector<Entry> Entries;
+  uint8_t UserSgprCount = 0; // == Entries.size() at end of user-SGPR region
+
+  // SGPR index that holds the low dword of the corresponding source, or no
+  // value when the source is not enabled in `kernel_code_properties` /
+  // `compute_pgm_rsrc2`. Handlers identify a source by comparing against these
+  // rather than assuming a fixed SGPR index.
+  std::optional<unsigned> kernargSegmentPtrSgpr() const {
+    return KernargSegmentPtrSgpr;
+  }
+  std::optional<unsigned> dispatchPtrSgpr() const { return DispatchPtrSgpr; }
+  std::optional<unsigned> queuePtrSgpr() const { return QueuePtrSgpr; }
+  std::optional<unsigned> dispatchIdSgpr() const { return DispatchIdSgpr; }
+  std::optional<unsigned> flatScratchInitSgpr() const {
+    return FlatScratchInitSgpr;
+  }
+  std::optional<unsigned> privateSegmentBufferSgpr() const {
+    return PrivateSegmentBufferSgpr;
+  }
+  std::optional<unsigned> privateSegmentSizeSgpr() const {
+    return PrivateSegmentSizeSgpr;
+  }
+  std::optional<unsigned> workgroupIdXSgpr() const { return WorkgroupIdXSgpr; }
+  std::optional<unsigned> workgroupIdYSgpr() const { return WorkgroupIdYSgpr; }
+  std::optional<unsigned> workgroupIdZSgpr() const { return WorkgroupIdZSgpr; }
+  std::optional<unsigned> workgroupInfoSgpr() const {
+    return WorkgroupInfoSgpr;
+  }
+
+  // SGPR index of the first preloaded kernarg dword, or no value when no
+  // kernarg preload is enabled.
+  std::optional<unsigned> firstPreloadedKernargSgpr() const {
+    return FirstPreloadedKernargSgpr;
+  }
+  uint8_t preloadedKernargLength() const { return PreloadedKernargLength; }
+  uint16_t preloadedKernargByteOffset() const {
+    return PreloadedKernargByteOffset;
+  }
+
+  // Build the layout from a parsed kernel descriptor. Returns llvm::Error
+  // when the descriptor is missing or internally inconsistent.
+  // `sourceProfile` selects ABI-versioned fields such as gfx125's 6-bit
+  // compute_pgm_rsrc2.USER_SGPR_COUNT. `sourceISA` is used only in diagnostics.
+  static llvm::Error tryFromKernelMeta(const KernelMeta &Meta,
+                                       const ISAProfile &SourceProfile,
+                                       llvm::StringRef SourceIsa,
+                                       UserSgprLayout &Layout);
+
+  // Stream a one-line debug summary useful for HSA_HOTSWAP_DEBUG output and
+  // failure diagnostics, in the form:
+  //   "user_sgpr_count=N s[0]=KernargSegmentPtr s[2]=PreloadedKernarg(off=0)"
+  void print(llvm::raw_ostream &OS) const;
+
+private:
+  std::optional<unsigned> KernargSegmentPtrSgpr;
+  std::optional<unsigned> DispatchPtrSgpr;
+  std::optional<unsigned> QueuePtrSgpr;
+  std::optional<unsigned> DispatchIdSgpr;
+  std::optional<unsigned> FlatScratchInitSgpr;
+  std::optional<unsigned> PrivateSegmentBufferSgpr;
+  std::optional<unsigned> PrivateSegmentSizeSgpr;
+  std::optional<unsigned> WorkgroupIdXSgpr;
+  std::optional<unsigned> WorkgroupIdYSgpr;
+  std::optional<unsigned> WorkgroupIdZSgpr;
+  std::optional<unsigned> WorkgroupInfoSgpr;
+  std::optional<unsigned> FirstPreloadedKernargSgpr;
+  uint8_t PreloadedKernargLength = 0;
+  uint16_t PreloadedKernargByteOffset = 0;
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/test-unit/hotswap/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/CMakeLists.txt
@@ -7,7 +7,7 @@ if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   add_subdirectory(decoder)
   list(APPEND COMGR_HOTSWAP_TEST_TARGETS
     RaiserScaffoldingTests WaveProjectionTests RaiseFailureTests RegFileTests
-    DecoderTests)
+    KernargAbiLayoutTests DecoderTests)
 endif()
 
 # The test binaries above, exported to the parent scope so the top-level

--- a/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
@@ -112,3 +112,27 @@ target_include_directories(RegFileTests PRIVATE
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
 
 comgr_configure_test_target(RegFileTests)
+
+# -- KernargAbiLayoutTests ----------------------------------------------------
+#
+# Covers the source kernel-argument ABI reconstruction: the user-SGPR layout
+# derived from the kernel descriptor, hidden-argument byte classification, and
+# the IR synthesis of source hidden argument values.
+
+add_executable(KernargAbiLayoutTests
+  KernargAbiLayoutTest.cpp)
+
+target_link_libraries(KernargAbiLayoutTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  hotswap::raiser
+  hotswap::decoder
+  hotswap::common
+  ${LLVM_PTHREAD_LIB})
+
+target_include_directories(KernargAbiLayoutTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+
+comgr_configure_test_target(KernargAbiLayoutTests)

--- a/amd/comgr/test-unit/hotswap/raiser/KernargAbiLayoutTest.cpp
+++ b/amd/comgr/test-unit/hotswap/raiser/KernargAbiLayoutTest.cpp
@@ -1,0 +1,468 @@
+//===- KernargAbiLayoutTest.cpp - Hotswap kernarg ABI layout tests --------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Covers the source kernel-argument ABI reconstruction the raiser seeds entry
+// registers from: the user-SGPR layout derived from the kernel descriptor, the
+// hidden-argument byte classification, and the IR synthesis of source hidden
+// argument values.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hotswap/raiser/kernarg-layout.h"
+#include "hotswap/raiser/raise_failure.h"
+#include "hotswap/raiser/source-hidden-args.h"
+#include "hotswap/raiser/user-sgpr-layout.h"
+
+#include "hotswap/decoder/isa-profile.h"
+#include "hotswap/decoder/mc-state.h"
+
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/AMDHSAKernelDescriptor.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "gtest/gtest.h"
+
+#include <mutex>
+
+// initMCState calls COMGR::ensureLLVMInitialized, whose production definition
+// lives in libamd_comgr. Provide the registration here so the test binary stays
+// minimal instead of linking the full Comgr.
+namespace COMGR {
+void ensureLLVMInitialized() {
+  static std::once_flag Once;
+  std::call_once(Once, [] {
+    LLVMInitializeAMDGPUTargetInfo();
+    LLVMInitializeAMDGPUTargetMC();
+    LLVMInitializeAMDGPUDisassembler();
+    LLVMInitializeAMDGPUAsmParser();
+    LLVMInitializeAMDGPUAsmPrinter();
+    LLVMInitializeAMDGPUTarget();
+  });
+}
+} // namespace COMGR
+
+using namespace COMGR::hotswap;
+using namespace llvm;
+
+namespace {
+
+KernelArgMeta arg(StringRef ValueKind, uint32_t Offset, uint32_t Size) {
+  KernelArgMeta A;
+  A.ValueKind = ValueKind.str();
+  A.Offset = Offset;
+  A.Size = Size;
+  return A;
+}
+
+// Reason of the RaiseFailure carried by an Error, or None when the Error is not
+// a RaiseFailure. Consumes the Error.
+RaiseFailureReason reasonOf(Error E) {
+  RaiseFailureReason Reason = RaiseFailureReason::None;
+  handleAllErrors(std::move(E),
+                  [&](const RaiseFailure &F) { Reason = F.reason(); });
+  return Reason;
+}
+
+// Whether an Error is success, consuming it either way (llvm::Error is not
+// directly convertible to the bool gtest's ASSERT_* macros expect).
+bool succeeded(Error E) {
+  if (E) {
+    consumeError(std::move(E));
+    return false;
+  }
+  return true;
+}
+
+// Owns an MCState so the ISAProfile's referenced subtarget outlives it.
+class Profile {
+public:
+  explicit Profile(StringRef Isa) {
+    if (Expected<MCState> S = initMCState(Isa)) {
+      State = std::move(*S);
+      Ok = true;
+    } else {
+      consumeError(S.takeError());
+    }
+  }
+  bool ok() const { return Ok && State.SubtargetInfo != nullptr; }
+  ISAProfile get() const {
+    return ISAProfile::fromSubtarget(*State.SubtargetInfo);
+  }
+
+private:
+  bool Ok = false;
+  MCState State;
+};
+
+// A module with one entry-block-positioned builder, for the IR-emitting
+// hidden-argument helpers.
+class HiddenArgHarness {
+public:
+  HiddenArgHarness() : M("kernarg-abi-test", C), B(C) {
+    Fn = Function::Create(FunctionType::get(Type::getVoidTy(C), false),
+                          GlobalValue::ExternalLinkage, "k", M);
+    B.SetInsertPoint(BasicBlock::Create(C, "entry", Fn));
+  }
+
+  SourceHiddenArgContext context(ArrayRef<KernelArgMeta> Args,
+                                 unsigned ScaledReplicationFactor = 1,
+                                 bool AssumeHipGlobalOffsetZero = false) {
+    return SourceHiddenArgContext{C,
+                                  M,
+                                  B,
+                                  *Fn,
+                                  B.getInt8Ty(),
+                                  B.getInt32Ty(),
+                                  B.getInt64Ty(),
+                                  Args,
+                                  AssumeHipGlobalOffsetZero,
+                                  /*TargetCodeObjectVersion=*/6,
+                                  ScaledReplicationFactor};
+  }
+
+  std::string dump() const {
+    std::string S;
+    raw_string_ostream OS(S);
+    Fn->print(OS);
+    return S;
+  }
+
+private:
+  LLVMContext C;
+  Module M;
+
+public:
+  IRBuilder<> B;
+  Function *Fn = nullptr;
+};
+
+TEST(UserSgprLayout, DerivesCanonicalOrderAndAccessors) {
+  Profile P("gfx942");
+  ASSERT_TRUE(P.ok());
+
+  using namespace llvm::amdhsa;
+  KernelMeta Meta;
+  Meta.Name = "k";
+  Meta.KernelCodeProperties =
+      KERNEL_CODE_PROPERTY_ENABLE_SGPR_DISPATCH_PTR |
+      KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR;
+  Meta.ComputePgmRsrc2 =
+      (4u << COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_SHIFT) |
+      COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_X;
+
+  UserSgprLayout Layout;
+  ASSERT_TRUE(succeeded(
+      UserSgprLayout::tryFromKernelMeta(Meta, P.get(), "gfx942", Layout)));
+
+  // dispatch_ptr precedes kernarg_segment_ptr in the canonical order; the
+  // workgroup id follows the user-SGPR region and is not counted in it.
+  EXPECT_EQ(Layout.UserSgprCount, 4u);
+  ASSERT_EQ(Layout.Entries.size(), 5u);
+  ASSERT_TRUE(Layout.dispatchPtrSgpr().has_value());
+  EXPECT_EQ(*Layout.dispatchPtrSgpr(), 0u);
+  ASSERT_TRUE(Layout.kernargSegmentPtrSgpr().has_value());
+  EXPECT_EQ(*Layout.kernargSegmentPtrSgpr(), 2u);
+  ASSERT_TRUE(Layout.workgroupIdXSgpr().has_value());
+  EXPECT_EQ(*Layout.workgroupIdXSgpr(), 4u);
+  EXPECT_EQ(Layout.Entries[1].SrcKind, UserSgprLayout::Source::DispatchPtr);
+  EXPECT_EQ(Layout.Entries[1].SubDword, 1u);
+  EXPECT_EQ(Layout.Entries[4].SrcKind, UserSgprLayout::Source::WorkgroupIdX);
+}
+
+TEST(UserSgprLayout, DisabledSourcesHaveNoSgpr) {
+  Profile P("gfx942");
+  ASSERT_TRUE(P.ok());
+
+  using namespace llvm::amdhsa;
+  KernelMeta Meta;
+  Meta.Name = "k";
+  Meta.KernelCodeProperties =
+      KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR;
+  Meta.ComputePgmRsrc2 = 2u
+                         << COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_SHIFT;
+
+  UserSgprLayout Layout;
+  ASSERT_TRUE(succeeded(
+      UserSgprLayout::tryFromKernelMeta(Meta, P.get(), "gfx942", Layout)));
+  ASSERT_TRUE(Layout.kernargSegmentPtrSgpr().has_value());
+  EXPECT_EQ(*Layout.kernargSegmentPtrSgpr(), 0u);
+  EXPECT_FALSE(Layout.dispatchPtrSgpr().has_value());
+  EXPECT_FALSE(Layout.queuePtrSgpr().has_value());
+  EXPECT_FALSE(Layout.firstPreloadedKernargSgpr().has_value());
+}
+
+TEST(UserSgprLayout, EntryRunLengthMatchesDwordCount) {
+  Profile P("gfx942");
+  ASSERT_TRUE(P.ok());
+
+  using namespace llvm::amdhsa;
+  using Source = UserSgprLayout::Source;
+  KernelMeta Meta;
+  Meta.Name = "k";
+  Meta.KernelCodeProperties =
+      KERNEL_CODE_PROPERTY_ENABLE_SGPR_PRIVATE_SEGMENT_BUFFER |
+      KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR;
+  // 4 (private_segment_buffer) + 2 (kernarg_segment_ptr) = 6 user SGPRs.
+  Meta.ComputePgmRsrc2 = 6u
+                         << COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_SHIFT;
+
+  UserSgprLayout Layout;
+  ASSERT_TRUE(succeeded(
+      UserSgprLayout::tryFromKernelMeta(Meta, P.get(), "gfx942", Layout)));
+
+  // Every source occupies exactly dwordCount(source) consecutive entries.
+  for (size_t I = 0; I < Layout.Entries.size();) {
+    UserSgprLayout::Source Src = Layout.Entries[I].SrcKind;
+    unsigned Run = 0;
+    while (I + Run < Layout.Entries.size() &&
+           Layout.Entries[I + Run].SrcKind == Src &&
+           Layout.Entries[I + Run].SubDword == Run) {
+      ++Run;
+    }
+    EXPECT_EQ(Run, UserSgprLayout::dwordCount(Src));
+    I += Run;
+  }
+  EXPECT_EQ(UserSgprLayout::dwordCount(Source::PrivateSegmentBuffer), 4u);
+  EXPECT_EQ(UserSgprLayout::dwordCount(Source::KernargSegmentPtr), 2u);
+  EXPECT_EQ(UserSgprLayout::dwordCount(Source::WorkgroupIdX), 1u);
+}
+
+TEST(UserSgprLayout, DecodesKernargPreload) {
+  Profile P("gfx1250");
+  ASSERT_TRUE(P.ok());
+
+  using namespace llvm::amdhsa;
+  KernelMeta Meta;
+  Meta.Name = "k";
+  Meta.KernelCodeProperties =
+      KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR;
+  const unsigned PreloadLen = 3;
+  const unsigned PreloadOffsetDwords = 2;
+  Meta.KernargPreload = static_cast<uint16_t>(
+      (PreloadLen << KERNARG_PRELOAD_SPEC_LENGTH_SHIFT) |
+      (PreloadOffsetDwords << KERNARG_PRELOAD_SPEC_OFFSET_SHIFT));
+  // 2 (kernarg_segment_ptr) + 3 (preload) = 5 user SGPRs.
+  Meta.ComputePgmRsrc2 = 5u << COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT_SHIFT;
+
+  UserSgprLayout Layout;
+  ASSERT_TRUE(succeeded(
+      UserSgprLayout::tryFromKernelMeta(Meta, P.get(), "gfx1250", Layout)));
+  EXPECT_EQ(Layout.preloadedKernargLength(), PreloadLen);
+  EXPECT_EQ(Layout.preloadedKernargByteOffset(), PreloadOffsetDwords * 4);
+  ASSERT_TRUE(Layout.firstPreloadedKernargSgpr().has_value());
+  EXPECT_EQ(*Layout.firstPreloadedKernargSgpr(), 2u);
+  ASSERT_EQ(Layout.Entries.size(), 5u);
+  EXPECT_EQ(Layout.Entries[2].SrcKind,
+            UserSgprLayout::Source::PreloadedKernarg);
+  EXPECT_EQ(Layout.Entries[2].KernargByteOffset, PreloadOffsetDwords * 4);
+  EXPECT_EQ(Layout.Entries[4].KernargByteOffset, (PreloadOffsetDwords + 2) * 4);
+}
+
+TEST(UserSgprLayout, InconsistentDescriptorIsRefused) {
+  Profile P("gfx942");
+  ASSERT_TRUE(P.ok());
+
+  using namespace llvm::amdhsa;
+  KernelMeta Meta;
+  Meta.Name = "k";
+  Meta.KernelCodeProperties =
+      KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR;
+  // Enable bits imply 2 user SGPRs, but the descriptor claims 5.
+  Meta.ComputePgmRsrc2 = 5u
+                         << COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_SHIFT;
+
+  UserSgprLayout Layout;
+  Error E = UserSgprLayout::tryFromKernelMeta(Meta, P.get(), "gfx942", Layout);
+  EXPECT_EQ(reasonOf(std::move(E)), RaiseFailureReason::UserSgprLayoutMismatch);
+}
+
+TEST(UserSgprLayout, UserSgprCountFieldWidthIsIsaVersioned) {
+  Profile Gfx942("gfx942");
+  Profile Gfx1250("gfx1250");
+  ASSERT_TRUE(Gfx942.ok());
+  ASSERT_TRUE(Gfx1250.ok());
+
+  using namespace llvm::amdhsa;
+  // A 33-entry layout: kernarg_segment_ptr (2) + 31 preloaded dwords. The
+  // descriptor stores USER_SGPR_COUNT=33, which needs the 6-bit gfx1250 field;
+  // the 5-bit gfx942 decode reads it as 33 & 0x1F == 1 and rejects the layout.
+  KernelMeta Meta;
+  Meta.Name = "k";
+  Meta.KernelCodeProperties =
+      KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR;
+  Meta.KernargPreload =
+      static_cast<uint16_t>(31u << KERNARG_PRELOAD_SPEC_LENGTH_SHIFT);
+  // Shift is identical for both field widths; only the width differs.
+  Meta.ComputePgmRsrc2 = 33u << COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT_SHIFT;
+
+  UserSgprLayout OnGfx1250;
+  EXPECT_TRUE(succeeded(UserSgprLayout::tryFromKernelMeta(
+      Meta, Gfx1250.get(), "gfx1250", OnGfx1250)));
+  EXPECT_EQ(OnGfx1250.UserSgprCount, 33u);
+
+  UserSgprLayout OnGfx942;
+  Error E =
+      UserSgprLayout::tryFromKernelMeta(Meta, Gfx942.get(), "gfx942", OnGfx942);
+  EXPECT_EQ(reasonOf(std::move(E)), RaiseFailureReason::UserSgprLayoutMismatch);
+}
+
+TEST(UserSgprLayout, PrintSummarizesEntries) {
+  Profile P("gfx942");
+  ASSERT_TRUE(P.ok());
+
+  using namespace llvm::amdhsa;
+  KernelMeta Meta;
+  Meta.Name = "k";
+  Meta.KernelCodeProperties =
+      KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR;
+  Meta.ComputePgmRsrc2 = 2u
+                         << COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_SHIFT;
+
+  UserSgprLayout Layout;
+  ASSERT_TRUE(succeeded(
+      UserSgprLayout::tryFromKernelMeta(Meta, P.get(), "gfx942", Layout)));
+  std::string S;
+  raw_string_ostream OS(S);
+  Layout.print(OS);
+  EXPECT_NE(S.find("user_sgpr_count=2"), std::string::npos);
+  EXPECT_NE(S.find("s[0]=KernargSegmentPtr"), std::string::npos);
+}
+
+TEST(ClassifySourceHiddenArgByte, MatchesHiddenArgByteIndex) {
+  std::vector<KernelArgMeta> Args = {arg("hidden_block_count_x", 8, 4)};
+  std::optional<SourceHiddenArgByte> B = classifySourceHiddenArgByte(Args, 11);
+  ASSERT_TRUE(B.has_value());
+  EXPECT_EQ(B->Kind, SourceHiddenArgKind::HiddenBlockCountX);
+  EXPECT_EQ(B->ArgOffset, 8u);
+  EXPECT_EQ(B->ByteOffset, 11u);
+  EXPECT_EQ(B->byteIndexInArg(), 3u);
+}
+
+TEST(ClassifySourceHiddenArgByte, RegularArgIsNotAMatch) {
+  std::vector<KernelArgMeta> Args = {arg("by_value", 0, 8)};
+  EXPECT_FALSE(classifySourceHiddenArgByte(Args, 0).has_value());
+}
+
+TEST(ClassifySourceHiddenArgByte, UnknownHiddenKindIsUnsupported) {
+  std::vector<KernelArgMeta> Args = {arg("hidden_something_new", 0, 4)};
+  std::optional<SourceHiddenArgByte> B = classifySourceHiddenArgByte(Args, 0);
+  ASSERT_TRUE(B.has_value());
+  EXPECT_EQ(B->Kind, SourceHiddenArgKind::UnsupportedHidden);
+}
+
+TEST(ClassifySourceHiddenArgByte, OffsetPastAllArgsIsNotAMatch) {
+  std::vector<KernelArgMeta> Args = {arg("hidden_block_count_x", 0, 4)};
+  EXPECT_FALSE(classifySourceHiddenArgByte(Args, 64).has_value());
+}
+
+TEST(EmitSourceHidden, BlockCountSynthesizesDispatchDivision) {
+  HiddenArgHarness H;
+  std::vector<KernelArgMeta> Args = {arg("hidden_block_count_x", 0, 4)};
+  SourceHiddenArgContext Ctx = H.context(Args);
+
+  Expected<Value *> V = emitSourceHiddenDword(Ctx, 0);
+  ASSERT_TRUE(static_cast<bool>(V));
+  EXPECT_NE(*V, nullptr);
+  // block_count = grid_size / group_size, backed by dispatch-packet reads.
+  std::string IR = H.dump();
+  EXPECT_NE(IR.find("udiv"), std::string::npos);
+  EXPECT_NE(IR.find("dispatch.ptr"), std::string::npos);
+}
+
+TEST(EmitSourceHidden, RegularArgReturnsNullWithoutError) {
+  HiddenArgHarness H;
+  std::vector<KernelArgMeta> Args = {arg("global_buffer", 0, 8)};
+  SourceHiddenArgContext Ctx = H.context(Args);
+
+  Expected<Value *> V = emitSourceHiddenDword(Ctx, 0);
+  ASSERT_TRUE(static_cast<bool>(V));
+  EXPECT_EQ(*V, nullptr);
+}
+
+TEST(EmitSourceHidden, UnsupportedHiddenKindIsAnError) {
+  HiddenArgHarness H;
+  std::vector<KernelArgMeta> Args = {arg("hidden_private_base", 0, 8)};
+  SourceHiddenArgContext Ctx = H.context(Args);
+
+  Expected<Value *> V = emitSourceHiddenDword(Ctx, 0);
+  ASSERT_FALSE(static_cast<bool>(V));
+  EXPECT_EQ(reasonOf(V.takeError()),
+            RaiseFailureReason::UnsupportedSourceHiddenArg);
+}
+
+TEST(EmitSourceHidden, GlobalOffsetNeedsHipZeroAssumption) {
+  std::vector<KernelArgMeta> Args = {arg("hidden_global_offset_x", 0, 8)};
+
+  HiddenArgHarness Reject;
+  SourceHiddenArgContext RejectCtx = Reject.context(Args);
+  Expected<Value *> Rejected = emitSourceHiddenDword(RejectCtx, 0);
+  ASSERT_FALSE(static_cast<bool>(Rejected));
+  EXPECT_EQ(reasonOf(Rejected.takeError()),
+            RaiseFailureReason::UnsupportedSourceHiddenArg);
+
+  HiddenArgHarness Accept;
+  SourceHiddenArgContext AcceptCtx =
+      Accept.context(Args, /*ScaledReplicationFactor=*/1,
+                     /*AssumeHipGlobalOffsetZero=*/true);
+  Expected<Value *> Accepted = emitSourceHiddenDword(AcceptCtx, 0);
+  ASSERT_TRUE(static_cast<bool>(Accepted));
+  EXPECT_NE(*Accepted, nullptr);
+}
+
+TEST(EmitSourceHidden, ScaledReplicationDescalesOnlyXGroupSize) {
+  std::vector<KernelArgMeta> ArgsX = {arg("hidden_group_size_x", 0, 2)};
+  std::vector<KernelArgMeta> ArgsY = {arg("hidden_group_size_y", 0, 2)};
+
+  HiddenArgHarness AlongX;
+  SourceHiddenArgContext CtxX =
+      AlongX.context(ArgsX, /*ScaledReplicationFactor=*/2);
+  ASSERT_TRUE(static_cast<bool>(
+      emitSourceHiddenInteger(CtxX, 0, /*ByteWidth=*/2, /*IsSigned=*/false)));
+  EXPECT_NE(AlongX.dump().find("_descaled"), std::string::npos);
+
+  HiddenArgHarness AlongY;
+  SourceHiddenArgContext CtxY =
+      AlongY.context(ArgsY, /*ScaledReplicationFactor=*/2);
+  ASSERT_TRUE(static_cast<bool>(
+      emitSourceHiddenInteger(CtxY, 0, /*ByteWidth=*/2, /*IsSigned=*/false)));
+  EXPECT_EQ(AlongY.dump().find("_descaled"), std::string::npos);
+}
+
+TEST(EmitSourceHidden, UnsupportedIntegerWidthIsAnError) {
+  HiddenArgHarness H;
+  std::vector<KernelArgMeta> Args = {arg("hidden_block_count_x", 0, 4)};
+  SourceHiddenArgContext Ctx = H.context(Args);
+
+  Expected<Value *> V =
+      emitSourceHiddenInteger(Ctx, 0, /*ByteWidth=*/3, /*IsSigned=*/false);
+  ASSERT_FALSE(static_cast<bool>(V));
+  EXPECT_EQ(reasonOf(V.takeError()),
+            RaiseFailureReason::UnsupportedSourceHiddenArg);
+}
+
+TEST(EmitSourceHidden, DwordSpanningNonHiddenByteIsAnError) {
+  HiddenArgHarness H;
+  // A 2-byte hidden field followed by a regular arg: a 4-byte read at offset 0
+  // starts hidden but runs into non-hidden memory.
+  std::vector<KernelArgMeta> Args = {arg("hidden_grid_dims", 0, 2),
+                                     arg("by_value", 2, 4)};
+  SourceHiddenArgContext Ctx = H.context(Args);
+
+  Expected<Value *> V = emitSourceHiddenDword(Ctx, 0);
+  ASSERT_FALSE(static_cast<bool>(V));
+  EXPECT_EQ(reasonOf(V.takeError()),
+            RaiseFailureReason::UnsupportedSourceHiddenArg);
+}
+
+} // namespace

--- a/amd/comgr/test-unit/hotswap/raiser/KernargAbiLayoutTest.cpp
+++ b/amd/comgr/test-unit/hotswap/raiser/KernargAbiLayoutTest.cpp
@@ -249,6 +249,7 @@ TEST(UserSgprLayout, DecodesKernargPreload) {
       KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR;
   const unsigned PreloadLen = 3;
   const unsigned PreloadOffsetDwords = 2;
+  Meta.KernargSegmentSize = 20;
   Meta.KernargPreload = static_cast<uint16_t>(
       (PreloadLen << KERNARG_PRELOAD_SPEC_LENGTH_SHIFT) |
       (PreloadOffsetDwords << KERNARG_PRELOAD_SPEC_OFFSET_SHIFT));
@@ -269,7 +270,7 @@ TEST(UserSgprLayout, DecodesKernargPreload) {
   EXPECT_EQ(Layout.Entries[4].KernargByteOffset, (PreloadOffsetDwords + 2) * 4);
 }
 
-TEST(UserSgprLayout, InconsistentDescriptorIsRefused) {
+TEST(UserSgprLayout, ReservedUserSgprsRemainUnset) {
   Profile P("gfx942");
   ASSERT_TRUE(P.ok());
 
@@ -278,13 +279,78 @@ TEST(UserSgprLayout, InconsistentDescriptorIsRefused) {
   Meta.Name = "k";
   Meta.KernelCodeProperties =
       KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR;
-  // Enable bits imply 2 user SGPRs, but the descriptor claims 5.
-  Meta.ComputePgmRsrc2 = 5u
+  Meta.ComputePgmRsrc2 =
+      (5u << COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_SHIFT) |
+      COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_X;
+
+  UserSgprLayout Layout;
+  ASSERT_TRUE(succeeded(
+      UserSgprLayout::tryFromKernelMeta(Meta, P.get(), "gfx942", Layout)));
+  EXPECT_EQ(Layout.UserSgprCount, 5u);
+  ASSERT_EQ(Layout.Entries.size(), 6u);
+  EXPECT_EQ(Layout.Entries[2].SrcKind, UserSgprLayout::Source::Unset);
+  EXPECT_EQ(Layout.Entries[4].SrcKind, UserSgprLayout::Source::Unset);
+  ASSERT_TRUE(Layout.workgroupIdXSgpr().has_value());
+  EXPECT_EQ(*Layout.workgroupIdXSgpr(), 5u);
+}
+
+TEST(UserSgprLayout, TooFewUserSgprsAreRefused) {
+  Profile P("gfx942");
+  ASSERT_TRUE(P.ok());
+
+  using namespace llvm::amdhsa;
+  KernelMeta Meta;
+  Meta.Name = "k";
+  Meta.KernelCodeProperties =
+      KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR;
+  Meta.ComputePgmRsrc2 = 1u
                          << COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_SHIFT;
 
   UserSgprLayout Layout;
   Error E = UserSgprLayout::tryFromKernelMeta(Meta, P.get(), "gfx942", Layout);
   EXPECT_EQ(reasonOf(std::move(E)), RaiseFailureReason::UserSgprLayoutMismatch);
+}
+
+TEST(UserSgprLayout, KernargPreloadOutsideSegmentIsRefused) {
+  Profile P("gfx1250");
+  ASSERT_TRUE(P.ok());
+
+  using namespace llvm::amdhsa;
+  KernelMeta Meta;
+  Meta.Name = "k";
+  Meta.KernargSegmentSize = 4;
+  Meta.KernargPreload =
+      static_cast<uint16_t>((1u << KERNARG_PRELOAD_SPEC_LENGTH_SHIFT) |
+                            (1u << KERNARG_PRELOAD_SPEC_OFFSET_SHIFT));
+  Meta.ComputePgmRsrc2 = 1u << COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT_SHIFT;
+
+  UserSgprLayout Layout;
+  Error E = UserSgprLayout::tryFromKernelMeta(Meta, P.get(), "gfx1250", Layout);
+  EXPECT_EQ(reasonOf(std::move(E)), RaiseFailureReason::UserSgprLayoutMismatch);
+}
+
+TEST(UserSgprLayout, ArchitectedWorkgroupIdsAreNotSequentialSgprs) {
+  Profile P("gfx1250");
+  ASSERT_TRUE(P.ok());
+
+  using namespace llvm::amdhsa;
+  KernelMeta Meta;
+  Meta.Name = "k";
+  Meta.ComputePgmRsrc2 = COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_X |
+                         COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Y |
+                         COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Z |
+                         COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_INFO;
+
+  UserSgprLayout Layout;
+  ASSERT_TRUE(succeeded(
+      UserSgprLayout::tryFromKernelMeta(Meta, P.get(), "gfx1250", Layout)));
+  EXPECT_FALSE(Layout.workgroupIdXSgpr().has_value());
+  EXPECT_FALSE(Layout.workgroupIdYSgpr().has_value());
+  EXPECT_FALSE(Layout.workgroupIdZSgpr().has_value());
+  ASSERT_TRUE(Layout.workgroupInfoSgpr().has_value());
+  EXPECT_EQ(*Layout.workgroupInfoSgpr(), 0u);
+  ASSERT_EQ(Layout.Entries.size(), 1u);
+  EXPECT_EQ(Layout.Entries[0].SrcKind, UserSgprLayout::Source::WorkgroupInfo);
 }
 
 TEST(UserSgprLayout, UserSgprCountFieldWidthIsIsaVersioned) {
@@ -294,26 +360,68 @@ TEST(UserSgprLayout, UserSgprCountFieldWidthIsIsaVersioned) {
   ASSERT_TRUE(Gfx1250.ok());
 
   using namespace llvm::amdhsa;
-  // A 33-entry layout: kernarg_segment_ptr (2) + 31 preloaded dwords. The
-  // descriptor stores USER_SGPR_COUNT=33, which needs the 6-bit gfx1250 field;
-  // the 5-bit gfx942 decode reads it as 33 & 0x1F == 1 and rejects the layout.
+  // Two pointer SGPRs and 30 preloaded dwords exercise count 32, which the
+  // gfx942 5-bit field decodes as zero.
   KernelMeta Meta;
   Meta.Name = "k";
   Meta.KernelCodeProperties =
       KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR;
   Meta.KernargPreload =
-      static_cast<uint16_t>(31u << KERNARG_PRELOAD_SPEC_LENGTH_SHIFT);
-  // Shift is identical for both field widths; only the width differs.
-  Meta.ComputePgmRsrc2 = 33u << COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT_SHIFT;
+      static_cast<uint16_t>(30u << KERNARG_PRELOAD_SPEC_LENGTH_SHIFT);
+  Meta.KernargSegmentSize = 30 * 4;
+  Meta.ComputePgmRsrc2 = 32u << COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT_SHIFT;
 
   UserSgprLayout OnGfx1250;
   EXPECT_TRUE(succeeded(UserSgprLayout::tryFromKernelMeta(
       Meta, Gfx1250.get(), "gfx1250", OnGfx1250)));
-  EXPECT_EQ(OnGfx1250.UserSgprCount, 33u);
+  EXPECT_EQ(OnGfx1250.UserSgprCount, 32u);
 
   UserSgprLayout OnGfx942;
   Error E =
       UserSgprLayout::tryFromKernelMeta(Meta, Gfx942.get(), "gfx942", OnGfx942);
+  EXPECT_EQ(reasonOf(std::move(E)), RaiseFailureReason::UserSgprLayoutMismatch);
+}
+
+TEST(UserSgprLayout, ExcessiveUserSgprCountIsRefused) {
+  Profile Gfx942("gfx942");
+  Profile Gfx1250("gfx1250");
+  ASSERT_TRUE(Gfx942.ok());
+  ASSERT_TRUE(Gfx1250.ok());
+
+  using namespace llvm::amdhsa;
+  KernelMeta Meta;
+  Meta.Name = "k";
+  UserSgprLayout Layout;
+
+  Meta.ComputePgmRsrc2 = 17u
+                         << COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_SHIFT;
+  Error Gfx942Error =
+      UserSgprLayout::tryFromKernelMeta(Meta, Gfx942.get(), "gfx942", Layout);
+  EXPECT_EQ(reasonOf(std::move(Gfx942Error)),
+            RaiseFailureReason::UserSgprLayoutMismatch);
+
+  Meta.ComputePgmRsrc2 = 33u << COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT_SHIFT;
+  Error Gfx1250Error =
+      UserSgprLayout::tryFromKernelMeta(Meta, Gfx1250.get(), "gfx1250", Layout);
+  EXPECT_EQ(reasonOf(std::move(Gfx1250Error)),
+            RaiseFailureReason::UserSgprLayoutMismatch);
+}
+
+TEST(UserSgprLayout, KernargPreloadOnUnsupportedIsaIsRefused) {
+  Profile P("gfx900");
+  ASSERT_TRUE(P.ok());
+
+  using namespace llvm::amdhsa;
+  KernelMeta Meta;
+  Meta.Name = "k";
+  Meta.KernargSegmentSize = 4;
+  Meta.KernargPreload =
+      static_cast<uint16_t>(1u << KERNARG_PRELOAD_SPEC_LENGTH_SHIFT);
+  Meta.ComputePgmRsrc2 = 1u
+                         << COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_SHIFT;
+
+  UserSgprLayout Layout;
+  Error E = UserSgprLayout::tryFromKernelMeta(Meta, P.get(), "gfx900", Layout);
   EXPECT_EQ(reasonOf(std::move(E)), RaiseFailureReason::UserSgprLayoutMismatch);
 }
 
@@ -392,7 +500,29 @@ TEST(EmitSourceHidden, RegularArgReturnsNullWithoutError) {
 
 TEST(EmitSourceHidden, UnsupportedHiddenKindIsAnError) {
   HiddenArgHarness H;
-  std::vector<KernelArgMeta> Args = {arg("hidden_private_base", 0, 8)};
+  std::vector<KernelArgMeta> Args = {arg("hidden_private_base", 0, 4)};
+  SourceHiddenArgContext Ctx = H.context(Args);
+
+  Expected<Value *> V = emitSourceHiddenDword(Ctx, 0);
+  ASSERT_FALSE(static_cast<bool>(V));
+  EXPECT_EQ(reasonOf(V.takeError()),
+            RaiseFailureReason::UnsupportedSourceHiddenArg);
+}
+
+TEST(EmitSourceHidden, InvalidHiddenArgSizeIsAnError) {
+  HiddenArgHarness H;
+  std::vector<KernelArgMeta> Args = {arg("hidden_block_count_x", 0, 8)};
+  SourceHiddenArgContext Ctx = H.context(Args);
+
+  Expected<Value *> V = emitSourceHiddenDword(Ctx, 0);
+  ASSERT_FALSE(static_cast<bool>(V));
+  EXPECT_EQ(reasonOf(V.takeError()),
+            RaiseFailureReason::UnsupportedSourceHiddenArg);
+}
+
+TEST(EmitSourceHidden, ZeroSizedHiddenArgIsAnError) {
+  HiddenArgHarness H;
+  std::vector<KernelArgMeta> Args = {arg("hidden_block_count_x", 0, 0)};
   SourceHiddenArgContext Ctx = H.context(Args);
 
   Expected<Value *> V = emitSourceHiddenDword(Ctx, 0);
@@ -457,6 +587,18 @@ TEST(EmitSourceHidden, DwordSpanningNonHiddenByteIsAnError) {
   // starts hidden but runs into non-hidden memory.
   std::vector<KernelArgMeta> Args = {arg("hidden_grid_dims", 0, 2),
                                      arg("by_value", 2, 4)};
+  SourceHiddenArgContext Ctx = H.context(Args);
+
+  Expected<Value *> V = emitSourceHiddenDword(Ctx, 0);
+  ASSERT_FALSE(static_cast<bool>(V));
+  EXPECT_EQ(reasonOf(V.takeError()),
+            RaiseFailureReason::UnsupportedSourceHiddenArg);
+}
+
+TEST(EmitSourceHidden, DwordStartingBeforeHiddenArgIsAnError) {
+  HiddenArgHarness H;
+  std::vector<KernelArgMeta> Args = {arg("by_value", 0, 2),
+                                     arg("hidden_grid_dims", 2, 2)};
   SourceHiddenArgContext Ctx = H.context(Args);
 
   Expected<Value *> V = emitSourceHiddenDword(Ctx, 0);

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -18,6 +18,7 @@
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Alignment.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/TargetParser/AMDGPUTargetParser.h"
 #include <array>
 #include <functional>
@@ -90,13 +91,13 @@ unsigned getDefaultAMDHSACodeObjectVersion();
 uint8_t getELFABIVersion(const Triple &OS, unsigned CodeObjectVersion);
 
 /// \returns The offset of the multigrid_sync_arg argument from implicitarg_ptr
-unsigned getMultigridSyncArgImplicitArgPosition(unsigned COV);
+LLVM_ABI unsigned getMultigridSyncArgImplicitArgPosition(unsigned COV);
 
 /// \returns The offset of the hostcall pointer argument from implicitarg_ptr
-unsigned getHostcallImplicitArgPosition(unsigned COV);
+LLVM_ABI unsigned getHostcallImplicitArgPosition(unsigned COV);
 
-unsigned getDefaultQueueImplicitArgPosition(unsigned COV);
-unsigned getCompletionActionImplicitArgPosition(unsigned COV);
+LLVM_ABI unsigned getDefaultQueueImplicitArgPosition(unsigned COV);
+LLVM_ABI unsigned getCompletionActionImplicitArgPosition(unsigned COV);
 
 struct GcnBufferFormatInfo {
   unsigned Format;


### PR DESCRIPTION
These reconstruct the source kernel's entry ABI from its descriptor and MsgPack
metadata: the user-SGPR layout (which enable_sgpr_* preloads and the gfx1250
kernarg preload the loader populates), the kernarg segment layout, and the
hidden-argument block. The raiser uses them to seed the entry registers so a
lifted kernel reads its arguments and dispatch state from the right places.
