### PR TITLE
[WaveTransform] Reuse frame register in FI elimination when SGPR scavenging fails

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -3269,10 +3269,18 @@ bool SIRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,
                   : RS->scavengeRegisterBackwards(AMDGPU::SReg_32_XM0RegClass,
                                                   MI, false, 0, !UseSGPR);
 
-      if (!TmpSReg || (!TmpReg && !UseSGPR)) {
-        assert(!FrameReg && "there is a frame register!");
+      // If no SGPR was scavenged but a frame register is available, fall
+      // through to reuse it as the temporary (computed in place, restored
+      // after). Only bail out when there is no frame register, or a VGPR
+      // operand is needed but none could be scavenged.
+      if ((!TmpSReg && !FrameReg) || (!TmpReg && !UseSGPR)) {
         int SVOpcode = AMDGPU::getFlatScratchInstSVfromSS(MI->getOpcode());
         if (ST.hasFlatScratchSVSMode() && SVOpcode != -1) {
+          // SV form encodes only the offset in vaddr; an SS-form scratch op
+          // keeps its FI in the SGPR saddr, so this is only reached with no
+          // frame register.
+          assert(!FrameReg &&
+                 "SV-form fallback cannot encode a frame register");
           Register TmpVGPR = RS->scavengeRegisterBackwards(
               AMDGPU::VGPR_32RegClass, MI, false, 0, /*AllowSpill=*/true);
 


### PR DESCRIPTION
In `SIRegisterInfo::eliminateFrameIndex`, the flat-scratch address-materialization path bails out to the SV-form fallback / `report_fatal_error("Cannot scavenge register in FI elimination!")` whenever a temporary SGPR cannot be scavenged, and asserts that no frame register is live.

That assumption is incorrect. When SGPR scavenging fails but a frame register is live, the code just below already recovers by reusing the frame register as the temporary (computing the address into it in place and restoring it afterwards). The overly-strict guard prevented that recovery from being reached, turning a recoverable case into an error.

This fix only takes the fallback/error path when there is genuinely nothing to reuse (no free SGPR and no frame register, or a required VGPR operand that could not be scavenged), letting the existing frame-register reuse path handle the rest.


