### PR TITLE
[Bitcode] Preserve distinct DIExpression nodes

### DIFF
--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -2621,7 +2621,8 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
     if (Error Err = upgradeDIExpression(Version, Elts, Buffer))
       return Err;
 
-    MetadataList.assignValue(DIExpression::get(Context, Elts), NextMetadataNo);
+    MetadataList.assignValue(GET_OR_DISTINCT(DIExpression, (Context, Elts)),
+                             NextMetadataNo);
     NextMetadataNo++;
     break;
   }

--- a/llvm/unittests/Bitcode/BitReaderTest.cpp
+++ b/llvm/unittests/Bitcode/BitReaderTest.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/DebugProgramInstruction.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/InstIterator.h"
@@ -65,6 +66,26 @@ static std::unique_ptr<Module> getLazyModuleFromAssembly(LLVMContext &Context,
   if (!ModuleOrErr)
     report_fatal_error("Could not parse bitcode module");
   return std::move(ModuleOrErr.get());
+}
+
+TEST(BitReaderTest, PreserveDistinctDIExpression) {
+  SmallString<1024> Mem;
+  LLVMContext WriteContext;
+  auto M = std::make_unique<Module>("test", WriteContext);
+  M->getOrInsertNamedMetadata("test")->addOperand(
+      DIExpression::getDistinct(WriteContext, {}));
+  writeModuleToBuffer(std::move(M), Mem);
+
+  LLVMContext ReadContext;
+  Expected<std::unique_ptr<Module>> ModuleOrErr =
+      parseBitcodeFile(MemoryBufferRef(Mem.str(), "test"), ReadContext);
+  if (!ModuleOrErr)
+    report_fatal_error("Could not parse bitcode module");
+
+  NamedMDNode *NMD = (*ModuleOrErr)->getNamedMetadata("test");
+  ASSERT_NE(NMD, nullptr);
+  ASSERT_EQ(NMD->getNumOperands(), 1u);
+  EXPECT_TRUE(cast<DIExpression>(NMD->getOperand(0))->isDistinct());
 }
 
 // Tests that lazy evaluation can parse functions out of order.


### PR DESCRIPTION
Downstream commit 6c3a285441fe forced legacy DIExpression records through DIExpression::get(). Later changes removed the metadata constraints and restored the distinct DIExpression API. The old reader path now drops an encoded distinct flag.

Restore GET_OR_DISTINCT to match the writer and upstream. Add a round-trip unit test that writes and reads a distinct DIExpression.

This change removes the remaining semantic delta from 6c3a285441fe.


