### PR TITLE
[Infra] Migrate multi-arch Linux CI build runners to AWS

### DIFF
--- a/.github/actions/rock-ci-deps/ci-config-matrix/config_ci_matrix.py
+++ b/.github/actions/rock-ci-deps/ci-config-matrix/config_ci_matrix.py
@@ -58,7 +58,7 @@ def main() -> None:
         "build_variant_suffix": "",
         "build_variant_cmake_preset": "",
         "build_pytorch": True,
-        "build_runs_on": select_build_runner("linux", variant),
+        "build_runs_on": "aws-linux-scale-rocm-large",
         "prebuilt_stages": prebuilt_stages,
         "baseline_run_id": baseline_run_id,
     }

--- a/.github/actions/rock-ci-deps/ci-config-matrix/config_ci_matrix.py
+++ b/.github/actions/rock-ci-deps/ci-config-matrix/config_ci_matrix.py
@@ -70,6 +70,7 @@ def main() -> None:
                 "amdgpu_targets": "",
                 "test-runs-on": "",
                 "benchmark-runs-on": "",
+                "sanity_check_only_for_family": False,
             },
         ],
         "dist_amdgpu_families": "gfx1151",

--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -99,7 +99,7 @@ jobs:
   build_rocm_wheels:
     name: Build Python | ${{ inputs.artifact_group }}
     # Note: GitHub-hosted runners run out of disk space for some gpu families
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-large' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
     container:

--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -99,8 +99,7 @@ jobs:
   build_rocm_wheels:
     name: Build Python | ${{ inputs.artifact_group }}
     # Note: GitHub-hosted runners run out of disk space for some gpu families
-    runs-on: azure-linux-scale-rocm
-    #runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
     container:

--- a/.github/workflows/manifest-diff.yml
+++ b/.github/workflows/manifest-diff.yml
@@ -77,7 +77,7 @@ permissions:
 jobs:
   generate-report:
     name: Generate Manifest Diff Report
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-large' || 'ubuntu-24.04' }}
     # Non-blocking under CI; strict on manual dispatch so regressions surface red.
     continue-on-error: ${{ github.event_name != 'workflow_dispatch' }}
     permissions:

--- a/.github/workflows/manifest-diff.yml
+++ b/.github/workflows/manifest-diff.yml
@@ -77,8 +77,7 @@ permissions:
 jobs:
   generate-report:
     name: Generate Manifest Diff Report
-    runs-on: azure-linux-scale-rocm
-    #runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     # Non-blocking under CI; strict on manual dispatch so regressions surface red.
     continue-on-error: ${{ github.event_name != 'workflow_dispatch' }}
     permissions:

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -52,8 +52,7 @@ run-name: Build ${{ inputs.native_package_type }} packages (${{ inputs.rocm_vers
 jobs:
   build_native_packages:
     name: Build ${{ inputs.native_package_type }} packages
-    runs-on: azure-linux-scale-rocm
-    #runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
       options: -v /runner/config:/home/awsconfig/

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -52,7 +52,7 @@ run-name: Build ${{ inputs.native_package_type }} packages (${{ inputs.rocm_vers
 jobs:
   build_native_packages:
     name: Build ${{ inputs.native_package_type }} packages
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-large' || 'ubuntu-24.04' }}
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
       options: -v /runner/config:/home/awsconfig/

--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -42,7 +42,7 @@ on:
         description: "Comma-separated build stages to skip (artifacts already copied by the orchestrator)"
       build_runs_on:
         type: string
-        default: "aws-linux-scale-rocm-prod"
+        default: "aws-linux-scale-rocm-large"
         description: "Build runner label (selected by configure script with weighted distribution)"
       release_type:
         description: 'Release type: "ci", "dev", "nightly", or "prerelease"'

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -58,7 +58,7 @@ on:
       build_runs_on:
         description: "Build runner label (selected by configure script with weighted distribution)"
         type: string
-        default: "aws-linux-scale-rocm-prod"
+        default: "aws-linux-scale-rocm-large"
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -75,8 +75,7 @@ on:
 jobs:
   build_stage:
     name: ${{ inputs.stage_display_name }}
-    runs-on: azure-linux-scale-rocm    #temp until aws access is provided
-    #runs-on: ${{ inputs.build_runs_on }}
+    runs-on: ${{ inputs.build_runs_on }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     permissions:
       id-token: write

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -145,8 +145,7 @@ permissions:
 jobs:
   build_pytorch_wheels:
     name: Build | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref }}
-    runs-on: azure-linux-scale-rocm
-    #runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -145,7 +145,7 @@ permissions:
 jobs:
   build_pytorch_wheels:
     name: Build | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref }}
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-large' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -99,8 +99,7 @@ run-name: Build portable Linux PyTorch Wheels CI (${{ inputs.artifact_group }}, 
 jobs:
   build_pytorch_wheels:
     name: Build PyTorch | ${{ inputs.artifact_group }} | torch ${{ inputs.pytorch_git_ref }} | py${{ inputs.python_version }}
-    runs-on: azure-linux-scale-rocm 
-    #runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -99,7 +99,7 @@ run-name: Build portable Linux PyTorch Wheels CI (${{ inputs.artifact_group }}, 
 jobs:
   build_pytorch_wheels:
     name: Build PyTorch | ${{ inputs.artifact_group }} | torch ${{ inputs.pytorch_git_ref }} | py${{ inputs.python_version }}
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-large' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -60,6 +60,10 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      build_runs_on:
+        description: "Build runner label (selected by configure script with weighted distribution)"
+        type: string
+        default: "azure-windows-scale-rocm" # need to change this 
       external_repo_config:
         description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package, fetch_sources_args)"
         type: string
@@ -68,7 +72,7 @@ on:
 jobs:
   build_stage:
     name: ${{ inputs.stage_display_name }}
-    runs-on: azure-windows-scale-rocm
+    runs-on: ${{ inputs.build_runs_on }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     permissions:
       id-token: write

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -74,6 +74,10 @@ on:
         description: "Compiler cache type ('none', 'sccache', or 'ccache')"
         type: string
         default: "sccache"
+      build_runs_on:
+        description: "Build runner label (selected by configure script with weighted distribution)"
+        type: string
+        default: "azure-windows-scale-rocm"          
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -141,7 +145,7 @@ permissions:
 jobs:
   build_pytorch_wheels:
     name: Build | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref }}
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && inputs.build_runs_on || 'windows-2022' }}      
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
@@ -60,6 +60,10 @@ on:
         description: "'true' if this is a kpack-split flat build."
         type: string
         default: "false"
