### PR TITLE
Revert "Fix ELF .so behaviour for clang-offload-packager"

### DIFF
--- a/llvm/tools/llvm-offload-binary/llvm-offload-binary.cpp
+++ b/llvm/tools/llvm-offload-binary/llvm-offload-binary.cpp
@@ -218,16 +218,6 @@ static Error unbundleImages() {
     SmallVector<const OffloadBinary *> Extracted;
     for (const OffloadFile &File : Binaries) {
       const auto *Binary = File.getBinary();
-      // If the user lists a .so file on the command line for the program
-      // that invokes this one (probably clang), it may contain offload
-      // binary sections that resemble those in an object file.  However,
-      // there is no late binding/shared object support on the target side
-      // (i.e. you cannot define a target function in a shared object and
-      // call it from a target region in the main program), and we don't want
-      // to *early* bind target regions in a shared object either.  So,
-      // ignore shared objects here.
-      if (identify_magic(Binary->getImage()) == file_magic::elf_shared_object)
-        continue;
       // We handle the 'file', 'kind', and 'member' identifiers differently.
       bool Match = llvm::all_of(Args, [&](auto &Arg) {
         const auto [Key, Value] = Arg;


### PR DESCRIPTION
This reverts the shared-object check added in d156159d244f, which now lives in `llvm/tools/llvm-offload-binary/llvm-offload-binary.cpp`.

Shared objects can only reach offload extraction through `clang-linker-wrapper`, and are already excluded there in `getDeviceInput()`, upstream since 1964c334782e (Jan 2023), so the check is unreachable.

It is also harmful. The AMD HSA runtime loader requires ET_DYN code objects, so `identify_magic()` reports `elf_shared_object` for every fully linked AMDGPU device image and unbundling silently extracts nothing. Packaging a gfx90a code object and extracting it again yields no output and exit status 0, where upstream round-trips the image byte for byte. No other target is affected, since cubins are ET_EXEC or ET_REL and SPIR-V is not ELF, so the check only ever fires where it is guaranteed to be wrong.

The unrelated `--allow-missing-packages` divergence in this file is left alone.

Made with [Cursor](https://cursor.com)