### PR TITLE
[offload] Use pinned memory for KLE

### DIFF
--- a/offload/include/Shared/APITypes.h
+++ b/offload/include/Shared/APITypes.h
@@ -93,6 +93,12 @@ struct __tgt_async_info {
   /// happening.
   KernelLaunchEnvironmentTy KernelLaunchEnvironment;
 
+  /// Pinned host copies of the launch environment, one per kernel issued on
+  /// this async info; empty if the plugin does not stage. The device reads
+  /// them asynchronously, so each launch needs its own. The device that handed
+  /// them out reclaims them once this async info's operations have completed.
+  llvm::SmallVector<void *, 2> PinnedKernelLaunchEnvironments;
+
   /// Use for sync interface. When false => synchronous execution
   bool ExecAsync = true;
   /// Maintain the actal data for OMPT.

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -4111,6 +4111,10 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
     return true;
   }
 
+  /// Submitting from pinned host memory avoids the intermediate buffer and the
+  /// host-to-host copy of the two-step path in dataSubmitImpl.
+  bool hasFastSubmitFromPinnedMemory() const override { return true; }
+
   /// Submit data to the device (host to device transfer).
   Error dataSubmitImpl(void *TgtPtr, const void *HstPtr, int64_t Size,
                        AsyncInfoWrapperTy &AsyncInfoWrapper) override {

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -176,6 +176,16 @@ struct AsyncInfoWrapperTy {
     AsyncInfoPtr->AssociatedAllocations.push_back(Ptr);
   }
 
+  /// Hand the pinned launch environment buffer \p Ptr to this async info,
+  /// which returns it to the device's pool once its operations have completed.
+  /// Call only after the transfer reading \p Ptr has been issued: a buffer
+  /// registered before that could be recycled by a concurrent synchronization
+  /// that observes the queue as complete.
+  void recycleLaunchEnvAfterSynchronization(void *Ptr) {
+    std::lock_guard<std::mutex> AllocationGuard(AsyncInfoPtr->Mutex);
+    AsyncInfoPtr->PinnedKernelLaunchEnvironments.push_back(Ptr);
+  }
+
 private:
   GenericDeviceTy &Device;
   __tgt_async_info LocalAsyncInfo;
@@ -1049,6 +1059,19 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
   virtual Error queryAsyncImpl(__tgt_async_info &AsyncInfo, bool ReleaseQueue,
                                bool *IsQueueWorkCompleted) = 0;
 
+  /// Indicate whether dataSubmitImpl has a faster path for host buffers that
+  /// are registered as pinned memory. If a plugin returns true, the kernel
+  /// launch environment is copied into a pinned host buffer before it is
+  /// submitted, so that its transfer takes that path.
+  virtual bool hasFastSubmitFromPinnedMemory() const { return false; }
+
+  /// Take a pinned buffer from this device's pool. The caller owns it until it
+  /// passes it to AsyncInfoWrapperTy::recycleLaunchEnvAfterSynchronization;
+  /// one that is never passed there is only freed at device deinit. Returns
+  /// nullptr if staging is unavailable, in which case the caller must submit
+  /// the launch environment from ordinary host memory.
+  KernelLaunchEnvironmentTy *getPinnedLaunchEnvBuffer();
+
   /// Check whether the architecture supports VA management
   virtual bool supportVAManagement() const { return false; }
 
@@ -1581,6 +1604,21 @@ private:
 
   /// Record and replay manager.
   RecordReplayTy *RecordReplay = nullptr;
+
+  /// Return \p AsyncInfo's pinned buffers to the pool. Call only once its
+  /// operations have completed, and with its mutex held.
+  void recyclePinnedLaunchEnvBuffers(__tgt_async_info &AsyncInfo);
+
+  /// Free every pinned buffer this device handed out, including those still
+  /// owned by an async info. This is the only place they are released, so one
+  /// whose async info never reported completion is simply not reused.
+  Error destroyPinnedLaunchEnvBuffers();
+
+  /// All pinned buffers allocated for staging launch environments, and the
+  /// subset of them not currently owned by an async info.
+  llvm::SmallVector<void *> PinnedLaunchEnvBuffers;
+  llvm::SmallVector<void *> FreePinnedLaunchEnvBuffers;
+  std::mutex PinnedLaunchEnvMutex;
 
 protected:
   /// Environment variables defined by the LLVM OpenMP implementation

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -213,10 +213,20 @@ GenericKernelTy::getKernelLaunchEnvironment(
     AsyncInfoWrapper.freeAllocationAfterSynchronization(*AllocOrErr);
   }
 
+  // Copy into a pinned buffer if the plugin transfers those faster: dataAlloc
+  // registers TARGET_ALLOC_HOST memory in PinnedAllocs, so the dataSubmit
+  // below can take the one-step copy path.
+  const void *LaunchEnvSrc = &LocalKLE;
+  auto *PinnedKLE = GenericDevice.getPinnedLaunchEnvBuffer();
+  if (PinnedKLE) {
+    *PinnedKLE = LocalKLE;
+    LaunchEnvSrc = PinnedKLE;
+  }
+
   INFO(OMP_INFOTYPE_DATA_TRANSFER, GenericDevice.getDeviceId(),
        "Copying data from host to device, HstPtr=" DPxMOD ", TgtPtr=" DPxMOD
        ", Size=%" PRId64 ", Name=KernelLaunchEnv\n",
-       DPxPTR(&LocalKLE), DPxPTR(*AllocOrErr),
+       DPxPTR(LaunchEnvSrc), DPxPTR(*AllocOrErr),
        sizeof(KernelLaunchEnvironmentTy));
 
   // The ProfilerData at this point will have a callback for a kernel launch,
@@ -229,20 +239,30 @@ GenericKernelTy::getKernelLaunchEnvironment(
   if (AI && AI->ProfilerData) {
     auto LocalOEI = AI->ProfilerData;
     AI->ProfilerData = nullptr;
-    auto Err = GenericDevice.dataSubmit(*AllocOrErr, &LocalKLE,
+    auto Err = GenericDevice.dataSubmit(*AllocOrErr, LaunchEnvSrc,
                                         sizeof(KernelLaunchEnvironmentTy),
                                         AsyncInfoWrapper);
     if (Err)
       return Err;
     AI->ProfilerData = LocalOEI;
+
+    // The transfer is issued, so the async info can now take the buffer.
+    if (PinnedKLE)
+      AsyncInfoWrapper.recycleLaunchEnvAfterSynchronization(PinnedKLE);
+
     return static_cast<KernelLaunchEnvironmentTy *>(*AllocOrErr);
   }
 
-  auto Err = GenericDevice.dataSubmit(*AllocOrErr, &LocalKLE,
+  auto Err = GenericDevice.dataSubmit(*AllocOrErr, LaunchEnvSrc,
                                       sizeof(KernelLaunchEnvironmentTy),
                                       AsyncInfoWrapper);
   if (Err)
     return Err;
+
+  // The transfer is issued, so the async info can now take the buffer.
+  if (PinnedKLE)
+    AsyncInfoWrapper.recycleLaunchEnvAfterSynchronization(PinnedKLE);
+
   return static_cast<KernelLaunchEnvironmentTy *>(*AllocOrErr);
 }
 
@@ -744,6 +764,10 @@ Error GenericDeviceTy::deinit(GenericPluginTy &Plugin) {
       return Err;
   LoadedImages.clear();
 
+  // Release the pinned staging buffers while the device is still alive.
+  if (auto Err = destroyPinnedLaunchEnvBuffers())
+    return Err;
+
   // Delete the memory manager before deinitializing the device. Otherwise,
   // we may delete device allocations after the device is deinitialized.
   if (MemoryManager)
@@ -1060,6 +1084,9 @@ Error GenericDeviceTy::synchronize(__tgt_async_info *AsyncInfo,
         return Err;
 
     std::swap(AllocsToDelete, AsyncInfo->AssociatedAllocations);
+
+    // The device no longer reads from this async info's pinned buffers.
+    recyclePinnedLaunchEnvBuffers(*AsyncInfo);
   }
 
   for (auto *Ptr : AllocsToDelete)
@@ -1076,7 +1103,87 @@ Error GenericDeviceTy::queryAsync(__tgt_async_info *AsyncInfo,
     return Plugin::error(ErrorCode::INVALID_ARGUMENT,
                          "invalid async info queue");
 
-  return queryAsyncImpl(*AsyncInfo, ReleaseQueue, IsQueueWorkCompleted);
+  bool WorkCompleted = false;
+
+  // Query and recycle under the mutex, as synchronize does. Querying outside
+  // it would let a launch issued in between register a buffer that this call
+  // then recycles, although the transfer reading it is still in flight.
+  std::lock_guard<std::mutex> AllocationGuard{AsyncInfo->Mutex};
+  auto Err = queryAsyncImpl(*AsyncInfo, ReleaseQueue, &WorkCompleted);
+
+  // An async info belonging to a nowait task is never synchronized, so this is
+  // its only completion notification; without recycling here it never reuses.
+  if (!Err && WorkCompleted)
+    recyclePinnedLaunchEnvBuffers(*AsyncInfo);
+
+  if (IsQueueWorkCompleted)
+    *IsQueueWorkCompleted = WorkCompleted;
+
+  return Err;
+}
+
+KernelLaunchEnvironmentTy *GenericDeviceTy::getPinnedLaunchEnvBuffer() {
+  if (!hasFastSubmitFromPinnedMemory())
+    return nullptr;
+
+  // While recording or replaying, dataAlloc serves every allocation kind from
+  // the record-replay device memory pool, so it cannot give us host memory.
+  if (RecordReplay && RecordReplay->isRecordingOrReplaying())
+    return nullptr;
+
+  void *Buffer = nullptr;
+  {
+    std::lock_guard<std::mutex> Guard{PinnedLaunchEnvMutex};
+    if (!FreePinnedLaunchEnvBuffers.empty())
+      Buffer = FreePinnedLaunchEnvBuffers.pop_back_val();
+  }
+
+  if (!Buffer) {
+    auto AllocOrErr =
+        dataAlloc(sizeof(KernelLaunchEnvironmentTy), /*HostPtr=*/nullptr,
+                  TargetAllocTy::TARGET_ALLOC_HOST, /*Alignment=*/0);
+    if (!AllocOrErr) {
+      // Staging is optional, so fall back to unpinned memory. Consume the
+      // error unconditionally: ODBG does not evaluate its operands unless
+      // debugging is enabled.
+      std::string ErrStr = toString(AllocOrErr.takeError());
+      ODBG(OLDT_Alloc) << "Failed to allocate a pinned buffer for the kernel "
+                          "launch environment, submitting it unstaged: "
+                       << ErrStr;
+      return nullptr;
+    }
+    Buffer = *AllocOrErr;
+
+    std::lock_guard<std::mutex> Guard{PinnedLaunchEnvMutex};
+    PinnedLaunchEnvBuffers.push_back(Buffer);
+  }
+
+  return static_cast<KernelLaunchEnvironmentTy *>(Buffer);
+}
+
+void GenericDeviceTy::recyclePinnedLaunchEnvBuffers(
+    __tgt_async_info &AsyncInfo) {
+  if (AsyncInfo.PinnedKernelLaunchEnvironments.empty())
+    return;
+
+  std::lock_guard<std::mutex> Guard{PinnedLaunchEnvMutex};
+  FreePinnedLaunchEnvBuffers.append(AsyncInfo.PinnedKernelLaunchEnvironments);
+  AsyncInfo.PinnedKernelLaunchEnvironments.clear();
+}
+
+Error GenericDeviceTy::destroyPinnedLaunchEnvBuffers() {
+  llvm::SmallVector<void *> Buffers;
+  {
+    std::lock_guard<std::mutex> Guard{PinnedLaunchEnvMutex};
+    std::swap(Buffers, PinnedLaunchEnvBuffers);
+    FreePinnedLaunchEnvBuffers.clear();
+  }
+
+  for (void *Buffer : Buffers)
+    if (auto Err = dataDelete(Buffer, TargetAllocTy::TARGET_ALLOC_HOST))
+      return Err;
+
+  return Plugin::success();
 }
 
 Error GenericDeviceTy::memoryVAMap(void **Addr, void *VAddr, size_t *RSize) {


### PR DESCRIPTION
Reduce kernel launch latency by using the fast path "pinned host memory -> device memory" for submitting the kernel launch environment.