### PR TITLE
[Driver][AMDGPU] Remove dead amdgpu::dlr namespace

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -705,27 +705,6 @@ void amdgpu::getAMDGPUTargetFeatures(const Driver &D,
                             options::OPT_m_amdgpu_Features_Group);
 }
 
-llvm::SmallVector<ToolChain::BitCodeLibraryInfo, 12>
-amdgpu::dlr::getCommonDeviceLibNames(
-    const llvm::opt::ArgList &DriverArgs, const SanitizerArgs &SanArgs,
-    const Driver &D, const std::string &GPUArch, bool isOpenMP,
-    const RocmInstallationDetector &RocmInstallation,
-    const clang::driver::Action::OffloadKind DeviceOffloadingKind) {
-  auto Kind = llvm::AMDGPU::parseArchAMDGCN(GPUArch);
-  const StringRef CanonArch = llvm::AMDGPU::getArchNameAMDGCN(Kind);
-
-  StringRef LibDeviceFile = RocmInstallation.getLibDeviceFile(CanonArch);
-  auto ABIVer = DeviceLibABIVersion::fromCodeObjectVersion(
-      getAMDGPUCodeObjectVersion(D, DriverArgs));
-  if (!RocmInstallation.checkCommonBitcodeLibs(CanonArch, LibDeviceFile,
-                                               ABIVer))
-    return {};
-  
-  return RocmInstallation.getCommonBitcodeLibs(
-      DriverArgs, LibDeviceFile, GPUArch, DeviceOffloadingKind,
-      SanArgs.needsAsanRt());
-}
-
 /// AMDGPU Toolchain
 AMDGPUToolChain::AMDGPUToolChain(const Driver &D, const llvm::Triple &Triple,
                                  const ArgList &Args, const ToolChain *HostTC_,

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -42,48 +42,6 @@ void getAMDGPUTargetFeatures(const Driver &D, const llvm::Triple &Triple,
                              std::vector<StringRef> &Features,
                              bool ForAS = false);
 
-namespace dlr {
-llvm::SmallVector<ToolChain::BitCodeLibraryInfo, 12>
-getCommonDeviceLibNames(const llvm::opt::ArgList &DriverArgs,
-                        const SanitizerArgs &SanArgs, const Driver &D,
-                        const std::string &GPUArch, bool isOpenMP,
-                        const RocmInstallationDetector &RocmInstallation,
-                        const clang::driver::Action::OffloadKind DeviceOffloadingKind = Action::OFK_OpenMP);
-
-const char *
-getCbslCommandArgs(Compilation &C, const llvm::opt::ArgList &Args,
-                   llvm::opt::ArgStringList &CbslArgs,
-                   const SmallVectorImpl<std::string> &InputFileNames,
-                   llvm::StringRef OutputFilePrefix);
-
-const char *
-getLinkCommandArgs(Compilation &C, const llvm::opt::ArgList &Args,
-                   llvm::opt::ArgStringList &LastLinkArgs, const ToolChain &TC,
-                   const llvm::Triple &Triple, llvm::StringRef TargetID,
-                   llvm::StringRef OutputFilePrefix, const char *InputFileName,
-                   const RocmInstallationDetector &RocmInstallation,
-                   llvm::opt::ArgStringList &EnvironmentLibraryPaths);
-
-const char *getOptCommandArgs(Compilation &C, const llvm::opt::ArgList &Args,
-                              llvm::opt::ArgStringList &OptArgs,
-                              const llvm::Triple &Triple,
-                              llvm::StringRef TargetID,
-                              llvm::StringRef OutputFilePrefix,
-                              const char *InputFileName);
-
-const char *
-getLlcCommandArgs(Compilation &C, const llvm::opt::ArgList &Args,
-                  llvm::opt::ArgStringList &LlcArgs, const llvm::Triple &Triple,
-                  llvm::StringRef TargetID, llvm::StringRef OutputFilePrefix,
-                  const char *InputFileName, bool OutputIsAsm = false);
-
-const char *getLldCommandArgs(
-    Compilation &C, const InputInfo &Output, const llvm::opt::ArgList &Args,
-    llvm::opt::ArgStringList &LldArgs, const llvm::Triple &Triple,
-    llvm::StringRef TargetID, const char *InputFileName,
-    const std::optional<std::string> OutputFilePrefix = std::nullopt);
-} // end namespace dlr
-
 void addFullLTOPartitionOption(const Driver &D, const llvm::opt::ArgList &Args,
                                llvm::opt::ArgStringList &CmdArgs);
 } // end namespace amdgpu


### PR DESCRIPTION
The tools::amdgpu::dlr namespace is entirely unreachable:

  - getCommonDeviceLibNames is defined but never called. Both call sites in AMDGPUToolChain::getDeviceLibs use the unqualified 4-argument form, which binds to the member AMDGPUToolChain::getCommonDeviceLibNames. The free function requires at least 6 arguments, so it cannot match by overload resolution or ADL.
  - getCbslCommandArgs, getLinkCommandArgs, getOptCommandArgs, getLlcCommandArgs and getLldCommandArgs are declared and never defined anywhere in the tree.

ToolChains/AMDGPU.h is a private driver header, so there is no external consumer either.

5c29313903f0 left the free function behind after moving its body to the same shape as upstream's AMDGPUToolChain::getCommonDeviceLibNames; the two now differ only in that this copy takes RocmInstallation and SanArgs as parameters instead of reaching them through the toolchain.


