### PR TITLE
[SPIRV] CI: drop secrets: inherit from spirv-ci dispatcher

### DIFF
--- a/.github/workflows/spirv-ci.yml
+++ b/.github/workflows/spirv-ci.yml
@@ -36,7 +36,6 @@ jobs:
          )
        ))
     uses: ./.github/workflows/spirv-ci-linux-amd-staging.yml
-    secrets: inherit
 
   windows_release:
     name: Windows::release
@@ -54,4 +53,3 @@ jobs:
          )
        ))
     uses: ./.github/workflows/spirv-ci-windows-amd-staging.yml
-    secrets: inherit


### PR DESCRIPTION
## Summary

The `spirv-ci` dispatcher passed the full set of repository secrets to its reusable linux/windows workflows via `secrets: inherit`, but neither reusable workflow references any repository secret. This removes the passthrough so no secrets are propagated to the callees (least privilege).

## Why this is safe

- `spirv-ci-linux-amd-staging.yml` and `spirv-ci-windows-amd-staging.yml` contain zero secret references (`${{ secrets.* }}`).
- `GITHUB_TOKEN` is provided to reusable workflows automatically and is **not** governed by `secrets: inherit`; the per-job `permissions:` blocks continue to scope it.
- No behavior change to the CI.

## Change

Remove `secrets: inherit` from both the `linux_release` and `windows_release` call sites in `.github/workflows/spirv-ci.yml`.
