### PR TITLE
[cmake] Drop stray leading blank line in llvm/CMakeLists.txt

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 # See docs/CMake.html for instructions about how to build LLVM with CMake.
 cmake_minimum_required(VERSION 3.20.0)
 if("${CMAKE_VERSION}" VERSION_LESS "3.31.0")


### PR DESCRIPTION
Converges with trunk

A 2022 copyright/Palamida sweep (fd009e0c5bcc) left a blank first line above the opening comment. It has no effect; remove it so line 1 matches upstream.


