### PR TITLE
[Comgr] Fix test-unit cl::opt double-registration in dylib builds

### DIFF
--- a/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
@@ -13,8 +13,14 @@ add_executable(RaiserScaffoldingTests
 # hotswap::raiser keeps its LLVM dependencies PRIVATE, so name them here. It also
 # carries the wave-projection objects, which call into hotswap::decoder; link it
 # too and inherit its curated LLVM component set.
-llvm_map_components_to_libnames(COMGR_TEST_UNIT_RAISER_LIBS
-  Core Support TargetParser)
+# Match the hotswap libs' linkage: in a dylib build these components already
+# come in via libLLVM, so static archives here would double-register cl::opts.
+if(LLVM_LINK_LLVM_DYLIB)
+  set(COMGR_TEST_UNIT_RAISER_LIBS LLVM)
+else()
+  llvm_map_components_to_libnames(COMGR_TEST_UNIT_RAISER_LIBS
+    Core Support TargetParser)
+endif()
 
 target_link_libraries(RaiserScaffoldingTests PRIVATE
   ${COMGR_GTEST_LIBS}
@@ -94,8 +100,13 @@ comgr_configure_test_target(RaiseFailureTests)
 add_executable(RegFileTests
   RegFileTest.cpp)
 
-llvm_map_components_to_libnames(COMGR_TEST_UNIT_REGFILE_LIBS
-  Analysis TransformUtils)
+# Dylib build: link libLLVM, not static archives (see RaiserScaffoldingTests).
+if(LLVM_LINK_LLVM_DYLIB)
+  set(COMGR_TEST_UNIT_REGFILE_LIBS LLVM)
+else()
+  llvm_map_components_to_libnames(COMGR_TEST_UNIT_REGFILE_LIBS
+    Analysis TransformUtils)
+endif()
 
 target_link_libraries(RegFileTests PRIVATE
   ${COMGR_GTEST_LIBS}


### PR DESCRIPTION
## Problem

Building comgr against an LLVM configured with `LLVM_LINK_LLVM_DYLIB=ON` (e.g. TheRock's build) aborts the `RegFileTests` unit test at startup, before any test runs:

```
: CommandLine Error: Option 'disable-fp-call-folding' registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options
Aborted (core dumped) .../test-unit/hotswap/raiser/RegFileTests
```

`RegFileTests` links `hotswap::raiser`/`hotswap::decoder`, which resolve to `libLLVM` in a dylib build, and *also* names `Analysis`/`TransformUtils` via `llvm_map_components_to_libnames`, which returns the individual static component archives. The test code reaches into those components (`PromoteMemToReg`, constant folding), so the linker pulls their objects out of the static archives on top of `libLLVM` — a second copy of their `cl::opt` globals, which LLVM rejects at startup.

`RaiserScaffoldingTests` (Core/Support/TargetParser) has the same unguarded pattern; it survives today only because nothing it calls forces a member out of those archives.

The comgr standalone CI builds static (no dylib), so it does not hit this; only a dylib LLVM build does.

## Fix

Guard both sites the way `hotswap-raiser`/`hotswap-decoder` already do — link `LLVM` in a dylib build, the individual static components otherwise. CMake-only change; no product code.

The other `test-unit` targets that name static components (`LoggerTests`, `HotswapElfTests`, `HotswapMCTests`, `HotswapProfileTests`) compile the source TUs directly and never link `libLLVM`, so they stay pure-static and are unaffected.