+      build_runs_on:
+        description: "Build runner label (selected by configure script with weighted distribution)"
+        type: string
+        default: "azure-windows-scale-rocm"          
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -107,7 +111,7 @@ run-name: Build Windows PyTorch Wheels CI (${{ inputs.artifact_group }}, py${{ i
 jobs:
   build_pytorch_wheels:
     name: Build PyTorch | ${{ inputs.artifact_group }} | torch ${{ inputs.pytorch_git_ref }} | py${{ inputs.python_version }}
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && inputs.build_runs_on || 'windows-2022' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -55,7 +55,7 @@ jobs:
   copy_prebuilt_stages:
     name: Copy Prebuilt Stages
     if: ${{ fromJSON(inputs.build_config).prebuilt_stages != '' && fromJSON(inputs.build_config).baseline_run_id != '' }}
-    runs-on: aws-linux-scale-rocm-prod
+    runs-on: aws-linux-scale-rocm-large
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -51,7 +51,7 @@ jobs:
     if: ${{ fromJSON(inputs.build_config).prebuilt_stages != '' && fromJSON(inputs.build_config).baseline_run_id != '' }}
     # TODO: Consider running on a Linux runner with --platform=windows to
     #   avoid Windows runner setup overhead (setup-python ~51s).
-    runs-on: azure-windows-scale-rocm
+    runs-on: ${{ fromJSON(inputs.build_config).build_runs_on || 'azure-windows-scale-rocm' }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Build Test CI Config matrix
         id: convergence_config
-        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/ci-config-matrix@amd/dev/kirthana14m/aws-migration
+        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/ci-config-matrix@amd-staging
         with:
           build_variant: ${{ inputs.build_variant }}
           ci_config_path: ci-config

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Build Test CI Config matrix
         id: convergence_config
-        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/ci-config-matrix@amd-staging
+        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/ci-config-matrix@amd/dev/kirthana14m/aws-migration
         with:
           build_variant: ${{ inputs.build_variant }}
           ci_config_path: ci-config

--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -68,8 +68,7 @@ permissions:
 jobs:
   test_artifact_structure:
     name: "Validate artifact structure"
-    runs-on: azure-linux-scale-rocm
-    #runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     container:
       image: python:3.12-slim
     env:

--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -68,7 +68,7 @@ permissions:
 jobs:
   test_artifact_structure:
     name: "Validate artifact structure"
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-large' || 'ubuntu-24.04' }}
     container:
       image: python:3.12-slim
     env:


### PR DESCRIPTION
Runner label (for Linux build) : aws-linux-scale-rocm-large

PR build (build time ~ 2 hours 10 minutes) : [[Infra][Test] Placeholder - Linux build to use AWS runner · ROCm/llvm-project@a91ab76](https://github.com/ROCm/llvm-project/actions/runs/31787495562?pr=3805)