### PR TITLE
[Comgr][hotswap] Link the transpile unit tests against static AMDGPU

### DIFF
--- a/amd/comgr/src/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/decoder/CMakeLists.txt
@@ -161,8 +161,7 @@ target_include_directories(hotswap-decoder PRIVATE
   "${HOTSWAP_COMGR_BINARY_DIR}/include"
 )
 
-# PRIVATE keeps these out of the link interface, but CMake still records them as
-# $<LINK_ONLY:> for an OBJECT library; clear the interface so consumers get the
-# objects only (see ../CMakeLists.txt).
+# Consumers choose their LLVM linkage, so do not propagate the OBJECT library's
+# private dependencies through $<LINK_ONLY:>.
 target_link_libraries(hotswap-decoder PRIVATE ${HOTSWAP_LLVM_LIBS})
 set_target_properties(hotswap-decoder PROPERTIES INTERFACE_LINK_LIBRARIES "")

--- a/amd/comgr/src/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/decoder/CMakeLists.txt
@@ -29,8 +29,7 @@ add_definitions(${LLVM_DEFINITIONS})
 # Follow COMGR's selected LLVM linkage mode: in a dylib build link the single
 # `LLVM` shared library, otherwise the individual static components. Linking
 # fixed component libraries unconditionally can pull both the dylib and the
-# static components into a dylib build, risking duplicate symbols. Kept PUBLIC
-# so consumers inherit the same set when they link this OBJECT library.
+# static components into a dylib build, risking duplicate symbols.
 if(LLVM_LINK_LLVM_DYLIB)
   set(HOTSWAP_LLVM_LIBS LLVM)
 else()
@@ -162,4 +161,8 @@ target_include_directories(hotswap-decoder PRIVATE
   "${HOTSWAP_COMGR_BINARY_DIR}/include"
 )
 
+# PRIVATE keeps these out of the link interface, but CMake still records them as
+# $<LINK_ONLY:> for an OBJECT library; clear the interface so consumers get the
+# objects only (see ../CMakeLists.txt).
 target_link_libraries(hotswap-decoder PRIVATE ${HOTSWAP_LLVM_LIBS})
+set_target_properties(hotswap-decoder PROPERTIES INTERFACE_LINK_LIBRARIES "")

