### PR TITLE
[Release] Match upstream in test-release.sh, dropping the local gzip -n

### DIFF
--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -369,7 +369,7 @@ function build_with_cmake_cache() {
  pushd $BuildDir/Release
  mv $InstallDir/usr/local $Package
  if [ "$use_gzip" = "yes" ]; then
-    tar cf - $Package | gzip -9c -n > $BuildDir/$Package.tar.gz
+    tar cf - $Package | gzip -9c > $BuildDir/$Package.tar.gz
   else
     tar cf - $Package | xz -9ce -T $NumJobs > $BuildDir/$Package.tar.xz
   fi
@@ -613,7 +613,7 @@ function package_release() {
     cd $BuildDir/Phase3/Release
     mv llvmCore-$Release-$RC.install/usr/local $Package
     if [ "$use_gzip" = "yes" ]; then
-      tar cf - $Package | gzip -9c -n > $BuildDir/$Package.tar.gz
+      tar cf - $Package | gzip -9c > $BuildDir/$Package.tar.gz
     else
       tar cf - $Package | xz -9ce -T $NumJobs > $BuildDir/$Package.tar.xz
     fi


### PR DESCRIPTION
Reverts the two-line delta added by 13f7dd1306ce ("fix lintian warning"), which
passed `-n` to the two `gzip -9c` invocations in
`llvm/utils/release/test-release.sh`.

This is irrelevant for modern gzip and is a difference from upstream.
