### PR TITLE
workflows: enable LLVM assertions for wave-transform TheRock builds

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -169,6 +169,21 @@ jobs:
         if: ${{ steps.stage_config.outputs.pip_install_cmd }}
         run: pip install ${{ steps.stage_config.outputs.pip_install_cmd }}
 
+      # TheRock is checked out at the workspace root and reads BRANCH_CONFIG.json
+      # from its own source root, so writing it here turns on assertions for this
+      # branch without modifying TheRock. Needs the LLVM_ENABLE_ASSERTIONS flag
+      # declared on TheRock's compiler/amd-staging (ROCm/TheRock#7291): overriding
+      # an undeclared flag default is a fatal configure error.
+      - name: Enable LLVM assertions
+        run: |
+          cat > BRANCH_CONFIG.json <<'EOF'
+          {
+            "flags": {
+              "LLVM_ENABLE_ASSERTIONS": "ON"
+            }
+          }
+          EOF
+
       - name: Configure PR Projects
         if: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.test_type != 'full') }}
         env:


### PR DESCRIPTION
The Linux build jobs check TheRock out at the workspace root and configure it there, and TheRock reads BRANCH_CONFIG.json from its own source root. Write that file before the configure steps so the LLVM_ENABLE_ASSERTIONS flag defaults to ON for this branch without modifying TheRock. The file is gitignored in TheRock, so the checkout stays clean.

Because the workflow is reusable and invoked once per stage, this covers all Linux stages, including compiler-runtime, which is the one that actually builds amd-llvm. The wsl-rocdxg job is deliberately left alone: it consumes artifacts rather than building the compiler, so the flag would be inert there.

Requires the flag declaration now on TheRock's compiler/amd-staging (ROCm/TheRock#7291); overriding an undeclared flag default is a fatal configure error. Expect roughly 20% longer builds, more on device-heavy stages.


