### PR TITLE
[Object] Remove unused locals from OffloadingBundleTest

### DIFF
--- a/llvm/unittests/Object/OffloadingBundleTest.cpp
+++ b/llvm/unittests/Object/OffloadingBundleTest.cpp
@@ -51,10 +51,6 @@ toBinary(SmallVectorImpl<char> &Storage, StringRef Yaml) {
 }
 
 TEST(OffloadingBundleTest, checkExtractOffloadBundleFatBinary) {
-
-  // create a Memory Buffer with a fatbin offloading section
-  MemoryBufferRef mbuf;
-  StringRef FileName;
   SmallVector<OffloadBundleEntry>();
   SmallString<0> Storage;
   // Expected<ELFObjectFile<ELF64LE>> ObjOrErr = toBinary<ELF64LE>(Storage, R"(
@@ -68,8 +64,6 @@ TEST(OffloadingBundleTest, checkExtractOffloadBundleFatBinary) {
 }
 
 TEST(OffloadingBundleTest, checkExtractCodeObject) {
-  // create a Memory Buffer with a fatbin offloading section
-  MemoryBufferRef mbuf;
   SmallVector<OffloadBundleEntry>();
   SmallString<0> Storage;
   // Expected<ELFObjectFile<ELF64LE>> ObjOrErr = toBinary<ELF64LE>(Storage, R"(


### PR DESCRIPTION
247da2cd5767, the merge-back of llvm/llvm-project#140286, is otherwise fully converged with upstream: nine of the ten files it touched are byte-identical to upstream `main`. This is the tenth.

`MemoryBufferRef mbuf` and `StringRef FileName` are unused, in test bodies whose contents are commented out. Upstream removed them. Deleting them makes the file identical to upstream as well.

Made with [Cursor](https://cursor.com)