--- a/amd/comgr/test-unit/hotswap/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/CMakeLists.txt
@@ -3,6 +3,17 @@ add_subdirectory(rewriter)
 # The raiser and decoder unit tests link the transpile-path OBJECT libraries,
 # entered only under COMGR_ENABLE_HOTSWAP_TRANSPILE; skip them otherwise.
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
+  # The transpile OBJECT libraries keep their LLVM dependencies PRIVATE, so a
+  # test executable names its own. libLLVM does not export the AMDGPU
+  # target-private helpers the decoder and wave projection call (mc2PseudoReg,
+  # getNamedOperandIdx, the isGFXn predicates), so link the static AMDGPU
+  # components rather than the dylib; a static-plus-dylib link would also
+  # re-register the AMDGPU cl::opts and abort at startup.
+  llvm_map_components_to_libnames(COMGR_HOTSWAP_TEST_LLVM_LIBS
+    AMDGPU
+    Analysis AsmPrinter BinaryFormat CodeGen Core MC MCDisassembler
+    MCParser Object Passes Support Target TargetParser TransformUtils)
+
   add_subdirectory(raiser)
   add_subdirectory(decoder)
   list(APPEND COMGR_HOTSWAP_TEST_TARGETS

--- a/amd/comgr/test-unit/hotswap/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/CMakeLists.txt
@@ -3,12 +3,9 @@ add_subdirectory(rewriter)
 # The raiser and decoder unit tests link the transpile-path OBJECT libraries,
 # entered only under COMGR_ENABLE_HOTSWAP_TRANSPILE; skip them otherwise.
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
-  # The transpile OBJECT libraries keep their LLVM dependencies PRIVATE, so a
-  # test executable names its own. libLLVM does not export the AMDGPU
-  # target-private helpers the decoder and wave projection call (mc2PseudoReg,
-  # getNamedOperandIdx, the isGFXn predicates), so link the static AMDGPU
-  # components rather than the dylib; a static-plus-dylib link would also
-  # re-register the AMDGPU cl::opts and abort at startup.
+  # These tests require target-private AMDGPU helpers. Link only the static LLVM
+  # components to avoid unresolved symbols and duplicate command-line option
+  # registration.
   llvm_map_components_to_libnames(COMGR_HOTSWAP_TEST_LLVM_LIBS
     AMDGPU
     Analysis AsmPrinter BinaryFormat CodeGen Core MC MCDisassembler

--- a/amd/comgr/test-unit/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/decoder/CMakeLists.txt
@@ -2,11 +2,6 @@
 # ISA profile, and the decoded-instruction model).
 
 # -- DecoderTests -------------------------------------------------------------
-#
-# Links the hotswap::decoder OBJECT library; initMCState registers the target
-# itself, so the test needs no separate target-init step. hotswap::decoder keeps
-# its LLVM dependencies PRIVATE, so name the LLVM components here
-# (COMGR_HOTSWAP_TEST_LLVM_LIBS, ../CMakeLists.txt).
 
 add_executable(DecoderTests
   DecoderTest.cpp)

--- a/amd/comgr/test-unit/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/decoder/CMakeLists.txt
@@ -3,9 +3,10 @@
 
 # -- DecoderTests -------------------------------------------------------------
 #
-# Links the hotswap::decoder OBJECT library, which carries the AMDGPU MC/CodeGen
-# LLVM components as PUBLIC usage requirements; initMCState registers the target
-# itself, so the test needs no separate target-init step.
+# Links the hotswap::decoder OBJECT library; initMCState registers the target
+# itself, so the test needs no separate target-init step. hotswap::decoder keeps
+# its LLVM dependencies PRIVATE, so name the LLVM components here
+# (COMGR_HOTSWAP_TEST_LLVM_LIBS, ../CMakeLists.txt).
 
 add_executable(DecoderTests
   DecoderTest.cpp)
@@ -14,6 +15,7 @@ target_link_libraries(DecoderTests PRIVATE
   ${COMGR_GTEST_LIBS}
   hotswap::decoder
   hotswap::common
+  ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
 target_include_directories(DecoderTests PRIVATE

--- a/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
@@ -10,9 +10,7 @@
 add_executable(RaiserScaffoldingTests
   RaiserScaffoldingTest.cpp)
 
-# hotswap::raiser carries the wave-projection objects, which call into
-# hotswap::decoder; link both. Both keep their LLVM dependencies PRIVATE, so
-# name the LLVM components here (COMGR_HOTSWAP_TEST_LLVM_LIBS, ../CMakeLists.txt).
+# The wave-projection objects require decoder symbols.
 target_link_libraries(RaiserScaffoldingTests PRIVATE
   ${COMGR_GTEST_LIBS}
   hotswap::raiser
@@ -38,10 +36,7 @@ comgr_configure_test_target(RaiserScaffoldingTests)
 add_executable(WaveProjectionTests
   WaveProjectionTest.cpp)
 
-# The wave projection lives in hotswap::raiser and calls into hotswap::decoder
-# (ISAProfile and the AMDGPU register queries); link both, plus the LLVM
-# components the OBJECT libraries keep PRIVATE (COMGR_HOTSWAP_TEST_LLVM_LIBS,
-# ../CMakeLists.txt).
+# The wave-projection objects require decoder symbols.
 target_link_libraries(WaveProjectionTests PRIVATE
   ${COMGR_GTEST_LIBS}
   hotswap::raiser
@@ -73,6 +68,7 @@ target_link_libraries(RaiseFailureTests PRIVATE
   hotswap::raiser
   hotswap::decoder
   hotswap::common
+  ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
 target_include_directories(RaiseFailureTests PRIVATE
@@ -86,27 +82,17 @@ comgr_configure_test_target(RaiseFailureTests)
 # -- RegFileTests -------------------------------------------------------------
 #
 # Round-trips values through AllocaRegFile's ParsedReg dispatch, then promotes
-# the allocas to SSA and constant-folds to confirm the value survives. Needs
-# TransformUtils (PromoteMemToReg) and Analysis (constant folding) on top of the
-# component set hotswap::decoder carries.
+# the allocas to SSA and constant-folds to confirm the value survives.
 
 add_executable(RegFileTests
   RegFileTest.cpp)
-
-# Dylib build: link libLLVM, not static archives (see RaiserScaffoldingTests).
-if(LLVM_LINK_LLVM_DYLIB)
-  set(COMGR_TEST_UNIT_REGFILE_LIBS LLVM)
-else()
-  llvm_map_components_to_libnames(COMGR_TEST_UNIT_REGFILE_LIBS
-    Analysis TransformUtils)
-endif()
 
 target_link_libraries(RegFileTests PRIVATE
   ${COMGR_GTEST_LIBS}
   hotswap::raiser
   hotswap::decoder
   hotswap::common
-  ${COMGR_TEST_UNIT_REGFILE_LIBS}
+  ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
 target_include_directories(RegFileTests PRIVATE
@@ -131,6 +117,7 @@ target_link_libraries(KernargAbiLayoutTests PRIVATE
   hotswap::raiser
   hotswap::decoder
   hotswap::common
+  ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
 target_include_directories(KernargAbiLayoutTests PRIVATE

--- a/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
@@ -10,24 +10,15 @@
 add_executable(RaiserScaffoldingTests
   RaiserScaffoldingTest.cpp)
 
-# hotswap::raiser keeps its LLVM dependencies PRIVATE, so name them here. It also
-# carries the wave-projection objects, which call into hotswap::decoder; link it
-# too and inherit its curated LLVM component set.
-# Match the hotswap libs' linkage: in a dylib build these components already
-# come in via libLLVM, so static archives here would double-register cl::opts.
-if(LLVM_LINK_LLVM_DYLIB)
-  set(COMGR_TEST_UNIT_RAISER_LIBS LLVM)
-else()
-  llvm_map_components_to_libnames(COMGR_TEST_UNIT_RAISER_LIBS
-    Core Support TargetParser)
-endif()
-
+# hotswap::raiser carries the wave-projection objects, which call into
+# hotswap::decoder; link both. Both keep their LLVM dependencies PRIVATE, so
+# name the LLVM components here (COMGR_HOTSWAP_TEST_LLVM_LIBS, ../CMakeLists.txt).
 target_link_libraries(RaiserScaffoldingTests PRIVATE
   ${COMGR_GTEST_LIBS}
   hotswap::raiser
   hotswap::decoder
   hotswap::common
-  ${COMGR_TEST_UNIT_RAISER_LIBS}
+  ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
 target_include_directories(RaiserScaffoldingTests PRIVATE
@@ -48,13 +39,15 @@ add_executable(WaveProjectionTests
   WaveProjectionTest.cpp)
 
 # The wave projection lives in hotswap::raiser and calls into hotswap::decoder
-# (ISAProfile and the AMDGPU register queries); link both. hotswap::decoder
-# carries the curated LLVM component set the projection needs.
+# (ISAProfile and the AMDGPU register queries); link both, plus the LLVM
+# components the OBJECT libraries keep PRIVATE (COMGR_HOTSWAP_TEST_LLVM_LIBS,
+# ../CMakeLists.txt).
 target_link_libraries(WaveProjectionTests PRIVATE
   ${COMGR_GTEST_LIBS}
   hotswap::raiser
   hotswap::decoder
   hotswap::common
+  ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
 target_include_directories(WaveProjectionTests PRIVATE


### PR DESCRIPTION
The decoder and the wave projection call AMDGPU target-private helpers that libLLVM does not export -- `mc2PseudoReg`, `getNamedOperandIdx`, the `isGFXn` predicates -- so a unit test that links the transpile OBJECT libraries against the dylib cannot resolve them. In the compiler-runtime (dylib) build this fails to link `RaiserScaffoldingTests`, `WaveProjectionTests`, and `DecoderTests` with `undefined reference to llvm::AMDGPU::...`. `amd_comgr` itself does not hit this because it links the static AMDGPU components directly; the unit tests were inheriting the dylib instead.

The decoder OBJECT library was the leak. It exposed its LLVM dependencies `PUBLIC`, unlike `common` and `raiser` which keep them `PRIVATE` and clear their link interface so consumers get only the objects. This makes the decoder match, and has each hotswap test name the LLVM components it needs, linking the static AMDGPU archives rather than libLLVM.

Linking the static AMDGPU components alongside the dylib is not an option: both register the AMDGPU `cl::opt`s (e.g. `amdhsa-code-object-version`) and the duplicate registration aborts at startup. The tests therefore stay off the dylib entirely, the same way LLVM's own target unit tests link static components under a dylib build (`DISABLE_LLVM_LINK_LLVM_DYLIB`).

This is the general fix for a whole class of latent failures: an audit of the wider hotswap tree found 16 AMDGPU target-private helpers used across the transpiler (all in `LLVMAMDGPUUtils`), and the essential ones (the tablegen lookups like `getNamedOperandIdx`) cannot be avoided per call, only linked. Any future slice whose unit test links a hotswap object using one would fail identically without this.

I verified the fix locally against a static (non-dylib) LLVM: with the tests linking the shared static component set, `DecoderTests` (12), `RaiserScaffoldingTests` (5), and `WaveProjectionTests` (11) all build and pass, and `amd_comgr` still links. Because the tests are now fully static in both configurations, this local build exercises the same test linkage the dylib CI will use; the dylib-specific path is left for CI to confirm.

Since #3862 landed, this also supersedes its two-test dylib workaround: all six Hotswap test executables stay off libLLVM, avoiding duplicate AMDGPU option registration while retaining access to target-private helpers. All 66 focused tests pass in both dylib and static builds, and none of the executables loads libLLVM.so or libclang-cpp.so.