### PR TITLE
[OpenMPOpt] Restore the callback SPMD-ization guard lost in a merge

### DIFF
--- a/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
+++ b/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
@@ -5202,16 +5202,10 @@ struct AAKernelInfoCallSite : AAKernelInfo {
       case OMPRTL___kmpc_for_static_loop_4u:
       case OMPRTL___kmpc_for_static_loop_8:
       case OMPRTL___kmpc_for_static_loop_8u:
-        // Parallel regions might be reached by these calls, as they take a
-        // callback argument potentially containing arbitrary user-provided
-        // code.
-        ReachedUnknownParallelRegions.insert(&CB);
-        // TODO: The presence of these calls on their own does not prevent a
-        // kernel from being SPMD-izable. We mark it as such because we need
-        // further changes in order to also consider the contents of the
-        // callbacks passed to them.
-        SPMDCompatibilityTracker.indicatePessimisticFixpoint();
-        SPMDCompatibilityTracker.insert(&CB);
+        if (DisableOpenMPOptCallbackSPMDization) {
+          SPMDCompatibilityTracker.indicatePessimisticFixpoint();
+          SPMDCompatibilityTracker.insert(&CB);
+        }
         break;
       default:
         // Unknown OpenMP runtime calls cannot be executed in SPMD-mode,

--- a/llvm/test/Transforms/OpenMP/callback_guards.ll
+++ b/llvm/test/Transforms/OpenMP/callback_guards.ll
@@ -1,5 +1,5 @@
 ; RUN: opt -passes=openmp-opt -openmp-opt-disable-callback-spmdization=false -S < %s | FileCheck %s
-; XFAIL: *
+
 %struct.ident_t = type { i32, i32, i32, i32, ptr }
 %struct.DynamicEnvironmentTy = type { i16 }
 %struct.KernelEnvironmentTy = type { %struct.ConfigurationEnvironmentTy, ptr, ptr }


### PR DESCRIPTION
The option openmp-opt-disable-callback-spmdization was added in 3bd664aeb8ba to gate the generic-to-SPMD conversion for the static-loop runtime entries that take a loop-body callback. It is still declared, but nothing reads it anymore, so the conversion can no longer be controlled at all.

Two unrelated changes combined to lose the check. Upstream llvm/llvm-project#211287 (4905109b00e6) rewrote those exact case bodies into a handleStaticLoop() helper, and the merge that brought it in (be1a3a8b81e0, #3750) resolved the overlapping lines in favour of upstream, deleting the guard. #211287 was then reverted in b9bb539fa3cd (#214278) because it caused UMT failures. Reverting restores the upstream pre-image of those lines, which never contained our guard, so the end state has neither the upstream helper nor the option, and callback_guards.ll was marked XFAIL in c8ce6bb7b313 rather than repaired.

This is a pure restoration: both files are put back byte for byte as they were in bdf9352f3c43, the last commit before that merge, and the XFAIL is dropped.


