### PR TITLE
[Driver][AMDGPU] Downstream convergence: remove redundant amdgcn/bitcode device-library search

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -379,6 +379,7 @@ void RocmInstallationDetector::detectDeviceLibrary() {
   else if (std::optional<std::string> LibPathEnv =
                llvm::sys::Process::GetEnv("HIP_DEVICE_LIB_PATH"))
     LibDevicePath = std::move(*LibPathEnv);
+
   auto &FS = D.getVFS();
   if (!LibDevicePath.empty()) {
     // Maintain compatability with HIP flag/envvar pointing directly at the
@@ -420,16 +421,6 @@ void RocmInstallationDetector::detectDeviceLibrary() {
   HasDeviceLibrary = CheckDeviceLib(LibDevicePath, true);
   if (HasDeviceLibrary)
     return;
-
-  // Find device libraries in <LLVM_DIR>/amdgcn/bitcode
-  auto &oROCmDirs = getInstallationPathCandidates();
-  for (const auto &Candidate : oROCmDirs) {
-    LibDevicePath = Candidate.Path;
-    llvm::sys::path::append(LibDevicePath, "amdgcn", "bitcode");
-    HasDeviceLibrary = CheckDeviceLib(LibDevicePath, true);
-    if (HasDeviceLibrary)
-      return;
-  }
 
   // Find device libraries in a legacy ROCm directory structure
   // ${ROCM_ROOT}/amdgcn/bitcode/*


### PR DESCRIPTION
## Summary

Part of the effort to converge `amd-staging` toward upstream LLVM by removing
redundant downstream deltas.

`RocmInstallationDetector::detectDeviceLibrary()` carried a downstream-only
pass (originally from #1357) that iterated the ROCm installation path
candidates for `<candidate>/amdgcn/bitcode` with strict checking **forced on**:

```cpp
// Find device libraries in <LLVM_DIR>/amdgcn/bitcode
auto &oROCmDirs = getInstallationPathCandidates();
for (const auto &Candidate : oROCmDirs) {
  LibDevicePath = Candidate.Path;
  llvm::sys::path::append(LibDevicePath, "amdgcn", "bitcode");
  HasDeviceLibrary = CheckDeviceLib(LibDevicePath, true);
  if (HasDeviceLibrary)
    return;
}
```

The legacy ROCm search **immediately below it** walks the same
`getInstallationPathCandidates()` and appends the same `amdgcn/bitcode`
subpath, differing only in that it honors each candidate's `StrictChecking`
flag rather than forcing it `true`:

```cpp
// Find device libraries in a legacy ROCm directory structure
// ${ROCM_ROOT}/amdgcn/bitcode/*
auto &ROCmDirs = getInstallationPathCandidates();
for (const auto &Candidate : ROCmDirs) {
  LibDevicePath = Candidate.Path;
  llvm::sys::path::append(LibDevicePath, "amdgcn", "bitcode");
  HasDeviceLibrary = CheckDeviceLib(LibDevicePath, Candidate.StrictChecking);
  ...
```

`CheckDeviceLib(path, /*StrictChecking=*/false)` is strictly more permissive
than `true`, so any directory located by the removed pass is also located by
the legacy pass. The removed block is therefore redundant.

## Change

- Delete the duplicate strict-first `amdgcn/bitcode` search.
- Restore the blank line the original change removed, so
  `detectDeviceLibrary()` is now byte-identical to upstream LLVM.

Net: `-10 / +1`, and `detectDeviceLibrary()` matches upstream exactly.

## Risk / validation

The only behavioral difference is the strict-vs-permissive check ordering over
identical candidate paths; the retained legacy search is a superset. Relying on
PSDB CI to confirm device-library detection is unaffected.
