### PR TITLE
[llvm-objdump] Drop unused fatbin includes to converge with trunk

### DIFF
--- a/llvm/tools/llvm-objdump/OffloadDump.cpp
+++ b/llvm/tools/llvm-objdump/OffloadDump.cpp
@@ -17,7 +17,6 @@
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Object/OffloadBinary.h"
 #include "llvm/Object/OffloadBundle.h"
-#include "llvm/Support/Alignment.h"
 
 using namespace llvm;
 using namespace llvm::object;

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -58,7 +58,6 @@
 #include "llvm/Object/MachO.h"
 #include "llvm/Object/MachOUniversal.h"
 #include "llvm/Object/OffloadBinary.h"
-#include "llvm/Object/OffloadBundle.h"
 #include "llvm/Object/Wasm.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"


### PR DESCRIPTION
The "Extend llvm objdump fatbin" reland (247da2cd5767, upstream #140286) left two unused includes not present upstream: Support/Alignment.h in OffloadDump.cpp and Object/OffloadBundle.h in llvm-objdump.cpp. Neither symbol is referenced; remove them. llvm-objdump builds cleanly.


