### PR TITLE
[Offload] Fix DYLIB command for CMake causing link errors with new offload project

### DIFF
--- a/offload/CMakeLists.txt
+++ b/offload/CMakeLists.txt
@@ -417,8 +417,7 @@ if(BUILD_LIBOMPTARGET)
 endif()
 
 add_subdirectory(liboffload)
-#disable for downstream AMDGPU 
-#add_subdirectory(languages)
+add_subdirectory(languages)
 
 # Add tests.
 if(OFFLOAD_INCLUDE_TESTS)

--- a/offload/languages/kernel/CMakeLists.txt
+++ b/offload/languages/kernel/CMakeLists.txt
@@ -42,8 +42,14 @@ add_llvm_library(
 
   LINK_COMPONENTS
   Support
-  Offload
   )
+
+# NOTE: LLVMOffload is a standalone shared library and is NOT part of the
+# aggregate libLLVM dylib. When building with -DLLVM_LINK_LLVM_DYLIB=ON, using
+# "LINK_COMPONENTS Offload" collapses to linking libLLVM only, which drops the
+# real libLLVMOffload dependency and leaves the ol* symbols undefined. Link it
+# explicitly to guarantee the dependency is always present.
+target_link_libraries(LLVMOffloadKernel PRIVATE LLVMOffload)
 
 if(LLVM_HAVE_LINK_VERSION_SCRIPT)
   target_link_libraries(LLVMOffloadKernel PRIVATE "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports")


### PR DESCRIPTION
This will hopefully be fixed upstream soon, I left a comment in the offending PR, so this may be a temporary fix. But at least it allows us to compile it with build_aomp.sh in the meantime which might allow us to avoid hidden issues while it gets fixed upstream.


