### PR TITLE
[Testing Only] [AMDGPU] gfx1250 A0/B0 in offload bundles

### DIFF
--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -109,6 +109,10 @@ def _fwd(*parts):
     return os.path.join(*parts).replace("\\", "/")
 
 # %-prefixed substitutions for LLVM tools (used as %clang, %llvm-dis, etc.)
+# Note: %clang-offload-bundler must precede %clang so the longer token is
+# substituted first (lit does plain string replacement in list order).
+config.substitutions.append(
+    ("%clang-offload-bundler", _fwd(config.llvm_tools_dir, "clang-offload-bundler")))
 config.substitutions.append(("%clang", _fwd(config.llvm_tools_dir, "clang")))
 config.substitutions.append(("%llvm-dis", _fwd(config.llvm_tools_dir, "llvm-dis")))
 config.substitutions.append(("%llvm-mc", _fwd(config.llvm_tools_dir, "llvm-mc")))

--- a/amd/comgr/test-lit/unbundle-gfx1250-revision.hip
+++ b/amd/comgr/test-lit/unbundle-gfx1250-revision.hip
@@ -1,0 +1,51 @@
+// Two gfx1250 code objects that differ only by the gfx1250 A0/B0 hardware
+// revision -- carried as the (temporary) gfx1250-b0-specific target-ID feature,
+// "+" = B0, "-" = A0 -- can coexist in one offload bundle and be unbundled
+// independently by their marker.
+//
+// This variant keeps the marker out of the canonical AMDGPU target-ID feature
+// set: the clang driver does not accept it in --offload-arch, so the bundle is
+// assembled with clang-offload-bundler directly (its create path validates
+// entry-ID format only). Comgr's unbundler recognizes the marker.
+
+// COM: Compile one plain gfx1250 device bitcode; bundle it under both revision
+// COM: markers (payload content is irrelevant here -- this exercises marker
+// COM: based selection).
+// RUN: %clang -c -x hip --offload-arch=gfx1250 -nogpulib -nogpuinc -emit-llvm \
+// RUN:   --no-gpu-bundle-output --offload-device-only %s -o %t.gfx1250.bc
+
+// COM: Store hipv4 entries (as a real HIP fat binary does) and query them below
+// COM: with the hip kind, so selection goes through the feature-comparison path
+// COM: rather than an exact string match.
+// RUN: %clang-offload-bundler -type=bc \
+// RUN:   -targets=hipv4-amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+,hipv4-amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   -input=%t.gfx1250.bc -input=%t.gfx1250.bc -output=%t.bundle.bc
+
+// COM: Each marker selects a gfx1250 code object.
+// RUN: unbundle %t.bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx1250:gfx1250-b0-specific+ %t.b0.bc
+// RUN: %llvm-dis %t.b0.bc -o - | %FileCheck --check-prefix=GFX1250 %s
+// RUN: unbundle %t.bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx1250:gfx1250-b0-specific- %t.a0.bc
+// RUN: %llvm-dis %t.a0.bc -o - | %FileCheck --check-prefix=GFX1250 %s
+
+// COM: A bare gfx1250 request (no revision) matches neither entry -> empty
+// COM: output, which is not valid bitcode.
+// RUN: unbundle %t.bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx1250 %t.bare.bc
+// RUN: not %llvm-dis %t.bare.bc -o /dev/null
+
+// COM: The markers are not interchangeable. A bundle carrying only B0 yields
+// COM: nothing for an A0 request, but the object for a B0 request.
+// RUN: %clang-offload-bundler -type=bc \
+// RUN:   -targets=hipv4-amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   -input=%t.gfx1250.bc -output=%t.b0only.bc
+// RUN: unbundle %t.b0only.bc hip-amdgcn-amd-amdhsa-unknown-gfx1250:gfx1250-b0-specific- %t.miss.bc
+// RUN: not %llvm-dis %t.miss.bc -o /dev/null
+// RUN: unbundle %t.b0only.bc hip-amdgcn-amd-amdhsa-unknown-gfx1250:gfx1250-b0-specific+ %t.hit.bc
+// RUN: %llvm-dis %t.hit.bc -o - | %FileCheck --check-prefix=GFX1250 %s
+
+// GFX1250: target triple = "amdgcn-amd-amdhsa"
+// GFX1250: "target-cpu"="gfx1250"
+
+__attribute__((device))
+void add_value(float* a, float* b, float* res) {
+    *res = *a + *b;
+}

