### PR TITLE
[Infra] Use TheRock checkout SHA for Compiler CI

### DIFF
--- a/.github/actions/rock-ci-deps/lit-comgr-tests/action.yml
+++ b/.github/actions/rock-ci-deps/lit-comgr-tests/action.yml
@@ -1,6 +1,6 @@
-name: LLVM toolchain Lit and COMGR tests
+name: LLVM toolchain Lit
 description: >
-  Runs check-llvm/clang/flang/mlir/lld, COMGR llvm-lit suite, and COMGR ctest
+  Runs check-llvm/clang/flang/mlir/lld
   when stage is compiler-runtime.
 
 inputs:
@@ -45,15 +45,3 @@ runs:
       run: |
         ninja -C "${{ inputs.build_dir }}/compiler/amd-llvm/build" check-lld
 
-    - name: COMGR Lit Tests
-      shell: bash
-      if: ${{ inputs.stage_name == 'compiler-runtime' }}
-      run: |
-        "${{ inputs.build_dir }}/compiler/amd-llvm/build/bin/llvm-lit" \
-          "${{ inputs.build_dir }}/compiler/amd-comgr/build/test-lit" -v
-
-    - name: COMGR CTest
-      shell: bash
-      if: ${{ inputs.stage_name == 'compiler-runtime' }}
-      run: |
-        ctest --test-dir "${{ inputs.build_dir }}/compiler/amd-comgr/build" --output-on-failure

--- a/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
+++ b/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
@@ -13,30 +13,34 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Update rocm-systems and rocm-libraries to tip sha
+    - name: Update rocm-systems and rocm-libraries from TheRock main
       shell: bash
       run: |
-        ROCM_SYSTEMS_SHA="$(git ls-remote https://github.com/ROCm/rocm-systems.git refs/heads/develop | awk '{print $1}')"
-        ROCM_LIBRARIES_SHA="$(git ls-remote https://github.com/ROCm/rocm-libraries.git refs/heads/develop | awk '{print $1}')"
-        if [[ -z "$ROCM_SYSTEMS_SHA" || -z "$ROCM_LIBRARIES_SHA" ]]; then
-          echo "::error::Failed to resolve rocm-systems or rocm-libraries develop tip." >&2
-          exit 1
-        fi
-        echo "rocm-systems develop tip: $ROCM_SYSTEMS_SHA"
-        echo "rocm-libraries develop tip: $ROCM_LIBRARIES_SHA"
         git config --global --add safe.directory "$PWD"
-        git config --global core.longpaths true
+	git config --global core.longpaths true
         git config --global user.email "z1-cciauto@amd.com"
         git config --global user.name "Z1 cciauto"
+
+        git fetch --no-tags --depth 1 origin \
+          refs/heads/main:refs/remotes/origin/main
+
+        ROCM_SYSTEMS_SHA="$(git ls-tree origin/main rocm-systems | awk '{print $3}')"
+        ROCM_LIBRARIES_SHA="$(git ls-tree origin/main rocm-libraries | awk '{print $3}')"
+
+        if [[ -z "$ROCM_SYSTEMS_SHA" || -z "$ROCM_LIBRARIES_SHA" ]]; then
+          echo "::error::Failed to read rocm-systems or rocm-libraries SHA from TheRock main." >&2
+          exit 1
+        fi
+
+        echo "rocm-systems SHA from TheRock main: $ROCM_SYSTEMS_SHA"
+        echo "rocm-libraries SHA from TheRock main: $ROCM_LIBRARIES_SHA"
         git update-index --cacheinfo 160000,"$ROCM_SYSTEMS_SHA",rocm-systems
         git update-index --cacheinfo 160000,"$ROCM_LIBRARIES_SHA",rocm-libraries
+
         if ! git diff --cached --quiet; then
-          git commit -m "Update rocm-systems and rocm-libraries submodules"
+          git commit -m "Update shared submodules from TheRock main"
         fi
-        git submodule update --init --depth 1 --jobs 2 \
-          rocm-systems \
-          rocm-libraries
-    
+
     - name: Update Submodule Pointer to the PR
       if: github.event_name == 'pull_request'
       shell: bash

--- a/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
+++ b/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
@@ -13,33 +13,25 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Update rocm-systems and rocm-libraries from TheRock main
+    - name: Update non-compiler submodules from TheRock main
       shell: bash
       run: |
         git config --global --add safe.directory "$PWD"
         git config --global core.longpaths true
         git config --global user.email "z1-cciauto@amd.com"
         git config --global user.name "Z1 cciauto"
-
         git fetch --no-tags --depth 1 origin \
           refs/heads/main:refs/remotes/origin/main
