### PR TITLE
ci(spirv): raise rocm-examples job timeout to 240m

### DIFF
--- a/.github/workflows/spirv-ci-linux-amd-staging.yml
+++ b/.github/workflows/spirv-ci-linux-amd-staging.yml
@@ -609,7 +609,9 @@ jobs:
     name: Test rocm-examples
     needs: [build, pick_runner]
     runs-on: ${{ needs.pick_runner.outputs.test_runs_on }}
-    timeout-minutes: 45
+    # Match the translator's spirv-ci-linux.yml (#268): the gfx942 runner is
+    # slow/contended and 45m was cutting the job before it could finish.
+    timeout-minutes: 240
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
       options: |


### PR DESCRIPTION
## What

Raise the `Test rocm-examples` job timeout in `spirv-ci-linux-amd-staging.yml`
from **45m** to **240m**.

## Why

`test_rocm_examples` runs on a scarce/contended gfx942 GPU runner. Runs were
queueing ~25–38m for a runner and then hitting the 45m cap before the build +
run could finish, so the lane rarely reported a clean result. This matches the
change already made on the translator side in
ROCm/SPIRV-LLVM-Translator#268 (after the runner machine changed).

The correctness failure this lane was hitting (16/23 HIP-Basic SIGSEGV, the
`@llvm.amdgcn.implicitarg.ptr` addrspace(4) reverse-translation bug) was fixed
by ROCm/SPIRV-LLVM-Translator#273 (closes ROCm/SPIRV-LLVM-Translator#271). This
PR's CI run doubles as the post-fix validation of the lane at `amd-staging` tip.