--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -1087,6 +1087,32 @@ Error OffloadBundler::ListBundleIDsInFile(
   return Error::success();
 }
 
+// TODO(gfx1250-A0): Temporary. The gfx1250 A0/B0 hardware revision is carried as
+// the gfx1250-b0-specific target-ID feature ("+" = B0, "-" = A0). It is not a
+// canonical AMDGPU target-ID feature, so parseTargetID() would reject any ID
+// containing it. Split the marker off a target ID, returning the remaining ID
+// and, if present, the marker's value. Remove once gfx1250 A0 is decommissioned.
+static std::string splitGfx1250B0Feature(StringRef TargetID,
+                                         std::optional<bool> &B0) {
+  SmallVector<StringRef, 4> Parts;
+  TargetID.split(Parts, ':');
+  std::string Rest;
+  for (StringRef Part : Parts) {
+    if (Part == "gfx1250-b0-specific+") {
+      B0 = true;
+      continue;
+    }
+    if (Part == "gfx1250-b0-specific-") {
+      B0 = false;
+      continue;
+    }
+    if (!Rest.empty())
+      Rest += ':';
+    Rest += Part.str();
+  }
+  return Rest;
+}
+
 /// @brief Checks if a code object \p CodeObjectInfo is compatible with a given
 /// target \p TargetInfo.
 /// @link https://clang.llvm.org/docs/ClangOffloadBundler.html#bundle-entry-id
@@ -1113,12 +1139,25 @@ bool isCodeObjectCompatible(const OffloadTargetInfo &CodeObjectInfo,
     return false;
   }
 
+  // TODO(gfx1250-A0): Temporary. Peel off the gfx1250 A0/B0 revision marker
+  // before parseTargetID (which does not recognize it). A code object that pins
+  // a revision is compatible only with a target requesting the same revision; a
+  // code object with no marker is revision-agnostic. Remove once gfx1250 A0 is
+  // decommissioned.
+  std::optional<bool> CodeObjectB0, TargetB0;
+  std::string CodeObjectTargetID =
+      splitGfx1250B0Feature(CodeObjectInfo.TargetID, CodeObjectB0);
+  std::string TargetTargetID =
+      splitGfx1250B0Feature(TargetInfo.TargetID, TargetB0);
+  if (CodeObjectB0 && (!TargetB0 || *TargetB0 != *CodeObjectB0))
+    return false;
+
   // Incompatible if Processors mismatch.
   llvm::StringMap<bool> CodeObjectFeatureMap, TargetFeatureMap;
   std::optional<StringRef> CodeObjectProc = clang::parseTargetID(
-      CodeObjectInfo.Triple, CodeObjectInfo.TargetID, &CodeObjectFeatureMap);
+      CodeObjectInfo.Triple, CodeObjectTargetID, &CodeObjectFeatureMap);
   std::optional<StringRef> TargetProc = clang::parseTargetID(
-      TargetInfo.Triple, TargetInfo.TargetID, &TargetFeatureMap);
+      TargetInfo.Triple, TargetTargetID, &TargetFeatureMap);
 
   // Both TargetProc and CodeObjectProc can't be empty here.
   if (!TargetProc || !CodeObjectProc ||


### PR DESCRIPTION
## Summary

**Alternative to #3975, for comparison.** Same goal — let a single offload bundle carry both a gfx1250 A0 and B0 code object, distinguished by the `gfx1250-b0-specific` revision marker (`+` = B0, `-` = A0) — but **without** adding `gfx1250-b0-specific` to the canonical AMDGPU target-ID feature set.

Instead of touching `clang/lib/Basic/TargetID.cpp` (`getAllPossibleAMDGPUTargetIDFeatures`), this handles the marker locally in the offload bundler's `isCodeObjectCompatible`:
- peel the `gfx1250-b0-specific±` marker off both the code-object and target IDs before `parseTargetID` (which does not recognize it),
- a code object that pins a revision matches only a target requesting the same revision; an unmarked code object stays revision-agnostic,
- then compare the remaining IDs normally.

Bundle creation is unaffected — `clang-offload-bundler` validates entry-ID format only.
