### PR TITLE
[Testing Only] [AMDGPU] Support gfx1250 A0/B0 revision in offload bundle target IDs

### DIFF
--- a/amd/comgr/test-lit/unbundle-gfx1250-revision.hip
+++ b/amd/comgr/test-lit/unbundle-gfx1250-revision.hip
@@ -1,0 +1,40 @@
+// Two gfx1250 code objects that differ only by the gfx1250 A0/B0 hardware
+// revision -- carried as the (temporary) gfx1250-b0-specific target-ID feature,
+// "+" = B0, "-" = A0 -- can coexist in one offload bundle and be unbundled
+// independently by their marker.
+
+// COM: Bundle both revisions for the same gfx1250 processor.
+// RUN: %clang -c -x hip \
+// RUN:   --offload-arch=gfx1250:gfx1250-b0-specific+ \
+// RUN:   --offload-arch=gfx1250:gfx1250-b0-specific- \
+// RUN:   -nogpulib -nogpuinc -emit-llvm --gpu-bundle-output --offload-device-only \
+// RUN:   %s -o %t.bundle.bc
+
+// COM: Each marker selects a gfx1250 code object.
+// RUN: unbundle %t.bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx1250:gfx1250-b0-specific+ %t.b0.bc
+// RUN: %llvm-dis %t.b0.bc -o - | %FileCheck --check-prefix=GFX1250 %s
+// RUN: unbundle %t.bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx1250:gfx1250-b0-specific- %t.a0.bc
+// RUN: %llvm-dis %t.a0.bc -o - | %FileCheck --check-prefix=GFX1250 %s
+
+// COM: A bare gfx1250 request (no revision) matches neither entry -> empty
+// COM: output, which is not valid bitcode.
+// RUN: unbundle %t.bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx1250 %t.bare.bc
+// RUN: not %llvm-dis %t.bare.bc -o /dev/null
+
+// COM: The markers are not interchangeable. A bundle carrying only B0 yields
+// COM: nothing for an A0 request, but the object for a B0 request.
+// RUN: %clang -c -x hip --offload-arch=gfx1250:gfx1250-b0-specific+ \
+// RUN:   -nogpulib -nogpuinc -emit-llvm --gpu-bundle-output --offload-device-only \
+// RUN:   %s -o %t.b0only.bc
+// RUN: unbundle %t.b0only.bc hip-amdgcn-amd-amdhsa-unknown-gfx1250:gfx1250-b0-specific- %t.miss.bc
+// RUN: not %llvm-dis %t.miss.bc -o /dev/null
+// RUN: unbundle %t.b0only.bc hip-amdgcn-amd-amdhsa-unknown-gfx1250:gfx1250-b0-specific+ %t.hit.bc
+// RUN: %llvm-dis %t.hit.bc -o - | %FileCheck --check-prefix=GFX1250 %s
+
+// GFX1250: target triple = "amdgcn-amd-amdhsa"
+// GFX1250: "target-cpu"="gfx1250"
+
+__attribute__((device))
+void add_value(float* a, float* b, float* res) {
+    *res = *a + *b;
+}

--- a/clang/lib/Basic/TargetID.cpp
+++ b/clang/lib/Basic/TargetID.cpp
@@ -30,6 +30,12 @@ getAllPossibleAMDGPUTargetIDFeatures(const llvm::Triple &T,
   if (ProcKind == llvm::AMDGPU::GK_NONE)
     return Ret;
   unsigned Features = llvm::AMDGPU::getArchAttrAMDGCN(ProcKind);
+  // TODO(gfx1250-A0): Temporary. Allow the gfx1250 A0/B0 hardware revision to be
+  // carried as a target-ID feature so A0 and B0 code objects can coexist in a
+  // single offload bundle and be selected independently. Remove once gfx1250 A0
+  // is decommissioned. (Alphabetical order: before "sramecc".)
+  if (ProcKind == llvm::AMDGPU::GK_GFX1250)
+    Ret.push_back("gfx1250-b0-specific");
   if (Features & llvm::AMDGPU::FEATURE_SRAMECC)
     Ret.push_back("sramecc");
   // Only allow xnack in target ID if the processor supports on/off modes.


### PR DESCRIPTION
## Summary

gfx1250 ships in two hardware revisions, A0 and B0, that share one gfxID and one ELF mach value and differ only by the `gfx1250-b0-specific` subtarget feature. Because that feature was not an allowed AMDGPU target-ID feature, a single offload bundle could not hold both an A0 and a B0 code object — both collapsed to the identical entry ID `...-gfx1250`.

This allows `gfx1250-b0-specific` to appear in a target ID (gated to gfx1250), so `clang-offload-bundler` and Comgr can create and select the distinct entries:
- `gfx1250:gfx1250-b0-specific+` (B0)
- `gfx1250:gfx1250-b0-specific-` (A0)

Normal `--offload-arch=gfx1250` builds are unaffected; the marker only appears when explicitly requested. A Comgr lit test bundles both revisions and unbundles each by its marker, and checks that a bare `gfx1250` request matches neither entry.

The change is intentionally minimal and marked temporary (removable once gfx1250 A0 is decommissioned).
