### PR TITLE
Re-apply broken [VPlan] VPSlotTracker reuse (#203386) for compile-tim…

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -3167,7 +3167,7 @@ void LoopVectorizationPlanner::emitInvalidCostRemarks(
         continue;
 
       VPCostContext CostCtx(*TLI, *Plan, CM, Config,
-                            /*ReusePrintingSlotTracker=*/true);
+                            std::make_unique<VPSlotTracker>(Plan.get()));
       precomputeCosts(*Plan, VF, CostCtx);
       auto Iter = vp_depth_first_deep(Plan->getVectorLoopRegion()->getEntry());
       for (VPBasicBlock *VPBB : VPBlockUtils::blocksOnly<VPBasicBlock>(Iter)) {
@@ -5603,14 +5603,15 @@ void LoopVectorizationPlanner::plan(ElementCount UserVF, unsigned UserIC) {
 VPCostContext::VPCostContext(const TargetLibraryInfo &TLI, const VPlan &Plan,
                              LoopVectorizationCostModel &CM,
                              VFSelectionContext &Config,
-                             bool ReusePrintingSlotTracker)
+                             std::unique_ptr<VPSlotTracker> SlotTracker)
     : TTI(Config.getTTI()), TLI(TLI), LLVMCtx(Plan.getContext()), CM(CM),
       Config(Config), CostKind(Config.CostKind), PSE(Config.getPSE()),
-      L(Config.getLoop()) {
+      L(Config.getLoop())
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  if (ReusePrintingSlotTracker)
-    PlanForSlotTracker = &Plan;
+      ,
+      SlotTracker(std::move(SlotTracker))
 #endif
+{
 }
 
 InstructionCost VPCostContext::getLegacyCost(Instruction *UI,
@@ -5796,7 +5797,7 @@ LoopVectorizationPlanner::precomputeCosts(VPlan &Plan, ElementCount VF,
 InstructionCost LoopVectorizationPlanner::cost(VPlan &Plan, ElementCount VF,
                                                VPRegisterUsage *RU) const {
   VPCostContext CostCtx(*TLI, Plan, CM, Config,
-                        /*ReusePrintingSlotTracker=*/true);
+                        std::make_unique<VPSlotTracker>(&Plan));
   InstructionCost Cost = precomputeCosts(Plan, VF, CostCtx);
 
   // Now compute and add the VPlan-based cost.
@@ -8148,7 +8149,7 @@ bool LoopVectorizePass::processLoop(Loop *L) {
     bool ForceVectorization =
         Hints.getForce() == LoopVectorizeHints::FK_Enabled;
     VPCostContext CostCtx(*TLI, *BestPlanPtr, CM, Config,
-                          /*ReusePrintingSlotTracker=*/true);
+                          std::make_unique<VPSlotTracker>(BestPlanPtr));
     if (!ForceVectorization &&
         !isOutsideLoopWorkProfitable(Checks, VF, L, PSE, CostCtx, *BestPlanPtr,
                                      SEL, Config.getVScaleForTuning())) {

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1894,16 +1894,6 @@ VPCostContext::getOperandInfo(VPValue *V) const {
   return {};
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-VPSlotTracker *VPCostContext::getSlotTracker() {
-  if (!PlanForSlotTracker)
-    return nullptr;
-  if (!SlotTracker)
-    SlotTracker = std::make_unique<VPSlotTracker>(PlanForSlotTracker);
-  return SlotTracker.get();
-}
-#endif
-
 InstructionCost VPCostContext::getScalarizationOverhead(
     Type *ResultTy, ArrayRef<const VPValue *> Operands, ElementCount VF,
     TTI::VectorInstrContext VIC, bool AlwaysIncludeReplicatingR) {

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -342,7 +342,7 @@ struct VPCostContext {
 
   VPCostContext(const TargetLibraryInfo &TLI, const VPlan &Plan,
                 LoopVectorizationCostModel &CM, VFSelectionContext &Config,
-                bool ReusePrintingSlotTracker = false);
+                std::unique_ptr<VPSlotTracker> SlotTracker = nullptr);
 
   /// Return the cost for \p UI with \p VF using the legacy cost model as
   /// fallback until computing the cost of all recipes migrates to VPlan.
@@ -389,18 +389,12 @@ struct VPCostContext {
   static bool isFreeScalarIntrinsic(Intrinsic::ID ID);
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  /// Return a VPSlotTracker to re-use for printing, lazily constructing it on
-  /// first use. Returns nullptr if slot-tracker re-use was not requested at
-  /// construction.
-  VPSlotTracker *getSlotTracker();
+  /// Return SlotTracker to re-use for printing, if set.
+  VPSlotTracker *getSlotTracker() const { return SlotTracker.get(); }
 
 private:
-  /// VPlan to build the printing VPSlotTracker for, or nullptr if slot-tracker
-  /// re-use was not requested.
-  const VPlan *PlanForSlotTracker = nullptr;
-
-  /// SlotTracker to re-use when printing, lazily constructed by getSlotTracker.
-  std::unique_ptr<VPSlotTracker> SlotTracker;
+  /// SlotTracker to re-use when printing.
+  const std::unique_ptr<VPSlotTracker> SlotTracker;
 #endif
 };
 

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -331,7 +331,7 @@ InstructionCost VPRecipeBase::cost(ElementCount VF, VPCostContext &Ctx) {
 
   LLVM_DEBUG({
     dbgs() << "Cost of " << RecipeCost << " for VF " << VF << ": ";
-    if (VPSlotTracker *SlotTracker = Ctx.getSlotTracker()) {
+    if (auto SlotTracker = Ctx.getSlotTracker()) {
       print(dbgs(), "", *SlotTracker);
       dbgs() << "\n";
     } else {


### PR DESCRIPTION
…e repro

Revert the #211763 fix (lazy slot tracker) and re-land the original VPCostContext call sites in Release builds, while only storing it under NDEBUG. Intended for local compile-time regression reproduction.


