### PR TITLE
[Support] Remove redundant CacheStream commit flag

### DIFF
--- a/llvm/lib/Support/Caching.cpp
+++ b/llvm/lib/Support/Caching.cpp
@@ -80,7 +80,6 @@ Expected<FileCache> llvm::localCache(const Twine &CacheNameRef,
       sys::fs::TempFile TempFile;
       std::string ModuleName;
       unsigned Task;
-      bool Committed = false;
 
       CacheStream(std::unique_ptr<raw_pwrite_stream> OS, AddBufferFn AddBuffer,
                   sys::fs::TempFile TempFile, std::string EntryPath,


### PR DESCRIPTION
Downstream commit 53f4fa3ce4e3 added a Committed member to CacheStream. The base CachedFileStream now owns the same state and updates it in commit(). The derived member shadows the base member and is never used.

Remove the stale member and align Caching.cpp with upstream.


