### PR TITLE
[AsmWriter] Remove single-use metadata list printer

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1923,7 +1923,6 @@ struct MDFieldPrinter {
   void printNameTableKind(StringRef Name,
                           DICompileUnit::DebugNameTableKind NTK);
   void printMemorySpace(StringRef Name, dwarf::MemorySpace MS);
-  template <class RangeT> void printMetadataList(StringRef Name, RangeT Range);
   void printFixedPointKind(StringRef Name, DIFixedPointType::FixedPointKind V);
 };
 
@@ -2090,19 +2089,6 @@ void MDFieldPrinter::printNameTableKind(StringRef Name,
   Out << FS << Name << ": " << DICompileUnit::nameTableKindString(NTK);
 }
 
-template <class RangeT>
-void MDFieldPrinter::printMetadataList(StringRef Name, RangeT Range) {
-  if (Range.begin() == Range.end())
-    return;
-  Out << FS << Name << ": {";
-  ListSeparator IFS;
-  for (const auto &I : Range) {
-    Out << IFS;
-    writeMetadataAsOperand(Out, I, WriterCtx);
-  }
-  Out << "}";
-}
-
 void MDFieldPrinter::printFixedPointKind(StringRef Name,
                                          DIFixedPointType::FixedPointKind V) {
   Out << FS << Name << ": " << DIFixedPointType::fixedPointKindString(V);
@@ -2128,7 +2114,15 @@ static void writeGenericDINode(raw_ostream &Out, const GenericDINode *N,
   MDFieldPrinter Printer(Out, WriterCtx);
   Printer.printTag(N);
   Printer.printString("header", N->getHeader());
-  Printer.printMetadataList("operands", N->dwarf_operands());
+  if (N->getNumDwarfOperands()) {
+    Out << Printer.FS << "operands: {";
+    ListSeparator IFS;
+    for (auto &I : N->dwarf_operands()) {
+      Out << IFS;
+      writeMetadataAsOperand(Out, I, WriterCtx);
+    }
+    Out << "}";
+  }
   Out << ")";
 }
 


### PR DESCRIPTION
I inline the only remaining use of printMetadataList. The DILifetime caller was removed, so the helper no longer provides shared behavior.

This restores the affected code to upstream/main and removes the divergence introduced by 728880f5f958.

Assisted-by: Claude Opus


