### PR TITLE
[AMDGPU][Scheduler] Align schedule revert code with upstream

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -1937,8 +1937,7 @@ void PreRARematStage::finalizeGCNRegion() {
   // target there is no point in trying to re-schedule further regions.
   if (!TargetOcc)
     return;
-  RegionReverts.emplace_back(RegionIdx, Unsched, PressureBefore,
-                             ScheduleReverted);
+  RegionReverts.emplace_back(RegionIdx, Unsched, PressureBefore);
   if (DAG.MinOccupancy < *TargetOcc) {
     REMAT_DEBUG(dbgs() << "Region " << RegionIdx
                        << " cannot meet occupancy target, interrupting "
@@ -1949,7 +1948,6 @@ void PreRARematStage::finalizeGCNRegion() {
 
 void GCNSchedStage::checkScheduling() {
   // Check the results of scheduling.
-  ScheduleReverted = false;
   PressureAfter = DAG.getRealRegPressure(RegionIdx);
 
   LLVM_DEBUG(dbgs() << "Pressure after scheduling: " << print(PressureAfter));
@@ -3205,11 +3203,7 @@ void PreRARematStage::finalizeGCNSchedStage() {
     return;
 
   // Revert re-scheduling in all affected regions.
-  for (const auto &[RegionIdx, OrigMIOrder, MaxPressure, AlreadyReverted] :
-       RegionReverts) {
-    DAG.Pressure[RegionIdx] = MaxPressure;
-    if (AlreadyReverted)
-      continue;
+  for (const auto &[RegionIdx, OrigMIOrder, MaxPressure] : RegionReverts) {
     REMAT_DEBUG(dbgs() << "Reverting re-scheduling in region " << RegionIdx
                        << '\n');
     DAG.Pressure[RegionIdx] = MaxPressure;

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -368,9 +368,6 @@ protected:
   // RP after scheduling the current region.
   GCNRegPressure PressureAfter;
 
-  // Whether checkScheduling reverted the schedule for the current region.
-  bool ScheduleReverted = false;
-
   std::vector<std::unique_ptr<ScheduleDAGMutation>> SavedMutations;
 
   GCNSchedStage(GCNSchedStageID StageID, GCNScheduleDAGMILive &DAG);
@@ -720,14 +717,11 @@ private:
     std::vector<MachineInstr *> OrigMIOrder;
     /// Maximum pressure recorded in the region.
     GCNRegPressure MaxPressure;
-    /// Whether the region was already reverted by per-region checkScheduling.
-    bool AlreadyReverted = false;
 
     RegionSchedRevert(unsigned RegionIdx, ArrayRef<MachineInstr *> OrigMIOrder,
-                      const GCNRegPressure &MaxPressure,
-                      bool AlreadyReverted = false)
+                      const GCNRegPressure &MaxPressure)
         : RegionIdx(RegionIdx), OrigMIOrder(OrigMIOrder),
-          MaxPressure(MaxPressure), AlreadyReverted(AlreadyReverted) {}
+          MaxPressure(MaxPressure) {}
   };
   /// After re-scheduling, contains pre-re-scheduling data for all re-scheduled
   /// regions.


### PR DESCRIPTION
The double-revert avoidance from a0ad28f531dc did not go upstream in PR #192039. Remove ScheduleReverted and RegionSchedRevert::AlreadyReverted so that the code matches upstream.

Assisted-by: Claude Opus


