### PR TITLE
[DebugInfo] Remove unused DIBuilder global variable helper

### DIFF
--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -903,26 +903,6 @@ namespace llvm {
                                DIGenericSubrange::BoundType Stride);
 
     /// Create a new descriptor for the specified variable.
-    /// \param Context       Variable scope.
-    /// \param Name          Name of the variable.
-    /// \param LinkageName   Mangled  name of the variable.
-    /// \param File          File where this variable is defined.
-    /// \param LineNo        Line number.
-    /// \param Ty            Variable Type.
-    /// \param IsLocalToUnit Boolean flag indicate whether this variable is
-    ///                      externally visible or not.
-    /// \param Decl          Reference to the corresponding declaration.
-    /// \param MS            DWARF memory space.
-    /// \param AlignInBits   Variable alignment(or 0 if no alignment attr was
-    ///                      specified)
-    DIGlobalVariable *createGlobalVariable(
-        DIScope *Context, StringRef Name, StringRef LinkageName, DIFile *File,
-        unsigned LineNo, DIType *Ty, bool IsLocalToUnit, bool isDefined = true,
-        MDNode *Decl = nullptr, MDTuple *TemplateParams = nullptr,
-        dwarf::MemorySpace MS = dwarf::DW_MSPACE_LLVM_none,
-        uint32_t AlignInBits = 0, DINodeArray Annotations = nullptr);
-
-    /// Create a new descriptor for the specified variable.
     /// \param Context     Variable scope.
     /// \param Name        Name of the variable.
     /// \param LinkageName Mangled  name of the variable.

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -952,19 +952,6 @@ static void checkGlobalVariableScope(DIScope *Context) {
 #endif
 }
 
-DIGlobalVariable *DIBuilder::createGlobalVariable(
-    DIScope *Context, StringRef Name, StringRef LinkageName, DIFile *F,
-    unsigned LineNumber, DIType *Ty, bool IsLocalToUnit, bool isDefined,
-    MDNode *Decl, MDTuple *TemplateParams, dwarf::MemorySpace MS,
-    uint32_t AlignInBits, DINodeArray Annotations) {
-  checkGlobalVariableScope(Context);
-  return DIGlobalVariable::getDistinct(
-      VMContext, cast_or_null<DIScope>(Context), Name, LinkageName, F,
-      LineNumber, Ty, IsLocalToUnit, isDefined,
-      cast_or_null<DIDerivedType>(Decl), TemplateParams, MS, AlignInBits,
-      Annotations);
-}
-
 DIGlobalVariableExpression *DIBuilder::createGlobalVariableExpression(
     DIScope *Context, StringRef Name, StringRef LinkageName, DIFile *F,
     unsigned LineNumber, DIType *Ty, bool IsLocalToUnit, bool isDefined,


### PR DESCRIPTION
Commit 83a67583216d added DIBuilder::createGlobalVariable downstream for heterogeneous DWARF. Upstream does not define this helper.

The follow-up commit 9dbe1345d5e2 used it with createFragment(). Commit 3ff28428bf7a removed that producer path. Commit 29bdf92637c removed createFragment(), but left this helper without consumers.

Remove the declaration and definition to continue the divergence cleanup.


