### PR TITLE
[Support] Remove dead #if 0 CodeGenOpt::getID to converge with trunk

### DIFF
--- a/llvm/include/llvm/Support/CodeGen.h
+++ b/llvm/include/llvm/Support/CodeGen.h
@@ -162,12 +162,6 @@ namespace llvm {
       return std::nullopt;
     return static_cast<CodeGenOptLevel>(OL);
   }
-#if 0
-  /// Get the integer \c ID of \p Level.
-  inline IDType getID(CodeGenOptLevel::Level Level) {
-    return static_cast<IDType>(Level);
-  }
-#endif
   /// Parse \p C as a single digit integer and get matching \c CodeGenLevel.
   ///
   /// Returns std::nullopt if the input is not a valid optimization level.


### PR DESCRIPTION
CodeGen.h carries a downstream-only CodeGenOpt::getID() that has been inside an #if 0 since it was added. It is unreachable in every configuration, has no callers anywhere in the tree, and no longer even names a valid type -- CodeGenOptLevel became a scoped enum, so CodeGenOptLevel::Level does not exist and the body would not compile if it were ever re-enabled.

Delete it. This makes the CodeGenOpt namespace byte-identical to llvm/main.

NFC: the removed text is entirely within #if 0, so preprocessed output is unchanged.


