### PR TITLE
[llvm-dwarfdump] Remove duplicate BinaryFormat dependencies

### DIFF
--- a/llvm/tools/llvm-dwarfdump/CMakeLists.txt
+++ b/llvm/tools/llvm-dwarfdump/CMakeLists.txt
@@ -4,14 +4,12 @@ set(LLVM_LINK_COMPONENTS
   DebugInfoDWARFLowLevel
   AllTargetsDescs
   AllTargetsInfos
-  BinaryFormat
   Core
   IRReader
   MC
   Object
   Support
   TargetParser
-  BinaryFormat
   )
 
 add_llvm_tool(llvm-dwarfdump


### PR DESCRIPTION
Upstream now provides the BinaryFormat dependency. Remove two redundant downstream entries and restore the upstream component list.

This change eliminates the divergence introduced by commits 05666559347f and f2ac593c68ed.


