### PR TITLE
[DebugInfo] Remove unused heterogeneous DWARF metadata version

### DIFF
--- a/llvm/include/llvm/IR/Metadata.h
+++ b/llvm/include/llvm/IR/Metadata.h
@@ -51,11 +51,7 @@ template <typename ValueTy> class StringMapEntryStorage;
 class Type;
 
 enum LLVMConstants : uint32_t {
-  // Current debug info version number.
-  DEBUG_METADATA_VERSION = 3,
-  // Debug info version number used for DWARF extensions for
-  // heterogeneous debugging.
-  DEBUG_METADATA_VERSION_HETEROGENEOUS_DWARF = 4
+  DEBUG_METADATA_VERSION = 3 // Current debug info version number.
 };
 
 /// Magic number in the value profile metadata showing a target has been


### PR DESCRIPTION
Commit b6e345ac04e2 added DEBUG_METADATA_VERSION_HETEROGENEOUS_DWARF downstream. Upstream does not define this constant.

Commit 3ff28428bf7a stopped emitting metadata version 4. No in-tree consumer remains. Remove the constant and restore the enum to its upstream form as a divergence cleanup.


