### PR TITLE
[MCParser] Converge .altmacro expandMacro with trunk now that MIOpen …

### DIFF
--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -2555,26 +2555,28 @@ bool AsmParser::expandMacro(raw_svector_ostream &OS, MCAsmMacro &Macro,
       }
     }
 
-    if (AltMacroMode && isIdentifierChar(Body[I])) {
-      size_t Len = 1;
-      while (I + Len != End && isIdentifierChar(Body[I + Len]))
-        ++Len;
-      StringRef Argument(Body.data() + I, Len);
+    if (!isIdentifierChar(Body[I]) || IsDarwin) {
+      OS << Body[I++];
+      continue;
+    }
+
+    const size_t Start = I;
+    while (++I && isIdentifierChar(Body[I])) {
+    }
+    StringRef Token(Body.data() + Start, I - Start);
+    if (AltMacroMode) {
       unsigned Index = 0;
       for (; Index != NParameters; ++Index)
-        if (Parameters[Index].Name == Argument)
+        if (Parameters[Index].Name == Token)
           break;
       if (Index != NParameters) {
         expandArg(Index);
-        I += Len;
         if (I != End && Body[I] == '&')
           ++I;
         continue;
       }
     }
-
-    OS << Body[I];
-    ++I;
+    OS << Token;
   }
 
   ++Macro.Count;

--- a/llvm/test/MC/AsmParser/altmacro-arg.s
+++ b/llvm/test/MC/AsmParser/altmacro-arg.s
@@ -1,10 +1,30 @@
 ## Arguments can be expanded even if they are not preceded by \
-# RUN: llvm-mc -triple=x86_64 %s | FileCheck %s
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -triple=x86_64 a.s | FileCheck %s
+# RUN: llvm-mc -triple=x86_64 b.s | FileCheck %s --check-prefix=CHECK1
 
-# CHECK:      1 1 1a
-# CHECK-NEXT: 1 2 1a 2b
-# CHECK-NEXT: \$b \$b
+#--- a.s
 .altmacro
+# CHECK:      ja .Ltmp0
+# CHECK-NEXT: xorq %rbx, %rbx
+# CHECK:      .data
+# CHECK-NEXT: .ascii "b cc rbx"
+# CHECK-NEXT: .ascii "bcc ccx rbx raxx"
+.macro gen a, ra, rax
+  ja 1f
+  xorq %rax, %rax
+1:
+.data
+  .ascii "\a \ra \rax"
+  .ascii "a\()ra ra\()x rax raxx"
+.endm
+gen b, cc, rbx
+
+#--- b.s
+.altmacro
+# CHECK1:      1 1 1a
+# CHECK1-NEXT: 1 2 1a 2b
+# CHECK1-NEXT: \$b \$b
 .irp ._a,1
   .print "\._a \._a& ._a&a"
   .irp $b,2
@@ -13,10 +33,11 @@
   .print "\$b \$b&"
 .endr
 
-# CHECK:      1 1& ._a&a
-# CHECK-NEXT: \$b \$b&
+# CHECK1:      1 1& ._a&a
+# CHECK1-NEXT: \$b \$b&
 .noaltmacro
 .irp ._a,1
   .print "\._a \._a& ._a&a"
   .print "\$b \$b&"
 .endr
+.altmacro


### PR DESCRIPTION
…is fixed

12d3b1ae88ea kept a downstream variant of the expandMacro loop tail (and a simplified altmacro-arg.s) because upstream's ".altmacro: argument expansion not preceded by \" behavior broke MIOpen's hand-written GCN assembly. MIOpen fixed its kernels to the new semantics in ROCm/MIOpen#3490 (merged 2025-02-13), so the workaround is no longer needed.

Restore expandMacro and altmacro-arg.s to the upstream form. MC/AsmParser and MC/AMDGPU lit tests pass (924 passed, 0 failures), including all altmacro*.s and the AMDGPU macro-examples test.


