### PR TITLE
[Comgr][hotswap] Raise a scalar-move kernel to LLVM IR

### DIFF
--- a/amd/comgr/src/hotswap/decoder/amdgpu-formats.cpp
+++ b/amd/comgr/src/hotswap/decoder/amdgpu-formats.cpp
@@ -10,37 +10,16 @@
 
 namespace COMGR::hotswap {
 
-// Mirrors SIInstrFlags bit positions from llvm/lib/Target/AMDGPU/SIDefines.h.
-// SIDefines.h is a backend-private header (not installed), and upstream now
-// walls off the raw bit constants (SIInstrFlags::DontUseRawTSFlags) behind
-// predicate functions that require an MCInst/MCInstrDesc — which formatName's
-// raw-uint64_t signature doesn't have. So duplicate the bits here (same idiom
-// as patch-wmma-hazard.cpp). Keep in sync if the TSFlags layout changes.
-namespace AmdgpuTSFlags {
-static constexpr uint64_t SOP1 = UINT64_C(1) << 2;
-static constexpr uint64_t SOP2 = UINT64_C(1) << 3;
-static constexpr uint64_t SOPC = UINT64_C(1) << 4;
-static constexpr uint64_t SOPK = UINT64_C(1) << 5;
-static constexpr uint64_t SOPP = UINT64_C(1) << 6;
-static constexpr uint64_t VOP1 = UINT64_C(1) << 7;
-static constexpr uint64_t VOP2 = UINT64_C(1) << 8;
-static constexpr uint64_t VOPC = UINT64_C(1) << 9;
-static constexpr uint64_t VOP3 = UINT64_C(1) << 10;
-static constexpr uint64_t VOP3P = UINT64_C(1) << 12;
-static constexpr uint64_t SDWA = UINT64_C(1) << 14;
-static constexpr uint64_t DPP = UINT64_C(1) << 15;
-static constexpr uint64_t MUBUF = UINT64_C(1) << 17;
-static constexpr uint64_t SMRD = UINT64_C(1) << 19;
-static constexpr uint64_t VIMAGE = UINT64_C(1) << 21;
-static constexpr uint64_t FLAT = UINT64_C(1) << 24;
-static constexpr uint64_t DS = UINT64_C(1) << 25;
-static constexpr uint64_t VOPD3 = UINT64_C(1) << 30;
-static constexpr uint64_t TENSOR_CNT = UINT64_C(1) << 38;
+// Two SIInstrFlags bits that refine the reported name without naming a format,
+// so they stay private here rather than joining AmdgpuFormat: IsMAI marks an
+// MFMA, which is VOP3-encoded, and TENSOR_CNT marks an instruction counted
+// against the tensor wait counter. Mirrored from SIDefines.h under the same
+// keep-in-sync caveat as the format bits.
 static constexpr uint64_t IsMAI = UINT64_C(1) << 54;
-} // namespace AmdgpuTSFlags
+static constexpr uint64_t TENSOR_CNT = UINT64_C(1) << 38;
 
 llvm::StringRef formatName(uint64_t TSFlags) {
-  using namespace AmdgpuTSFlags;
+  using namespace AmdgpuFormat;
   // Only the gfx1250 VOPD3 form carries a TSFlags bit; classic (gfx11) VOPD has
   // none, but the transpiler's target ISAs do not emit it. MAI is a VOP3
   // subclass and VOP3P coexists with VOP3, so the more specific tests come

--- a/amd/comgr/src/hotswap/decoder/amdgpu-formats.h
+++ b/amd/comgr/src/hotswap/decoder/amdgpu-formats.h
@@ -15,9 +15,48 @@
 
 namespace COMGR::hotswap {
 
-// The AMDGPU instruction-format label (e.g. "SOP1", "VOP3", "FLAT") for an
-// instruction with the given MC `TSFlags`, or "Unknown". Consumed only by
-// diagnostics; there is no dispatch on the returned string.
+// The bits an MC `TSFlags` value sets to name the format an instruction is
+// encoded in, mirroring the instruction-format section of SIInstrFlags in
+// llvm/lib/Target/AMDGPU/SIDefines.h. SIDefines.h is a backend-private header
+// (not installed), and upstream walls off the raw bit constants
+// (SIInstrFlags::DontUseRawTSFlags) behind predicate functions taking an
+// MCInst/MCInstrDesc, which a stored TSFlags value does not have. So duplicate
+// the bits here (same idiom as patch-wmma-hazard.cpp). Keep in sync if the
+// TSFlags layout changes.
+//
+// These name encodings. The remaining SIInstrFlags bits name a property an
+// instruction has rather than the form it is encoded in -- an MFMA sets IsMAI
+// on top of the VOP3 bit that encodes it -- and belong to whoever needs the
+// property. Encodings nest as well, VOP3P setting VOP3 and a VOP3P DPP variant
+// setting both DPP and VOP3P, so a consumer testing several bits orders the
+// specific before the general.
+namespace AmdgpuFormat {
+enum : uint64_t {
+  SOP1 = UINT64_C(1) << 2,
+  SOP2 = UINT64_C(1) << 3,
+  SOPC = UINT64_C(1) << 4,
+  SOPK = UINT64_C(1) << 5,
+  SOPP = UINT64_C(1) << 6,
+  VOP1 = UINT64_C(1) << 7,
+  VOP2 = UINT64_C(1) << 8,
+  VOPC = UINT64_C(1) << 9,
+  VOP3 = UINT64_C(1) << 10,
+  VOP3P = UINT64_C(1) << 12,
+  SDWA = UINT64_C(1) << 14,
+  DPP = UINT64_C(1) << 15,
+  MUBUF = UINT64_C(1) << 17,
+  SMRD = UINT64_C(1) << 19,
+  VIMAGE = UINT64_C(1) << 21,
+  FLAT = UINT64_C(1) << 24,
+  DS = UINT64_C(1) << 25,
+  VOPD3 = UINT64_C(1) << 30,
+};
+} // namespace AmdgpuFormat
+
+// The instruction-family label (e.g. "SOP1", "MFMA", "FLAT") for an instruction
+// with the given MC `TSFlags`, or "Unknown". Names the family a reader would
+// recognize rather than the encoding alone, so it is for diagnostics; a
+// consumer that has to act on the format tests the AmdgpuFormat bits.
 llvm::StringRef formatName(uint64_t TSFlags);
 
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/raiser/CMakeLists.txt
@@ -37,6 +37,8 @@ add_library(hotswap-raiser OBJECT
   register-state.cpp
   raise-context.cpp
   op-resolver.cpp
+  handle-sop1.cpp
+  handle-sopp.cpp
 )
 
 if(NOT TARGET hotswap::raiser)

--- a/amd/comgr/src/hotswap/raiser/handle-sop1.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-sop1.cpp
@@ -1,0 +1,37 @@
+//===- handle-sop1.cpp - Hotswap transpiler -------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hotswap/raiser/handlers.h"
+
+#include "hotswap/decoder/amdgpu-formats.h"
+#include "hotswap/decoder/mc-state.h"
+#include "hotswap/raiser/raise_failure.h"
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+Error handleSOP1(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op) {
+  if (Di.CanonOp == CanonicalOp::S_MOV_B32) {
+    Expected<ParsedReg> Dst = Op.dst();
+    if (!Dst)
+      return Dst.takeError();
+    Expected<Value *> Src = Op.src(0);
+    if (!Src)
+      return Src.takeError();
+    Ctx.registers().writeReg32(*Dst, *Src);
+    return Error::success();
+  }
+
+  return RaiseFailure::atInstruction(
+      RaiseFailureReason::UnsupportedInstructionForm,
+      strippedMnemonic(Ctx.MC, Di.Inst), Di.Offset,
+      formatName(Di.TargetSpecificFlags));
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/handle-sopp.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-sopp.cpp
@@ -1,0 +1,31 @@
+//===- handle-sopp.cpp - Hotswap transpiler -------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hotswap/raiser/handlers.h"
+
+#include "hotswap/decoder/amdgpu-formats.h"
+#include "hotswap/decoder/mc-state.h"
+#include "hotswap/raiser/raise_failure.h"
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+Error handleSOPP(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &) {
+  if (Di.CanonOp == CanonicalOp::S_ENDPGM) {
+    Ctx.B.CreateRetVoid();
+    return Error::success();
+  }
+
+  return RaiseFailure::atInstruction(
+      RaiseFailureReason::UnsupportedInstructionForm,
+      strippedMnemonic(Ctx.MC, Di.Inst), Di.Offset,
+      formatName(Di.TargetSpecificFlags));
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/handlers.h
+++ b/amd/comgr/src/hotswap/raiser/handlers.h
@@ -1,0 +1,32 @@
+//===- handlers.h - Hotswap transpiler ------------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_HANDLERS_H
+#define HOTSWAP_TRANSPILER_HANDLERS_H
+
+#include "hotswap/decoder/decoded-inst.h"
+#include "hotswap/raiser/op-resolver.h"
+#include "hotswap/raiser/raise-context.h"
+
+#include "llvm/Support/Error.h"
+
+namespace COMGR::hotswap {
+
+// Lower one instruction of the format the handler is named for, emitting into
+// `Ctx`'s builder and reading its operands through `Op`. The raiser runs the
+// first handler whose format bit matches and only that one, so a handler that
+// does not recognize the opcode returns a `RaiseFailure` rather than declining:
+// no later handler gets the chance to claim it.
+llvm::Error handleSOP1(RaiseContext &Ctx, const DecodedInst &Di,
+                       OpResolver &Op);
+llvm::Error handleSOPP(RaiseContext &Ctx, const DecodedInst &Di,
+                       OpResolver &Op);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/raiser/raise-context.cpp
+++ b/amd/comgr/src/hotswap/raiser/raise-context.cpp
@@ -19,33 +19,37 @@ using namespace llvm;
 
 namespace COMGR::hotswap {
 
-Expected<RaiseContext> RaiseContext::create(
-    IRBuilder<> &B, const WaveProjection &Projection, const MCState &MC,
-    const KernelMeta &Meta, DenseMap<uint64_t, BasicBlock *> OffsetToBb,
-    ArrayRef<uint8_t> SourceTextBytes, uint64_t SourceTextBaseAddress,
-    ArrayRef<TextSection::ImageSection> SourceImageSections,
-    uint64_t KernelStartOffset, uint64_t KernelEndOffset) {
+Expected<RaiseContext>
+RaiseContext::create(IRBuilder<> &B, const WaveProjection &Projection,
+                     const MCState &MC, const KernelMeta &Meta,
+                     ArrayRef<uint8_t> SourceTextBytes,
+                     uint64_t SourceTextBaseAddress,
+                     ArrayRef<TextSection::ImageSection> SourceImageSections,
+                     uint64_t KernelStartOffset, uint64_t KernelEndOffset) {
   Expected<RegisterState> Registers =
       RegisterState::create(B, Projection, MC, Meta);
   if (!Registers)
     return Registers.takeError();
-  return RaiseContext(B, Projection, MC, std::move(*Registers),
-                      std::move(OffsetToBb), SourceTextBytes,
+  return RaiseContext(B, Projection, MC, std::move(*Registers), SourceTextBytes,
                       SourceTextBaseAddress, SourceImageSections,
                       KernelStartOffset, KernelEndOffset);
 }
 
 RaiseContext::RaiseContext(
     IRBuilder<> &B, const WaveProjection &Projection, const MCState &MC,
-    RegisterState Registers, DenseMap<uint64_t, BasicBlock *> OffsetToBb,
-    ArrayRef<uint8_t> SourceTextBytes, uint64_t SourceTextBaseAddress,
+    RegisterState Registers, ArrayRef<uint8_t> SourceTextBytes,
+    uint64_t SourceTextBaseAddress,
     ArrayRef<TextSection::ImageSection> SourceImageSections,
     uint64_t KernelStartOffset, uint64_t KernelEndOffset)
     : B(B), Projection(Projection), MC(MC), Registers(std::move(Registers)),
-      OffsetToBb(std::move(OffsetToBb)), SourceTextBytes(SourceTextBytes),
+      SourceTextBytes(SourceTextBytes),
       SourceTextBaseAddress(SourceTextBaseAddress),
       SourceImageSections(SourceImageSections),
-      KernelStartOffset(KernelStartOffset), KernelEndOffset(KernelEndOffset) {}
+      KernelStartOffset(KernelStartOffset), KernelEndOffset(KernelEndOffset) {
+  // The builder is positioned in the entry block, which is what the source
+  // kernel's first instruction raised into.
+  OffsetToBb[KernelStartOffset] = B.GetInsertBlock();
+}
 
 BasicBlock *RaiseContext::lookupBB(uint64_t Addr) {
   DenseMap<uint64_t, BasicBlock *>::iterator It = OffsetToBb.find(Addr);

--- a/amd/comgr/src/hotswap/raiser/raise-context.h
+++ b/amd/comgr/src/hotswap/raiser/raise-context.h
@@ -28,12 +28,12 @@ class RaiseContext {
 public:
   // Build the context for the source kernel described by Meta. B must be
   // positioned in the entry block: the register file and the cross-block
-  // shadow storage are allocated there. Fails when the kernel descriptor and
+  // shadow storage are allocated there, and that block is what
+  // `KernelStartOffset` resolves to. Fails when the kernel descriptor and
   // the metadata disagree on the user-SGPR layout.
   static llvm::Expected<RaiseContext>
   create(llvm::IRBuilder<> &B, const WaveProjection &Projection,
          const MCState &MC, const KernelMeta &Meta,
-         llvm::DenseMap<uint64_t, llvm::BasicBlock *> OffsetToBb,
          llvm::ArrayRef<uint8_t> SourceTextBytes,
          uint64_t SourceTextBaseAddress,
          llvm::ArrayRef<TextSection::ImageSection> SourceImageSections,
@@ -91,7 +91,6 @@ public:
 private:
   RaiseContext(llvm::IRBuilder<> &B, const WaveProjection &Projection,
                const MCState &MC, RegisterState Registers,
-               llvm::DenseMap<uint64_t, llvm::BasicBlock *> OffsetToBb,
                llvm::ArrayRef<uint8_t> SourceTextBytes,
                uint64_t SourceTextBaseAddress,
                llvm::ArrayRef<TextSection::ImageSection> SourceImageSections,

--- a/amd/comgr/src/hotswap/raiser/raise_failure.cpp
+++ b/amd/comgr/src/hotswap/raiser/raise_failure.cpp
@@ -25,6 +25,9 @@ void RaiseFailure::log(llvm::raw_ostream &OS) const {
     OS << " @offset=0x";
     OS.write_hex(*Offset);
   }
+  if (Origin)
+    OS << " in kernel '" << Origin->KernelName << "' (" << Origin->SourceCpu
+       << " -> " << Origin->TargetCpu << ")";
   if (!Detail.empty())
     OS << " :: " << Detail;
 }
@@ -50,6 +53,8 @@ llvm::StringRef reasonString(RaiseFailureReason R) {
     return "IRVerificationFailed";
   case RaiseFailureReason::KernelBoundaryViolation:
     return "kernel-boundary-violation";
+  case RaiseFailureReason::UnterminatedKernelExtent:
+    return "unterminated-kernel-extent";
   case RaiseFailureReason::DeviceLibraryLinkFailed:
     return "device-library-link-failed";
   case RaiseFailureReason::CrossWaveLaneIdLeak:
@@ -70,6 +75,8 @@ llvm::StringRef reasonString(RaiseFailureReason R) {
     return "missing-kernel-descriptor";
   case RaiseFailureReason::UserSgprLayoutMismatch:
     return "user-sgpr-layout-mismatch";
+  case RaiseFailureReason::UnsupportedEntrySgprSource:
+    return "unsupported-entry-sgpr-source";
   case RaiseFailureReason::UnsupportedSourceClusterDims:
     return "unsupported-source-cluster-dims";
   }
@@ -99,6 +106,18 @@ llvm::Error RaiseFailure::general(RaiseFailureReason Reason,
   return llvm::make_error<RaiseFailure>(
       Reason, std::string(), std::optional<std::string>(std::nullopt),
       std::optional<uint64_t>(std::nullopt), Detail.str());
+}
+
+llvm::Error RaiseFailure::withOrigin(llvm::Error Err,
+                                     llvm::StringRef KernelName,
+                                     llvm::StringRef SourceCpu,
+                                     llvm::StringRef TargetCpu) {
+  return llvm::handleErrors(
+      std::move(Err), [&](std::unique_ptr<RaiseFailure> F) -> llvm::Error {
+        return llvm::make_error<RaiseFailure>(
+            F->Reason, F->Mnemonic, F->Format, F->Offset, F->Detail,
+            FailureOrigin{KernelName.str(), SourceCpu.str(), TargetCpu.str()});
+      });
 }
 
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/raise_failure.h
+++ b/amd/comgr/src/hotswap/raiser/raise_failure.h
@@ -48,6 +48,11 @@ enum class RaiseFailureReason : uint16_t {
   // in-extent target could not be decoded. Crossing the boundary would inspect
   // neighboring symbols.
   KernelBoundaryViolation,
+  // The kernel extent runs out without an instruction that ends the program,
+  // so the code is truncated or the extent is misbounded. Distinct from a
+  // boundary violation, which is a branch leaving the extent rather than
+  // execution falling off its end.
+  UnterminatedKernelExtent,
   // A helper or device-library bitcode link step failed. Distinct from a
   // verifier failure: the module is intentionally incomplete until the linked
   // body is inlined.
@@ -71,6 +76,9 @@ enum class RaiseFailureReason : uint16_t {
   // Source descriptor fields do not describe a valid, self-consistent user
   // SGPR layout.
   UserSgprLayoutMismatch,
+  // The source ABI preloads an entry SGPR the raiser cannot reproduce on the
+  // target, so its value would be read as undef.
+  UnsupportedEntrySgprSource,
   // The source object declares non-disabled workgroup cluster dimensions, so
   // TTMP6 carries per-cluster state the Hotswap ABI model does not reconstruct.
   UnsupportedSourceClusterDims,
@@ -79,6 +87,15 @@ enum class RaiseFailureReason : uint16_t {
 // Human-readable name for a `RaiseFailureReason`. Stable enough for
 // diagnostics and tests to bucket on.
 llvm::StringRef reasonString(RaiseFailureReason R);
+
+// Which kernel of a batch raise a failure came out of, and the ISA pair that
+// raise ran under. Both processor names are the ones the MC layers were built
+// for, so they name a GPU even when the caller passed a full target identifier.
+struct FailureOrigin {
+  std::string KernelName;
+  std::string SourceCpu;
+  std::string TargetCpu;
+};
 
 // Payload of the `llvm::Error` the raiser produces on a refusal. Build one
 // through the shape factories below, which return the `llvm::Error` directly;
@@ -90,9 +107,11 @@ struct RaiseFailure : public llvm::ErrorInfo<RaiseFailure> {
 
   RaiseFailure(RaiseFailureReason Reason, std::string Mnemonic,
                std::optional<std::string> Format,
-               std::optional<uint64_t> Offset, std::string Detail)
+               std::optional<uint64_t> Offset, std::string Detail,
+               std::optional<FailureOrigin> Origin = std::nullopt)
       : Reason(Reason), Mnemonic(std::move(Mnemonic)),
-        Format(std::move(Format)), Offset(Offset), Detail(std::move(Detail)) {}
+        Format(std::move(Format)), Offset(Offset), Detail(std::move(Detail)),
+        Origin(std::move(Origin)) {}
 
   RaiseFailureReason reason() const { return Reason; }
 
@@ -141,12 +160,21 @@ struct RaiseFailure : public llvm::ErrorInfo<RaiseFailure> {
   static llvm::Error general(RaiseFailureReason Reason,
                              const llvm::Twine &Detail);
 
+  // Name the kernel and ISA pair `Err` came out of. Refusals are raised deep in
+  // the dispatch, which knows the offending instruction but not which of a
+  // batch's kernels holds it, so the raise stamps that on the way out. An error
+  // that is not a `RaiseFailure` passes through unchanged.
+  static llvm::Error withOrigin(llvm::Error Err, llvm::StringRef KernelName,
+                                llvm::StringRef SourceCpu,
+                                llvm::StringRef TargetCpu);
+
 private:
   RaiseFailureReason Reason;
   std::string Mnemonic;
   std::optional<std::string> Format;
   std::optional<uint64_t> Offset;
   std::string Detail;
+  std::optional<FailureOrigin> Origin;
 };
 
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser/raiser.cpp
+++ b/amd/comgr/src/hotswap/raiser/raiser.cpp
@@ -1,97 +1,106 @@
-//===- raiser.cpp - Hotswap MC -> LLVM IR raiser scaffolding --------------===//
+//===- raiser.cpp - Hotswap MC -> LLVM IR raiser -------------------------===//
 //
 // Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
 // amd/comgr/LICENSE.TXT in this repository for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// Decodes each requested kernel's .text into a typed `DecodedInst` stream,
+// dispatches each decoded instruction to its per-format handler, promotes the
+// register-file allocas to SSA, and verifies the module of `amdgpu_kernel`
+// functions this produces. The MC layer the decode runs on is built once and
+// shared, since the kernels come from one code object.
+//
+// A raise reads two ISAs. The source one is what the code object was compiled
+// for, and the decode is written in its terms. The target one is what the
+// raised IR will be lowered for, and the wave projection reads it to translate
+// a source lane into the target lane that runs it.
+//
+//===----------------------------------------------------------------------===//
 
 #include "hotswap/raiser/raiser.h"
 
+#include "hotswap/decoder/amdgpu-formats.h"
+#include "hotswap/decoder/decode.h"
+#include "hotswap/decoder/isa-profile.h"
+#include "hotswap/decoder/mc-state.h"
+#include "hotswap/decoder/opcode-map.h"
+#include "hotswap/raiser/handlers.h"
+#include "hotswap/raiser/op-resolver.h"
+#include "hotswap/raiser/raise-context.h"
 #include "hotswap/raiser/raise_failure.h"
+#include "hotswap/raiser/wave-projection.h"
 
+#include "comgr.h"
+
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Analysis/AssumptionCache.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Dominators.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/Verifier.h"
 #include "llvm/Support/Alignment.h"
+#include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/AMDGPUTargetParser.h"
 #include "llvm/TargetParser/Triple.h"
+#include "llvm/Transforms/Utils/PromoteMemToReg.h"
+
+#include <cassert>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+using namespace llvm;
 
 namespace COMGR::hotswap {
-
-namespace {
-
-constexpr llvm::StringLiteral AMDGPUTriple = "amdgcn-amd-amdhsa";
 
 // Address space the kernarg segment lives in.
 constexpr unsigned ConstantAddressSpace = 4;
 
-// Minimum kernarg segment alignment the AMDGPU ABI mandates.
-constexpr llvm::Align KernargSegmentAlign = llvm::Align::Constant<16>();
+// Identifier the raised module carries. A code object names no module of its
+// own, and one raise holds every kernel of it.
+constexpr StringLiteral kRaisedModuleName = "hotswap.raised";
 
-// Reject obviously-bad inputs before constructing IR. Mirrors the
-// preconditions the full pipeline enforces in subsequent commits.
-//
-// Ideally we would reuse `COMGR::parseTargetIdentifier`, but that helper
-// currently lives behind the comgr-metadata layer in `src/comgr.cpp` and
-// is not reachable from the hotswap subproject. As a stop-gap, validate
-// the AMDGPU processor name through `llvm::AMDGPU::parseArchAMDGCN`.
-llvm::Error validateInputs(llvm::StringRef SourceISA,
-                           llvm::StringRef KernelName) {
-  if (SourceISA.empty())
-    return RaiseFailure::general(RaiseFailureReason::BadInput,
-                                 "source ISA string is empty");
-  // The disassembler-facing identifier is `<arch>-<vendor>-<os>-<env>-<gfx>`;
-  // `parseArchAMDGCN` inspects the trailing component.
-  llvm::StringRef GfxName = SourceISA.rsplit('-').second;
-  if (GfxName.empty()) {
-    GfxName = SourceISA;
-  }
-  if (llvm::AMDGPU::parseArchAMDGCN(GfxName) == llvm::AMDGPU::GK_NONE)
-    return RaiseFailure::general(RaiseFailureReason::BadInput,
-                                 "source ISA '" + SourceISA +
-                                     "' does not name an AMDGPU GPU");
-  if (KernelName.empty())
-    return RaiseFailure::general(RaiseFailureReason::BadInput,
-                                 "kernel name is empty");
-  return llvm::Error::success();
+// Minimum kernarg segment alignment the AMDGPU ABI mandates.
+constexpr Align KernargSegmentAlign = Align::Constant<16>();
+
+// The bare AMDGPU processor name `Isa` denotes. Callers pass either that name
+// (`gfx942`) or a canonical target identifier
+// (`amdgcn-amd-amdhsa--gfx942:xnack-`); the MC layer accepts only the former.
+// The result points into `Isa`.
+static StringRef processorName(StringRef Isa) {
+  TargetIdentifier Ident;
+  if (parseTargetIdentifier(Isa, Ident) == AMD_COMGR_STATUS_SUCCESS)
+    return Ident.Processor;
+  return Isa;
 }
 
-} // namespace
-
-llvm::Expected<RaiseResult> raiseToIR(llvm::StringRef SourceISA,
-                                      llvm::StringRef KernelName,
-                                      const KernelMeta &Meta) {
-  using namespace llvm;
-
-  if (Error E = validateInputs(SourceISA, KernelName))
-    return std::move(E);
-
-  RaiseResult Result;
-  Result.Ctx = std::make_unique<LLVMContext>();
-  LLVMContext &C = *Result.Ctx;
-  Result.Module = std::make_unique<Module>("transpiler_module", C);
-  Module &M = *Result.Module;
-  M.setTargetTriple(Triple(AMDGPUTriple));
-
-  // A single opaque parameter spanning the source kernarg segment, so the
-  // emitted kernel descriptor reports the source segment size and the ABI
-  // alignment. The raised body reads arguments as ordinary loads off the
-  // kernarg pointer, at the byte offsets the source metadata gives them, so it
-  // needs no typed view of the source signature.
+// Declare the lifted kernel: one opaque parameter spanning the source kernarg
+// segment, so the emitted descriptor reports the source segment size and the
+// ABI alignment. The raised body reads arguments as ordinary loads off the
+// kernarg pointer, at the byte offsets the source metadata gives them.
+static Function *declareKernel(Module &M, StringRef KernelName,
+                               const KernelMeta &Meta) {
+  LLVMContext &C = M.getContext();
   SmallVector<Type *> ParamTys;
-  Type *KernargSegmentTy = nullptr;
-  if (Meta.KernargSegmentSize > 0) {
-    KernargSegmentTy =
-        ArrayType::get(Type::getInt8Ty(C), Meta.KernargSegmentSize);
+  if (Meta.KernargSegmentSize > 0)
     ParamTys.push_back(PointerType::get(C, ConstantAddressSpace));
-  }
 
   FunctionType *FuncTy =
       FunctionType::get(Type::getVoidTy(C), ParamTys, /*isVarArg=*/false);
@@ -99,12 +108,15 @@ llvm::Expected<RaiseResult> raiseToIR(llvm::StringRef SourceISA,
       Function::Create(FuncTy, GlobalValue::ExternalLinkage, KernelName, &M);
   F->setCallingConv(CallingConv::AMDGPU_KERNEL);
 
-  // AMDGPULowerKernelArguments honors the `align` parameter attribute only on a
-  // byref kernel argument; without `byref` the segment would take the array
-  // type's natural one-byte alignment.
-  if (KernargSegmentTy) {
-    F->addParamAttr(0, Attribute::getWithByRefType(C, KernargSegmentTy));
+  if (Meta.KernargSegmentSize > 0) {
+    // AMDGPULowerKernelArguments honors the `align` parameter attribute only on
+    // a byref kernel argument; without `byref` the segment would take the array
+    // type's natural one-byte alignment.
+    Type *SegmentTy =
+        ArrayType::get(Type::getInt8Ty(C), Meta.KernargSegmentSize);
+    F->addParamAttr(0, Attribute::getWithByRefType(C, SegmentTy));
     F->addParamAttr(0, Attribute::getWithAlignment(C, KernargSegmentAlign));
+    F->getArg(0)->setName("kernarg_segment");
   }
 
   // The host fills the kernarg buffer from the source metadata and leaves no
@@ -112,9 +124,212 @@ llvm::Expected<RaiseResult> raiseToIR(llvm::StringRef SourceISA,
   // must not be appended to it.
   F->addFnAttr("amdgpu-no-implicitarg-ptr");
 
+  // Both attributes below take a "min,max" range, and both source sizes are
+  // exact, so each is written as a range of one.
+  //
+  // Pin the block to the size the source kernel declared, so the backend lays
+  // out workitem ids the way the source binary did.
+  F->addFnAttr("amdgpu-flat-work-group-size",
+               formatv("{0},{0}", Meta.MaxFlatWorkgroupSize).str());
+  if (Meta.GroupSegmentFixedSize > 0) {
+    // The raiser addresses LDS by absolute offset rather than through a
+    // GlobalVariable, so without this the backend would emit
+    // group_segment_fixed_size = 0 and treat every LDS access as out of
+    // segment.
+    F->addFnAttr("amdgpu-lds-size",
+                 formatv("{0},{0}", Meta.GroupSegmentFixedSize).str());
+  }
+  return F;
+}
+
+// Lower one decoded instruction into `Ctx`'s current insertion point, routing
+// it by instruction format. A format with no handler is refused rather than
+// lowered as something else.
+static Error raiseInst(RaiseContext &Ctx, const DecodedInst &Di) {
+  using namespace AmdgpuFormat;
+  OpResolver Op{Ctx, Di};
+
+  if (Di.TargetSpecificFlags & SOP1)
+    return handleSOP1(Ctx, Di, Op);
+  if (Di.TargetSpecificFlags & SOPP)
+    return handleSOPP(Ctx, Di, Op);
+
+  return RaiseFailure::atInstruction(
+      RaiseFailureReason::UnsupportedInstructionForm,
+      strippedMnemonic(Ctx.MC, Di.Inst), Di.Offset,
+      formatName(Di.TargetSpecificFlags));
+}
+
+// The MC layer for one ISA and the profile read off it. The profile points
+// into the MC state, so the two are kept together and move together. `Role`
+// names which end of the raise this is, and only reaches diagnostics.
+namespace {
+struct IsaContext {
+  MCState MC;
+  ISAProfile Profile;
+  // Bare AMDGPU processor the MC layer was built for.
+  std::string Cpu;
+
+  static Expected<IsaContext> create(StringRef Isa, StringRef Role);
+};
+} // namespace
+
+Expected<IsaContext> IsaContext::create(StringRef Isa, StringRef Role) {
+  // Reject a bad ISA before reaching the MC stack: createMCSubtargetInfo
+  // accepts an unknown name and returns a featureless subtarget, and the
+  // failure only surfaces inside createMCDisassembler, which aborts the
+  // process instead of returning.
+  StringRef Cpu = processorName(Isa);
+  if (AMDGPU::parseArchAMDGCN(Cpu) == AMDGPU::GK_NONE)
+    return RaiseFailure::general(RaiseFailureReason::BadInput,
+                                 Role + " ISA '" + Isa +
+                                     "' does not name an AMDGPU GPU");
+
+  // The target side reads only the subtarget behind the profile and the
+  // registered target behind the machine, and pays for a disassembler and a
+  // printer it never uses. That is one extra MC stack per raise, against a
+  // second way of standing a subtarget up that has to be kept in step with
+  // this one.
+  Expected<MCState> MC = initMCState(Cpu);
+  if (!MC)
+    return MC.takeError();
+
+  ISAProfile Profile = ISAProfile::fromSubtarget(*MC->SubtargetInfo);
+  return IsaContext{std::move(*MC), Profile, Cpu.str()};
+}
+
+// What every kernel of one raise runs against: the ISA the code object was
+// compiled for, the ISA it is being raised onto, and the opcode map built over
+// the source MC layer. Built once per raise and outlives each kernel's context.
+namespace {
+struct RaiseEnvironment {
+  IsaContext Source;
+  IsaContext Target;
+  OpcodeMap OpcMap;
+
+  static Expected<RaiseEnvironment> create(StringRef SourceIsa,
+                                           StringRef TargetIsa);
+};
+} // namespace
+
+Expected<RaiseEnvironment> RaiseEnvironment::create(StringRef SourceIsa,
+                                                    StringRef TargetIsa) {
+  Expected<IsaContext> Source = IsaContext::create(SourceIsa, "source");
+  if (!Source)
+    return Source.takeError();
+
+  Expected<IsaContext> Target = IsaContext::create(TargetIsa, "target");
+  if (!Target)
+    return Target.takeError();
+
+  RaiseEnvironment Env{std::move(*Source), std::move(*Target), OpcodeMap()};
+  Env.OpcMap.build(*Env.Source.MC.InstrInfo);
+  return Env;
+}
+
+// Raise one kernel into `M`. Everything this allocates -- the projection, the
+// builder, the register file behind the context -- describes that one kernel
+// and dies with the call; only the emitted function outlives it.
+static Error raiseKernel(const RaiseEnvironment &Env, Module &M,
+                         const TextSection &Text, const KernelRequest &Kernel) {
+  const KernelMeta &Meta = Kernel.Meta;
+  Expected<DecodeResult> Decoded = decodeKernel(
+      Env.Source.MC, Env.OpcMap, Text.Bytes, Kernel.StartOffset,
+      Kernel.EndOffset == 0 ? std::nullopt : std::optional(Kernel.EndOffset));
+  if (!Decoded)
+    return Decoded.takeError();
+
+  LLVMContext &C = M.getContext();
+
+  // Replication is the only projection policy the raiser can select: a target
+  // lane reads the source EXEC bit of the source lane it stands in for. What
+  // that costs when the two wave sizes differ is the policy's own business.
+  ReplicationProjection Projection(Env.Source.Profile, Env.Target.Profile,
+                                   Type::getInt32Ty(C), Type::getInt64Ty(C));
+  Projection.setMaxFlatWorkgroupSize(Meta.MaxFlatWorkgroupSize);
+
+  Function *F = declareKernel(M, Kernel.Name, Meta);
   BasicBlock *Entry = BasicBlock::Create(C, "entry", F);
   IRBuilder<> B(Entry);
-  B.CreateRetVoid();
+
+  // The kernel entry is the only block start the decoder reports, so the whole
+  // kernel raises into one block. A second block start means a handler routed
+  // below would have to branch, and none of them can.
+  assert(Decoded->BlockStarts.size() <= 1 &&
+         "no dispatched instruction format recovers a block start");
+
+  Expected<RaiseContext> Ctx = RaiseContext::create(
+      B, Projection, Env.Source.MC, Meta, Text.Bytes, Text.Address,
+      Text.ImageSections, Kernel.StartOffset, Kernel.EndOffset);
+  if (!Ctx)
+    return Ctx.takeError();
+
+  for (const DecodedInst &Di : Decoded->Insts) {
+    Ctx->registers().computeVGPRAdjust(Di);
+    if (Error Err = raiseInst(*Ctx, Di))
+      return Err;
+  }
+
+  // Execution reaching the end of the extent means the code is truncated or
+  // the extent is misbounded. Closing the block with a return instead would
+  // hand back a kernel that reads as having run to completion.
+  if (!Entry->hasTerminator())
+    return RaiseFailure::general(
+        RaiseFailureReason::UnterminatedKernelExtent,
+        "kernel extent ends without an instruction that ends the program");
+
+  DominatorTree DT(*F);
+  AssumptionCache AC(*F);
+  SmallVector<AllocaInst *> Allocas;
+  Ctx->registers().collectAllocas(Allocas);
+  PromoteMemToReg(Allocas, DT, &AC);
+  return Error::success();
+}
+
+Expected<RaiseResult> raiseToIR(const TextSection &Text, StringRef SourceIsa,
+                                StringRef TargetIsa,
+                                ArrayRef<KernelRequest> Kernels) {
+  Expected<RaiseEnvironment> Env =
+      RaiseEnvironment::create(SourceIsa, TargetIsa);
+  if (!Env)
+    return Env.takeError();
+
+  RaiseResult Result;
+  Result.Ctx = std::make_unique<LLVMContext>();
+  Result.Module = std::make_unique<Module>(kRaisedModuleName, *Result.Ctx);
+  Module &M = *Result.Module;
+  M.setTargetTriple(Triple(kAMDGPUTriple));
+
+  // A module with no data layout leaves every consumer to assume one, so take
+  // the AMDGPU layout from a machine built for the processor the raised IR
+  // will be lowered for. That machine is also what names the target here: the
+  // triple carries no processor, and the raiser emits no target instructions
+  // of its own for one to appear in.
+  TargetOptions Opts;
+  std::unique_ptr<TargetMachine> TM(Env->Target.MC.Target->createTargetMachine(
+      Triple(kAMDGPUTriple), Env->Target.Cpu, /*Features=*/"", Opts,
+      Reloc::PIC_));
+  if (!TM)
+    return RaiseFailure::general(
+        RaiseFailureReason::TargetMachineCreationFailed,
+        "no target machine for '" + Env->Target.Cpu + "'");
+  M.setDataLayout(TM->createDataLayout());
+
+  // A refusal is raised where the offending instruction is, which is below the
+  // point that knows which kernel of the batch is being raised, so the name and
+  // the ISA pair are attached here.
+  for (const KernelRequest &Kernel : Kernels)
+    if (Error Err = raiseKernel(*Env, M, Text, Kernel))
+      return RaiseFailure::withOrigin(std::move(Err), Kernel.Name,
+                                      Env->Source.Cpu, Env->Target.Cpu);
+
+  // Verify once the module is whole: a kernel is only well-formed together
+  // with the intrinsic declarations its neighbours may also have added.
+  std::string VerifyErr;
+  raw_string_ostream VerifyOs(VerifyErr);
+  if (verifyModule(M, &VerifyOs))
+    return RaiseFailure::general(RaiseFailureReason::IRVerificationFailed,
+                                 VerifyErr);
 
   return Result;
 }

--- a/amd/comgr/src/hotswap/raiser/raiser.h
+++ b/amd/comgr/src/hotswap/raiser/raiser.h
@@ -10,7 +10,9 @@
 #define HOTSWAP_TRANSPILER_RAISER_H
 
 #include "hotswap/common/kernel-meta.h"
+#include "hotswap/loader/code-object-utils.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 
@@ -28,18 +30,36 @@ struct RaiseResult {
   std::unique_ptr<llvm::Module> Module;
 };
 
-// Raise a kernel named `KernelName` whose source ISA is `SourceISA`. `Meta`
-// carries the per-kernel metadata already loaded and validated by
-// `CodeObjectInfo`. The kernel declares the source kernarg segment and
-// suppresses the target hidden-argument block; the scaffolding implementation
-// gives it a `ret void` body and refuses inputs the full pipeline would also
-// refuse: an empty kernel name and `SourceISA` strings that don't parse via
-// `llvm::AMDGPU::parseArchAMDGCN`. The kernel-text bytes, kernel offset, and
-// compilation-target ISA become real parameters once the decoder is wired
-// in (subsequent commit).
-llvm::Expected<RaiseResult> raiseToIR(llvm::StringRef SourceISA,
-                                      llvm::StringRef KernelName,
-                                      const KernelMeta &Meta);
+// One kernel to raise: the name the lifted function takes, the metadata
+// `CodeObjectInfo` loaded and validated for it, and the extent
+// [`StartOffset`, `EndOffset`) its code occupies in the shared text section. A
+// zero `EndOffset` runs the kernel to the end of that section.
+struct KernelRequest {
+  llvm::StringRef Name;
+  const KernelMeta &Meta;
+  uint64_t StartOffset;
+  uint64_t EndOffset;
+};
+
+// Raise every kernel in `Kernels` onto `TargetIsa`, into one module of
+// amdgpu_kernel functions. `SourceIsa` names the ISA the code object was
+// compiled for and `TargetIsa` the one the raised IR will be lowered for; each
+// is either a bare processor (`gfx942`) or a canonical target identifier. The
+// two differ whenever the raise moves a kernel to another GPU, and the wave
+// projection reads both to translate a source lane into the target lane that
+// runs it. The kernels share a text section and the source ISA, so they also
+// share the MC layer built over it.
+//
+// The raise refuses rather than mislowers: either ISA naming something that is
+// not an AMDGPU processor, a descriptor that does not describe a consistent
+// user-SGPR layout, and any instruction outside the dispatched families all
+// come back as a `RaiseFailure`. One refused kernel refuses the whole batch,
+// since a module missing a kernel the caller asked for is not a usable partial
+// result.
+llvm::Expected<RaiseResult> raiseToIR(const TextSection &Text,
+                                      llvm::StringRef SourceIsa,
+                                      llvm::StringRef TargetIsa,
+                                      llvm::ArrayRef<KernelRequest> Kernels);
 
 } // namespace COMGR::hotswap
 

--- a/amd/comgr/src/hotswap/raiser/register-state.cpp
+++ b/amd/comgr/src/hotswap/raiser/register-state.cpp
@@ -15,17 +15,22 @@
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
 #include "SIDefines.h"
 #include "Utils/AMDGPUBaseInfo.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/IR/Module.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
+#include <optional>
 #include <utility>
 
 using namespace llvm;
@@ -40,7 +45,65 @@ Expected<RegisterState> RegisterState::create(IRBuilder<> &B,
   if (Error Err = UserSgprLayout::tryFromKernelMeta(
           Meta, Projection.sourceIsa(), MC.SubtargetInfo->getCPU(), Layout))
     return std::move(Err);
-  return RegisterState(B, Projection, MC, std::move(Layout));
+  RegisterState Registers(B, Projection, MC, std::move(Layout));
+  if (Error Err = Registers.seedEntrySgprs())
+    return std::move(Err);
+  return Registers;
+}
+
+// Seed the SGPRs the source ABI preloads before entry with the target
+// intrinsics that produce the same values. The layout, not a fixed SGPR
+// numbering, says where each source lands: kernarg preload and the
+// enable_sgpr_* toggles legally move them.
+Error RegisterState::seedEntrySgprs() {
+  Module &M = *B.GetInsertBlock()->getModule();
+  auto Seed = [&](std::optional<unsigned> Sgpr, Intrinsic::ID Id, bool Is64,
+                  const Twine &Name) {
+    if (!Sgpr)
+      return;
+    Value *V =
+        B.CreateCall(Intrinsic::getOrInsertDeclaration(&M, Id), {}, Name);
+    if (Is64)
+      Regs.storeSGPR64(B, *Sgpr, V);
+    else
+      Regs.storeSGPR32(B, *Sgpr, V);
+  };
+
+  Seed(Layout.dispatchPtrSgpr(), Intrinsic::amdgcn_dispatch_ptr, true,
+       "dispatch_ptr");
+  Seed(Layout.queuePtrSgpr(), Intrinsic::amdgcn_queue_ptr, true, "queue_ptr");
+  Seed(Layout.kernargSegmentPtrSgpr(), Intrinsic::amdgcn_kernarg_segment_ptr,
+       true, "kernarg_ptr");
+  Seed(Layout.dispatchIdSgpr(), Intrinsic::amdgcn_dispatch_id, true,
+       "dispatch_id");
+  Seed(Layout.workgroupIdXSgpr(), Intrinsic::amdgcn_workgroup_id_x, false,
+       "workgroup_id_x");
+  Seed(Layout.workgroupIdYSgpr(), Intrinsic::amdgcn_workgroup_id_y, false,
+       "workgroup_id_y");
+  Seed(Layout.workgroupIdZSgpr(), Intrinsic::amdgcn_workgroup_id_z, false,
+       "workgroup_id_z");
+
+  // No target intrinsic reproduces the remaining entry sources, which carry
+  // source private-segment, kernarg-buffer, and packed dispatch state. Refuse
+  // rather than leave them unseeded: a handler would read an undef SGPR as if
+  // it held real entry state.
+  for (auto [Index, LayoutEntry] : enumerate(Layout.Entries)) {
+    switch (LayoutEntry.SrcKind) {
+    case UserSgprLayout::Source::PrivateSegmentBuffer:
+    case UserSgprLayout::Source::FlatScratchInit:
+    case UserSgprLayout::Source::PrivateSegmentSize:
+    case UserSgprLayout::Source::PreloadedKernarg:
+    case UserSgprLayout::Source::WorkgroupInfo:
+      return RaiseFailure::general(
+          RaiseFailureReason::UnsupportedEntrySgprSource,
+          "s" + Twine(Index) +
+              " holds an entry source the raise cannot "
+              "reproduce on the target");
+    default:
+      break;
+    }
+  }
+  return Error::success();
 }
 
 RegisterState::RegisterState(IRBuilder<> &B, const WaveProjection &Projection,

--- a/amd/comgr/src/hotswap/raiser/register-state.h
+++ b/amd/comgr/src/hotswap/raiser/register-state.h
@@ -34,10 +34,12 @@ namespace COMGR::hotswap {
 // that a later write to the same register invalidates.
 class RegisterState {
 public:
-  // Build the register state for the source kernel described by Meta. B must be
-  // positioned in the entry block: the register file and the cross-block shadow
-  // storage are allocated there. Fails when the kernel descriptor and the
-  // metadata disagree on the user-SGPR layout.
+  // Build the register state for the source kernel described by Meta, with the
+  // SGPRs the source ABI preloads before entry already seeded. B must be
+  // positioned in the entry block: the register file, the cross-block shadow
+  // storage, and the seeds are emitted there. Fails when the kernel descriptor
+  // and the metadata disagree on the user-SGPR layout, and when the layout
+  // preloads an entry source the target cannot reproduce.
   static llvm::Expected<RegisterState> create(llvm::IRBuilder<> &B,
                                               const WaveProjection &Projection,
                                               const MCState &MC,
@@ -181,6 +183,9 @@ public:
 private:
   RegisterState(llvm::IRBuilder<> &B, const WaveProjection &Projection,
                 const MCState &MC, UserSgprLayout Layout);
+
+  // Give the preloaded entry SGPRs the values the source ABI hands them.
+  llvm::Error seedEntrySgprs();
 
   // Storage shadowing one SGPR across block boundaries.
   struct SgprShadow {

--- a/amd/comgr/test-lit/CMakeLists.txt
+++ b/amd/comgr/test-lit/CMakeLists.txt
@@ -70,13 +70,14 @@ add_comgr_lit_binary(isa-enumeration c)
 add_comgr_lit_binary(test-get-data-isa-name c)
 
 # The hotswap transpiler driver used by the hotswap/raiser lit tests. It links
-# the hotswap-loader OBJECT library and the shared comgr-object-utils
-# objects (which carry the buffer-facing getElfIsaName / getMetadataRoot /
-# lookupSymbolByName entry points) rather than recompiling the comgr sources, so
-# the driver and amd_comgr share one set of objects and compile flags. Those
-# objects also contain amd_comgr C-API helpers the driver never calls and that
-# reference the rest of comgr; --gc-sections drops them (they were built with
-# function/data sections). MSVC's default /OPT:REF removes them the same way.
+# the hotswap decoder, raiser, loader, and common OBJECT libraries and the
+# shared comgr-object-utils objects (which carry the buffer-facing
+# getElfIsaName / getMetadataRoot / lookupSymbolByName entry points) rather than
+# recompiling the comgr sources, so the driver and amd_comgr share one set of
+# objects and compile flags. Those objects also contain amd_comgr C-API helpers
+# the driver never calls and that reference the rest of comgr; --gc-sections
+# drops them (they were built with function/data sections). MSVC's default
+# /OPT:REF removes them the same way.
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   add_executable(hotswap_transpile_cli comgr-sources/hotswap_transpile_cli.cpp)
   # Match the C++ standard the rest of comgr compiles with. The comgr build
@@ -98,15 +99,18 @@ if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
       target_compile_options(hotswap_transpile_cli PRIVATE -fno-rtti)
     endif()
   endif()
+
   target_include_directories(hotswap_transpile_cli PRIVATE
     ${LLVM_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
     ${CMAKE_CURRENT_BINARY_DIR}/../include)
   # The hotswap OBJECT libraries contribute objects only, so name the LLVM set
   # this driver needs explicitly; ${LLVM_LIBS} is the same curated set amd_comgr
-  # links, already resolved to the dylib or the static components.
+  # links, already resolved to the dylib or the static components. It carries
+  # the AMDGPU components the driver's LLVMInitializeAMDGPU* calls register.
   target_link_libraries(hotswap_transpile_cli
-    PRIVATE hotswap::common hotswap::loader comgr-object-utils ${LLVM_LIBS})
+    PRIVATE hotswap::common hotswap::loader hotswap::decoder hotswap::raiser
+            comgr-object-utils ${LLVM_LIBS})
   if(NOT WIN32)
     target_link_options(hotswap_transpile_cli PRIVATE -Wl,--gc-sections)
   endif()

--- a/amd/comgr/test-lit/comgr-sources/hotswap_transpile_cli.cpp
+++ b/amd/comgr/test-lit/comgr-sources/hotswap_transpile_cli.cpp
@@ -7,25 +7,61 @@
 //===----------------------------------------------------------------------===//
 //
 // Command-line front end for the hotswap transpiler, used by the lit tests
-// under test-lit/hotswap/raiser. Its modes grow with the stack; this milestone
-// supports --dump-meta, which prints the metadata extracted from a code object
-// so the extraction can be checked without any MC or raiser machinery.
+// under test-lit/hotswap/raiser. Its modes grow with the stack:
+//   --dump-meta      print the metadata extracted from a code object.
+//   --dump-decoded   print the decoded canonical-op instruction listing.
+//   --emit-ir        raise the selected kernels and print the LLVM IR.
+// Diagnostics go to stderr and results to stdout, so a refuse test can
+// FileCheck stderr under `not ... 2>&1` while a raise test checks stdout.
 //
 //===----------------------------------------------------------------------===//
 
 #include "comgr-metadata.h"
+#include "comgr.h"
+#include "hotswap/decoder/canonical-op.h"
+#include "hotswap/decoder/decode.h"
+#include "hotswap/decoder/mc-state.h"
+#include "hotswap/decoder/opcode-map.h"
 #include "hotswap/loader/code-object-utils.h"
+#include "hotswap/raiser/raiser.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
+
+using namespace llvm;
+using namespace COMGR::hotswap;
+
+// The decoder calls this to register AMDGPU before building its MC stack.
+// Its production definition sits inside amd_comgr.so, which bakes its own copy
+// of LLVM and hides every internal symbol; linking the .so for it would
+// register AMDGPU into the .so's TargetRegistry while this driver's own LLVM
+// kept an empty one. Defining it here lands the registration on the LLVM this
+// driver is linked against.
+void COMGR::ensureLLVMInitialized() {
+  static std::once_flag Once;
+  std::call_once(Once, [] {
+    LLVMInitializeAMDGPUTargetInfo();
+    LLVMInitializeAMDGPUTargetMC();
+    LLVMInitializeAMDGPUDisassembler();
+    LLVMInitializeAMDGPUAsmParser();
+    LLVMInitializeAMDGPUAsmPrinter();
+    LLVMInitializeAMDGPUTarget();
+  });
+}
 
 namespace {
 
@@ -38,56 +74,198 @@ cl::opt<std::string> IsaOpt("isa", cl::value_desc("arch"),
                             cl::desc("Source ISA; defaults to the ELF e_flags "
                                      "when not given."));
 
-cl::opt<std::string> KernelOpt(
-    "kernel", cl::value_desc("name"),
-    cl::desc("Restrict output to this kernel instead of every kernel."));
+cl::opt<std::string>
+    TargetIsaOpt("target-isa", cl::value_desc("arch"),
+                 cl::desc("ISA to raise onto; defaults to the source ISA, "
+                          "which raises the code object back onto the GPU it "
+                          "was compiled for."));
 
-cl::opt<bool> DumpMetaOpt(
-    "dump-meta",
+// The three modes are mutually exclusive and each names the kernels it runs
+// over the same way: bare selects every kernel in code-object order,
+// =<k>[,<k>...] selects those kernels in the order given.
+cl::opt<std::string> DumpMetaOpt(
+    "dump-meta", cl::ValueOptional, cl::value_desc("kernel[,kernel...]"),
     cl::desc(
         "Print the metadata extracted from the code object (per-kernel ABI "
         "surface, kernel-descriptor fields, and .text extent) and exit."));
 
+cl::opt<std::string>
+    EmitIrOpt("emit-ir", cl::ValueOptional,
+              cl::value_desc("kernel[,kernel...]"),
+              cl::desc("Raise the selected kernels and print the LLVM IR on "
+                       "stdout."));
+
+cl::opt<std::string> DumpDecodedOpt(
+    "dump-decoded", cl::ValueOptional, cl::value_desc("kernel[,kernel...]"),
+    cl::desc("Print the decoded instruction listing (offset, canonical op, "
+             "disassembly) instead of raising."));
+
 // Print the ABI and descriptor fields for one kernel, in a form the lit tests
 // FileCheck.
-int dumpKernel(const COMGR::hotswap::CodeObjectInfo &Info,
-               llvm::StringRef Name) {
-  llvm::Expected<const COMGR::hotswap::KernelMeta *> MetaOrErr =
-      Info.kernel(Name);
+int dumpKernel(const CodeObjectInfo &Info, StringRef Name) {
+  Expected<const KernelMeta *> MetaOrErr = Info.kernel(Name);
   if (!MetaOrErr) {
-    llvm::errs() << "hotswap_transpile_cli: kernel '" << Name
-                 << "': " << llvm::toString(MetaOrErr.takeError()) << "\n";
+    errs() << "hotswap_transpile_cli: kernel '" << Name
+           << "': " << toString(MetaOrErr.takeError()) << "\n";
     return 1;
   }
-  const COMGR::hotswap::KernelMeta &Meta = **MetaOrErr;
+  const KernelMeta &Meta = **MetaOrErr;
 
-  llvm::Expected<COMGR::hotswap::KernelSymbolExtent> ExtOrErr =
-      Info.kernelSymbolExtent(Name);
+  Expected<KernelSymbolExtent> ExtOrErr = Info.kernelSymbolExtent(Name);
   if (!ExtOrErr) {
-    llvm::errs() << "hotswap_transpile_cli: kernel '" << Name
-                 << "' extent: " << llvm::toString(ExtOrErr.takeError())
-                 << "\n";
+    errs() << "hotswap_transpile_cli: kernel '" << Name
+           << "' extent: " << toString(ExtOrErr.takeError()) << "\n";
     return 1;
   }
 
   // has_kd is always 1: create() refuses a code object whose descriptor it
   // cannot read and validate, so the register fields below are always present.
-  llvm::outs() << "kernel: " << Meta.Name
-               << " kernarg=" << Meta.KernargSegmentSize
-               << " group=" << Meta.GroupSegmentFixedSize
-               << " maxflat=" << Meta.MaxFlatWorkgroupSize << " has_kd=1"
-               << " rsrc1=" << llvm::format_hex(Meta.ComputePgmRsrc1, 10)
-               << " rsrc2=" << llvm::format_hex(Meta.ComputePgmRsrc2, 10)
-               << " code_props="
-               << llvm::format_hex(Meta.KernelCodeProperties, 6)
-               << " preload=" << llvm::format_hex(Meta.KernargPreload, 6)
-               << " extent_size=" << ExtOrErr->Size << "\n";
-  for (const COMGR::hotswap::KernelArgMeta &Arg : Meta.Args)
-    llvm::outs() << "arg: name=" << Arg.Name << " offset=" << Arg.Offset
-                 << " size=" << Arg.Size << " kind=" << Arg.ValueKind
-                 << " address_space="
-                 << (Arg.AddressSpace.empty() ? "<none>" : Arg.AddressSpace)
-                 << "\n";
+  outs() << "kernel: " << Meta.Name << " kernarg=" << Meta.KernargSegmentSize
+         << " group=" << Meta.GroupSegmentFixedSize
+         << " maxflat=" << Meta.MaxFlatWorkgroupSize << " has_kd=1"
+         << " rsrc1=" << format_hex(Meta.ComputePgmRsrc1, 10)
+         << " rsrc2=" << format_hex(Meta.ComputePgmRsrc2, 10)
+         << " code_props=" << format_hex(Meta.KernelCodeProperties, 6)
+         << " preload=" << format_hex(Meta.KernargPreload, 6)
+         << " extent_size=" << ExtOrErr->Size << "\n";
+  for (const KernelArgMeta &Arg : Meta.Args)
+    outs() << "arg: name=" << Arg.Name << " offset=" << Arg.Offset
+           << " size=" << Arg.Size << " kind=" << Arg.ValueKind
+           << " address_space="
+           << (Arg.AddressSpace.empty() ? "<none>" : Arg.AddressSpace) << "\n";
+  return 0;
+}
+
+// Resolve a mode's value into the ordered list of kernels to process: empty
+// selects every kernel in code-object order; a comma list selects the named
+// kernels in order. Reports unknown names on stderr.
+bool resolveTargets(StringRef Requested, ArrayRef<std::string> KernelNames,
+                    StringRef CoPath, SmallVectorImpl<std::string> &Targets) {
+  if (Requested.empty()) {
+    Targets.assign(KernelNames.begin(), KernelNames.end());
+    return true;
+  }
+  SmallVector<StringRef> RequestedNames;
+  Requested.split(RequestedNames, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+  for (StringRef Name : RequestedNames) {
+    Name = Name.trim();
+    if (!is_contained(KernelNames, Name)) {
+      errs() << "hotswap_transpile_cli: kernel '" << Name << "' not found in "
+             << CoPath << "\n";
+      return false;
+    }
+    Targets.push_back(Name.str());
+  }
+  return true;
+}
+
+// --dump-meta: print the metadata the loader extracted for each selected
+// kernel, then the .text size. Needs no MC or raiser machinery.
+int runDumpMeta(const CodeObjectInfo &Info, StringRef Isa,
+                ArrayRef<std::string> Targets) {
+  outs() << "isa: " << Isa << "\n";
+  for (StringRef Name : Targets)
+    if (int Rc = dumpKernel(Info, Name))
+      return Rc;
+
+  Expected<TextSection> TsOrErr = Info.textSection();
+  if (!TsOrErr) {
+    errs() << "hotswap_transpile_cli: .text: " << toString(TsOrErr.takeError())
+           << "\n";
+    return 1;
+  }
+  outs() << "text_bytes: " << TsOrErr->Bytes.size() << "\n";
+  return 0;
+}
+
+// --dump-decoded: decode each selected kernel's .text to a canonical
+// instruction listing without raising. Exercises the MC stack, opcode map, and
+// decoder.
+int runDumpDecoded(const CodeObjectInfo &Info, const TextSection &Text,
+                   StringRef Isa, ArrayRef<std::string> Targets) {
+  // initMCState wants the bare AMDGPU processor (e.g. gfx942); the --isa / ELF
+  // form may be a full target id like "amdgcn-amd-amdhsa--gfx942:xnack-".
+  StringRef Cpu = Isa;
+  COMGR::TargetIdentifier Ident;
+  if (COMGR::parseTargetIdentifier(Isa, Ident) == AMD_COMGR_STATUS_SUCCESS)
+    Cpu = Ident.Processor;
+
+  Expected<MCState> MCOrErr = initMCState(Cpu);
+  if (!MCOrErr) {
+    errs() << "hotswap_transpile_cli: MC init failed for ISA '" << Isa
+           << "': " << toString(MCOrErr.takeError()) << "\n";
+    return 2;
+  }
+  MCState MC = std::move(*MCOrErr);
+  OpcodeMap OpcMap;
+  OpcMap.build(*MC.InstrInfo);
+
+  bool Multi = Targets.size() > 1;
+  bool AnyFailed = false;
+  for (const std::string &Target : Targets) {
+    Expected<KernelSymbolExtent> ExtentOrErr = Info.kernelSymbolExtent(Target);
+    if (!ExtentOrErr) {
+      errs() << "hotswap_transpile_cli: kernel '" << Target
+             << "' extent: " << toString(ExtentOrErr.takeError()) << "\n";
+      AnyFailed = true;
+      continue;
+    }
+    Expected<DecodeResult> DecodedOrErr =
+        decodeKernel(MC, OpcMap, Text.Bytes, ExtentOrErr->Offset,
+                     ExtentOrErr->Offset + ExtentOrErr->Size);
+    if (!DecodedOrErr) {
+      errs() << "hotswap_transpile_cli: kernel '" << Target
+             << "' decode: " << toString(DecodedOrErr.takeError()) << "\n";
+      AnyFailed = true;
+      continue;
+    }
+    if (Multi)
+      outs() << "; === hotswap_transpile_cli kernel: " << Target << " ===\n";
+    for (const DecodedInst &Di : DecodedOrErr->Insts) {
+      outs() << "0x";
+      outs().write_hex(Di.Offset);
+      outs() << "  " << canonicalOpName(Di.CanonOp) << "  "
+             << printInst(MC, Di.Inst) << "\n";
+    }
+  }
+  return AnyFailed ? 1 : 0;
+}
+
+// --emit-ir: raise the selected kernels from SourceIsa onto TargetIsa, into one
+// module, and print its IR.
+int runEmitIr(const CodeObjectInfo &Info, const TextSection &Text,
+              StringRef SourceIsa, StringRef TargetIsa,
+              ArrayRef<std::string> Targets) {
+  SmallVector<KernelRequest> Kernels;
+  for (const std::string &Target : Targets) {
+    Expected<const KernelMeta *> MetaOrErr = Info.kernel(Target);
+    if (!MetaOrErr) {
+      errs() << "hotswap_transpile_cli: kernel '" << Target
+             << "' metadata: " << toString(MetaOrErr.takeError()) << "\n";
+      return 1;
+    }
+
+    Expected<KernelSymbolExtent> ExtentOrErr = Info.kernelSymbolExtent(Target);
+    if (!ExtentOrErr) {
+      errs() << "hotswap_transpile_cli: kernel '" << Target
+             << "' extent: " << toString(ExtentOrErr.takeError()) << "\n";
+      return 1;
+    }
+
+    Kernels.push_back(KernelRequest{Target, **MetaOrErr, ExtentOrErr->Offset,
+                                    ExtentOrErr->Offset + ExtentOrErr->Size});
+  }
+
+  Expected<RaiseResult> RaisedOrErr =
+      raiseToIR(Text, SourceIsa, TargetIsa, Kernels);
+  if (!RaisedOrErr) {
+    // The raiser only returns a module on success, so a failure has no partial
+    // IR to dump; report the structured reason on stderr.
+    errs() << "hotswap_transpile_cli: failed to raise: "
+           << toString(RaisedOrErr.takeError()) << "\n";
+    return 1;
+  }
+  RaisedOrErr->Module->print(outs(), nullptr);
   return 0;
 }
 
@@ -96,61 +274,74 @@ int dumpKernel(const COMGR::hotswap::CodeObjectInfo &Info,
 int main(int Argc, char **Argv) {
   cl::ParseCommandLineOptions(Argc, Argv, "Hotswap transpiler test driver.\n");
 
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> CoBufOrErr =
-      llvm::MemoryBuffer::getFile(CoPathOpt, /*IsText=*/false);
+  ErrorOr<std::unique_ptr<MemoryBuffer>> CoBufOrErr =
+      MemoryBuffer::getFile(CoPathOpt, /*IsText=*/false);
   if (!CoBufOrErr) {
-    llvm::errs() << "hotswap_transpile_cli: cannot read " << CoPathOpt << ": "
-                 << CoBufOrErr.getError().message() << "\n";
+    errs() << "hotswap_transpile_cli: cannot read " << CoPathOpt << ": "
+           << CoBufOrErr.getError().message() << "\n";
     return 2;
   }
-  llvm::MemoryBufferRef CoData = (*CoBufOrErr)->getMemBufferRef();
+  MemoryBufferRef CoData = (*CoBufOrErr)->getMemBufferRef();
 
-  if (!DumpMetaOpt) {
-    llvm::errs()
-        << "hotswap_transpile_cli: no mode selected; pass --dump-meta\n";
+  bool DumpMeta = DumpMetaOpt.getNumOccurrences() > 0;
+  bool DumpDecoded = DumpDecodedOpt.getNumOccurrences() > 0;
+  bool EmitIr = EmitIrOpt.getNumOccurrences() > 0;
+  if (!DumpMeta && !DumpDecoded && !EmitIr) {
+    errs() << "hotswap_transpile_cli: no mode selected; pass --dump-meta, "
+              "--dump-decoded, or --emit-ir\n";
     return 2;
   }
 
   // Validate and load the code object before interpreting anything else, so a
   // structural or metadata refusal is reported rather than a downstream error.
-  llvm::Expected<COMGR::hotswap::CodeObjectInfo> InfoOrErr =
-      COMGR::hotswap::CodeObjectInfo::create(CoData);
+  Expected<CodeObjectInfo> InfoOrErr = CodeObjectInfo::create(CoData);
   if (!InfoOrErr) {
-    llvm::errs() << "hotswap_transpile_cli: " << CoPathOpt << ": "
-                 << llvm::toString(InfoOrErr.takeError()) << "\n";
+    errs() << "hotswap_transpile_cli: " << CoPathOpt << ": "
+           << toString(InfoOrErr.takeError()) << "\n";
     return 1;
   }
-  COMGR::hotswap::CodeObjectInfo &Info = *InfoOrErr;
+  CodeObjectInfo &Info = *InfoOrErr;
 
   // ISA: explicit --isa overrides, otherwise the ELF e_flags are authoritative.
   std::string Isa = IsaOpt;
   if (Isa.empty()) {
-    llvm::Expected<std::string> ElfIsa = COMGR::metadata::getElfIsaName(CoData);
+    Expected<std::string> ElfIsa = COMGR::metadata::getElfIsaName(CoData);
     if (!ElfIsa) {
-      llvm::errs() << "hotswap_transpile_cli: cannot read ISA from "
-                   << CoPathOpt << ": " << llvm::toString(ElfIsa.takeError())
-                   << "\n";
+      errs() << "hotswap_transpile_cli: cannot read ISA from " << CoPathOpt
+             << ": " << toString(ElfIsa.takeError()) << "\n";
       return 2;
     }
     Isa = std::move(*ElfIsa);
   }
 
-  llvm::outs() << "isa: " << Isa << "\n";
-  if (!KernelOpt.empty()) {
-    if (int Rc = dumpKernel(Info, KernelOpt))
-      return Rc;
-  } else {
-    for (llvm::StringRef Name : Info.kernelNames())
-      if (int Rc = dumpKernel(Info, Name))
-        return Rc;
+  // Every mode names its kernels the same way, so the selection is resolved
+  // once from whichever mode's value carries it.
+  StringRef Requested = DumpMeta      ? StringRef(DumpMetaOpt)
+                        : DumpDecoded ? StringRef(DumpDecodedOpt)
+                                      : StringRef(EmitIrOpt);
+  SmallVector<std::string> Targets;
+  if (!resolveTargets(Requested, Info.kernelNames(), CoPathOpt, Targets))
+    return 2;
+
+  if (DumpMeta)
+    return runDumpMeta(Info, Isa, Targets);
+
+  // The decode and raise modes work over the kernel .text, so AMDGPU has to be
+  // registered before the MC stack is built.
+  COMGR::ensureLLVMInitialized();
+
+  Expected<TextSection> TextOrErr = Info.textSection();
+  if (!TextOrErr) {
+    errs() << "hotswap_transpile_cli: could not extract .text from "
+           << CoPathOpt << ": " << toString(TextOrErr.takeError()) << "\n";
+    return 2;
   }
 
-  llvm::Expected<COMGR::hotswap::TextSection> TsOrErr = Info.textSection();
-  if (!TsOrErr) {
-    llvm::errs() << "hotswap_transpile_cli: .text: "
-                 << llvm::toString(TsOrErr.takeError()) << "\n";
-    return 1;
-  }
-  llvm::outs() << "text_bytes: " << TsOrErr->Bytes.size() << "\n";
-  return 0;
+  if (DumpDecoded)
+    return runDumpDecoded(Info, *TextOrErr, Isa, Targets);
+
+  // Only the raise reads a target ISA; the decode is written in source terms.
+  return runEmitIr(
+      Info, *TextOrErr, Isa,
+      TargetIsaOpt.empty() ? StringRef(Isa) : StringRef(TargetIsaOpt), Targets);
 }

--- a/amd/comgr/test-lit/hotswap/raiser/kernel_scaffolding.s
+++ b/amd/comgr/test-lit/hotswap/raiser/kernel_scaffolding.s
@@ -1,0 +1,92 @@
+; REQUIRES: comgr-has-hotswap-transpile
+
+; RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx942 %s -o %t.o
+; RUN: %ld.lld -shared %t.o -o %t.hsaco
+
+; The raise declares a kernel from its metadata alone, so what the module says
+; it targets and what signature the lifted function takes are fixed before any
+; instruction is lifted. Both kernels here run to an s_endpgm and lift to the
+; terminator alone, leaving the declaration as the only thing under test.
+; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir | %FileCheck %s
+
+; The layout comes from a machine built for the GPU being raised onto, so
+; private is the 32-bit address space it is on AMDGPU rather than the 64-bit one
+; a module carrying no layout of its own would report.
+; CHECK: target datalayout = {{.+}}p5:32:32
+; CHECK: target triple = "amdgcn-amd-amdhsa"
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
+	.amdhsa_code_object_version 6
+	.text
+	.globl	karg_kernel
+	.p2align	8
+	.type	karg_kernel,@function
+; The source kernarg segment is passed whole and by reference, so the raised
+; kernel reads the segment the source ABI laid out instead of one rebuilt from
+; individual arguments.
+; CHECK-LABEL: define amdgpu_kernel void @karg_kernel(ptr addrspace(4) byref([40 x i8]) align 16
+; CHECK: ret void
+karg_kernel:
+	s_mov_b32 s0, 0
+	s_endpgm
+
+	.globl	noarg_kernel
+	.p2align	8
+	.type	noarg_kernel,@function
+; An empty kernarg segment is no segment: the function takes no parameter
+; rather than an empty one.
+; CHECK-LABEL: define amdgpu_kernel void @noarg_kernel()
+; CHECK: ret void
+noarg_kernel:
+	s_endpgm
+
+; The target's hidden arguments are suppressed. The source segment is passed as
+; it stands, so there is nothing for the target ABI to append to it.
+; CHECK: attributes {{.+}} "amdgpu-no-implicitarg-ptr"
+
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel karg_kernel
+		.amdhsa_kernarg_size 40
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_next_free_vgpr 1
+		.amdhsa_next_free_sgpr 4
+		.amdhsa_accum_offset 4
+		.amdhsa_reserve_vcc 1
+	.end_amdhsa_kernel
+	.amdhsa_kernel noarg_kernel
+		.amdhsa_kernarg_size 0
+		.amdhsa_next_free_vgpr 1
+		.amdhsa_next_free_sgpr 1
+		.amdhsa_accum_offset 4
+		.amdhsa_reserve_vcc 1
+	.end_amdhsa_kernel
+	.text
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args: []
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 40
+    .max_flat_workgroup_size: 1024
+    .name:           karg_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     4
+    .symbol:         karg_kernel.kd
+    .vgpr_count:     1
+    .wavefront_size: 64
+  - .args: []
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 0
+    .max_flat_workgroup_size: 1024
+    .name:           noarg_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     1
+    .symbol:         noarg_kernel.kd
+    .vgpr_count:     1
+    .wavefront_size: 64
+amdhsa.version: [1, 2]
+...
+	.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap/raiser/mov_endpgm.s
+++ b/amd/comgr/test-lit/hotswap/raiser/mov_endpgm.s
@@ -1,0 +1,110 @@
+; REQUIRES: comgr-has-hotswap-transpile
+
+; RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx942 %s -o %t.o
+; RUN: %ld.lld -shared %t.o -o %t.hsaco
+
+; s0 is never read, so the moved value is dead and the lifted body is just the
+; terminator.
+; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=mov_endpgm_kernel | %FileCheck %s
+; CHECK-LABEL: define amdgpu_kernel void @mov_endpgm_kernel(
+; CHECK: ret void
+
+; The decoder maps the two instructions onto their canonical ops.
+; RUN: %hotswap_transpile_cli %t.hsaco --dump-decoded=mov_endpgm_kernel \
+; RUN:   | %FileCheck %s --check-prefix=DECODE
+
+; The dispatch only routes the landed SOP1 / SOPP families; a VALU opcode has
+; no handler yet, so vmov_kernel is refused with a structured diagnostic rather
+; than mislowered or crashed.
+; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=vmov_kernel 2>&1 \
+; RUN:   | %FileCheck %s --check-prefix=UNHANDLED
+; UNHANDLED: unsupported-instruction-form: v_mov_b32
+
+; Raising the whole code object runs both kernels through one call, so the
+; refusal names the kernel it came out of and the ISA pair it ran under rather
+; than leaving the caller to work out which request failed.
+; RUN: not %hotswap_transpile_cli %t.hsaco --target-isa=gfx950 --emit-ir 2>&1 \
+; RUN:   | %FileCheck %s --check-prefix=BATCH
+; BATCH: unsupported-instruction-form: v_mov_b32 {{.+}} in kernel 'vmov_kernel' (gfx942 -> gfx950)
+
+; The target ISA is a parameter of the raise, so a gfx942 kernel raises onto
+; another GPU. Nothing this kernel lifts to depends on which one, so what the
+; run pins is that naming a second GPU stands its side of the raise up.
+; RUN: %hotswap_transpile_cli %t.hsaco --target-isa=gfx950 --emit-ir=mov_endpgm_kernel \
+; RUN:   | %FileCheck %s --check-prefix=RETARGET
+; RETARGET-LABEL: define amdgpu_kernel void @mov_endpgm_kernel(
+; RETARGET: ret void
+
+; An unrecognised ISA is refused before decoding, at whichever end named it.
+; RUN: not %hotswap_transpile_cli %t.hsaco --isa=gfxbogus --emit-ir=mov_endpgm_kernel 2>&1 \
+; RUN:   | %FileCheck %s --check-prefix=BADISA
+; BADISA: source ISA 'gfxbogus' does not name an AMDGPU GPU
+
+; RUN: not %hotswap_transpile_cli %t.hsaco --target-isa=gfxbogus --emit-ir=mov_endpgm_kernel 2>&1 \
+; RUN:   | %FileCheck %s --check-prefix=BADTARGET
+; BADTARGET: target ISA 'gfxbogus' does not name an AMDGPU GPU
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
+	.amdhsa_code_object_version 6
+	.text
+	.globl	mov_endpgm_kernel
+	.p2align	8
+	.type	mov_endpgm_kernel,@function
+mov_endpgm_kernel:
+; DECODE: S_MOV_B32{{.+}}s_mov_b32 s0, 0
+	s_mov_b32 s0, 0
+; DECODE: S_ENDPGM{{.+}}s_endpgm
+	s_endpgm
+
+	.globl	vmov_kernel
+	.p2align	8
+	.type	vmov_kernel,@function
+vmov_kernel:
+	v_mov_b32_e32 v0, 0
+	s_endpgm
+
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel mov_endpgm_kernel
+		.amdhsa_kernarg_size 0
+		.amdhsa_next_free_vgpr 1
+		.amdhsa_next_free_sgpr 1
+		.amdhsa_accum_offset 4
+		.amdhsa_reserve_vcc 1
+	.end_amdhsa_kernel
+	.amdhsa_kernel vmov_kernel
+		.amdhsa_kernarg_size 0
+		.amdhsa_next_free_vgpr 1
+		.amdhsa_next_free_sgpr 1
+		.amdhsa_accum_offset 4
+		.amdhsa_reserve_vcc 1
+	.end_amdhsa_kernel
+	.text
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args: []
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 0
+    .max_flat_workgroup_size: 1024
+    .name:           mov_endpgm_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     1
+    .symbol:         mov_endpgm_kernel.kd
+    .vgpr_count:     1
+    .wavefront_size: 64
+  - .args: []
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 0
+    .max_flat_workgroup_size: 1024
+    .name:           vmov_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     1
+    .symbol:         vmov_kernel.kd
+    .vgpr_count:     1
+    .wavefront_size: 64
+amdhsa.version: [1, 2]
+...
+	.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap/raiser/refuse_unterminated_kernel.s
+++ b/amd/comgr/test-lit/hotswap/raiser/refuse_unterminated_kernel.s
@@ -2,23 +2,26 @@
 
 ; RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx942 %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
-; A mode's value selects kernels by name; an absent name is reported rather
-; than silently producing no output.
-; RUN: not %hotswap_transpile_cli %t.hsaco --dump-meta=nope 2>&1 \
+
+; Execution running off the end of a kernel extent means the code is truncated
+; or the extent is misbounded. Returning there would hand back a kernel that
+; reads as having run to completion, so the raise refuses instead.
+; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=trunc_kernel 2>&1 \
 ; RUN:   | %FileCheck %s
-; CHECK: kernel 'nope' not found in
+; CHECK: unterminated-kernel-extent in kernel 'trunc_kernel'
 
 	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
 	.amdhsa_code_object_version 6
 	.text
-	.globl	meta_kernel
+	.globl	trunc_kernel
 	.p2align	8
-	.type	meta_kernel,@function
-meta_kernel:
-	s_endpgm
+	.type	trunc_kernel,@function
+trunc_kernel:
+	s_mov_b32 s0, 0
+
 	.section	.rodata,"a",@progbits
 	.p2align	6, 0x0
-	.amdhsa_kernel meta_kernel
+	.amdhsa_kernel trunc_kernel
 		.amdhsa_kernarg_size 0
 		.amdhsa_next_free_vgpr 1
 		.amdhsa_next_free_sgpr 1
@@ -33,11 +36,11 @@ amdhsa.kernels:
     .group_segment_fixed_size: 0
     .kernarg_segment_align: 8
     .kernarg_segment_size: 0
-    .max_flat_workgroup_size: 256
-    .name:           meta_kernel
+    .max_flat_workgroup_size: 1024
+    .name:           trunc_kernel
     .private_segment_fixed_size: 0
     .sgpr_count:     1
-    .symbol:         meta_kernel.kd
+    .symbol:         trunc_kernel.kd
     .vgpr_count:     1
     .wavefront_size: 64
 amdhsa.version: [1, 2]

--- a/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
@@ -1,11 +1,15 @@
 # Unit tests for the hotswap raiser (ISA-to-IR transpiler scaffolding).
+#
+# Every target here links hotswap::raiser, which normalizes a source ISA string
+# through COMGR::parseTargetIdentifier, so each also links the
+# comgr-object-utils objects that define it.
 
 # -- RaiserScaffoldingTests ---------------------------------------------------
 #
-# Pins the bare-bones raiser scaffolding contract (`hotswap/raiser/raiser.h`):
-# empty input produces a verifyModule-clean `llvm::Module` with a single
-# `AMDGPU_KERNEL` `ret void` function, plus the failure paths for missing
-# kernel descriptor / malformed ISA.
+# Pins the refusals `hotswap/raiser/raiser.h` reaches before it has a kernel to
+# raise, or on input no code object can express: a malformed ISA at either end,
+# and a kernel extent holding no code. The shape of a raised module is pinned
+# from the emitted IR by test-lit/hotswap/raiser/kernel_scaffolding.s instead.
 
 add_executable(RaiserScaffoldingTests
   RaiserScaffoldingTest.cpp)
@@ -16,6 +20,7 @@ target_link_libraries(RaiserScaffoldingTests PRIVATE
   hotswap::raiser
   hotswap::decoder
   hotswap::common
+  comgr-object-utils
   ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
@@ -42,6 +47,7 @@ target_link_libraries(WaveProjectionTests PRIVATE
   hotswap::raiser
   hotswap::decoder
   hotswap::common
+  comgr-object-utils
   ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
@@ -68,6 +74,7 @@ target_link_libraries(RaiseFailureTests PRIVATE
   hotswap::raiser
   hotswap::decoder
   hotswap::common
+  comgr-object-utils
   ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
@@ -92,6 +99,7 @@ target_link_libraries(RegFileTests PRIVATE
   hotswap::raiser
   hotswap::decoder
   hotswap::common
+  comgr-object-utils
   ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
@@ -117,6 +125,7 @@ target_link_libraries(RegisterStateTests PRIVATE
   hotswap::raiser
   hotswap::decoder
   hotswap::common
+  comgr-object-utils
   ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
@@ -140,6 +149,7 @@ target_link_libraries(RaiseContextTests PRIVATE
   hotswap::raiser
   hotswap::decoder
   hotswap::common
+  comgr-object-utils
   ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
@@ -164,6 +174,7 @@ target_link_libraries(OpResolverTests PRIVATE
   hotswap::raiser
   hotswap::decoder
   hotswap::common
+  comgr-object-utils
   ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
@@ -189,6 +200,7 @@ target_link_libraries(UserSgprLayoutTests PRIVATE
   hotswap::raiser
   hotswap::decoder
   hotswap::common
+  comgr-object-utils
   ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 

--- a/amd/comgr/test-unit/hotswap/raiser/OpResolverTest.cpp
+++ b/amd/comgr/test-unit/hotswap/raiser/OpResolverTest.cpp
@@ -93,9 +93,8 @@ protected:
               Function::ExternalLinkage, "kernel", Mod)) {
       B.SetInsertPoint(BasicBlock::Create(LLVMCtx, "entry", Kernel));
       Ctx.emplace(cantFail(RaiseContext::create(
-          B, Projection, Mc, KernelMeta(), DenseMap<uint64_t, BasicBlock *>(),
-          ArrayRef<uint8_t>(), 0, ArrayRef<TextSection::ImageSection>(), 0,
-          0)));
+          B, Projection, Mc, KernelMeta(), ArrayRef<uint8_t>(), 0,
+          ArrayRef<TextSection::ImageSection>(), 0, 0)));
     }
   };
 

--- a/amd/comgr/test-unit/hotswap/raiser/RaiseContextTest.cpp
+++ b/amd/comgr/test-unit/hotswap/raiser/RaiseContextTest.cpp
@@ -50,8 +50,10 @@ namespace {
 
 class RaiseContextTest : public ::testing::Test {
 protected:
-  // Source offset the environment maps to a block.
-  static constexpr uint64_t KTargetOffset = 0x40;
+  // Offset the source kernel starts at, which the context maps to the entry
+  // block. Deliberately not zero: the mapping tracks the kernel's own start,
+  // not the start of the text section it sits in.
+  static constexpr uint64_t KKernelStartOffset = 0x40;
 
   void SetUp() override {
     Expected<MCState> State = initMCState("gfx942");
@@ -67,7 +69,7 @@ protected:
     ISAProfile Isa;
     ReplicationProjection Projection;
     Function *Kernel;
-    BasicBlock *Target;
+    BasicBlock *Entry;
     std::optional<RaiseContext> Ctx;
 
     explicit ContextEnvironment(const MCState &Mc)
@@ -77,16 +79,11 @@ protected:
           Kernel(Function::Create(
               FunctionType::get(B.getVoidTy(), /*isVarArg=*/false),
               Function::ExternalLinkage, "kernel", Mod)),
-          Target(BasicBlock::Create(LLVMCtx, "target", Kernel)) {
-      BasicBlock *Entry =
-          BasicBlock::Create(LLVMCtx, "entry", Kernel, /*InsertBefore=*/Target);
+          Entry(BasicBlock::Create(LLVMCtx, "entry", Kernel)) {
       B.SetInsertPoint(Entry);
-      DenseMap<uint64_t, BasicBlock *> OffsetToBb;
-      OffsetToBb[KTargetOffset] = Target;
-      Ctx.emplace(cantFail(
-          RaiseContext::create(B, Projection, Mc, KernelMeta(),
-                               std::move(OffsetToBb), ArrayRef<uint8_t>(), 0,
-                               ArrayRef<TextSection::ImageSection>(), 0, 0)));
+      Ctx.emplace(cantFail(RaiseContext::create(
+          B, Projection, Mc, KernelMeta(), ArrayRef<uint8_t>(), 0,
+          ArrayRef<TextSection::ImageSection>(), KKernelStartOffset, 0)));
     }
   };
 
@@ -95,7 +92,7 @@ protected:
 };
 
 TEST_F(RaiseContextTest, ResolvesBlocksBySourceOffset) {
-  EXPECT_EQ(Env->Ctx->lookupBB(KTargetOffset), Env->Target);
+  EXPECT_EQ(Env->Ctx->lookupBB(KKernelStartOffset), Env->Entry);
 }
 
 } // namespace

--- a/amd/comgr/test-unit/hotswap/raiser/RaiserScaffoldingTest.cpp
+++ b/amd/comgr/test-unit/hotswap/raiser/RaiserScaffoldingTest.cpp
@@ -6,13 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Pins the scaffolding contract `raiseToIR` advertises: an empty input
-// produces a well-formed `llvm::Module` containing one `AMDGPU_KERNEL`
-// function whose body is exactly `ret void`, with the AMDGPU triple set and
-// the source kernarg segment declared. Empty inputs succeed; malformed ISA
-// inputs are rejected with a BadInput RaiseFailure carried in the returned
-// `llvm::Error`. Descriptor presence is enforced upstream by the code-object
-// loader, so it is no longer a raiser precondition.
+// Pins the refusals `raiseToIR` reaches before it has a kernel to raise, or on
+// input no code object can express. The shape of a raised module -- its triple,
+// data layout, and the signature and attributes of the lifted function -- is
+// pinned by test-lit/hotswap/raiser/kernel_scaffolding.s, which reads it off
+// the emitted IR. What is left here is what only the entry point can be handed:
+// an ISA string the driver would have taken from the code object, and a kernel
+// extent holding no code at all.
+//
+// These assert the `RaiseFailureReason` rather than the rendered message, which
+// is the distinction the enumerators exist for: a caller buckets a refusal
+// without parsing diagnostic text.
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,17 +24,12 @@
 
 #include "hotswap/raiser/raise_failure.h"
 
-#include "llvm/IR/BasicBlock.h"
-#include "llvm/IR/CallingConv.h"
-#include "llvm/IR/DerivedTypes.h"
-#include "llvm/IR/Function.h"
-#include "llvm/IR/Instructions.h"
+// RaiseResult owns the context and module by pointer, so destroying one needs
+// both definitions even though no test here looks inside them.
+#include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
-#include "llvm/IR/Verifier.h"
-#include "llvm/Support/Alignment.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include "gtest/gtest.h"
 
@@ -60,15 +59,31 @@ using COMGR::hotswap::RaiseFailure;
 using COMGR::hotswap::RaiseFailureReason;
 using COMGR::hotswap::RaiseResult;
 using COMGR::hotswap::raiseToIR;
+using COMGR::hotswap::TextSection;
 
 namespace {
 
-KernelMeta makeKernelMeta(llvm::StringRef Name,
-                          uint32_t KernargSegmentSize = 0) {
+KernelMeta makeKernelMeta(llvm::StringRef Name) {
   KernelMeta Meta;
   Meta.Name = Name.str();
-  Meta.KernargSegmentSize = KernargSegmentSize;
   return Meta;
+}
+
+// Raise a kernel whose extent holds no code, onto an ISA other than the one it
+// was compiled for.
+llvm::Expected<RaiseResult> raiseEmptyText(llvm::StringRef SourceIsa,
+                                           llvm::StringRef TargetIsa,
+                                           const KernelMeta &Meta) {
+  COMGR::hotswap::KernelRequest Kernel{"kernel", Meta, /*StartOffset=*/0,
+                                       /*EndOffset=*/0};
+  return raiseToIR(TextSection{}, SourceIsa, TargetIsa, Kernel);
+}
+
+// The same raise back onto the ISA the kernel was compiled for, for the cases
+// the target ISA has no say in.
+llvm::Expected<RaiseResult> raiseEmptyText(llvm::StringRef Isa,
+                                           const KernelMeta &Meta) {
+  return raiseEmptyText(Isa, Isa, Meta);
 }
 
 // The RaiseFailureReason a refused raise reports, or None if the error was not
@@ -82,82 +97,17 @@ RaiseFailureReason refusalReason(llvm::Error E) {
 
 } // namespace
 
-TEST(RaiserScaffolding, EmptyInputProducesValidModule) {
+TEST(RaiserScaffolding, EmptySourceIsaIsRejected) {
   KernelMeta Meta = makeKernelMeta("kernel");
-  llvm::Expected<RaiseResult> Result = raiseToIR("gfx942", "kernel", Meta);
+  llvm::Expected<RaiseResult> Result = raiseEmptyText("", Meta);
 
-  ASSERT_TRUE(static_cast<bool>(Result)) << llvm::toString(Result.takeError());
-  ASSERT_NE(Result->Ctx, nullptr);
-  ASSERT_NE(Result->Module, nullptr);
-
-  std::string Err;
-  llvm::raw_string_ostream ErrStream(Err);
-  EXPECT_FALSE(llvm::verifyModule(*Result->Module, &ErrStream)) << Err;
+  ASSERT_FALSE(static_cast<bool>(Result));
+  EXPECT_EQ(refusalReason(Result.takeError()), RaiseFailureReason::BadInput);
 }
 
-TEST(RaiserScaffolding, ModuleAdvertisesAMDGPUTriple) {
+TEST(RaiserScaffolding, MalformedSourceIsaIsRejected) {
   KernelMeta Meta = makeKernelMeta("kernel");
-  llvm::Expected<RaiseResult> Result = raiseToIR("gfx942", "kernel", Meta);
-
-  ASSERT_TRUE(static_cast<bool>(Result)) << llvm::toString(Result.takeError());
-  ASSERT_NE(Result->Module, nullptr);
-  EXPECT_EQ(Result->Module->getTargetTriple().str(), "amdgcn-amd-amdhsa");
-}
-
-TEST(RaiserScaffolding, KernelFunctionIsAMDGPUKernelWithRetVoid) {
-  KernelMeta Meta = makeKernelMeta("kernel");
-  llvm::Expected<RaiseResult> Result = raiseToIR("gfx942", "kernel", Meta);
-
-  ASSERT_TRUE(static_cast<bool>(Result)) << llvm::toString(Result.takeError());
-  llvm::Function *Fn = Result->Module->getFunction("kernel");
-  ASSERT_NE(Fn, nullptr);
-  EXPECT_EQ(Fn->getCallingConv(), llvm::CallingConv::AMDGPU_KERNEL);
-  ASSERT_EQ(Fn->size(), 1u);
-  llvm::BasicBlock &Entry = Fn->getEntryBlock();
-  ASSERT_FALSE(Entry.empty());
-  EXPECT_TRUE(llvm::isa<llvm::ReturnInst>(Entry.getTerminator()));
-}
-
-TEST(RaiserScaffolding, KernelDeclaresSourceKernargSegment) {
-  KernelMeta Meta = makeKernelMeta("kernel", /*KernargSegmentSize=*/40);
-  llvm::Expected<RaiseResult> Result = raiseToIR("gfx942", "kernel", Meta);
-
-  ASSERT_TRUE(static_cast<bool>(Result)) << llvm::toString(Result.takeError());
-  llvm::Function *Fn = Result->Module->getFunction("kernel");
-  ASSERT_NE(Fn, nullptr);
-  ASSERT_EQ(Fn->arg_size(), 1u);
-  EXPECT_EQ(Fn->getArg(0)->getType()->getPointerAddressSpace(), 4u);
-  auto *SegmentTy =
-      llvm::dyn_cast_if_present<llvm::ArrayType>(Fn->getParamByRefType(0));
-  ASSERT_NE(SegmentTy, nullptr);
-  EXPECT_TRUE(SegmentTy->getElementType()->isIntegerTy(8));
-  EXPECT_EQ(SegmentTy->getNumElements(), 40u);
-  EXPECT_EQ(Fn->getParamAlign(0).valueOrOne().value(), 16u);
-}
-
-TEST(RaiserScaffolding, EmptyKernargSegmentTakesNoParameter) {
-  KernelMeta Meta = makeKernelMeta("kernel");
-  llvm::Expected<RaiseResult> Result = raiseToIR("gfx942", "kernel", Meta);
-
-  ASSERT_TRUE(static_cast<bool>(Result)) << llvm::toString(Result.takeError());
-  llvm::Function *Fn = Result->Module->getFunction("kernel");
-  ASSERT_NE(Fn, nullptr);
-  EXPECT_EQ(Fn->arg_size(), 0u);
-}
-
-TEST(RaiserScaffolding, KernelSuppressesTargetHiddenArguments) {
-  KernelMeta Meta = makeKernelMeta("kernel", /*KernargSegmentSize=*/40);
-  llvm::Expected<RaiseResult> Result = raiseToIR("gfx942", "kernel", Meta);
-
-  ASSERT_TRUE(static_cast<bool>(Result)) << llvm::toString(Result.takeError());
-  llvm::Function *Fn = Result->Module->getFunction("kernel");
-  ASSERT_NE(Fn, nullptr);
-  EXPECT_TRUE(Fn->hasFnAttribute("amdgpu-no-implicitarg-ptr"));
-}
-
-TEST(RaiserScaffolding, EmptyTargetIsaIsRejected) {
-  KernelMeta Meta = makeKernelMeta("kernel");
-  llvm::Expected<RaiseResult> Result = raiseToIR("", "kernel", Meta);
+  llvm::Expected<RaiseResult> Result = raiseEmptyText("not-a-real-isa", Meta);
 
   ASSERT_FALSE(static_cast<bool>(Result));
   EXPECT_EQ(refusalReason(Result.takeError()), RaiseFailureReason::BadInput);
@@ -166,8 +116,19 @@ TEST(RaiserScaffolding, EmptyTargetIsaIsRejected) {
 TEST(RaiserScaffolding, MalformedTargetIsaIsRejected) {
   KernelMeta Meta = makeKernelMeta("kernel");
   llvm::Expected<RaiseResult> Result =
-      raiseToIR("not-a-real-isa", "kernel", Meta);
+      raiseEmptyText("gfx942", "not-a-real-isa", Meta);
 
   ASSERT_FALSE(static_cast<bool>(Result));
   EXPECT_EQ(refusalReason(Result.takeError()), RaiseFailureReason::BadInput);
+}
+
+TEST(RaiserScaffolding, EmptyKernelExtentIsRejected) {
+  KernelMeta Meta = makeKernelMeta("kernel");
+  llvm::Expected<RaiseResult> Result = raiseEmptyText("gfx942", Meta);
+
+  // An extent with nothing in it never reaches an instruction that ends the
+  // program, so it is refused for the same reason a truncated one is.
+  ASSERT_FALSE(static_cast<bool>(Result));
+  EXPECT_EQ(refusalReason(Result.takeError()),
+            RaiseFailureReason::UnterminatedKernelExtent);
 }


### PR DESCRIPTION
A gfx942 s_mov_b32 + s_endpgm kernel lifts to a verified amdgpu_kernel function,
running the real pipeline over the preceding layers.

A raise reads two ISAs. The source one is what the code object was compiled for
and the decode is written in its terms; the target one is what the raised IR will
be lowered for, and the wave projection reads it to turn a source lane into the
target lane that runs it. The target one also stands up the machine the module
takes its data layout from. The entry point takes a list of kernels, since the
kernels of a code object share a text section and a source ISA and so can share
the MC stack built over them.

Only SOP1 and SOPP are routed to the dispatch; every other opcode falls through
to a structured refusal. Running out of code is refused the same way: an extent
that ends without an instruction that ends the program would otherwise be closed
with a return, turning truncated or misbounded machine code into a kernel that
reads as having run to completion. A refusal is raised below the point that knows
which kernel of a batch holds the offending instruction, so the kernel name and
the ISA pair are attached as the failure leaves the raise.

raise_cli grows --dump-decoded, --emit-ir, and --target-isa. Each mode names the
kernels it runs over in its own value: bare for all of them, =<k>[,<k>...] for a
subset in order.

Raised IR being readable from a test puts the contract in lit -- what a kernel is
declared with, the decoded listing, raising onto another GPU, and the refusals.
The scaffolding unit test keeps what only the entry point can be handed, and
asserts the refusal reason rather than the rendered text.
