### PR TITLE
[DebugInfo] Remove redundant debug metadata version check

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -6278,8 +6278,7 @@ bool llvm::UpgradeDebugInfo(Module &M) {
     }
   }
 
-  bool VersionSupported = Version == DEBUG_METADATA_VERSION;
-  if (VersionSupported) {
+  if (Version == DEBUG_METADATA_VERSION) {
     bool BrokenDebugInfo = false;
     if (verifyModule(M, &llvm::errs(), &BrokenDebugInfo))
       report_fatal_error("Broken module found, compilation aborted!");
@@ -6293,7 +6292,7 @@ bool llvm::UpgradeDebugInfo(Module &M) {
     }
   }
   bool Modified = StripDebugInfo(M);
-  if (Modified && !VersionSupported) {
+  if (Modified && Version != DEBUG_METADATA_VERSION) {
     // Diagnose a version mismatch.
     DiagnosticInfoDebugMetadataVersion DiagVersion(M, Version);
     M.getContext().diagnose(DiagVersion);


### PR DESCRIPTION
Commit f35e7d1b7134 introduced VersionSupported when metadata versions 3 and 4 were supported downstream. Upstream supports only version 3.

Commit 29bdf92637c removed version 4 support, but left the wrapper around one comparison. Restore the direct upstream checks as a divergence cleanup.


