### PR TITLE
[runtimes] Always add the LLVM lib/cmake path for external ROCm projects

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -584,12 +584,17 @@ if(build_runtimes)
   # CMAKE_PREFIX_PATH is the search path for CMake packages. In order to pass through
   # the command line interface, the CMake semicolon separator needs to be replaced
   # with $<SEMICOLON>
-  if(CMAKE_PREFIX_PATH)
-    string(JOIN "$<SEMICOLON>" escaped_cmake_prefix_path ${CMAKE_PREFIX_PATH})
-    # Some projects require access to the LLVM lib/cmake directory
-    if (OFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR OR DEFINED LIBOMPTARGET_EXTERNAL_PROJECT_ROCM_DEVICE_LIBS_PATH)
+  string(JOIN "$<SEMICOLON>" escaped_cmake_prefix_path ${CMAKE_PREFIX_PATH})
+  # Some projects require access to the LLVM lib/cmake directory, whether or not
+  # the user provided a prefix path of their own.
+  if (OFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR OR DEFINED LIBOMPTARGET_EXTERNAL_PROJECT_ROCM_DEVICE_LIBS_PATH)
+    if(escaped_cmake_prefix_path)
       string(PREPEND escaped_cmake_prefix_path "${CMAKE_BINARY_DIR}/lib/cmake$<SEMICOLON>")
+    else()
+      set(escaped_cmake_prefix_path "${CMAKE_BINARY_DIR}/lib/cmake")
     endif()
+  endif()
+  if(escaped_cmake_prefix_path)
     list(APPEND extra_cmake_args "-DCMAKE_PREFIX_PATH=${escaped_cmake_prefix_path}")
   endif()
 


### PR DESCRIPTION
## Summary

Fixes a regression from 62ef67d5672a in `llvm/runtimes/CMakeLists.txt`.

That commit moved the ROCm-specific prefix-path prepend into the generic `if(CMAKE_PREFIX_PATH)` block:

```cmake
if(CMAKE_PREFIX_PATH)
  string(JOIN "$<SEMICOLON>" escaped_cmake_prefix_path ${CMAKE_PREFIX_PATH})
  # Some projects require access to the LLVM lib/cmake directory
  if (OFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR OR DEFINED LIBOMPTARGET_EXTERNAL_PROJECT_ROCM_DEVICE_LIBS_PATH)
    string(PREPEND escaped_cmake_prefix_path "${CMAKE_BINARY_DIR}/lib/cmake$<SEMICOLON>")
  endif()
  list(APPEND extra_cmake_args "-DCMAKE_PREFIX_PATH=${escaped_cmake_prefix_path}")
endif()
```

The prepend is now conditional on the *user* having supplied a `CMAKE_PREFIX_PATH`. When external unified ROCr or external device-libs is enabled and the user supplied nothing, `extra_cmake_args` ends up with no `-DCMAKE_PREFIX_PATH` at all, so `ExternalProject_Add(rocr-runtime ...)` and the install-prefix `rocm-device-libs` build cannot find the cmake config of the LLVM being built. Before the move they received `${CMAKE_BINARY_DIR}/lib/cmake` unconditionally, since it was hardcoded in each `ExternalProject_Add` and then, after b6894a321809, prepended in the ROCm block itself.

The `else()` device-libs branch is unaffected because it still hardcodes the path. CI presumably always passes a `CMAKE_PREFIX_PATH`, which is likely why this has gone unnoticed.

## Fix

Compute the escaped path unconditionally, prepend the build-tree cmake directory when an external ROCm project needs it, and forward the argument only when the result is non-empty. The `$<SEMICOLON>` escaping that 62ef67d5672a introduced is preserved.

## Test plan

Verified by lifting the block verbatim into a standalone `cmake -P` harness and comparing old against new for all four combinations. Only the previously broken case changes:

| user `CMAKE_PREFIX_PATH` | external ROCm project | before | after |
| --- | --- | --- | --- |
| `/opt/rocm;/usr/local` | on | `-DCMAKE_PREFIX_PATH=/build/llvm/lib/cmake$<SEMICOLON>/opt/rocm$<SEMICOLON>/usr/local` | unchanged |
| unset | on | *no argument forwarded* | `-DCMAKE_PREFIX_PATH=/build/llvm/lib/cmake` |
| `/opt/rocm;/usr/local` | off | `-DCMAKE_PREFIX_PATH=/opt/rocm$<SEMICOLON>/usr/local` | unchanged |
| unset | off | *no argument forwarded* | unchanged |

ROCm-only change: upstream has no such prepend, so the pending upstream escaping fix (llvm/llvm-project#216169) is unaffected.
