### PR TITLE
[Analysis] Remove dead PGOCtxProfLowering.h include

### DIFF
--- a/llvm/lib/Analysis/CtxProfAnalysis.cpp
+++ b/llvm/lib/Analysis/CtxProfAnalysis.cpp
@@ -23,7 +23,6 @@
 #include "llvm/ProfileData/PGOCtxProfReader.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Transforms/Instrumentation/PGOCtxProfLowering.h"
 #include "llvm/Support/Path.h"
 #include <deque>
 #include <memory>


### PR DESCRIPTION
Converges with trunk

73960c3f63e8 re-applied upstream aca01bff0 ([ctx_prof] CtxProfAnalysis: populate module data, #102930) after a downstream revert. At the time the include was legitimate, but upstream later dropped it as unused and added Support/Path.h in its place. A subsequent merge kept the reinstated line and placed Path.h after it, leaving the include block out of alphabetical order.

None of the symbols PGOCtxProfLowering.h declares (PGOCtxProfLoweringPass, NoinlineNonPrevailing, isCtxIRPGOInstrEnabled) is referenced in this file. With the include removed, CtxProfAnalysis.cpp is byte-identical to upstream/main.


