### PR TITLE
[DebugInfo] Remove obsolete dbg.def and dbg.kill intrinsics

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1656,12 +1656,6 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable] in {
                                         llvm_metadata_ty]>;
   def int_dbg_label        : DefaultAttrsIntrinsic<[],
                                        [llvm_metadata_ty]>;
-  def int_dbg_def          : DefaultAttrsIntrinsic<[],
-                                       [llvm_metadata_ty,
-                                        llvm_metadata_ty]>;
-  def int_dbg_kill         : DefaultAttrsIntrinsic<[],
-                                        [llvm_metadata_ty]>;
-
 }
 
 //===------------------ Exception Handling Intrinsics----------------------===//

--- a/llvm/lib/Analysis/ObjCARCInstKind.cpp
+++ b/llvm/lib/Analysis/ObjCARCInstKind.cpp
@@ -185,8 +185,6 @@ static bool isInertIntrinsic(unsigned ID) {
   case Intrinsic::dbg_declare:
   case Intrinsic::dbg_value:
   case Intrinsic::dbg_label:
-  case Intrinsic::dbg_def:
-  case Intrinsic::dbg_kill:
     // Short cut: Some intrinsics obviously don't use ObjC pointers.
     return true;
   default:

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -2348,9 +2348,6 @@ bool IRTranslator::translateKnownIntrinsic(const CallInst &CI, Intrinsic::ID ID,
                        DI.getExpression(), DI.getDebugLoc(), MIRBuilder);
     return true;
   }
-  case Intrinsic::dbg_def:
-  case Intrinsic::dbg_kill:
-    report_fatal_error("unsupported DIExpr-based metadata");
   case Intrinsic::uadd_with_overflow:
     return translateOverflowIntrinsic(CI, TargetOpcode::G_UADDO, MIRBuilder);
   case Intrinsic::sadd_with_overflow:

--- a/llvm/lib/CodeGen/IntrinsicLowering.cpp
+++ b/llvm/lib/CodeGen/IntrinsicLowering.cpp
@@ -329,9 +329,7 @@ void IntrinsicLowering::LowerIntrinsicCall(CallInst *CI) {
   case Intrinsic::dbg_declare:
   case Intrinsic::dbg_label:
     break;    // Simply strip out debugging intrinsics
-  case Intrinsic::dbg_def:
-  case Intrinsic::dbg_kill:
-    report_fatal_error("unsupported DIExpr-based metadata");
+
   case Intrinsic::eh_typeid_for:
     // Return something different to eh_selector.
     CI->replaceAllUsesWith(ConstantInt::get(CI->getType(), 1));


### PR DESCRIPTION
I remove the unused intrinsic definitions and their remaining fallback cases. The DILifetime metadata and all valid producers and tests were removed earlier.

This removes the divergence introduced by b1ae1a462550 and its dependent GlobalISel handling.

Assisted-by: Claude Opus


