### PR TITLE
[llvm-objdump] Drop orphaned --offload-fatbin option

### DIFF
--- a/llvm/lib/Object/ObjectFile.cpp
+++ b/llvm/lib/Object/ObjectFile.cpp
@@ -215,6 +215,7 @@ ObjectFile::createObjectFile(StringRef ObjectPath) {
   if (std::error_code EC = FileOrErr.getError())
     return errorCodeToError(EC);
   std::unique_ptr<MemoryBuffer> Buffer = std::move(FileOrErr.get());
+
   Expected<std::unique_ptr<ObjectFile>> ObjOrErr =
       createObjectFile(Buffer->getMemBufferRef());
   if (Error Err = ObjOrErr.takeError())

--- a/llvm/test/tools/llvm-objdump/Offloading/fatbin.test
+++ b/llvm/test/tools/llvm-objdump/Offloading/fatbin.test
@@ -1,6 +1,7 @@
 ## Test that --offloading with a fatbin works correctly
 
 # REQUIRES: target={{x86_64-.*-linux.*}}
+# REQUIRES: amdgpu-registered-target
 # RUN: yaml2obj %s -o %t.elf
 # RUN: llvm-objdump --offloading %t.elf 
 # RUN: llvm-objdump -d %t.elf.0.hipv4-amdgcn-amd-amdhsa--gfx908 | FileCheck %s 

--- a/llvm/tools/llvm-objdump/ObjdumpOpts.td
+++ b/llvm/tools/llvm-objdump/ObjdumpOpts.td
@@ -113,9 +113,6 @@ def fault_map_section : Flag<["--"], "fault-map-section">,
 def offloading : Flag<["--"], "offloading">,
   HelpText<"Display the content of the offloading section">;
 
-def offload_fatbin : Flag<["--"], "offload-fatbin">,
-  HelpText<"Display the content of the offload FatBin section">;
-
 def file_headers : Flag<["--"], "file-headers">,
   HelpText<"Display the contents of the overall file header">;
 def : Flag<["-"], "f">, Alias<file_headers>,


### PR DESCRIPTION
d8d3bc1c15b7 added `--offload-fatbin` along with its implementation. The same functionality later came in from upstream under the existing `--offloading` flag (llvm/llvm-project#140286, same author), and amd-staging took the upstream files verbatim: `OffloadDump.cpp`, `OffloadDump.h` and `llvm-objdump.cpp` are byte-identical to upstream today.

That convergence removed the option's `static bool OffloadFatBin`, its `OBJDUMP_offload_fatbin` parse, its dispatch to `dumpOffloadBundleFatBinary()`, and its entry in the "no operation specified" guard. Only the option definition was left behind, so llvm-objdump advertises `--offload-fatbin` in `--help` but prints the usage message and exits 2 when it is used. Nothing in the tree references it.

Also restores the `amdgpu-registered-target` requirement in `fatbin.test`, which disassembles a gfx908 image and so fails on builds without the AMDGPU target registered, and a blank line in `ObjectFile.cpp`. With these, all files touched by d8d3bc1c15b7 match upstream exactly.

If the roc-obj replacement (SWDEV-333176) still wants a real `--offload-fatbin`, that is new work and belongs upstream; nothing can be relying on the current flag.

Made with [Cursor](https://cursor.com)