### PR TITLE
[hipcc] Skip llc version probe when llc is not installed

### DIFF
--- a/amd/hipcc/src/hipBin_amd.h
+++ b/amd/hipcc/src/hipBin_amd.h
@@ -224,8 +224,13 @@ void HipBinAmd::printCompilerInfo() const {
   const string& hipPath = getHipPath();
   string cmd = hipClangPath + "/clang++ --version";
   system(cmd.c_str());  // hipclang version
-  cmd = hipClangPath + "/llc --version";
-  system(cmd.c_str());  // llc version
+  // llc is not shipped in all ROCm packaging configurations.
+  fs::path llcPath = hipClangPath;
+  llcPath /= "llc";
+  if (fs::exists(llcPath)) {
+    cmd = llcPath.string() + " --version";
+    system(cmd.c_str());  // llc version
+  }
   cout << "hip-clang-cxxflags :" << endl;
   cmd = hipPath + "/bin/hipcc --cxxflags";
   system(cmd.c_str());  // cxx flags


### PR DESCRIPTION
## Problem

`hipconfig --full` unconditionally executes `<hip_clang_path>/llc --version`, but `llc` is not shipped by any ROCm package. On a stock ROCm install the shell error leaks into hipconfig's output on every invocation:

```
$ hipconfig --full
...
AMD clang version 23.0.0git (...)
sh: 1: /opt/rocm/core-7.14/lib/llvm/bin/llc: not found
hip-clang-cxxflags :
```

Confirmed no ROCm package provides it:

```
$ for p in $(dpkg -l | grep amdrocm | awk '{print $2}'); do dpkg -L $p | grep -E "/bin/llc$"; done
(no output)
```

This is noise for interactive users and can confuse scripts that capture hipconfig's stderr. ROCm/HIP#287 previously adjusted the `llc` path, but the call site still assumes the binary is present.

## Fix

Check that `llc` exists before invoking it. When present, behaviour is unchanged.

## Test

Built `hipconfig` from this branch and verified both paths:

| Case | Before | After |
|---|---|---|
| `llc` absent (stock ROCm 7.14) | `sh: 1: .../llc: not found` | clean, no error |
| `llc` present (stub on `HIP_CLANG_PATH`) | probe runs | probe runs (unchanged) |

Remaining `--full` output (HIP version, paths, compiler version, cxxflags/ldflags) is byte-identical, and `--version/--path/--rocmpath/--compiler/--platform/--runtime/--hipclangpath/-C` are unaffected.

Environment: ROCm 7.14.0~pre3, gfx1100 (RX 7900 XTX), Ubuntu 26.04.
