### PR TITLE
[IR] Remove dead sanitized padded global attribute code

### DIFF
--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -352,9 +352,6 @@ public:
   /// Return the FPClassTest for nofpclass
   LLVM_ABI FPClassTest getNoFPClass() const;
 
-  /// Return if global variable is instrumented by AddrSanitizer.
-  bool isSanitizedPaddedGlobal() const;
-
   /// Returns the value of the range attribute.
   LLVM_ABI const ConstantRange &getRange() const;
 

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -523,10 +523,6 @@ FPClassTest Attribute::getNoFPClass() const {
   return static_cast<FPClassTest>(pImpl->getValueAsInt());
 }
 
-bool Attribute::isSanitizedPaddedGlobal() const {
-  return hasAttribute(Attribute::SanitizedPaddedGlobal);
-}
-
 const ConstantRange &Attribute::getRange() const {
   assert(hasAttribute(Attribute::Range) &&
          "Trying to get range args from non-range attribute");
@@ -731,9 +727,6 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
     raw_string_ostream(Result) << getNoFPClass();
     return Result;
   }
-
-  if (hasAttribute(Attribute::SanitizedPaddedGlobal))
-    return "sanitized_padded_global";
 
   if (hasAttribute(Attribute::Range)) {
     std::string Result;


### PR DESCRIPTION
I remove the unused isSanitizedPaddedGlobal accessor and an unreachable printing fallback. The common enum-attribute path already prints this attribute before the fallback can run.

This removes dead scaffolding introduced by c9245932a880. The live downstream ASan attribute and its bitcode support remain unchanged.

Assisted-by: Claude Opus


