### PR TITLE
[Comgr] [Do not merge] Select static LLVM components independently of LLVM's default linkage

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -194,20 +194,27 @@ else()
   endif()
 endif()
 
-# Allow the super-project to force static linking of LLVM/Clang into comgr.
-# When ON, LLVM symbols are hidden by comgr's version script (local: *;),
-# avoiding symbol interposition issues without requiring namespace isolation.
-option(COMGR_STATIC_LLVM "Statically link LLVM/Clang into comgr (hides LLVM symbols)" OFF)
-if(COMGR_ENABLE_HOTSWAP_TRANSPILE AND NOT COMGR_STATIC_LLVM AND
-   (LLVM_LINK_LLVM_DYLIB OR CLANG_LINK_CLANG_DYLIB))
+# COMGR's export restrictions keep embedded LLVM, Clang, and LLD symbols from
+# interposing on other compiler libraries in the process.
+option(COMGR_STATIC_LLVM
+  "Statically link LLVM, Clang, and LLD into the comgr shared library" OFF)
+if(COMGR_STATIC_LLVM)
+  set(COMGR_LINK_LLVM_DYLIB OFF)
+  set(COMGR_LINK_CLANG_DYLIB OFF)
+else()
+  set(COMGR_LINK_LLVM_DYLIB ${LLVM_LINK_LLVM_DYLIB})
+  set(COMGR_LINK_CLANG_DYLIB ${CLANG_LINK_CLANG_DYLIB})
+endif()
+if(COMGR_ENABLE_HOTSWAP_TRANSPILE AND
+   (COMGR_LINK_LLVM_DYLIB OR COMGR_LINK_CLANG_DYLIB))
   message(FATAL_ERROR
     "COMGR_ENABLE_HOTSWAP_TRANSPILE requires static LLVM and Clang linkage. "
-    "Enable COMGR_STATIC_LLVM or disable LLVM_LINK_LLVM_DYLIB and "
-    "CLANG_LINK_CLANG_DYLIB.")
+    "Enable COMGR_STATIC_LLVM or use LLVM and Clang packages configured for "
+    "static component linkage.")
 endif()
