### PR TITLE
[Object] Drop redundant .str() in OffloadBundleFatBin::readEntries

### DIFF
--- a/llvm/lib/Object/OffloadBundle.cpp
+++ b/llvm/lib/Object/OffloadBundle.cpp
@@ -159,7 +159,7 @@ Error OffloadBundleFatBin::readEntries(StringRef Buffer,
       return Err;
 
     auto Entry = std::make_unique<OffloadBundleEntry>(
-        EntryOffset + SectionOffset, EntrySize, EntryIDSize, EntryID.str());
+        EntryOffset + SectionOffset, EntrySize, EntryIDSize, EntryID);
 
     Entries.push_back(*Entry);
   }


### PR DESCRIPTION
4b06a51d5b8c is already upstream. The fatbin bundle API it added to `OffloadBinary.{h,cpp}` landed upstream as `llvm/lib/Object/OffloadBundle.{h,cpp}` in llvm/llvm-project#140286 and has been developed there since, so amd-staging has converged onto the upstream copy.

`OffloadBinary.h`, `OffloadBinary.cpp` and `OffloadBundle.h` are already byte-identical to upstream, and this one line is all that is left of the divergence. `OffloadBundleEntry` takes a `StringRef` and copies it into its own `std::string`, so `EntryID.str()` only builds a redundant temporary. Removing it makes `OffloadBundle.cpp` identical to upstream as well.

Made with [Cursor](https://cursor.com)