### PR TITLE
[Flang][OpenMP] Stop emitting implicit mappers for allocatable derived types (and arrays of them) unconditionally

### DIFF
--- a/flang/lib/Lower/OpenMP/Utils.cpp
+++ b/flang/lib/Lower/OpenMP/Utils.cpp
@@ -1210,7 +1210,6 @@ resolveMapperId(Fortran::lower::AbstractConverter &converter,
           (mapTypeBits & mlir::omp::ClauseMapFlags::implicit) ==
           mlir::omp::ClauseMapFlags::implicit;
       bool needsDefaultMapper =
-          isAllocOrPointer ||
           requiresImplicitDefaultDeclareMapper(*objectTypeSpec);
       // For implicit captures, avoid synthesizing default mappers for
       // pointer entities (which can over-map pointer payloads) and for


### PR DESCRIPTION
We should not be emitting these implicit mappers at the top level if the contents of the derived type do not require mapping of allocatables. If we do this, we negatively impact performance with unneccessary maps, in certain cases (array of structs) this can be quite significant.