-if(COMGR_STATIC_LLVM)
-  set(LLVM_LINK_LLVM_DYLIB OFF)
-  set(CLANG_LINK_CLANG_DYLIB OFF)
+if(NOT COMGR_LINK_LLVM_DYLIB AND NOT COMGR_LINK_CLANG_DYLIB)
+  set_property(TARGET amd_comgr PROPERTY LLVM_LINK_STATIC_COMPONENTS ON)
+  add_compile_definitions(CLANG_BUILD_STATIC LLVM_BUILD_STATIC)
 endif()
 
 target_include_directories(amd_comgr
@@ -588,7 +595,7 @@ install(FILES
   COMPONENT amd-comgr
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/${AMD_COMGR_PACKAGE_PREFIX}")
 
-if(NOT CLANG_LINK_CLANG_DYLIB)
+if(NOT COMGR_LINK_CLANG_DYLIB)
   set(CLANG_LIBS
     clangBasic
     clangDriver
@@ -613,7 +620,7 @@ else()
   set(SPIRV_STATIC_LIB "")
 endif()
 
-if (LLVM_LINK_LLVM_DYLIB)
+if (COMGR_LINK_LLVM_DYLIB)
   set(LLVM_LIBS LLVM ${SPIRV_DYNAMIC_LIB})
 else()
   llvm_map_components_to_libnames(LLVM_LIBS
@@ -747,7 +754,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   endif()
   set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/ROCm/llvm-project/tree/amd-staging/amd/comgr")
   set(DEBIAN_DEPENDENCIES "libzstd1, zlib1g, libc6, libstdc++6, libgcc-s1 | libgcc1")
-  if (LLVM_LINK_LLVM_DYLIB)
+  if (COMGR_LINK_LLVM_DYLIB)
     set(CPACK_DEBIAN_PACKAGE_DEPENDS "libtinfo-dev, rocm-core, rocm-llvm-core, ${DEBIAN_DEPENDENCIES}")
     set(CPACK_DEBIAN_ASAN_PACKAGE_DEPENDS "libtinfo-dev, rocm-core-asan, rocm-llvm-core, ${DEBIAN_DEPENDENCIES}")
   else()
@@ -781,7 +788,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(RPM_DEPENDENCIES "(zlib or libz1), (libzstd or libzstd1), glibc, (libstdc++ or libstdc++6), (libgcc or libgcc_s1)")
   endif()
 
-  if (LLVM_LINK_LLVM_DYLIB)
+  if (COMGR_LINK_LLVM_DYLIB)
     set(CPACK_RPM_PACKAGE_REQUIRES "rocm-core, rocm-llvm-core, ${RPM_DEPENDENCIES}")
     set(CPACK_RPM_ASAN_PACKAGE_REQUIRES "rocm-core-asan, rocm-llvm-core, ${RPM_DEPENDENCIES}")
   else()

--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -80,10 +80,11 @@ may be enabled during development via `-DADDRESS_SANITIZER=On` during the Comgr
 **Static Comgr:** Comgr can be built as a static library by passing
 `-DCOMGR_BUILD_SHARED_LIBS=OFF` during the Comgr `cmake` step.
 
-**Static LLVM Linking:** When building Comgr as a shared library within a
-super-project, you can statically link LLVM/Clang into Comgr by passing
-`-DCOMGR_STATIC_LLVM=ON`. By default (`OFF`), Comgr respects the existing
-`LLVM_LINK_LLVM_DYLIB` and `CLANG_LINK_CLANG_DYLIB` settings.
+**Static LLVM Linking:** When building Comgr as a shared library, pass
+`-DCOMGR_STATIC_LLVM=ON` to select the static LLVM, Clang, and LLD component
+libraries independently of the LLVM package's default linkage. By default
+(`OFF`), Comgr respects the existing `LLVM_LINK_LLVM_DYLIB` and
+`CLANG_LINK_CLANG_DYLIB` settings.
 
 **Windows DLL Name:** On Windows, the DLL is named `amd_comgr.dll` by default.
 To override this, pass `-DCOMGR_DLL_NAME=<name>.dll` during the Comgr `cmake`

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -15,9 +15,11 @@
 #
 # If none is available, skip the test-unit suite with a warning rather
 # than failing configure.
+set(COMGR_GTEST_NEEDS_LLVM_SUPPORT OFF)
 if(TARGET llvm_gtest)
   set(COMGR_GTEST_LIBS llvm_gtest_main llvm_gtest)
   set(COMGR_GTEST_INCLUDE_DIRS "")
+  set(COMGR_GTEST_NEEDS_LLVM_SUPPORT ON)
 else()
   find_library(COMGR_LLVM_GTEST_LIB llvm_gtest
     PATHS ${LLVM_LIBRARY_DIRS} NO_DEFAULT_PATH)
@@ -30,6 +32,7 @@ else()
     set(COMGR_GTEST_LIBS
       ${COMGR_LLVM_GTEST_MAIN_LIB} ${COMGR_LLVM_GTEST_LIB})
     set(COMGR_GTEST_INCLUDE_DIRS ${COMGR_LLVM_GTEST_INCLUDE_DIR})
+    set(COMGR_GTEST_NEEDS_LLVM_SUPPORT ON)
   else()
     find_package(GTest CONFIG QUIET)
     if(GTest_FOUND)
@@ -75,8 +78,18 @@ add_subdirectory(hotswap)
 add_executable(DemangleSymbolNameTest
   DemangleSymbolNameTest.cpp)
 
+# LLVM's GTest leaves its Support dependency for consumers to select.
+if(COMGR_GTEST_NEEDS_LLVM_SUPPORT)
+  if(COMGR_LINK_LLVM_DYLIB)
+    set(COMGR_TEST_UNIT_DEMANGLE_LLVM_LIBS LLVM)
+  else()
+    llvm_map_components_to_libnames(COMGR_TEST_UNIT_DEMANGLE_LLVM_LIBS Support)
+  endif()
+endif()
+
 target_link_libraries(DemangleSymbolNameTest PRIVATE
   ${COMGR_GTEST_LIBS}
+  ${COMGR_TEST_UNIT_DEMANGLE_LLVM_LIBS}
   amd_comgr
   ${LLVM_PTHREAD_LIB})
 

--- a/clang/cmake/modules/AddClang.cmake
+++ b/clang/cmake/modules/AddClang.cmake
@@ -106,7 +106,8 @@ macro(add_clang_library name)
     endif()
     set_property(GLOBAL APPEND PROPERTY CLANG_STATIC_LIBS ${name})
   endif()
-  llvm_add_library(${name} ${LIBTYPE} ${ARG_UNPARSED_ARGUMENTS} ${srcs})
+  llvm_add_library(${name} ${LIBTYPE} ENABLE_LLVM_STATIC_LINK_INTERFACE
+    ${ARG_UNPARSED_ARGUMENTS} ${srcs})
 
   if((WIN32 AND NOT MINGW) AND NOT CLANG_LINK_CLANG_DYLIB)
     # Make sure all consumers also turn off visibility macros so they're not

--- a/lld/cmake/modules/AddLLD.cmake
+++ b/lld/cmake/modules/AddLLD.cmake
@@ -10,7 +10,8 @@ macro(add_lld_library name)
   if(ARG_SHARED)
     set(ARG_ENABLE_SHARED SHARED)
   endif()
-  llvm_add_library(${name} ${ARG_ENABLE_SHARED} ${ARG_UNPARSED_ARGUMENTS})
+  llvm_add_library(${name} ${ARG_ENABLE_SHARED}
+    ENABLE_LLVM_STATIC_LINK_INTERFACE ${ARG_UNPARSED_ARGUMENTS})
 
   if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     get_target_export_arg(${name} LLD export_to_lldtargets UMBRELLA lld-libraries)

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -566,6 +566,9 @@ endfunction(set_windows_version_resource_properties)
 #   DISABLE_LLVM_LINK_LLVM_DYLIB
 #     Do not link this library to libLLVM, even if
 #     LLVM_LINK_LLVM_DYLIB is enabled.
+#   ENABLE_LLVM_STATIC_LINK_INTERFACE
+#     Let final consumers of a static library select its LLVM components by
+#     setting the LLVM_LINK_STATIC_COMPONENTS target property.
 #   OUTPUT_NAME name
 #     Corresponds to OUTPUT_NAME in target properties.
 #   DEPENDS targets...
@@ -596,7 +599,7 @@ endfunction(set_windows_version_resource_properties)
 #   )
 function(llvm_add_library name)
   cmake_parse_arguments(ARG
-    "MODULE;SHARED;STATIC;OBJECT;DISABLE_LLVM_LINK_LLVM_DYLIB;SONAME;NO_INSTALL_RPATH;COMPONENT_LIB;DISABLE_PCH_REUSE"
+    "MODULE;SHARED;STATIC;OBJECT;DISABLE_LLVM_LINK_LLVM_DYLIB;ENABLE_LLVM_STATIC_LINK_INTERFACE;SONAME;NO_INSTALL_RPATH;COMPONENT_LIB;DISABLE_PCH_REUSE"
     "OUTPUT_NAME;PLUGIN_TOOL;ENTITLEMENTS;BUNDLE_PATH"
     "ADDITIONAL_HEADERS;PRECOMPILE_HEADERS;DEPENDS;LINK_COMPONENTS;LINK_LIBS;OBJLIBS"
     ${ARGN})
@@ -707,8 +710,13 @@ function(llvm_add_library name)
       set(output_name OUTPUT_NAME "${ARG_OUTPUT_NAME}")
     endif()
     # DEPENDS has been appended to LLVM_COMMON_LIBS.
+    set(llvm_static_link_interface_arg)
+    if(ARG_ENABLE_LLVM_STATIC_LINK_INTERFACE)
+      set(llvm_static_link_interface_arg ENABLE_LLVM_STATIC_LINK_INTERFACE)
+    endif()
     llvm_add_library(${name_static} STATIC
       ${output_name}
+      ${llvm_static_link_interface_arg}
       OBJLIBS ${ALL_FILES} # objlib
       LINK_LIBS ${ARG_LINK_LIBS}
       LINK_COMPONENTS ${LLVM_LINK_COMPONENTS}
@@ -863,7 +871,21 @@ function(llvm_add_library name)
     set(llvm_libs ${ARG_PLUGIN_TOOL})
   elseif (NOT ARG_COMPONENT_LIB)
     if (LLVM_LINK_LLVM_DYLIB AND NOT ARG_DISABLE_LLVM_LINK_LLVM_DYLIB)
-      set(llvm_libs LLVM)
+      if(ARG_ENABLE_LLVM_STATIC_LINK_INTERFACE AND ARG_STATIC)
+        llvm_map_components_to_libnames(llvm_component_libs
+          ${LLVM_LINK_COMPONENTS}
+        )
+        set(link_static_components
+          "$<BOOL:$<TARGET_PROPERTY:LLVM_LINK_STATIC_COMPONENTS>>")
+        set(llvm_libs)
+        foreach(llvm_component_lib IN LISTS llvm_component_libs)
+          list(APPEND llvm_libs
+            "$<${link_static_components}:${llvm_component_lib}>")
+        endforeach()
+        list(APPEND llvm_libs "$<$<NOT:${link_static_components}>:LLVM>")
+      else()
+        set(llvm_libs LLVM)
+      endif()
     else()
       if(ARG_DISABLE_LLVM_LINK_LLVM_DYLIB)
         target_compile_definitions(${name} PRIVATE LLVM_BUILD_STATIC)
@@ -1023,10 +1045,13 @@ endfunction()
 
 macro(add_llvm_library name)
   cmake_parse_arguments(ARG
-    "SHARED;BUILDTREE_ONLY;MODULE;INSTALL_WITH_TOOLCHAIN;NO_EXPORT"
+    "SHARED;BUILDTREE_ONLY;MODULE;INSTALL_WITH_TOOLCHAIN;NO_EXPORT;DISABLE_LLVM_STATIC_LINK_INTERFACE"
     ""
     ""
     ${ARGN})
+  if(NOT ARG_DISABLE_LLVM_STATIC_LINK_INTERFACE)
+    list(APPEND ARG_UNPARSED_ARGUMENTS ENABLE_LLVM_STATIC_LINK_INTERFACE)
+  endif()
   if(ARG_MODULE)
     llvm_add_library(${name} MODULE ${ARG_UNPARSED_ARGUMENTS})
   elseif( BUILD_SHARED_LIBS OR ARG_SHARED )

--- a/third-party/unittest/CMakeLists.txt
+++ b/third-party/unittest/CMakeLists.txt
@@ -76,6 +76,8 @@ add_llvm_library("${gtest_name}"
   googletest/src/gtest-all.cc
   googlemock/src/gmock-all.cc
 
+  DISABLE_LLVM_STATIC_LINK_INTERFACE
+
   LINK_LIBS
   ${LIBS}
 
@@ -124,6 +126,8 @@ endif()
 
 add_llvm_library("${gtest_name}_main"
   ${gtest_main_src}
+
+  DISABLE_LLVM_STATIC_LINK_INTERFACE
 
   LINK_LIBS
   "${gtest_name}"


### PR DESCRIPTION
When LLVM is configured to link consumers against `libLLVM`, the exported Clang and LLD static targets still carry `libLLVM` in their link interfaces. Changing `LLVM_LINK_LLVM_DYLIB` later in COMGR therefore cannot produce a complete static compiler closure.

Teach `llvm_add_library` to expose a consumer-selectable static component interface alongside the normal `libLLVM` interface. `COMGR_STATIC_LLVM` selects that interface for the shared `amd_comgr` target and records COMGR's effective LLVM and Clang linkage without mutating package-wide variables. Normal LLVM, Clang, and LLD consumers retain their configured dylib linkage, while shared COMGR embeds the required LLVM, Clang, and LLD archives without depending on `libLLVM` or `libclang-cpp`.

I verified build-tree and installed-package consumption, the default dylib-linked COMGR configuration, a TheRock-equivalent configuration, and integration with #3720. The resulting `libamd_comgr.so` loads directly, exports only the COMGR API, and has no `libLLVM` or `libclang-cpp` `DT_NEEDED` entries or unresolved LLVM, Clang, or LLD symbols.

Addresses #2927.
