### PR TITLE
[ASan][AMDGPU] Retry HSA resolution after late HIP load

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
@@ -177,6 +177,17 @@ void AmdgpuMemFuncs::RegisterSystemEventHandlers() {
   // Check if shutdown event handler is already registered
   if (atomic_compare_exchange_strong(&amdgpu_event_registered, &registered, 1,
                                      memory_order_acq_rel)) {
+    // ASan can be initialized before ROCr is loaded, for example when an
+    // application dlopen()s HIP. Retry symbol resolution after hsa_init() has
+    // loaded the runtime, and never call through an unresolved entry point.
+    if (!Init()) {
+      VReport(1,
+              "Amdgpu RegisterSystemEventHandlers: AMDGPU runtime functions "
+              "are unavailable\n");
+      atomic_store(&amdgpu_event_registered, 0, memory_order_release);
+      return;
+    }
+
     // Callback to detect and notify AMDGPU runtime shutdown
     hsa_amd_system_event_callback_t callback = [](const hsa_amd_event_t* event,
                                                   void* data) {

--- a/compiler-rt/test/asan/TestCases/AMDGPU/hip-dlopen-init.cpp
+++ b/compiler-rt/test/asan/TestCases/AMDGPU/hip-dlopen-init.cpp
@@ -1,0 +1,32 @@
+// RUN: %clangxx_asan %s -ldl -o %t && %ROCM_ENV && %run %t 2>&1 | FileCheck %s
+// CHECK: hipInit succeeded
+
+// Verify that ASan can initialize before HIP and resolve the HSA allocator
+// callbacks after libamdhip64 loads ROCr.
+
+#include <dlfcn.h>
+#include <stdio.h>
+
+int main() {
+  void *hip = dlopen("libamdhip64.so.7", RTLD_NOW | RTLD_GLOBAL);
+  if (!hip) {
+    fprintf(stderr, "dlopen failed: %s\n", dlerror());
+    return 1;
+  }
+
+  using HipInit = int (*)(unsigned int);
+  auto hip_init = reinterpret_cast<HipInit>(dlsym(hip, "hipInit"));
+  if (!hip_init) {
+    fprintf(stderr, "dlsym failed: %s\n", dlerror());
+    return 1;
+  }
+
+  const int status = hip_init(0);
+  if (status != 0) {
+    fprintf(stderr, "hipInit failed: %d\n", status);
+    return 1;
+  }
+
+  puts("hipInit succeeded");
+  return 0;
+}


### PR DESCRIPTION
ASan can initialize before applications that `dlopen()` HIP have loaded ROCr. The initial `RTLD_NEXT` lookups then leave the AMDGPU HSA callback table incomplete.

After the real `hsa_init()` succeeds, retry the idempotent HSA symbol lookup before registering the shutdown callback. If resolution still fails, reset the registration guard and return instead of calling through a null function pointer.

Add a regression that starts ASan first, dlopens `libamdhip64.so.7`, and calls `hipInit`.

Validation:
- `clang_rt.asan-dynamic-x86_64` rebuilt successfully.
- The regression reproduces the null-PC abort with the old runtime.
- The rebuilt runtime prints `hipInit succeeded`.
- The matching ctypes/GPU probe returns `hipInit_status 0`.
- `clang-format --dry-run --Werror` and `git diff --check` pass.