-
-        ROCM_SYSTEMS_SHA="$(git ls-tree origin/main rocm-systems | awk '{print $3}')"
-        ROCM_LIBRARIES_SHA="$(git ls-tree origin/main rocm-libraries | awk '{print $3}')"
-
-        if [[ -z "$ROCM_SYSTEMS_SHA" || -z "$ROCM_LIBRARIES_SHA" ]]; then
-          echo "::error::Failed to read rocm-systems or rocm-libraries SHA from TheRock main." >&2
-          exit 1
-        fi
-
-        echo "rocm-systems SHA from TheRock main: $ROCM_SYSTEMS_SHA"
-        echo "rocm-libraries SHA from TheRock main: $ROCM_LIBRARIES_SHA"
-        git update-index --cacheinfo 160000,"$ROCM_SYSTEMS_SHA",rocm-systems
-        git update-index --cacheinfo 160000,"$ROCM_LIBRARIES_SHA",rocm-libraries
-
+        git ls-tree -r origin/main |
+          while read -r mode type sha path; do
+            [[ "$mode" == "160000" ]] || continue
+            [[ "$path" == compiler/* ]] && continue
+            echo "${path} SHA from TheRock main: ${sha}"
+            git update-index --cacheinfo 160000,"$sha","$path"
+          done
         if ! git diff --cached --quiet; then
-          git commit -m "Update shared submodules from TheRock main"
-        fi    
+          git commit -m "Update non-compiler submodules from TheRock main"
+        fi
 
     - name: Update Submodule Pointer to the PR
       if: github.event_name == 'pull_request'

--- a/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
+++ b/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         git config --global --add safe.directory "$PWD"
-	git config --global core.longpaths true
+        git config --global core.longpaths true
         git config --global user.email "z1-cciauto@amd.com"
         git config --global user.name "Z1 cciauto"
 
@@ -39,7 +39,7 @@ runs:
 
         if ! git diff --cached --quiet; then
           git commit -m "Update shared submodules from TheRock main"
-        fi
+        fi    
 
     - name: Update Submodule Pointer to the PR
       if: github.event_name == 'pull_request'

--- a/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
+++ b/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
@@ -52,7 +52,7 @@ runs:
         fi
         
         git commit -m "Update compiler submodule references for llvm-project PR"
-        git submodule update --init --recursive \
+        git submodule update --init --depth 1 --jobs 4 \
           compiler/amd-llvm \
           compiler/spirv-llvm-translator \
           compiler/hipify
@@ -97,7 +97,7 @@ runs:
         fi
 
         git commit -m "Update compiler submodule references for llvm-project PR"
-        git submodule update --init --recursive \
+        git submodule update --init --depth 1 --jobs 4 \
           compiler/amd-llvm \
           compiler/spirv-llvm-translator \
           compiler/hipify
@@ -160,7 +160,7 @@ runs:
         merge_upstream_prs() {
           local pr_urls="$1"
           local url repo num ref
-          git submodule update --init --jobs 1 compiler/amd-llvm
+          git submodule update --init --depth 1 --jobs 1 compiler/amd-llvm
           IFS=',' read -ra PR_URLS <<< "$pr_urls"
           for url in "${PR_URLS[@]}"; do
             url="$(echo "$url" | xargs)"
@@ -224,7 +224,7 @@ runs:
         fi
 
         git commit -m "Update submodule references from PR URLs"
-        git submodule update --init --recursive \
+        git submodule update --init --depth 1 --jobs 4 \
           compiler/amd-llvm \
           compiler/spirv-llvm-translator \
           compiler/hipify

--- a/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
+++ b/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
@@ -25,6 +25,7 @@ runs:
         echo "rocm-systems develop tip: $ROCM_SYSTEMS_SHA"
         echo "rocm-libraries develop tip: $ROCM_LIBRARIES_SHA"
         git config --global --add safe.directory "$PWD"
+        git config --global core.longpaths true
         git config --global user.email "z1-cciauto@amd.com"
         git config --global user.name "Z1 cciauto"
         git update-index --cacheinfo 160000,"$ROCM_SYSTEMS_SHA",rocm-systems

--- a/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
+++ b/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
@@ -13,26 +13,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Update non-compiler submodules from TheRock main
-      shell: bash
-      run: |
-        git config --global --add safe.directory "$PWD"
-        git config --global core.longpaths true
-        git config --global user.email "z1-cciauto@amd.com"
-        git config --global user.name "Z1 cciauto"
-        git fetch --no-tags --depth 1 origin \
-          refs/heads/main:refs/remotes/origin/main
-        git ls-tree -r origin/main |
-          while read -r mode type sha path; do
-            [[ "$mode" == "160000" ]] || continue
-            [[ "$path" == compiler/* ]] && continue
-            echo "${path} SHA from TheRock main: ${sha}"
-            git update-index --cacheinfo 160000,"$sha","$path"
-          done
-        if ! git diff --cached --quiet; then
-          git commit -m "Update non-compiler submodules from TheRock main"
-        fi
-
     - name: Update Submodule Pointer to the PR
       if: github.event_name == 'pull_request'
       shell: bash

--- a/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
+++ b/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
@@ -13,6 +13,29 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Update rocm-systems and rocm-libraries to tip sha
+      shell: bash
+      run: |
+        ROCM_SYSTEMS_SHA="$(git ls-remote https://github.com/ROCm/rocm-systems.git refs/heads/develop | awk '{print $1}')"
+        ROCM_LIBRARIES_SHA="$(git ls-remote https://github.com/ROCm/rocm-libraries.git refs/heads/develop | awk '{print $1}')"
+        if [[ -z "$ROCM_SYSTEMS_SHA" || -z "$ROCM_LIBRARIES_SHA" ]]; then
+          echo "::error::Failed to resolve rocm-systems or rocm-libraries develop tip." >&2
+          exit 1
+        fi
+        echo "rocm-systems develop tip: $ROCM_SYSTEMS_SHA"
+        echo "rocm-libraries develop tip: $ROCM_LIBRARIES_SHA"
+        git config --global --add safe.directory "$PWD"
+        git config --global user.email "z1-cciauto@amd.com"
+        git config --global user.name "Z1 cciauto"
+        git update-index --cacheinfo 160000,"$ROCM_SYSTEMS_SHA",rocm-systems
+        git update-index --cacheinfo 160000,"$ROCM_LIBRARIES_SHA",rocm-libraries
+        if ! git diff --cached --quiet; then
+          git commit -m "Update rocm-systems and rocm-libraries submodules"
+        fi
+        git submodule update --init --depth 1 --jobs 2 \
+          rocm-systems \
+          rocm-libraries
+    
     - name: Update Submodule Pointer to the PR
       if: github.event_name == 'pull_request'
       shell: bash
@@ -65,9 +88,6 @@ runs:
       shell: bash
       run: |
         git config --global --add safe.directory $PWD
-        echo "sha: $GITHUB_SHA"
-        # Update the submodule pointer using cacheinfo
-        git update-index --cacheinfo 160000,$GITHUB_SHA,compiler/amd-llvm
         git config --global user.email "z1-cciauto@amd.com"
         git config --global user.name "Z1 cciauto"
         trim_sha() {
@@ -79,9 +99,13 @@ runs:
           trim_sha "$(git ls-remote "${repo_url}" refs/heads/amd-staging | awk '{print $1}')"
         }
 
-        PR_SHA="$(trim_sha "${{ github.event.pull_request.head.sha }}")"
-        echo "ROCm LLVM PR head SHA: $PR_SHA"
-        git update-index --cacheinfo 160000,"$PR_SHA",compiler/amd-llvm
+        BRANCH_SHA="$(trim_sha "$GITHUB_SHA")"
+        echo "ROCm LLVM branch SHA: $BRANCH_SHA"
+        if [[ -z "$BRANCH_SHA" ]]; then
+          echo "::error::GITHUB_SHA is empty." >&2
+          exit 1
+        fi
+        git update-index --cacheinfo 160000,"$BRANCH_SHA",compiler/amd-llvm
 
         SPIRV_SHA="$(read_amd_staging_tip https://github.com/ROCm/SPIRV-LLVM-Translator.git)"
         echo "SPIRV amd-staging tip SHA: $SPIRV_SHA"
@@ -96,7 +120,7 @@ runs:
           exit 1
         fi
 
-        git commit -m "Update compiler submodule references for llvm-project PR"
+        git commit -m "Update compiler submodule references for Windows debug branch"
         git submodule update --init --depth 1 --jobs 4 \
           compiler/amd-llvm \
           compiler/spirv-llvm-translator \

--- a/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
+++ b/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
@@ -1,7 +1,6 @@
 name: LLVM submodule & PR-parameter setup
 description: >
-  On pull_request updates amd-llvm submodule pointer to PR head and aligns
-  spirv-llvm-translator and hipify with amd-staging tip.
+  On pull_request updates amd-llvm submodule pointer to PR head.
   On workflow_dispatch downloads PR params artifact, sources env, merges upstream PRs, updates submodule pointers.
 
 inputs:
@@ -24,38 +23,8 @@ runs:
         git update-index --cacheinfo 160000,$PR_SHA,compiler/amd-llvm
         git config --global user.email "z1-cciauto@amd.com"
         git config --global user.name "Z1 cciauto"
-        
-        trim_sha() {
-          printf '%s' "$1" | tr -d '[:space:]'
-        }
-
-        read_amd_staging_tip() {
-          local repo_url="$1"
-          trim_sha "$(git ls-remote "${repo_url}" refs/heads/amd-staging | awk '{print $1}')"
-        }
-
-        PR_SHA="$(trim_sha "${{ github.event.pull_request.head.sha }}")"
-        echo "ROCm LLVM PR head SHA: $PR_SHA"
-        git update-index --cacheinfo 160000,"$PR_SHA",compiler/amd-llvm
-
-        SPIRV_SHA="$(read_amd_staging_tip https://github.com/ROCm/SPIRV-LLVM-Translator.git)"
-        echo "SPIRV amd-staging tip SHA: $SPIRV_SHA"
-        git update-index --cacheinfo 160000,"$SPIRV_SHA",compiler/spirv-llvm-translator
-
-        HIPIFY_SHA="$(read_amd_staging_tip https://github.com/ROCm/HIPIFY.git)"
-        echo "HIPIFY amd-staging tip SHA: $HIPIFY_SHA"
-        git update-index --cacheinfo 160000,"$HIPIFY_SHA",compiler/hipify
-
-        if [[ -z "$SPIRV_SHA" || -z "$HIPIFY_SHA" ]]; then
-          echo "::error::Failed to resolve SPIRV/HIPIFY amd-staging tip SHAs." >&2
-          exit 1
-        fi
-        
-        git commit -m "Update compiler submodule references for llvm-project PR"
-        git submodule update --init --recursive \
-          compiler/amd-llvm \
-          compiler/spirv-llvm-translator \
-          compiler/hipify
+        git commit -m "Update submodule reference for compiler/amd-llvm"
+        git submodule update --init --recursive compiler/amd-llvm
         # Verify the pointer update
         git submodule status
         git submodule
@@ -70,37 +39,9 @@ runs:
         git update-index --cacheinfo 160000,$GITHUB_SHA,compiler/amd-llvm
         git config --global user.email "z1-cciauto@amd.com"
         git config --global user.name "Z1 cciauto"
-        trim_sha() {
-          printf '%s' "$1" | tr -d '[:space:]'
-        }
-
-        read_amd_staging_tip() {
-          local repo_url="$1"
-          trim_sha "$(git ls-remote "${repo_url}" refs/heads/amd-staging | awk '{print $1}')"
-        }
-
-        PR_SHA="$(trim_sha "${{ github.event.pull_request.head.sha }}")"
-        echo "ROCm LLVM PR head SHA: $PR_SHA"
-        git update-index --cacheinfo 160000,"$PR_SHA",compiler/amd-llvm
-
-        SPIRV_SHA="$(read_amd_staging_tip https://github.com/ROCm/SPIRV-LLVM-Translator.git)"
-        echo "SPIRV amd-staging tip SHA: $SPIRV_SHA"
-        git update-index --cacheinfo 160000,"$SPIRV_SHA",compiler/spirv-llvm-translator
-
-        HIPIFY_SHA="$(read_amd_staging_tip https://github.com/ROCm/HIPIFY.git)"
-        echo "HIPIFY amd-staging tip SHA: $HIPIFY_SHA"
-        git update-index --cacheinfo 160000,"$HIPIFY_SHA",compiler/hipify
-
-        if [[ -z "$SPIRV_SHA" || -z "$HIPIFY_SHA" ]]; then
-          echo "::error::Failed to resolve SPIRV/HIPIFY amd-staging tip SHAs." >&2
-          exit 1
-        fi
-
-        git commit -m "Update compiler submodule references for llvm-project PR"
-        git submodule update --init --recursive \
-          compiler/amd-llvm \
-          compiler/spirv-llvm-translator \
-          compiler/hipify
+        git commit -m "Update submodule reference for compiler/amd-llvm using branch SHA"
+        # Verify the pointer update
+        git submodule update --init --recursive compiler/amd-llvm          
         git submodule status
         git submodule
 
@@ -193,17 +134,12 @@ runs:
           git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
         fi
 
-        read_amd_staging_tip() {
-          local repo_url="$1"
-          trim_sha "$(git ls-remote "${repo_url}" refs/heads/amd-staging | awk '{print $1}')"
-        }
-        
         if [[ -n "${SPIRV_PR_URL:-}" ]]; then
           SPIRV_SHA="$(get_pr_sha "$SPIRV_PR_URL")"
           echo "SPIRV head SHA: $SPIRV_SHA"
           git update-index --cacheinfo 160000,"$SPIRV_SHA","compiler/spirv-llvm-translator"
         else
-          SPIRV_SHA="$(read_amd_staging_tip https://github.com/ROCm/SPIRV-LLVM-Translator.git)"
+          SPIRV_SHA="$(git ls-remote https://github.com/ROCm/SPIRV-LLVM-Translator.git refs/heads/amd-staging | awk '{print $1}')"
           echo "SPIRV PR NOT Passed, defaulting to the amd-staging tip : $SPIRV_SHA"
           git update-index --cacheinfo 160000,"$SPIRV_SHA","compiler/spirv-llvm-translator"
         fi
@@ -213,20 +149,12 @@ runs:
           echo "HIPIFY head SHA: $HIPIFY_SHA"
           git update-index --cacheinfo 160000,"$HIPIFY_SHA","compiler/hipify"
         else
-          HIPIFY_SHA="$(read_amd_staging_tip https://github.com/ROCm/HIPIFY.git)"
+          HIPIFY_SHA="$(git ls-remote https://github.com/ROCm/HIPIFY.git refs/heads/amd-staging | awk '{print $1}')"
           echo "HIPIFY PR NOT Passed, defaulting to the amd-staging tip : $HIPIFY_SHA"
           git update-index --cacheinfo 160000,"$HIPIFY_SHA","compiler/hipify"
         fi
 
-        if [[ -z "$SPIRV_SHA" || -z "$HIPIFY_SHA" ]]; then
-          echo "::error::Failed to resolve SPIRV/HIPIFY amd-staging tip SHAs." >&2
-          exit 1
-        fi
-
         git commit -m "Update submodule references from PR URLs"
-        git submodule update --init --recursive \
-          compiler/amd-llvm \
-          compiler/spirv-llvm-translator \
-          compiler/hipify
+        git submodule update --init --recursive compiler/amd-llvm
         git submodule status
         git submodule

--- a/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
+++ b/.github/actions/rock-ci-deps/submodule-pr-update/action.yml
@@ -1,6 +1,7 @@
 name: LLVM submodule & PR-parameter setup
 description: >
-  On pull_request updates amd-llvm submodule pointer to PR head.
+  On pull_request updates amd-llvm submodule pointer to PR head and aligns
+  spirv-llvm-translator and hipify with amd-staging tip.
   On workflow_dispatch downloads PR params artifact, sources env, merges upstream PRs, updates submodule pointers.
 
 inputs:
@@ -23,8 +24,38 @@ runs:
         git update-index --cacheinfo 160000,$PR_SHA,compiler/amd-llvm
         git config --global user.email "z1-cciauto@amd.com"
         git config --global user.name "Z1 cciauto"
-        git commit -m "Update submodule reference for compiler/amd-llvm"
-        git submodule update --init --recursive compiler/amd-llvm
+        
+        trim_sha() {
+          printf '%s' "$1" | tr -d '[:space:]'
+        }
+
+        read_amd_staging_tip() {
+          local repo_url="$1"
+          trim_sha "$(git ls-remote "${repo_url}" refs/heads/amd-staging | awk '{print $1}')"
+        }
+
+        PR_SHA="$(trim_sha "${{ github.event.pull_request.head.sha }}")"
+        echo "ROCm LLVM PR head SHA: $PR_SHA"
+        git update-index --cacheinfo 160000,"$PR_SHA",compiler/amd-llvm
+
+        SPIRV_SHA="$(read_amd_staging_tip https://github.com/ROCm/SPIRV-LLVM-Translator.git)"
+        echo "SPIRV amd-staging tip SHA: $SPIRV_SHA"
+        git update-index --cacheinfo 160000,"$SPIRV_SHA",compiler/spirv-llvm-translator
+
+        HIPIFY_SHA="$(read_amd_staging_tip https://github.com/ROCm/HIPIFY.git)"
+        echo "HIPIFY amd-staging tip SHA: $HIPIFY_SHA"
+        git update-index --cacheinfo 160000,"$HIPIFY_SHA",compiler/hipify
+
+        if [[ -z "$SPIRV_SHA" || -z "$HIPIFY_SHA" ]]; then
+          echo "::error::Failed to resolve SPIRV/HIPIFY amd-staging tip SHAs." >&2
+          exit 1
+        fi
+        
+        git commit -m "Update compiler submodule references for llvm-project PR"
+        git submodule update --init --recursive \
+          compiler/amd-llvm \
+          compiler/spirv-llvm-translator \
+          compiler/hipify
         # Verify the pointer update
         git submodule status
         git submodule
@@ -39,9 +70,37 @@ runs:
         git update-index --cacheinfo 160000,$GITHUB_SHA,compiler/amd-llvm
         git config --global user.email "z1-cciauto@amd.com"
         git config --global user.name "Z1 cciauto"
-        git commit -m "Update submodule reference for compiler/amd-llvm using branch SHA"
-        # Verify the pointer update
-        git submodule update --init --recursive compiler/amd-llvm          
+        trim_sha() {
+          printf '%s' "$1" | tr -d '[:space:]'
+        }
+
+        read_amd_staging_tip() {
+          local repo_url="$1"
+          trim_sha "$(git ls-remote "${repo_url}" refs/heads/amd-staging | awk '{print $1}')"
+        }
+
+        PR_SHA="$(trim_sha "${{ github.event.pull_request.head.sha }}")"
+        echo "ROCm LLVM PR head SHA: $PR_SHA"
+        git update-index --cacheinfo 160000,"$PR_SHA",compiler/amd-llvm
+
+        SPIRV_SHA="$(read_amd_staging_tip https://github.com/ROCm/SPIRV-LLVM-Translator.git)"
+        echo "SPIRV amd-staging tip SHA: $SPIRV_SHA"
+        git update-index --cacheinfo 160000,"$SPIRV_SHA",compiler/spirv-llvm-translator
+
+        HIPIFY_SHA="$(read_amd_staging_tip https://github.com/ROCm/HIPIFY.git)"
+        echo "HIPIFY amd-staging tip SHA: $HIPIFY_SHA"
+        git update-index --cacheinfo 160000,"$HIPIFY_SHA",compiler/hipify
+
+        if [[ -z "$SPIRV_SHA" || -z "$HIPIFY_SHA" ]]; then
+          echo "::error::Failed to resolve SPIRV/HIPIFY amd-staging tip SHAs." >&2
+          exit 1
+        fi
+
+        git commit -m "Update compiler submodule references for llvm-project PR"
+        git submodule update --init --recursive \
+          compiler/amd-llvm \
+          compiler/spirv-llvm-translator \
+          compiler/hipify
         git submodule status
         git submodule
 
@@ -134,12 +193,17 @@ runs:
           git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
         fi
 
+        read_amd_staging_tip() {
+          local repo_url="$1"
+          trim_sha "$(git ls-remote "${repo_url}" refs/heads/amd-staging | awk '{print $1}')"
+        }
+        
         if [[ -n "${SPIRV_PR_URL:-}" ]]; then
           SPIRV_SHA="$(get_pr_sha "$SPIRV_PR_URL")"
           echo "SPIRV head SHA: $SPIRV_SHA"
           git update-index --cacheinfo 160000,"$SPIRV_SHA","compiler/spirv-llvm-translator"
         else
-          SPIRV_SHA="$(git ls-remote https://github.com/ROCm/SPIRV-LLVM-Translator.git refs/heads/amd-staging | awk '{print $1}')"
+          SPIRV_SHA="$(read_amd_staging_tip https://github.com/ROCm/SPIRV-LLVM-Translator.git)"
           echo "SPIRV PR NOT Passed, defaulting to the amd-staging tip : $SPIRV_SHA"
           git update-index --cacheinfo 160000,"$SPIRV_SHA","compiler/spirv-llvm-translator"
         fi
@@ -149,12 +213,20 @@ runs:
           echo "HIPIFY head SHA: $HIPIFY_SHA"
           git update-index --cacheinfo 160000,"$HIPIFY_SHA","compiler/hipify"
         else
-          HIPIFY_SHA="$(git ls-remote https://github.com/ROCm/HIPIFY.git refs/heads/amd-staging | awk '{print $1}')"
+          HIPIFY_SHA="$(read_amd_staging_tip https://github.com/ROCm/HIPIFY.git)"
           echo "HIPIFY PR NOT Passed, defaulting to the amd-staging tip : $HIPIFY_SHA"
           git update-index --cacheinfo 160000,"$HIPIFY_SHA","compiler/hipify"
         fi
 
+        if [[ -z "$SPIRV_SHA" || -z "$HIPIFY_SHA" ]]; then
+          echo "::error::Failed to resolve SPIRV/HIPIFY amd-staging tip SHAs." >&2
+          exit 1
+        fi
+
         git commit -m "Update submodule references from PR URLs"
-        git submodule update --init --recursive compiler/amd-llvm
+        git submodule update --init --recursive \
+          compiler/amd-llvm \
+          compiler/spirv-llvm-translator \
+          compiler/hipify
         git submodule status
         git submodule

--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Install Python requirements
         run: pip install -r requirements.txt

--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: "ROCm/TheRock"
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
 
       - name: Install Python requirements

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: "ROCm/TheRock"
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/manifest-diff.yml
+++ b/.github/workflows/manifest-diff.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'          
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Adjust git config

--- a/.github/workflows/manifest-diff.yml
+++ b/.github/workflows/manifest-diff.yml
@@ -92,8 +92,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || '' }}
           fetch-depth: 0
 
       - name: Adjust git config

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -72,8 +72,8 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || '' }}      
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -109,7 +109,7 @@ jobs:
           path: ${{ fromJSON(inputs.external_repo_config).checkout_path }}
 
       - name: Submodule PR update (covers parameterised and PR creation)
-        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd-staging
+        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd/dev/kirthana14m/rockci-sha
       - name: Install python deps
         run: pip install -r requirements.txt
 

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Checkout external repository
         if: ${{ inputs.external_repo_config != '' }}

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -215,15 +215,25 @@ jobs:
         run: |
           python3 build_tools/github_actions/detect_failed_logs.py
 
-      - name: LIT (llvm, clang, flang, mlir, lld) / COMGR Lit & CTest
-        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/lit-comgr-tests@amd-staging
+      - name: LIT (llvm, clang, flang, mlir, lld)
+        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/lit-comgr-tests@amd/dev/kirthana14m/rockci-sha
         continue-on-error: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         env:
           BUILD_DIR: ${{ env.BUILD_DIR }}
         with:
           stage_name: ${{ inputs.stage_name }}
- 
-      - name: Run build tests
+
+      - name: Run build tests (Comgr, blocking)
+        if: ${{ !cancelled() && inputs.stage_name == 'compiler-runtime' }}
+        env:
+          TEATIME_FORCE_INTERACTIVE: 1
+        run: |
+          cmake --build "${BUILD_DIR}" --target build-test-amd-comgr -- -k 0
+
+      # Remaining build tests (e.g. rocjitsu, mirage) still run and report, but
+      # are not yet gating. Comgr is split out above so its failures block CI.
+      # TODO(#6112): rocjitsu tests are being moved out; drop this step once done.
+      - name: Run build tests (other, non-blocking)
         if: ${{ !cancelled() && inputs.stage_name == 'compiler-runtime' }}
         continue-on-error: true
         env:

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
 
       - name: Checkout external repository
@@ -109,7 +109,7 @@ jobs:
           path: ${{ fromJSON(inputs.external_repo_config).checkout_path }}
 
       - name: Submodule PR update (covers parameterised and PR creation)
-        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd/dev/kirthana14m/rockci-sha
+        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd-staging
       - name: Install python deps
         run: pip install -r requirements.txt
 

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -109,7 +109,8 @@ jobs:
           path: ${{ fromJSON(inputs.external_repo_config).checkout_path }}
 
       - name: Submodule PR update (covers parameterised and PR creation)
-        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd-staging
+        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd/dev/kirthana14m/rockci-sha
+
       - name: Install python deps
         run: pip install -r requirements.txt
 

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -109,7 +109,7 @@ jobs:
           path: ${{ fromJSON(inputs.external_repo_config).checkout_path }}
 
       - name: Submodule PR update (covers parameterised and PR creation)
-        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd/dev/kirthana14m/rockci-sha
+        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd-staging
 
       - name: Install python deps
         run: pip install -r requirements.txt
@@ -216,7 +216,7 @@ jobs:
           python3 build_tools/github_actions/detect_failed_logs.py
 
       - name: LIT (llvm, clang, flang, mlir, lld)
-        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/lit-comgr-tests@amd/dev/kirthana14m/rockci-sha
+        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/lit-comgr-tests@amd-staging
         continue-on-error: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         env:
           BUILD_DIR: ${{ env.BUILD_DIR }}

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
 
       - name: Configure Git Identity

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -175,7 +175,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Configure Git Identity
         run: |

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -123,7 +123,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Configure Git Identity
         run: |

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
 
       - name: Configure Git Identity

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Checkout external repository
         if: ${{ inputs.external_repo_config != '' }}

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -110,7 +110,7 @@ jobs:
           path: ${{ fromJSON(inputs.external_repo_config).checkout_path }}
 
       - name: Submodule PR update (covers parameterised and PR creation)
-        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd-staging
+        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd/dev/kirthana14m/rockci-sha
 
       - name: "Map Current Directory to L Drive"
         id: subst

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -110,7 +110,7 @@ jobs:
           path: ${{ fromJSON(inputs.external_repo_config).checkout_path }}
 
       - name: Submodule PR update (covers parameterised and PR creation)
-        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd/dev/kirthana14m/rockci-sha
+        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd-staging
 
       - name: "Map Current Directory to L Drive"
         id: subst

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -277,22 +277,8 @@ jobs:
           cd L:
           cmake --build "${BUILD_DIR}" --target stage-${STAGE_NAME} therock-artifacts -- -k 0
 
-      - name: COMGR Lit Tests
-        if: ${{ inputs.stage_name == 'compiler-runtime' }}
-        continue-on-error: true
-        run: |
-          python "${BUILD_DIR}"/compiler/amd-llvm/build/bin/llvm-lit.py \
-            "${BUILD_DIR}"/compiler/amd-comgr/build/test-lit -v
-
-      - name: COMGR CTest
-        if: ${{ inputs.stage_name == 'compiler-runtime' }}
-        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
-        run: |
-          ctest --test-dir "${BUILD_DIR}"/compiler/amd-comgr/build --output-on-failure
- 
-      - name: Run build tests
+      - name: Run build tests (Comgr, blocking)
         if: ${{ !cancelled() && inputs.stage_name == 'compiler-runtime' }}
-        continue-on-error: true
         env:
           TEATIME_FORCE_INTERACTIVE: 1
         run: |

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -98,8 +98,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
 
       - name: Checkout external repository
         if: ${{ inputs.external_repo_config != '' }}
@@ -110,7 +110,7 @@ jobs:
           path: ${{ fromJSON(inputs.external_repo_config).checkout_path }}
 
       - name: Submodule PR update (covers parameterised and PR creation)
-        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd/dev/kirthana14m/rockci-sha
+        uses: ROCm/llvm-project/.github/actions/rock-ci-deps/submodule-pr-update@amd-staging
 
       - name: "Map Current Directory to L Drive"
         id: subst

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -175,7 +175,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Configure Git Identity
         run: |

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -174,8 +174,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
 
       - name: Configure Git Identity
         run: |

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
@@ -136,8 +136,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
 
       - name: Configure Git Identity
         run: |

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Configure Git Identity
         run: |

--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
 
       - name: Checkout external repository
         if: ${{ inputs.external_repo_config != '' }}

--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Checkout external repository
         if: ${{ inputs.external_repo_config != '' }}

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Install artifact manager dependencies
         run: pip install boto3

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
 
       - name: Install artifact manager dependencies
         run: pip install boto3

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
+++ b/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
@@ -68,10 +68,6 @@ on:
         type: boolean
         default: true
         description: "Build PyTorch wheels"
-      ref:
-        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
-        type: string
-        default: ""          
 
 permissions:
   contents: read
@@ -114,6 +110,7 @@ jobs:
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       build_pytorch: ${{ github.event_name != 'workflow_dispatch' || inputs.build_pytorch }}
       build_jax: false
+      ref: ${{ vars.THEROCK_CI_MAIN_REF || '' }}        
 
   linux_build_and_test:
     name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}
@@ -135,6 +132,7 @@ jobs:
       rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
       test_type: 'quick'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      ref: ${{ needs.setup.outputs.ref }}      
     permissions:
       contents: read
       id-token: write
@@ -157,6 +155,7 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: 'quick'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      ref: ${{ needs.setup.outputs.ref }}        
     permissions:
       contents: read
       id-token: write
@@ -172,7 +171,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.setup.outputs.ref }}
       - name: Evaluate workflow results
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
+++ b/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
@@ -110,6 +110,7 @@ jobs:
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       build_pytorch: ${{ github.event_name != 'workflow_dispatch' || inputs.build_pytorch }}
       build_jax: false
+      repository: "ROCm/TheRock"
       ref: ${{ vars.THEROCK_CI_MAIN_REF || '' }}        
 
   linux_build_and_test:
@@ -132,6 +133,7 @@ jobs:
       rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
       test_type: 'quick'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      repository: "ROCm/TheRock"
       ref: ${{ needs.setup.outputs.ref }}      
     permissions:
       contents: read
@@ -155,6 +157,7 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: 'quick'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      repository: "ROCm/TheRock"
       ref: ${{ needs.setup.outputs.ref }}        
     permissions:
       contents: read

--- a/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
+++ b/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
@@ -68,6 +68,10 @@ on:
         type: boolean
         default: true
         description: "Build PyTorch wheels"
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""          
 
 permissions:
   contents: read
@@ -168,7 +172,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
       - name: Evaluate workflow results
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/rockci-windows-debug-support.yml
+++ b/.github/workflows/rockci-windows-debug-support.yml
@@ -77,6 +77,7 @@ jobs:
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       build_pytorch: ${{ github.event_name != 'workflow_dispatch' || inputs.build_pytorch }}
       build_jax: false
+      ref: ${{ vars.THEROCK_CI_MAIN_REF || '' }}        
 
   windows_build_and_test:
     name: Windows::${{ fromJSON(needs.setup.outputs.windows_build_config || '{}').build_variant_label || 'skip' }}
@@ -94,6 +95,7 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: 'quick'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      ref: ${{ needs.setup.outputs.ref }}        
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/rockci-windows-debug-support.yml
+++ b/.github/workflows/rockci-windows-debug-support.yml
@@ -77,6 +77,7 @@ jobs:
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       build_pytorch: ${{ github.event_name != 'workflow_dispatch' || inputs.build_pytorch }}
       build_jax: false
+      repository: "ROCm/TheRock"
       ref: ${{ vars.THEROCK_CI_MAIN_REF || '' }}        
 
   windows_build_and_test:
@@ -95,6 +96,7 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: 'quick'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      repository: "ROCm/TheRock"
       ref: ${{ needs.setup.outputs.ref }}        
     permissions:
       contents: read

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -53,10 +53,6 @@ on:
         type: boolean
         default: true
         description: "Build PyTorch wheels"
-      ref:
-        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
-        type: string
-        default: ""
 
   pull_request:
     branches: [amd-staging]
@@ -107,6 +103,7 @@ jobs:
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       build_pytorch: ${{ github.event_name != 'workflow_dispatch' || inputs.build_pytorch }}
       build_jax: false
+      ref: ${{ vars.THEROCK_CI_MAIN_REF || '' }}
 
   linux_build_and_test:
     name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}
@@ -126,6 +123,7 @@ jobs:
       rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
       test_type: 'quick'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      ref: ${{ needs.setup.outputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -146,6 +144,8 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: 'quick'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      ref: ${{ needs.setup.outputs.ref }}
+      
     permissions:
       contents: read
       id-token: write
@@ -157,6 +157,8 @@ jobs:
     if: ${{ false }} 
     #if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule' }}
     uses: ./.github/workflows/manifest-diff.yml
+    with:
+      ref: ${{ needs.setup.outputs.ref }}      
     permissions:
       contents: read
       id-token: write
@@ -172,7 +174,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.setup.outputs.ref }}
       - name: Evaluate workflow results
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -103,6 +103,7 @@ jobs:
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       build_pytorch: ${{ github.event_name != 'workflow_dispatch' || inputs.build_pytorch }}
       build_jax: false
+      repository: "ROCm/TheRock"
       ref: ${{ vars.THEROCK_CI_MAIN_REF || '' }}
 
   linux_build_and_test:
@@ -123,6 +124,7 @@ jobs:
       rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
       test_type: 'quick'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      repository: "ROCm/TheRock"
       ref: ${{ needs.setup.outputs.ref }}
     permissions:
       contents: read
@@ -144,6 +146,7 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: 'quick'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      repository: "ROCm/TheRock"
       ref: ${{ needs.setup.outputs.ref }}
       
     permissions:

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -53,6 +53,11 @@ on:
         type: boolean
         default: true
         description: "Build PyTorch wheels"
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
+
   pull_request:
     branches: [amd-staging]
     types:
@@ -167,7 +172,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
       - name: Evaluate workflow results
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/rockci_multi_arch_nightly.yml
+++ b/.github/workflows/rockci_multi_arch_nightly.yml
@@ -72,6 +72,7 @@ jobs:
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       build_pytorch: ${{ github.event_name != 'workflow_dispatch' || inputs.build_pytorch }}
       build_jax: false
+      repository: "ROCm/TheRock"
       ref: ${{ vars.THEROCK_CI_MAIN_REF || '' }}        
 
   linux_build_and_test:
@@ -92,6 +93,7 @@ jobs:
       rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
       test_type: 'full'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      repository: "ROCm/TheRock"
       ref: ${{ needs.setup.outputs.ref }}        
     permissions:
       contents: read
@@ -113,6 +115,7 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: 'full'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      repository: "ROCm/TheRock"
       ref: ${{ needs.setup.outputs.ref }}        
     permissions:
       contents: read

--- a/.github/workflows/rockci_multi_arch_nightly.yml
+++ b/.github/workflows/rockci_multi_arch_nightly.yml
@@ -72,6 +72,7 @@ jobs:
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       build_pytorch: ${{ github.event_name != 'workflow_dispatch' || inputs.build_pytorch }}
       build_jax: false
+      ref: ${{ vars.THEROCK_CI_MAIN_REF || '' }}        
 
   linux_build_and_test:
     name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}
@@ -91,6 +92,7 @@ jobs:
       rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
       test_type: 'full'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      ref: ${{ needs.setup.outputs.ref }}        
     permissions:
       contents: read
       id-token: write
@@ -111,6 +113,7 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: 'full'
       changed_projects: ${{ inputs.changed_projects || '' }}
+      ref: ${{ needs.setup.outputs.ref }}        
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -131,7 +131,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
           # We need the parent commit to do a diff
           fetch-depth: 2
 

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -130,8 +130,8 @@ jobs:
         id: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
           # We need the parent commit to do a diff
           fetch-depth: 2
 

--- a/.github/workflows/test_aomp_smoke.yml
+++ b/.github/workflows/test_aomp_smoke.yml
@@ -33,6 +33,10 @@ on:
         description: Total number of AOMP shards
         type: string
         default: "6"
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""          
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
@@ -65,6 +69,10 @@ on:
       total_shards:
         type: string
         default: "6"
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""          
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
@@ -134,8 +142,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
           fetch-depth: 1
 
       - name: Pre-job cleanup Docker containers on Linux

--- a/.github/workflows/test_aomp_smoke.yml
+++ b/.github/workflows/test_aomp_smoke.yml
@@ -32,7 +32,12 @@ on:
       total_shards:
         description: Total number of AOMP shards
         type: string
-        default: "6"          
+        default: "6"
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
+          
   workflow_call:
     inputs:
       artifact_group:
@@ -59,7 +64,12 @@ on:
         type: string
       total_shards:
         type: string
-        default: "6"          
+        default: "6"
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
+          
   push:
     branches:
       - ADHOCBUILD
@@ -125,7 +135,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
           fetch-depth: 1
 
       - name: Pre-job cleanup Docker containers on Linux

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -129,8 +129,8 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
 
       - name: Checkout CI config
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -130,7 +130,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Checkout CI config
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -226,6 +226,8 @@ jobs:
       suite_list: ${{ matrix.suite_list }}
       shard: ${{ matrix.shard }}
       total_shards: "6"
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}        
 
   test_components:
     name: 'Test ${{ matrix.components.job_name }}'

--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Install test requirements
         run: |

--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
 
       - name: Install test requirements
         run: |

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -92,8 +92,8 @@ jobs:
       - name: "Fetch 'build_tools' from repository"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -111,8 +111,8 @@ jobs:
       - name: Checking repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}          
 
       - name: Run setup test environment workflow
         timeout-minutes: 15

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Run setup test environment workflow
         timeout-minutes: 15

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -109,8 +109,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || '' }}
 
       - name: Derive package type, GPU architecture, and container image
         id: derive
@@ -192,8 +192,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: "ROCm/TheRock"
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || '' }}
 
       - name: Setup Python and install runtime
         run: |

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Derive package type, GPU architecture, and container image
         id: derive
@@ -193,7 +193,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Setup Python and install runtime
         run: |

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}          
 
       # actions/setup-python only has prebuilt binaries for Ubuntu
       - name: Set up Python

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: "ROCm/TheRock"
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}          
 
       # actions/setup-python only has prebuilt binaries for Ubuntu

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -18,6 +18,11 @@ on:
         type: string
       platform:
         type: string
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
+          
   workflow_call:
     inputs:
       artifact_group:
@@ -35,6 +40,11 @@ on:
         type: string
       platform:
         type: string
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
+          
   push:
     branches:
       - ADHOCBUILD
@@ -94,7 +104,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "ROCm/TheRock"
-          ref: 'compiler/amd-staging'
+          ref: ${{ inputs.ref }}
 
       - name: Pre-job cleanup Docker containers on Linux
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -18,6 +18,10 @@ on:
         type: string
       platform:
         type: string
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""          
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
@@ -40,6 +44,10 @@ on:
         type: string
       platform:
         type: string
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""          
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
@@ -103,7 +111,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: "ROCm/TheRock"
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
 
       - name: Pre-job cleanup Docker containers on Linux


### PR DESCRIPTION
This PR uses the rockci main ref sha instead of compiler/amd-staging branch using the repo variable THEROCK_CI_MAIN_REF 

Current ref : fc11b46 (Aug 27th)

Verification link : https://github.com/ROCm/llvm-project/actions/runs/33068573859/job/98573539671?pr=3836