### PR TITLE
[IR] Reformat MetadataTyID case to converge with trunk

### DIFF
--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -46,8 +46,7 @@ Type *Type::getPrimitiveType(LLVMContext &C, TypeID IDNumber) {
   case FP128TyID     : return getFP128Ty(C);
   case PPC_FP128TyID : return getPPC_FP128Ty(C);
   case LabelTyID     : return getLabelTy(C);
-  case MetadataTyID:
-    return getMetadataTy(C);
+  case MetadataTyID  : return getMetadataTy(C);
   case X86_AMXTyID   : return getX86_AMXTy(C);
   case TokenTyID     : return getTokenTy(C);
   default:


### PR DESCRIPTION
The x86_mmx type-removal reland (8d00fc8a05c6) left the MetadataTyID case in Type::getPrimitiveType reformatted onto two lines. Restore upstream's aligned one-liner. Formatting-only, no behavioral change.


