### PR TITLE
[Comgr] Materialize header inputs in the VFS instead of on disk

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1602,8 +1602,8 @@ amd_comgr_status_t AMDGPUCompiler::outputResource(llvm::StringRef Path,
   return AMD_COMGR_STATUS_SUCCESS;
 }
 
-amd_comgr_status_t
-AMDGPUCompiler::materializeHeaderFile(DataObject *Object, StringRef Path) {
+amd_comgr_status_t AMDGPUCompiler::materializeHeaderFile(DataObject *Object,
+                                                         StringRef Path) {
   return outputResource(Path, StringRef(Object->Data, Object->Size));
 }
 

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -548,14 +548,16 @@ bool executeAssembler(AssemblerInvocation &Opts, DiagnosticsEngine &Diags,
 SmallString<128> getFilePath(DataObject *Object, StringRef Dir) {
   SmallString<128> Path(Dir);
   path::append(Path, Object->Name);
+  return Path;
+}
 
-  // Create directories specified in the File Path so that the in-process driver
-  // can successfully execute clang commands that use this file path as an
-  // output argument
+// Also creates the parent directory, which only paths the in-process driver
+// writes itself need; outputToFile creates its own.
+SmallString<128> getOutputFilePath(DataObject *Object, StringRef Dir) {
+  SmallString<128> Path = getFilePath(Object, Dir);
   if (fs::create_directories(path::parent_path(Path))) {
     return SmallString<128>();
   }
-
   return Path;
 }
 
@@ -570,8 +572,7 @@ amd_comgr_status_t inputFromFile(DataObject *Object, StringRef Path) {
   if (std::error_code EC = BufOrError.getError()) {
     return AMD_COMGR_STATUS_ERROR;
   }
-  Object->setData(BufOrError.get()->getBuffer());
-  return AMD_COMGR_STATUS_SUCCESS;
+  return Object->setData(std::move(*BufOrError));
 }
 
 amd_comgr_status_t outputToFile(StringRef Data, StringRef Path) {
@@ -1394,7 +1395,7 @@ AMDGPUCompiler::processFiles(amd_comgr_data_kind_t OutputKind,
       continue;
     }
     auto IncludeFilePath = getFilePath(Input, IncludeDir);
-    if (auto Status = outputToFile(Input, IncludeFilePath)) {
+    if (auto Status = materializeHeaderFile(Input, IncludeFilePath)) {
       return Status;
     }
   }
@@ -1426,7 +1427,7 @@ AMDGPUCompiler::processFiles(amd_comgr_data_kind_t OutputKind,
     sys::path::replace_extension(OutputName, OutputSuffix);
     Output->setName(OutputName);
 
-    auto OutputFilePath = getFilePath(Output, OutputDir);
+    auto OutputFilePath = getOutputFilePath(Output, OutputDir);
 
     if (auto Status =
             processFile(Input, InputFilePath.c_str(), OutputFilePath.c_str())) {
@@ -1456,7 +1457,7 @@ amd_comgr_status_t AMDGPUCompiler::addIncludeFlags() {
     SmallString<128> OpenCLCBasePath = IncludeDir;
     sys::path::append(OpenCLCBasePath, "opencl-c-base.h");
     if (auto Status =
-            outputToFile(getOpenCLCBaseHeaderContents(), OpenCLCBasePath)) {
+            outputResource(OpenCLCBasePath, getOpenCLCBaseHeaderContents())) {
       return Status;
     }
     Args.push_back("-include");
@@ -1483,7 +1484,7 @@ amd_comgr_status_t AMDGPUCompiler::addIncludeFlags() {
     }
     PrecompiledHeaders.push_back(getFilePath(Input, IncludeDir));
     auto &PrecompiledHeaderPath = PrecompiledHeaders.back();
-    if (auto Status = outputToFile(Input, PrecompiledHeaderPath)) {
+    if (auto Status = materializeHeaderFile(Input, PrecompiledHeaderPath)) {
       return Status;
     }
     Args.push_back("-include-pch");
@@ -1584,8 +1585,12 @@ amd_comgr_status_t AMDGPUCompiler::outputResource(llvm::StringRef Path,
   // TODO: We should abstract the logic of deciding whether to use the VFS
   // or the real file system within inputFromFile and outputToFile.
   if (UseVFS) {
-    if (!InMemoryFS->addFile(Path, /* ModificationTime */ 0,
-                             llvm::MemoryBuffer::getMemBuffer(FileContent))) {
+    // Not null-terminated: set_data_from_file_slice hands us a raw mapping.
+    if (!InMemoryFS->addFile(
+            Path, /* ModificationTime */ 0,
+            llvm::MemoryBuffer::getMemBuffer(FileContent, Path,
+                                             /* RequiresNullTerminator */
+                                             false))) {
       return AMD_COMGR_STATUS_ERROR;
     }
   } else {
@@ -1595,6 +1600,11 @@ amd_comgr_status_t AMDGPUCompiler::outputResource(llvm::StringRef Path,
   }
 
   return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t
+AMDGPUCompiler::materializeHeaderFile(DataObject *Object, StringRef Path) {
+  return outputResource(Path, StringRef(Object->Data, Object->Size));
 }
 
 amd_comgr_status_t AMDGPUCompiler::addDeviceLibraries() {
@@ -2244,7 +2254,7 @@ amd_comgr_status_t AMDGPUCompiler::linkToRelocatable() {
 
   DataObject *Output = DataObject::convert(OutputT);
   Output->setName("a.o");
-  auto OutputFilePath = getFilePath(Output, OutputDir);
+  auto OutputFilePath = getOutputFilePath(Output, OutputDir);
   Args.push_back("-o");
   Args.push_back(OutputFilePath.c_str());
 
@@ -2305,7 +2315,7 @@ amd_comgr_status_t AMDGPUCompiler::linkToExecutable() {
 
   DataObject *Output = DataObject::convert(OutputT);
   Output->setName("a.so");
-  auto OutputFilePath = getFilePath(Output, OutputDir);
+  auto OutputFilePath = getOutputFilePath(Output, OutputDir);
   Args.push_back("-o");
   Args.push_back(OutputFilePath.c_str());
 

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1395,7 +1395,7 @@ AMDGPUCompiler::processFiles(amd_comgr_data_kind_t OutputKind,
       continue;
     }
     auto IncludeFilePath = getFilePath(Input, IncludeDir);
-    if (auto Status = materializeHeaderFile(Input, IncludeFilePath)) {
+    if (auto Status = materializeDataObjectData(Input, IncludeFilePath)) {
       return Status;
     }
   }
@@ -1484,7 +1484,7 @@ amd_comgr_status_t AMDGPUCompiler::addIncludeFlags() {
     }
     PrecompiledHeaders.push_back(getFilePath(Input, IncludeDir));
     auto &PrecompiledHeaderPath = PrecompiledHeaders.back();
-    if (auto Status = materializeHeaderFile(Input, PrecompiledHeaderPath)) {
+    if (auto Status = materializeDataObjectData(Input, PrecompiledHeaderPath)) {
       return Status;
     }
     Args.push_back("-include-pch");
@@ -1602,8 +1602,8 @@ amd_comgr_status_t AMDGPUCompiler::outputResource(llvm::StringRef Path,
   return AMD_COMGR_STATUS_SUCCESS;
 }
 
-amd_comgr_status_t AMDGPUCompiler::materializeHeaderFile(DataObject *Object,
-                                                         StringRef Path) {
+amd_comgr_status_t AMDGPUCompiler::materializeDataObjectData(DataObject *Object,
+                                                             StringRef Path) {
   return outputResource(Path, StringRef(Object->Data, Object->Size));
 }
 

--- a/amd/comgr/src/comgr-compiler.h
+++ b/amd/comgr/src/comgr-compiler.h
@@ -64,6 +64,11 @@ class AMDGPUCompiler {
   amd_comgr_status_t addCompilationFlags();
   amd_comgr_status_t outputResource(llvm::StringRef Path,
                                     llvm::StringRef FileContent);
+
+  // Only for paths read back through Clang's FileManager, since under VFS the
+  // content never reaches the real filesystem.
+  amd_comgr_status_t materializeHeaderFile(DataObject *Object,
+                                           llvm::StringRef Path);
   amd_comgr_status_t addDeviceLibraries();
   amd_comgr_status_t extractSpirvFlags(DataSet *BcSet);
   amd_comgr_status_t cloneKernelsInBitcode(DataSet *BcSet);

--- a/amd/comgr/src/comgr-compiler.h
+++ b/amd/comgr/src/comgr-compiler.h
@@ -67,8 +67,8 @@ class AMDGPUCompiler {
 
   // Only for paths read back through Clang's FileManager, since under VFS the
   // content never reaches the real filesystem.
-  amd_comgr_status_t materializeHeaderFile(DataObject *Object,
-                                           llvm::StringRef Path);
+  amd_comgr_status_t materializeDataObjectData(DataObject *Object,
+                                               llvm::StringRef Path);
   amd_comgr_status_t addDeviceLibraries();
   amd_comgr_status_t extractSpirvFlags(DataSet *BcSet);
   amd_comgr_status_t cloneKernelsInBitcode(DataSet *BcSet);

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -198,6 +198,36 @@ if(WIN32 AND COMGR_BUILD_SHARED_LIBS)
       $<TARGET_FILE:amd_comgr> $<TARGET_FILE_DIR:SymbolIndexTest>)
 endif()
 
+# -- IncludeMaterializationTest -----------------------------------------------
+#
+# Includes are served out of the in-memory VFS rather than real temp files, so
+# this runs the preprocessor with the filesystem pinned both ways via
+# amd_comgr_action_info_set_vfs. Public API only; AMDGPUCompiler's VFS state is
+# private and not exported from the shared library.
+
+add_executable(IncludeMaterializationTest
+  IncludeMaterializationTest.cpp)
+
+target_link_libraries(IncludeMaterializationTest PRIVATE
+  ${COMGR_GTEST_LIBS}
+  amd_comgr
+  ${LLVM_PTHREAD_LIB})
+
+target_compile_definitions(IncludeMaterializationTest PRIVATE
+  GTEST_NO_LLVM_SUPPORT=true)
+
+target_include_directories(IncludeMaterializationTest PRIVATE
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
+
+comgr_configure_test_target(IncludeMaterializationTest)
+
+if(WIN32 AND COMGR_BUILD_SHARED_LIBS)
+  add_custom_command(TARGET IncludeMaterializationTest POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      $<TARGET_FILE:amd_comgr> $<TARGET_FILE_DIR:IncludeMaterializationTest>)
+endif()
+
 # Register every test binary with the test-unit / check-comgr plumbing.
 add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapElfTests>
@@ -206,9 +236,11 @@ add_custom_target(test-unit
   COMMAND $<TARGET_FILE:DemangleSymbolNameTest>
   COMMAND $<TARGET_FILE:LoggerTests>
   COMMAND $<TARGET_FILE:MetadataCacheTest>
-  COMMAND $<TARGET_FILE:SymbolIndexTest>)
+  COMMAND $<TARGET_FILE:SymbolIndexTest>
+  COMMAND $<TARGET_FILE:IncludeMaterializationTest>)
 add_dependencies(test-unit HotswapElfTests HotswapMCTests HotswapProfileTests
-  DemangleSymbolNameTest LoggerTests MetadataCacheTest SymbolIndexTest)
+  DemangleSymbolNameTest LoggerTests MetadataCacheTest SymbolIndexTest
+  IncludeMaterializationTest)
 
 # The transpile-path test binaries, exported by hotswap/CMakeLists.txt in
 # COMGR_HOTSWAP_TEST_TARGETS (empty unless COMGR_ENABLE_HOTSWAP_TRANSPILE is on).

--- a/amd/comgr/test-unit/IncludeMaterializationTest.cpp
+++ b/amd/comgr/test-unit/IncludeMaterializationTest.cpp
@@ -1,0 +1,135 @@
+//===- IncludeMaterializationTest.cpp - Header materialization tests ------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "common.h"
+#include "gtest/gtest.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace {
+
+void setEnv(const char *Name, const char *Value) {
+#ifdef _WIN32
+  _putenv_s(Name, Value ? Value : "");
+#else
+  if (Value)
+    setenv(Name, Value, /* Overwrite */ 1);
+  else
+    unsetenv(Name);
+#endif
+}
+
+// AMD_COMGR_USE_VFS and AMD_COMGR_SAVE_TEMPS both take precedence over the
+// per-action setting these tests pin, and the command cache would let the
+// second mode's compile be served from the first mode's result. Comgr reads
+// each of these once into a static, so clear them before any action runs.
+class EnvironmentSetup : public ::testing::Environment {
+public:
+  void SetUp() override {
+    setEnv("AMD_COMGR_USE_VFS", nullptr);
+    setEnv("AMD_COMGR_SAVE_TEMPS", nullptr);
+    setEnv("AMD_COMGR_CACHE", "0");
+  }
+};
+
+[[maybe_unused]] const auto *Registered =
+    ::testing::AddGlobalTestEnvironment(new EnvironmentSetup);
+
+struct Include {
+  const char *Name;
+  const char *Contents;
+};
+
+// Two distinct subdirectory shapes, since the include path is built by
+// appending the data name to the include directory.
+const Include Includes[] = {
+    {"subdir/header1.h", "int x = 1;"},
+    {"sub/dir/header2.h", "int y = 1;"},
+    {"sub/dir/header3.h", "int z = 1;"},
+};
+
+const char *const Source = "#include \"subdir/header1.h\"\n"
+                           "#include \"sub/dir/header2.h\"\n"
+                           "#include \"sub/dir/header3.h\"\n";
+
+std::string preprocess(bool UseVFS) {
+  amd_comgr_data_set_t In, Out;
+  amd_comgr_action_info_t Action;
+  amd_comgr_data_t Data;
+
+  EXPECT_COMGR(create_data_set(&In));
+
+  EXPECT_COMGR(create_data(AMD_COMGR_DATA_KIND_SOURCE, &Data));
+  EXPECT_COMGR(set_data(Data, strlen(Source), Source));
+  EXPECT_COMGR(set_data_name(Data, "source.cl"));
+  EXPECT_COMGR(data_set_add(In, Data));
+  EXPECT_COMGR(release_data(Data));
+
+  for (const Include &I : Includes) {
+    EXPECT_COMGR(create_data(AMD_COMGR_DATA_KIND_INCLUDE, &Data));
+    EXPECT_COMGR(set_data(Data, strlen(I.Contents), I.Contents));
+    EXPECT_COMGR(set_data_name(Data, I.Name));
+    EXPECT_COMGR(data_set_add(In, Data));
+    EXPECT_COMGR(release_data(Data));
+  }
+
+  EXPECT_COMGR(create_action_info(&Action));
+  EXPECT_COMGR(action_info_set_language(Action, AMD_COMGR_LANGUAGE_OPENCL_1_2));
+  EXPECT_COMGR(action_info_set_isa_name(Action, "amdgcn-amd-amdhsa--gfx900"));
+  EXPECT_COMGR(action_info_set_vfs(Action, UseVFS));
+
+  EXPECT_COMGR(create_data_set(&Out));
+  EXPECT_COMGR(
+      do_action(AMD_COMGR_ACTION_SOURCE_TO_PREPROCESSOR, Action, In, Out));
+
+  size_t Count = 0;
+  EXPECT_COMGR(action_data_count(Out, AMD_COMGR_DATA_KIND_SOURCE, &Count));
+  EXPECT_EQ(size_t(1), Count);
+
+  std::string Result;
+  if (Count == 1) {
+    EXPECT_COMGR(
+        action_data_get_data(Out, AMD_COMGR_DATA_KIND_SOURCE, 0, &Data));
+
+    size_t Size = 0;
+    EXPECT_COMGR(get_data(Data, &Size, nullptr));
+    Result.resize(Size);
+    EXPECT_COMGR(get_data(Data, &Size, Result.data()));
+
+    EXPECT_COMGR(release_data(Data));
+  }
+
+  EXPECT_COMGR(destroy_data_set(Out));
+  EXPECT_COMGR(destroy_action_info(Action));
+  EXPECT_COMGR(destroy_data_set(In));
+  return Result;
+}
+
+class IncludeMaterializationTest : public ::testing::TestWithParam<bool> {};
+
+// Includes are written into the in-memory VFS rather than to real temp files,
+// so cover both filesystems: the contents have to reach the preprocessor
+// either way, including from nested subdirectories.
+TEST_P(IncludeMaterializationTest, SubdirectoryIncludesAreVisible) {
+  const std::string Preprocessed = preprocess(GetParam());
+  ASSERT_FALSE(Preprocessed.empty());
+
+  for (const Include &I : Includes)
+    EXPECT_NE(std::string::npos, Preprocessed.find(I.Contents))
+        << "missing contents of " << I.Name;
+}
+
+INSTANTIATE_TEST_SUITE_P(FileSystem, IncludeMaterializationTest,
+                         ::testing::Bool(),
+                         [](const ::testing::TestParamInfo<bool> &Info) {
+                           return Info.param ? "VFS" : "RealFS";
+                         });
+
+} // namespace

--- a/amd/comgr/test-unit/common.h
+++ b/amd/comgr/test-unit/common.h
@@ -19,9 +19,9 @@
 
 // For helpers that return a value, where ASSERT_COMGR's `return;` will not
 // compile.
-#define EXPECT_COMGR(call)                                                \
-  do {                                                                    \
-    amd_comgr_status_t status = amd_comgr_##call;                         \
-    EXPECT_EQ(AMD_COMGR_STATUS_SUCCESS, status);                          \
+#define EXPECT_COMGR(call)                                                     \
+  do {                                                                         \
+    amd_comgr_status_t status = amd_comgr_##call;                              \
+    EXPECT_EQ(AMD_COMGR_STATUS_SUCCESS, status);                               \
   } while (false)
 #endif // COMGR_TEST_COMMON_H

--- a/amd/comgr/test-unit/common.h
+++ b/amd/comgr/test-unit/common.h
@@ -16,4 +16,12 @@
     amd_comgr_status_t status = amd_comgr_##call;                         \
     ASSERT_EQ(AMD_COMGR_STATUS_SUCCESS, status);                          \
   } while (false)
+
+// For helpers that return a value, where ASSERT_COMGR's `return;` will not
+// compile.
+#define EXPECT_COMGR(call)                                                \
+  do {                                                                    \
+    amd_comgr_status_t status = amd_comgr_##call;                         \
+    EXPECT_EQ(AMD_COMGR_STATUS_SUCCESS, status);                          \
+  } while (false)
 #endif // COMGR_TEST_COMMON_H

--- a/amd/comgr/test/CMakeLists.txt
+++ b/amd/comgr/test/CMakeLists.txt
@@ -248,6 +248,21 @@ add_comgr_test(compile_hip_to_relocatable c)
 add_comgr_test(mangled_names_hip_test c)
 #add_comgr_test(unbundle_hip_test c)
 
+# The header materialization test, with the filesystem choice pinned both ways.
+foreach(UseVFS 0 1)
+  add_test(NAME comgr_include_subdirectory_test_vfs${UseVFS}
+    COMMAND include_subdirectory_test)
+  if (UNIX)
+    set_tests_properties(comgr_include_subdirectory_test_vfs${UseVFS}
+      PROPERTIES ENVIRONMENT
+      "AMD_COMGR_CACHE=0;AMD_COMGR_USE_VFS=${UseVFS}")
+  else()
+    set_tests_properties(comgr_include_subdirectory_test_vfs${UseVFS}
+      PROPERTIES ENVIRONMENT_MODIFICATION
+      "PATH=path_list_prepend:$<TARGET_LINKER_FILE_DIR:amd_comgr>;AMD_COMGR_CACHE=set:0;AMD_COMGR_USE_VFS=set:${UseVFS}")
+  endif()
+endforeach()
+
 add_test(
   NAME comgr_hotswap_reduce_test
   COMMAND "${Python3_EXECUTABLE}"

--- a/amd/comgr/test/CMakeLists.txt
+++ b/amd/comgr/test/CMakeLists.txt
@@ -248,21 +248,6 @@ add_comgr_test(compile_hip_to_relocatable c)
 add_comgr_test(mangled_names_hip_test c)
 #add_comgr_test(unbundle_hip_test c)
 
-# The header materialization test, with the filesystem choice pinned both ways.
-foreach(UseVFS 0 1)
-  add_test(NAME comgr_include_subdirectory_test_vfs${UseVFS}
-    COMMAND include_subdirectory_test)
-  if (UNIX)
-    set_tests_properties(comgr_include_subdirectory_test_vfs${UseVFS}
-      PROPERTIES ENVIRONMENT
-      "AMD_COMGR_CACHE=0;AMD_COMGR_USE_VFS=${UseVFS}")
-  else()
-    set_tests_properties(comgr_include_subdirectory_test_vfs${UseVFS}
-      PROPERTIES ENVIRONMENT_MODIFICATION
-      "PATH=path_list_prepend:$<TARGET_LINKER_FILE_DIR:amd_comgr>;AMD_COMGR_CACHE=set:0;AMD_COMGR_USE_VFS=set:${UseVFS}")
-  endif()
-endforeach()
-
 add_test(
   NAME comgr_hotswap_reduce_test
   COMMAND "${Python3_EXECUTABLE}"


### PR DESCRIPTION
This is third in a series of PRs that improves Comgr.

Includes, precompiled headers and opencl-c-base.h were written to real temp files on every compile even though the in-memory VFS is enabled by default. These paths are read back only through Clang's FileManager, which is built on the driver's OverlayFS, so they can be served from memory. Source, bitcode and link inputs stay on disk: cc1as, lld, the offload bundler and the command cache's input hashing all read the real filesystem.

Also stop `getFilePath` running `fs::create_directories` on every path it builds; only the three paths the in-process driver writes need it, and `outputToFile` already creates the parent for the paths Comgr writes. And take ownership of the output buffer in `inputFromFile` rather than malloc+memcpy every artifact a second time.

60 OpenCL preprocess actions with 24 8KB includes: 1521 ms -> ~1400 ms.

[1/3] <- https://github.com/ROCm/llvm-project/pull/3840
[2/3] <- https://github.com/ROCm/llvm-project/pull/3841
[3/3] <- you are here