### PR TITLE
[Object] Remove dead OffloadBinary residue to converge with trunk

### DIFF
--- a/llvm/include/llvm/Object/OffloadBinary.h
+++ b/llvm/include/llvm/Object/OffloadBinary.h
@@ -21,8 +21,6 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Object/Binary.h"
-#include "llvm/Object/ObjectFile.h"
-#include "llvm/Support/Compression.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"

--- a/llvm/lib/Object/OffloadBinary.cpp
+++ b/llvm/lib/Object/OffloadBinary.cpp
@@ -16,15 +16,12 @@
 #include "llvm/MC/StringTableBuilder.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/Binary.h"
-#include "llvm/Object/COFF.h"
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Object/Error.h"
 #include "llvm/Object/IRObjectFile.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/Alignment.h"
-#include "llvm/Support/BinaryStreamReader.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/Timer.h"
 #include "llvm/TargetParser/AMDGPUTargetParser.h"
 
 using namespace llvm;
@@ -32,9 +29,6 @@ using namespace llvm::object;
 
 namespace {
 
-static llvm::TimerGroup
-    OffloadBundlerTimerGroup("Offload Bundler Timer Group",
-                             "Timer group for offload bundler");
 /// A MemoryBuffer that shares ownership of the underlying memory.
 /// This allows multiple OffloadBinary instances to share the same buffer.
 class SharedMemoryBuffer : public MemoryBuffer {


### PR DESCRIPTION
The offload-bundler feature that 4b06a51d5b8c added to OffloadBinary was upstreamed into OffloadBundle.{h,cpp}, leaving behind only unused includes and a duplicate TimerGroup:

  - OffloadBinary.h: ObjectFile.h, Compression.h
  - OffloadBinary.cpp: COFF.h, BinaryStreamReader.h, Timer.h, and a file-local OffloadBundlerTimerGroup that is never referenced (the live one is in OffloadBundle.cpp).

With these removed both files are byte-identical to upstream/main.


