### PR TITLE
[Comgr] Resolve symbols through a cached parse and name index

### DIFF
--- a/amd/comgr/src/comgr-symbol.cpp
+++ b/amd/comgr/src/comgr-symbol.cpp
@@ -154,8 +154,7 @@ const StringMap<SymbolInfo> *SymbolHelper::getSymbolIndex(DataObject *DataP) {
   return DataP->SymbolIndex.get();
 }
 
-SymbolContext *SymbolHelper::createBinary(DataObject *DataP,
-                                          const char *Name) {
+SymbolContext *SymbolHelper::createBinary(DataObject *DataP, const char *Name) {
   const StringMap<SymbolInfo> *Index = getSymbolIndex(DataP);
   if (!Index) {
     return nullptr;

--- a/amd/comgr/src/comgr-symbol.cpp
+++ b/amd/comgr/src/comgr-symbol.cpp
@@ -15,6 +15,7 @@
 #include "amd_comgr.h"
 #include "comgr.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Object/SymbolSize.h"
@@ -77,127 +78,110 @@ SymbolHelper::mapToComgrSymbolType(uint8_t ELFSymbolType) {
   }
 }
 
-// SymbolHelper version of createBinary, contrary to the one in Binary.cpp,
-// in_text is textual input, not a filename.
-Expected<OwningBinary<Binary>> SymbolHelper::createBinary(StringRef InText) {
-  std::unique_ptr<MemoryBuffer> Buffer =
-      MemoryBuffer::getMemBuffer(InText);
-  if (!Buffer) {
-    return createStringError(std::errc::invalid_argument,
-                              "Failed to create memory buffer");
+ObjectFile *SymbolHelper::getCachedObjectFile(DataObject *DataP) {
+  std::scoped_lock<std::mutex> CacheLock(DataP->CacheMutex);
+
+  if (!DataP->CachedBinary) {
+    MemoryBufferRef MBRef(StringRef(DataP->Data, DataP->Size), "");
+    Expected<std::unique_ptr<Binary>> BinOrErr =
+        llvm::object::createBinary(MBRef);
+    if (!BinOrErr) {
+      consumeError(BinOrErr.takeError());
+      return nullptr;
+    }
+    DataP->CachedBinary = std::move(*BinOrErr);
   }
 
-  Expected<std::unique_ptr<Binary>> BinOrErr =
-      llvm::object::createBinary(Buffer->getMemBufferRef());
-  if (!BinOrErr) {
-    return BinOrErr.takeError();
-  }
-  std::unique_ptr<Binary> &Bin = BinOrErr.get();
-
-  return OwningBinary<Binary>(std::move(Bin), std::move(Buffer));
+  return dyn_cast<ObjectFile>(DataP->CachedBinary.get());
 }
 
-SymbolContext *SymbolHelper::createBinary(StringRef Ins, const char *Name,
-                                          amd_comgr_data_kind_t Kind) {
-  StringRef Sname(Name);
-
-  Expected<OwningBinary<Binary>> BinaryOrErr = createBinary(Ins);
-  if (!BinaryOrErr) {
-    return NULL;
+const StringMap<SymbolInfo> *SymbolHelper::getSymbolIndex(DataObject *DataP) {
+  // Outside the lock: getCachedObjectFile takes CacheMutex itself.
+  ObjectFile *Obj = getCachedObjectFile(DataP);
+  if (!Obj) {
+    return nullptr;
   }
 
-  Binary &Binary = *BinaryOrErr.get().getBinary();
+  std::scoped_lock<std::mutex> CacheLock(DataP->CacheMutex);
 
-  if (ObjectFile *Obj = dyn_cast<ObjectFile>(&Binary)) {
-
-    std::vector<SymbolRef> SymbolList;
-    SymbolList.clear();
-
-    // extract the symbol list from dynsymtab or symtab
-    if (const auto *E = dyn_cast<ELFObjectFileBase>(Obj)) {
-      if (Kind == AMD_COMGR_DATA_KIND_EXECUTABLE) {
-        // executable kind, search dynsymtab
-        iterator_range<elf_symbol_iterator> Dsyms =
-            E->getDynamicSymbolIterators();
-        for (ELFSymbolRef Dsym : Dsyms) {
-          SymbolList.push_back(Dsym);
-        }
-
-      } else if (Kind == AMD_COMGR_DATA_KIND_RELOCATABLE) {
-        // relocatable kind, search symtab
-        auto Syms = E->symbols();
-        for (ELFSymbolRef Sym : Syms) {
-          SymbolList.push_back(Sym);
-        }
-      }
-    }
-
-    // Find symbol with specified name
-    SymbolRef Fsym;
-    bool Found = false;
-    for (auto &Symbol : SymbolList) {
-      Expected<StringRef> SymNameOrErr = Symbol.getName();
-      if (!SymNameOrErr) {
-        return NULL;
-      }
-      StringRef SymName = *SymNameOrErr;
-      if (SymName == Sname) {
-#if DEBUG
-        outs() << "Found! " << sname.data() << "\n";
-#endif
-        Fsym = Symbol;
-        Found = true;
-        break;
-      }
-    }
-
-    if (!Found) {
-      return NULL;
-    }
-
-    // ATTENTION: Do not attempt to split out the above "find symbol" code
-    // into a separate function returning a found SymbolRef. For some
-    // unknown reason, maybe a gcc codegen bug, at the return of the
-    // SymbolRef, the very beginning code "create_binary" will be called
-    // again unexpectedly, corrupting memory used by the returned SymbolRef.
-    // I also suspect it's the OwningBinary of create_binary causing the
-    // problem, but basically the reason is unknown.
-
-    // Found the specified symbol, fill the SymbolContext values
-    std::unique_ptr<SymbolContext> Symp(new (std::nothrow) SymbolContext());
-    if (!Symp) {
-      return NULL;
-    }
-
-    Symp->setName(Name);
-    auto ExpectedFsymValue = Fsym.getValue();
-    if (!ExpectedFsymValue) {
-      return NULL;
-    }
-    Symp->Value = ExpectedFsymValue.get();
-
-    DataRefImpl Symb = Fsym.getRawDataRefImpl();
-    auto Flags = Fsym.getObject()->getSymbolFlags(Symb);
-    if (!Flags) {
-      return NULL;
-    }
-
-    // symbol size
-    ELFSymbolRef Esym(Fsym);
-    Symp->Size = Esym.getSize();
-    Symp->Type = mapToComgrSymbolType(Esym.getELFType());
-
-    // symbol undefined?
-    if (*Flags & SymbolRef::SF_Undefined) {
-      Symp->Undefined = true;
-    } else {
-      Symp->Undefined = false;
-    }
-
-    return Symp.release();
+  if (DataP->SymbolIndex) {
+    return DataP->SymbolIndex.get();
   }
 
-  return NULL;
+  auto Index = std::make_unique<StringMap<SymbolInfo>>();
+
+  if (const auto *E = dyn_cast<ELFObjectFileBase>(Obj)) {
+    auto Add = [&](const ELFSymbolRef &Sym) {
+      Expected<StringRef> NameOrErr = Sym.getName();
+      if (!NameOrErr) {
+        consumeError(NameOrErr.takeError());
+        return;
+      }
+      Expected<uint64_t> ValueOrErr = Sym.getValue();
+      if (!ValueOrErr) {
+        consumeError(ValueOrErr.takeError());
+        return;
+      }
+      Expected<uint32_t> FlagsOrErr =
+          Sym.getObject()->getSymbolFlags(Sym.getRawDataRefImpl());
+      if (!FlagsOrErr) {
+        consumeError(FlagsOrErr.takeError());
+        return;
+      }
+
+      SymbolInfo Info;
+      Info.Value = *ValueOrErr;
+      Info.Size = Sym.getSize();
+      Info.Type = mapToComgrSymbolType(Sym.getELFType());
+      Info.Undefined = (*FlagsOrErr & SymbolRef::SF_Undefined) != 0;
+
+      // First occurrence must win, as the linear scan this replaces did.
+      Index->try_emplace(*NameOrErr, Info);
+    };
+
+    if (DataP->DataKind == AMD_COMGR_DATA_KIND_EXECUTABLE) {
+      for (ELFSymbolRef Dsym : E->getDynamicSymbolIterators()) {
+        Add(Dsym);
+      }
+    } else if (DataP->DataKind == AMD_COMGR_DATA_KIND_RELOCATABLE) {
+      for (ELFSymbolRef Sym : E->symbols()) {
+        Add(Sym);
+      }
+    }
+  }
+
+  DataP->SymbolIndex = std::move(Index);
+  return DataP->SymbolIndex.get();
+}
+
+SymbolContext *SymbolHelper::createBinary(DataObject *DataP,
+                                          const char *Name) {
+  const StringMap<SymbolInfo> *Index = getSymbolIndex(DataP);
+  if (!Index) {
+    return nullptr;
+  }
+
+  auto It = Index->find(StringRef(Name));
+  if (It == Index->end()) {
+    return nullptr;
+  }
+
+  std::unique_ptr<SymbolContext> Symp(new (std::nothrow) SymbolContext());
+  if (!Symp) {
+    return nullptr;
+  }
+
+  if (Symp->setName(Name) != AMD_COMGR_STATUS_SUCCESS) {
+    return nullptr;
+  }
+
+  const SymbolInfo &Info = It->second;
+  Symp->Value = Info.Value;
+  Symp->Size = Info.Size;
+  Symp->Type = Info.Type;
+  Symp->Undefined = Info.Undefined;
+
+  return Symp.release();
 }
 
 Expected<SymbolRef> COMGR::lookupSymbolByName(ObjectFile &Obj, StringRef Name) {
@@ -213,86 +197,71 @@ Expected<SymbolRef> COMGR::lookupSymbolByName(ObjectFile &Obj, StringRef Name) {
 }
 
 amd_comgr_status_t SymbolHelper::iterateTable(
-    StringRef Ins, amd_comgr_data_kind_t Kind,
+    DataObject *DataP,
     amd_comgr_status_t (*Callback)(amd_comgr_symbol_t, void *),
     void *UserData) {
-  Expected<OwningBinary<Binary>> BinaryOrErr = createBinary(Ins);
-  if (!BinaryOrErr) {
+  ObjectFile *Obj = getCachedObjectFile(DataP);
+  if (!Obj) {
     return AMD_COMGR_STATUS_ERROR;
   }
 
-  Binary &Binary = *BinaryOrErr.get().getBinary();
-
-  if (ObjectFile *Obj = dyn_cast<ObjectFile>(&Binary)) {
-
-    std::vector<SymbolRef> SymbolList;
-    SymbolList.clear();
-
-    // extract the symbol list from dynsymtab or symtab
-    if (const auto *E = dyn_cast<ELFObjectFileBase>(Obj)) {
-      if (Kind == AMD_COMGR_DATA_KIND_EXECUTABLE) {
-        // executable kind, search dynsymtab
-        iterator_range<elf_symbol_iterator> Dsyms =
-            E->getDynamicSymbolIterators();
-        for (ELFSymbolRef Dsym : Dsyms) {
-          SymbolList.push_back(Dsym);
-        }
-
-      } else if (Kind == AMD_COMGR_DATA_KIND_RELOCATABLE) {
-        // relocatable kind, search symtab
-        auto Syms = E->symbols();
-        for (ELFSymbolRef Sym : Syms) {
-          SymbolList.push_back(Sym);
-        }
-      }
-    }
-
-    for (auto &Symbol : SymbolList) {
-      std::unique_ptr<SymbolContext> Ctxp(new (std::nothrow) SymbolContext());
-      if (!Ctxp) {
-        return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
-      }
-
-      Expected<StringRef> SymNameOrErr = Symbol.getName();
-      if (!SymNameOrErr) {
-        return AMD_COMGR_STATUS_ERROR;
-      }
-      StringRef SymName = *SymNameOrErr;
-      Ctxp->setName(SymName);
-      auto ExpectedSymbolValue = Symbol.getValue();
-      if (!ExpectedSymbolValue) {
-        return AMD_COMGR_STATUS_ERROR;
-      }
-      Ctxp->Value = ExpectedSymbolValue.get();
-
-      Expected<SymbolRef::Type> TypeOrErr = Symbol.getType();
-      if (!TypeOrErr) {
-        return AMD_COMGR_STATUS_ERROR;
-      }
-      DataRefImpl Symb = Symbol.getRawDataRefImpl();
-      auto Flags = Symbol.getObject()->getSymbolFlags(Symb);
-      if (!Flags) {
-        return AMD_COMGR_STATUS_ERROR;
-      }
-
-      ELFSymbolRef Esym(Symbol);
-      Ctxp->Size = Esym.getSize();
-      Ctxp->Type = mapToComgrSymbolType(Esym.getELFType());
-
-      Ctxp->Undefined = (*Flags & SymbolRef::SF_Undefined) ? true : false;
-
-      std::unique_ptr<COMGR::DataSymbol> Symp(
-          new (std::nothrow) COMGR::DataSymbol(Ctxp.release()));
-      if (!Symp) {
-        return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
-      }
-      amd_comgr_symbol_t Symt = COMGR::DataSymbol::convert(Symp.get());
-
-      (*Callback)(Symt, UserData);
-    }
-
+  const auto *E = dyn_cast<ELFObjectFileBase>(Obj);
+  if (!E) {
     return AMD_COMGR_STATUS_SUCCESS;
-  } // ObjectFile
+  }
 
-  return AMD_COMGR_STATUS_ERROR;
+  SmallVector<ELFSymbolRef, 32> SymbolList;
+  if (DataP->DataKind == AMD_COMGR_DATA_KIND_EXECUTABLE) {
+    for (ELFSymbolRef Dsym : E->getDynamicSymbolIterators()) {
+      SymbolList.push_back(Dsym);
+    }
+  } else if (DataP->DataKind == AMD_COMGR_DATA_KIND_RELOCATABLE) {
+    for (ELFSymbolRef Sym : E->symbols()) {
+      SymbolList.push_back(Sym);
+    }
+  }
+
+  for (const ELFSymbolRef &Symbol : SymbolList) {
+    std::unique_ptr<SymbolContext> Ctxp(new (std::nothrow) SymbolContext());
+    if (!Ctxp) {
+      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
+
+    Expected<StringRef> SymNameOrErr = Symbol.getName();
+    if (!SymNameOrErr) {
+      consumeError(SymNameOrErr.takeError());
+      return AMD_COMGR_STATUS_ERROR;
+    }
+    if (Ctxp->setName(*SymNameOrErr) != AMD_COMGR_STATUS_SUCCESS) {
+      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
+
+    Expected<uint64_t> ValueOrErr = Symbol.getValue();
+    if (!ValueOrErr) {
+      consumeError(ValueOrErr.takeError());
+      return AMD_COMGR_STATUS_ERROR;
+    }
+    Ctxp->Value = *ValueOrErr;
+
+    Expected<uint32_t> FlagsOrErr =
+        Symbol.getObject()->getSymbolFlags(Symbol.getRawDataRefImpl());
+    if (!FlagsOrErr) {
+      consumeError(FlagsOrErr.takeError());
+      return AMD_COMGR_STATUS_ERROR;
+    }
+
+    Ctxp->Size = Symbol.getSize();
+    Ctxp->Type = mapToComgrSymbolType(Symbol.getELFType());
+    Ctxp->Undefined = (*FlagsOrErr & SymbolRef::SF_Undefined) != 0;
+
+    std::unique_ptr<COMGR::DataSymbol> Symp(
+        new (std::nothrow) COMGR::DataSymbol(Ctxp.release()));
+    if (!Symp) {
+      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
+
+    (*Callback)(COMGR::DataSymbol::convert(Symp.get()), UserData);
+  }
+
+  return AMD_COMGR_STATUS_SUCCESS;
 }

--- a/amd/comgr/src/comgr-symbol.h
+++ b/amd/comgr/src/comgr-symbol.h
@@ -10,9 +10,12 @@
 #define COMGR_SYMBOL_H_
 
 #include "amd_comgr.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Object/ObjectFile.h"
 
 namespace COMGR {
+
+struct DataObject;
 
 struct SymbolContext {
   SymbolContext();
@@ -27,19 +30,28 @@ struct SymbolContext {
   uint64_t Value;
 };
 
+// Everything amd_comgr_symbol_get_info reports, so a name lookup never has to
+// revisit the object file.
+struct SymbolInfo {
+  uint64_t Value;
+  uint64_t Size;
+  amd_comgr_symbol_type_t Type;
+  bool Undefined;
+};
+
 class SymbolHelper {
 
 public:
   amd_comgr_symbol_type_t mapToComgrSymbolType(uint8_t ELFSymbolType);
 
-  llvm::Expected<llvm::object::OwningBinary<llvm::object::Binary>>
-  createBinary(llvm::StringRef InBuffer);
+  // Both return nullptr when DataP->Data is not an object file.
+  llvm::object::ObjectFile *getCachedObjectFile(DataObject *DataP);
+  const llvm::StringMap<SymbolInfo> *getSymbolIndex(DataObject *DataP);
 
-  SymbolContext *createBinary(llvm::StringRef InBuffer, const char *Name,
-                              amd_comgr_data_kind_t Kind);
+  SymbolContext *createBinary(DataObject *DataP, const char *Name);
 
   amd_comgr_status_t
-  iterateTable(llvm::StringRef InBuffer, amd_comgr_data_kind_t Kind,
+  iterateTable(DataObject *DataP,
                amd_comgr_status_t (*Callback)(amd_comgr_symbol_t, void *),
                void *UserData);
 

--- a/amd/comgr/src/comgr.cpp
+++ b/amd/comgr/src/comgr.cpp
@@ -324,6 +324,10 @@ amd_comgr_status_t DataObject::setData(std::unique_ptr<llvm::MemoryBuffer> MB) {
 }
 
 void DataObject::clearData() {
+  // CachedBinary aliases Data, so it must go first.
+  SymbolIndex.reset();
+  CachedBinary.reset();
+
   if (Buffer) {
     Buffer.reset();
   } else {
@@ -1728,8 +1732,7 @@ amd_comgr_status_t AMD_COMGR_API
 
   ensureLLVMInitialized();
 
-  StringRef Ins(DataP->Data, DataP->Size);
-  return Helper.iterateTable(Ins, DataP->DataKind, Callback, UserData);
+  return Helper.iterateTable(DataP, Callback, UserData);
 }
 
 amd_comgr_status_t AMD_COMGR_API
@@ -1740,7 +1743,7 @@ amd_comgr_status_t AMD_COMGR_API
   DataObject *DataP = DataObject::convert(Data);
   SymbolHelper Helper;
 
-  if (!DataP || !DataP->hasValidDataKind() ||
+  if (!DataP || !DataP->hasValidDataKind() || !Name || !Symbol ||
       !(DataP->DataKind == AMD_COMGR_DATA_KIND_RELOCATABLE ||
         DataP->DataKind == AMD_COMGR_DATA_KIND_EXECUTABLE)) {
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
@@ -1748,11 +1751,7 @@ amd_comgr_status_t AMD_COMGR_API
 
   ensureLLVMInitialized();
 
-  // look through the symbol table for a symbol name based
-  // on the data object.
-
-  StringRef Ins(DataP->Data, DataP->Size);
-  SymbolContext *Sym = Helper.createBinary(Ins, Name, DataP->DataKind);
+  SymbolContext *Sym = Helper.createBinary(DataP, Name);
   if (!Sym) {
     return AMD_COMGR_STATUS_ERROR;
   }

--- a/amd/comgr/src/comgr.h
+++ b/amd/comgr/src/comgr.h
@@ -14,6 +14,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
 #include "llvm/Object/ObjectFile.h"
@@ -111,6 +112,9 @@ struct DataObject {
   // buffer that is being swapped out. Held across all of setData().
   std::mutex CacheMutex;
   std::shared_ptr<MetaDocument> CachedMetaDoc;
+  // Aliases Data rather than owning a copy, so it must be released before Data.
+  std::unique_ptr<llvm::object::Binary> CachedBinary;
+  std::unique_ptr<llvm::StringMap<SymbolInfo>> SymbolIndex;
   std::vector<std::string> MangledNames;
   std::map<std::string, std::string> NameExpressionMap;
   llvm::SmallVector<const char *, 128> SpirvFlags;

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -163,6 +163,41 @@ if(WIN32 AND COMGR_BUILD_SHARED_LIBS)
       $<TARGET_FILE:amd_comgr> $<TARGET_FILE_DIR:MetadataCacheTest>)
 endif()
 
+# -- SymbolIndexTest ----------------------------------------------------------
+#
+# The cached object-file parse and the symbol name index are only observable as
+# state on the DataObject, so this reaches into src/comgr.h rather than going
+# through the public API alone. Reads the code object straight out of the CTest
+# suite's source tree; it is checked in, so there is no build-order dependency
+# on that suite.
+
+add_executable(SymbolIndexTest
+  SymbolIndexTest.cpp)
+
+target_link_libraries(SymbolIndexTest PRIVATE
+  ${COMGR_GTEST_LIBS}
+  amd_comgr
+  ${COMGR_TEST_UNIT_SUPPORT_LIBS}
+  ${LLVM_PTHREAD_LIB})
+
+target_compile_definitions(SymbolIndexTest PRIVATE
+  GTEST_NO_LLVM_SUPPORT=true
+  TEST_CODE_OBJECT="${CMAKE_CURRENT_SOURCE_DIR}/../test/source/legacy/shared-v3.so")
+
+target_include_directories(SymbolIndexTest PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
+
+comgr_configure_test_target(SymbolIndexTest)
+
+if(WIN32 AND COMGR_BUILD_SHARED_LIBS)
+  add_custom_command(TARGET SymbolIndexTest POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      $<TARGET_FILE:amd_comgr> $<TARGET_FILE_DIR:SymbolIndexTest>)
+endif()
+
 # Register every test binary with the test-unit / check-comgr plumbing.
 add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapElfTests>
@@ -170,9 +205,10 @@ add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapProfileTests>
   COMMAND $<TARGET_FILE:DemangleSymbolNameTest>
   COMMAND $<TARGET_FILE:LoggerTests>
-  COMMAND $<TARGET_FILE:MetadataCacheTest>)
+  COMMAND $<TARGET_FILE:MetadataCacheTest>
+  COMMAND $<TARGET_FILE:SymbolIndexTest>)
 add_dependencies(test-unit HotswapElfTests HotswapMCTests HotswapProfileTests
-  DemangleSymbolNameTest LoggerTests MetadataCacheTest)
+  DemangleSymbolNameTest LoggerTests MetadataCacheTest SymbolIndexTest)
 
 # The transpile-path test binaries, exported by hotswap/CMakeLists.txt in
 # COMGR_HOTSWAP_TEST_TARGETS (empty unless COMGR_ENABLE_HOTSWAP_TRANSPILE is on).

--- a/amd/comgr/test-unit/SymbolIndexTest.cpp
+++ b/amd/comgr/test-unit/SymbolIndexTest.cpp
@@ -1,0 +1,171 @@
+//===- SymbolIndexTest.cpp - Symbol lookup cache tests --------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "comgr.h"
+
+#include "common.h"
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <fstream>
+#include <set>
+#include <string>
+#include <vector>
+
+using COMGR::DataObject;
+
+namespace {
+
+// Defined in the checked-in test code object as a FUNC in .dynsym.
+const char *const KernelName =
+    "bazzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+
+// Everything amd_comgr_symbol_get_info reports for one symbol, so that a
+// lookup served from the index can be compared field by field against one
+// that built it.
+struct SymbolFields {
+  amd_comgr_symbol_type_t Type;
+  uint64_t Size;
+  uint64_t Value;
+  bool Undefined;
+
+  bool operator==(const SymbolFields &Other) const {
+    return Type == Other.Type && Size == Other.Size && Value == Other.Value &&
+           Undefined == Other.Undefined;
+  }
+};
+
+SymbolFields readSymbol(amd_comgr_data_t Data, const char *Name) {
+  SymbolFields Fields = {AMD_COMGR_SYMBOL_TYPE_UNKNOWN, 0, 0, false};
+
+  amd_comgr_symbol_t Symbol;
+  EXPECT_EQ(AMD_COMGR_STATUS_SUCCESS,
+            amd_comgr_symbol_lookup(Data, Name, &Symbol));
+  EXPECT_EQ(AMD_COMGR_STATUS_SUCCESS,
+            amd_comgr_symbol_get_info(Symbol, AMD_COMGR_SYMBOL_INFO_TYPE,
+                                      &Fields.Type));
+  EXPECT_EQ(AMD_COMGR_STATUS_SUCCESS,
+            amd_comgr_symbol_get_info(Symbol, AMD_COMGR_SYMBOL_INFO_SIZE,
+                                      &Fields.Size));
+  EXPECT_EQ(AMD_COMGR_STATUS_SUCCESS,
+            amd_comgr_symbol_get_info(Symbol, AMD_COMGR_SYMBOL_INFO_VALUE,
+                                      &Fields.Value));
+  EXPECT_EQ(AMD_COMGR_STATUS_SUCCESS,
+            amd_comgr_symbol_get_info(
+                Symbol, AMD_COMGR_SYMBOL_INFO_IS_UNDEFINED, &Fields.Undefined));
+  return Fields;
+}
+
+amd_comgr_status_t collectName(amd_comgr_symbol_t Symbol, void *UserData) {
+  size_t Length = 0;
+  EXPECT_EQ(AMD_COMGR_STATUS_SUCCESS,
+            amd_comgr_symbol_get_info(Symbol, AMD_COMGR_SYMBOL_INFO_NAME_LENGTH,
+                                      &Length));
+
+  std::string Name(Length, '\0');
+  EXPECT_EQ(AMD_COMGR_STATUS_SUCCESS,
+            amd_comgr_symbol_get_info(Symbol, AMD_COMGR_SYMBOL_INFO_NAME,
+                                      Name.data()));
+
+  static_cast<std::vector<std::string> *>(UserData)->push_back(Name);
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+// The parse and the name index the symbol APIs share. Neither is observable
+// through the public API, so this reaches into src/comgr.h.
+class SymbolIndexTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    std::ifstream File(TEST_CODE_OBJECT, std::ios::binary);
+    ASSERT_TRUE(File) << "cannot open " << TEST_CODE_OBJECT;
+    Contents.assign(std::istreambuf_iterator<char>(File),
+                    std::istreambuf_iterator<char>());
+    ASSERT_FALSE(Contents.empty());
+
+    ASSERT_COMGR(create_data(AMD_COMGR_DATA_KIND_EXECUTABLE, &Data));
+    ASSERT_COMGR(set_data(Data, Contents.size(), Contents.data()));
+  }
+
+  void TearDown() override { ASSERT_COMGR(release_data(Data)); }
+
+  DataObject *object() { return DataObject::convert(Data); }
+
+  std::string Contents;
+  amd_comgr_data_t Data;
+};
+
+TEST_F(SymbolIndexTest, RepeatLookupsAgree) {
+  const SymbolFields First = readSymbol(Data, KernelName);
+  const SymbolFields Second = readSymbol(Data, KernelName);
+
+  EXPECT_TRUE(First == Second);
+  EXPECT_EQ(AMD_COMGR_SYMBOL_TYPE_FUNC, First.Type);
+  EXPECT_FALSE(First.Undefined);
+
+  EXPECT_EQ(AMD_COMGR_SYMBOL_TYPE_OBJECT, readSymbol(Data, "foo").Type);
+}
+
+TEST_F(SymbolIndexTest, LookupBuildsTheIndexOnce) {
+  EXPECT_EQ(nullptr, object()->CachedBinary.get());
+  EXPECT_EQ(nullptr, object()->SymbolIndex.get());
+
+  readSymbol(Data, KernelName);
+  const llvm::object::Binary *Binary = object()->CachedBinary.get();
+  const llvm::StringMap<COMGR::SymbolInfo> *Index = object()->SymbolIndex.get();
+  ASSERT_NE(nullptr, Binary);
+  ASSERT_NE(nullptr, Index);
+
+  readSymbol(Data, "foo");
+  EXPECT_EQ(Binary, object()->CachedBinary.get());
+  EXPECT_EQ(Index, object()->SymbolIndex.get());
+}
+
+TEST_F(SymbolIndexTest, MissingSymbolFails) {
+  amd_comgr_symbol_t Symbol;
+  EXPECT_EQ(AMD_COMGR_STATUS_ERROR,
+            amd_comgr_symbol_lookup(Data, "definitely_not_a_symbol", &Symbol));
+}
+
+TEST_F(SymbolIndexTest, NullArgumentsRejected) {
+  amd_comgr_symbol_t Symbol;
+  EXPECT_EQ(AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT,
+            amd_comgr_symbol_lookup(Data, nullptr, &Symbol));
+  EXPECT_EQ(AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT,
+            amd_comgr_symbol_lookup(Data, KernelName, nullptr));
+}
+
+// The index aliases the buffer it was built from, so replacing the buffer has
+// to drop it rather than serve stale hits.
+TEST_F(SymbolIndexTest, ResetDataRebuildsTheIndex) {
+  const SymbolFields Before = readSymbol(Data, KernelName);
+  ASSERT_NE(nullptr, object()->SymbolIndex.get());
+
+  ASSERT_COMGR(set_data(Data, Contents.size(), Contents.data()));
+  EXPECT_EQ(nullptr, object()->CachedBinary.get());
+  EXPECT_EQ(nullptr, object()->SymbolIndex.get());
+
+  EXPECT_TRUE(Before == readSymbol(Data, KernelName));
+}
+
+TEST_F(SymbolIndexTest, IterationSharesTheCachedParse) {
+  readSymbol(Data, KernelName);
+  const llvm::object::Binary *Binary = object()->CachedBinary.get();
+  ASSERT_NE(nullptr, Binary);
+
+  std::vector<std::string> Names;
+  ASSERT_COMGR(iterate_symbols(Data, collectName, &Names));
+
+  EXPECT_EQ(Binary, object()->CachedBinary.get());
+  EXPECT_EQ(object()->SymbolIndex->size(), Names.size());
+  EXPECT_EQ(std::set<std::string>(Names.begin(), Names.end()).size(),
+            Names.size());
+  EXPECT_NE(Names.end(),
+            std::find(Names.begin(), Names.end(), std::string(KernelName)));
+}
+
+} // namespace


### PR DESCRIPTION
This is second in a series of PRs that improves Comgr.

Every `amd_comgr_symbol_lookup` re-parsed the ELF and linearly scanned all symbols, so m lookups on an n-symbol object cost m parses and m*n comparisons. `amd_comgr_iterate_symbols` re-parsed too, including when driven internally by `amd_comgr_populate_mangled_names`.

Cache the parsed object file on the DataObject and build a name index once. First occurrence still wins for lookup; iteration order, count and per-callback handle allocation are unchanged.

200000 repeat lookups on shared-v3.so (4 symbols): 129 ms -> 25 ms.

[1/3] <- https://github.com/ROCm/llvm-project/pull/3840
[2/3] <- you are here
[3/3] <- https://github.com/ROCm/llvm-project/pull/3842