### PR TITLE
[compiler-rt][asan] Fix hsa_amd_pointer_info on freed chunks.

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -1691,6 +1691,17 @@ hsa_status_t asan_hsa_amd_pointer_info(const void* ptr,
         ptr_, info, alloc, num_agents_accessible, accessible);
     if (status == HSA_STATUS_SUCCESS && info) {
       static_assert(AP_.kMetadataSize == 0, "Expression below requires this");
+      // Quarantine keeps the block allocated in ROCr so that use-after-free
+      // stays detectable, but the user allocation is gone. Report it as
+      // unowned, matching how ROCr reports a released fragment. Otherwise
+      // clients cannot tell a freed pointer from a live one. The acquire load
+      // pairs with the release store that publishes the header in Allocate(),
+      // ordering the UsedSize() read below.
+      if (atomic_load(&m->chunk_state, memory_order_acquire) !=
+          CHUNK_ALLOCATED) {
+        info->type = HSA_EXT_POINTER_TYPE_UNKNOWN;
+        return status;
+      }
       // Adjust base address of agent,host and sizeInBytes so as to return
       // the actual pointer information of user allocation rather than asan
       // allocation. Asan allocation pointer info can be acquired using internal

--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -1691,12 +1691,8 @@ hsa_status_t asan_hsa_amd_pointer_info(const void* ptr,
         ptr_, info, alloc, num_agents_accessible, accessible);
     if (status == HSA_STATUS_SUCCESS && info) {
       static_assert(AP_.kMetadataSize == 0, "Expression below requires this");
-      // Quarantine keeps the block allocated in ROCr so that use-after-free
-      // stays detectable, but the user allocation is gone. Report it as
-      // unowned, matching how ROCr reports a released fragment. Otherwise
-      // clients cannot tell a freed pointer from a live one. The acquire load
-      // pairs with the release store that publishes the header in Allocate(),
-      // ordering the UsedSize() read below.
+      // Quarantine keeps the block mapped in ROCr, but the user allocation is
+      // gone. Report it as unowned, as ROCr does for a released fragment.
       if (atomic_load(&m->chunk_state, memory_order_acquire) !=
           CHUNK_ALLOCATED) {
         info->type = HSA_EXT_POINTER_TYPE_UNKNOWN;

--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -1692,9 +1692,12 @@ hsa_status_t asan_hsa_amd_pointer_info(const void* ptr,
     if (status == HSA_STATUS_SUCCESS && info) {
       static_assert(AP_.kMetadataSize == 0, "Expression below requires this");
       // Quarantine keeps the block mapped in ROCr, but the user allocation is
-      // gone. Report it as unowned, as ROCr does for a released fragment.
+      // gone. Report it as unowned, as ROCr does for memory it does not own.
       if (atomic_load(&m->chunk_state, memory_order_acquire) !=
           CHUNK_ALLOCATED) {
+        const uint32_t info_size = info->size;
+        internal_memset(info, 0, info_size);
+        info->size = info_size;
         info->type = HSA_EXT_POINTER_TYPE_UNKNOWN;
         return status;
       }


### PR DESCRIPTION
asan_hsa_amd_pointer_info() reported quarantined allocations as live HSA memory. Quarantine intentionally keeps the underlying ROCr block mapped so that use-after-free stays detectable, so REAL(hsa_amd_pointer_info) still succeeds for a freed pointer. The wrapper then rewrote agentBaseAddress, hostBaseAddress and sizeInBytes to describe the user allocation without ever consulting chunk state, which left a freed pointer indistinguishable from a live one: type remained HSA_EXT_POINTER_TYPE_HSA with a plausible base and size.

Consult chunk state and report a non-allocated chunk as HSA_EXT_POINTER_TYPE_UNKNOWN. This mirrors Runtime::PtrInfo(), which already reports a released fragment missing from allocation_map_ as unknown. Testing against CHUNK_ALLOCATED rather than CHUNK_QUARANTINE also covers CHUNK_INVALID, where the chunk header is not yet initialized and the reported size would be garbage. The remaining fields continue to describe the former user range, matching how ROCr reports a released
fragment.