### PR TITLE
ci: switch SPIRV CI Linux runners to aws-linux-scale-rocm-large

### DIFF
--- a/.github/workflows/spirv-ci-linux-amd-staging.yml
+++ b/.github/workflows/spirv-ci-linux-amd-staging.yml
@@ -29,7 +29,7 @@ jobs:
   # =====================================================================
   build:
     name: Build
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-large
     timeout-minutes: 120
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
@@ -343,7 +343,7 @@ jobs:
   test_translator_lit:
     name: Test SPIRV translator lit
     needs: build
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-large
     timeout-minutes: 30
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
@@ -458,7 +458,7 @@ jobs:
   test_codegen:
     name: Test LLVM SPIRV codegen
     needs: build
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-large
     timeout-minutes: 15
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
@@ -509,7 +509,7 @@ jobs:
   test_comgr:
     name: Test Comgr
     needs: build
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-large
     timeout-minutes: 30
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
@@ -577,7 +577,7 @@ jobs:
   pick_runner:
     name: Select gfx942 test runner
     needs: [build]
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-large
     timeout-minutes: 5
     outputs:
       test_runs_on: ${{ steps.pick.outputs.label }}


### PR DESCRIPTION
Switch the Linux CPU build/test jobs in the SPIRV PR CI from the `azure-linux-scale-rocm` runner pool to `aws-linux-scale-rocm-large`.

The GPU test runners and the Windows workflow are unchanged.
