### PR TITLE
[Support] Match upstream llvm#216528 in TypeName.h instead of local asserts

### DIFF
--- a/llvm/include/llvm/Support/TypeName.h
+++ b/llvm/include/llvm/Support/TypeName.h
@@ -9,19 +9,21 @@
 #ifndef LLVM_SUPPORT_TYPENAME_H
 #define LLVM_SUPPORT_TYPENAME_H
 
+#include <cassert>
 #include <string_view>
 
 #include "llvm/ADT/StringRef.h"
 
-// Versions of GCC prior to GCC 9 don't declare __PRETTY_FUNCTION__ as constexpr
-#if defined(__clang__) || defined(_MSC_VER) ||                                 \
-    (defined(__GNUC__) && __GNUC__ >= 9)
+// Versions of GCC prior to GCC 9 don't declare __PRETTY_FUNCTION__ as
+// constexpr, and versions of MSVC prior to VS2017 15.3 (_MSC_VER 1910) don't
+// declare __FUNCSIG__ as constexpr.
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 9) ||              \
+    (defined(_MSC_VER) && _MSC_VER >= 1910)
 #define LLVM_GET_TYPE_NAME_CONSTEXPR constexpr
 #define LLVM_GET_TYPE_NAME_STATIC_ASSERT 1
 #else
 #define LLVM_GET_TYPE_NAME_CONSTEXPR
 #define LLVM_GET_TYPE_NAME_STATIC_ASSERT 0
-#include <cassert>
 #endif
 
 namespace llvm {
@@ -42,15 +44,18 @@ inline LLVM_GET_TYPE_NAME_CONSTEXPR StringRef getTypeName() {
   LLVM_GET_TYPE_NAME_CONSTEXPR std::string_view Name = __PRETTY_FUNCTION__;
 
   LLVM_GET_TYPE_NAME_CONSTEXPR std::string_view Key = "DesiredTypeName = ";
-  LLVM_GET_TYPE_NAME_CONSTEXPR std::string_view TemplateParamsStart =
-      Name.substr(Name.find(Key));
+  LLVM_GET_TYPE_NAME_CONSTEXPR std::string_view::size_type KeyPos =
+      Name.find(Key);
 #if LLVM_GET_TYPE_NAME_STATIC_ASSERT
-  static_assert(!TemplateParamsStart.empty(),
+  static_assert(KeyPos != std::string_view::npos,
                 "Unable to find the template parameter!");
 #else
-  assert(!TemplateParamsStart.empty() &&
+  assert(KeyPos != std::string_view::npos &&
          "Unable to find the template parameter!");
 #endif
+
+  LLVM_GET_TYPE_NAME_CONSTEXPR std::string_view TemplateParamsStart =
+      Name.substr(KeyPos);
 
   LLVM_GET_TYPE_NAME_CONSTEXPR std::string_view SubstitutionKey =
       TemplateParamsStart.substr(Key.size());
@@ -69,11 +74,19 @@ inline LLVM_GET_TYPE_NAME_CONSTEXPR StringRef getTypeName() {
   LLVM_GET_TYPE_NAME_CONSTEXPR std::string_view Name = __FUNCSIG__;
 
   LLVM_GET_TYPE_NAME_CONSTEXPR std::string_view Key = "getTypeName<";
+  LLVM_GET_TYPE_NAME_CONSTEXPR std::string_view::size_type KeyPos =
+      Name.find(Key);
+#if LLVM_GET_TYPE_NAME_STATIC_ASSERT
+  static_assert(KeyPos != std::string_view::npos,
+                "Unable to find the template parameter!");
+#else
+  assert(KeyPos != std::string_view::npos &&
+         "Unable to find the template parameter!");
+#endif
+
   LLVM_GET_TYPE_NAME_CONSTEXPR std::string_view GetTypeNameStart =
-      Name.substr(Name.find(Key));
-  // TODO: SWDEV-517818 - Changed from static_assert to assert to ensure
-  // compiler compatibility
-  assert(!GetTypeNameStart.empty() && "Unable to find the template parameter!");
+      Name.substr(KeyPos);
+
   LLVM_GET_TYPE_NAME_CONSTEXPR std::string_view SubstitutionKey =
       GetTypeNameStart.substr(Key.size());
 
@@ -96,10 +109,14 @@ inline LLVM_GET_TYPE_NAME_CONSTEXPR StringRef getTypeName() {
           : RmPrefixUnion;
 
   LLVM_GET_TYPE_NAME_CONSTEXPR auto AnglePos = RmPrefixEnum.rfind('>');
-  // TODO: SWDEV-517818 - Changed from static_assert to assert to ensure
-  // compiler compatibility
+#if LLVM_GET_TYPE_NAME_STATIC_ASSERT
+  static_assert(AnglePos != std::string_view::npos,
+                "Unable to find the closing '>'!");
+#else
   assert(AnglePos != std::string_view::npos &&
          "Unable to find the closing '>'!");
+#endif
+
   return RmPrefixEnum.substr(0, AnglePos);
 #else
   // No known technique for statically extracting a type name on this compiler.


### PR DESCRIPTION
Cherry-pick of https://github.com/llvm/llvm-project/pull/216528; `TypeName.h` here is byte-identical to that PR's version, so the next `main` -> `amd-staging` merge that carries it is a no-op for this file.

This replaces d5e274f4c4e0 (SWDEV-517818), which hand-edited the two `static_assert`s in the `_MSC_VER` branch into `assert`s. That kept the Windows build going but left the file diverged from upstream, with nothing recording which compiler needed it or when the `static_assert`s could come back. Upstream already has the mechanism for exactly this — `LLVM_GET_TYPE_NAME_STATIC_ASSERT`, from llvm/llvm-project#128212.

The upstream change also fixes the assertions themselves: they were checking the substring *after* `substr(Name.find(Key))`, which throws when `find` fails, so the messages could never be reported.

ROCm's Windows builders are on MSVC 14.29 and 14.44, both far past 19.10, so they keep the compile-time checks and nothing about their behaviour changes.

## Test plan

- No functional change relative to upstream; the file is a copy.
- GCC path in both the `static_assert` and `assert` configurations compiles and returns the expected type name; the MSVC branch was exercised by forcing it with a representative `__FUNCSIG__`. Details in llvm/llvm-project#216528.
