### PR TITLE
[cmake] Restore GCC minimum to 7.4 to converge with trunk

### DIFF
--- a/llvm/cmake/modules/CheckCompilerVersion.cmake
+++ b/llvm/cmake/modules/CheckCompilerVersion.cmake
@@ -4,8 +4,8 @@
 
 include(CheckCXXSourceCompiles)
 
-set(GCC_MIN 7.3)
-set(GCC_SOFT_ERROR 7.3)
+set(GCC_MIN 7.4)
+set(GCC_SOFT_ERROR 7.4)
 set(CLANG_MIN 5.0)
 set(CLANG_SOFT_ERROR 5.0)
 set(APPLECLANG_MIN 10.0)


### PR DESCRIPTION
d54e30246106 lowered GCC_MIN/GCC_SOFT_ERROR from 7.4 to 7.3 so CentOS 7 (GCC 7.3) could build. CentOS 7 reached end-of-life on 2024-06-30, so restore upstream's 7.4 minimum. Reverts the file to its upstream form.


