### PR TITLE
[cmake] Remove the MSVC /Zm20 flag

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -624,10 +624,6 @@ if( MSVC )
     append("/WX" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
   endif (LLVM_ENABLE_WERROR)
 
-  # FIXME(kzhuravl): Need to check if it affects windows ci builds. If yes,
-  # we might need to upstream this, possibly under a cmake option.
-  append("/Zm20" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
-
   append("/Zc:inline" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 
   if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")


### PR DESCRIPTION
Removes the downstream-only `/Zm20` flag from the `if(MSVC)` block of
`llvm/cmake/modules/HandleLLVMOptions.cmake`, added in 346412ce5d3b to chase heap
space failures on the Windows CI.

That commit left a FIXME asking whether the flag was needed at all:

```cmake
  # FIXME(kzhuravl): Need to check if it affects windows ci builds. If yes,
  # we might need to upstream this, possibly under a cmake option.
  append("/Zm20" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
```

Microsoft's answer is that it should not be used here.

- `/Zm<factor>` sets the precompiled-header memory allocation limit as a
  percentage of the default work buffer, so `/Zm20` *reduces* the reservation to
  a fifth of the default.
- Since Visual Studio 2015 the compiler grows its heaps dynamically and lets a
  precompiled header span multiple address ranges, so
  [`/Zm` is "rarely necessary"](https://learn.microsoft.com/en-us/cpp/build/reference/zm-specify-precompiled-header-memory-allocation-limit?view=msvc-170).
  It was retained only for the `#pragma hdrstop` scenario, which LLVM does not
  use — LLVM gets its PCH from CMake's `target_precompile_headers`.
- The [PCH issues and recommendations](https://devblogs.microsoft.com/cppblog/precompiled-header-pch-issues-and-recommendations/)
  guidance is explicit: "If you're using the `/Zm` switch on your compile command
  line, remove it. That flag is no longer required to accommodate large PCH files
  in Visual Studio 2015 and forward." For the C1076/C3859 errors this was aimed
  at, the documented remedies are the x64-hosted compiler and fewer parallel
  build processes, and the `/Zm` value suggested by C3859 is to be ignored outside
  the `#pragma hdrstop` case.

Dropping it also removes the last difference between the downstream and upstream
copies of this file: after this change
`llvm/cmake/modules/HandleLLVMOptions.cmake` is byte-identical to `origin/main`
(checked at e5174fe68). `/Zm` appears nowhere else in the tree.

## Test plan

- Windows CI is the test. The flag only takes effect under MSVC, and the point of
  removing it is that the modern compiler manages PCH memory itself, so a clean
  Windows build is the whole verification.
- Non-Windows builds cannot be affected; the deleted lines are inside `if(MSVC)`.
- If Windows builds do fail on C1076/C3859 after this, the documented fix is the
  x64-hosted toolset or a lower parallelism, not restoring `/Zm`.

Co-authored-by: Cursor <cursoragent@cursor.com>
