### PR TITLE
[Flang][OpenMP] Prevent unrequired implicit maps for private variables on composite directives

### DIFF
--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
@@ -548,8 +548,23 @@ void DataSharingProcessor::collectPrivatizedSymbols(
       // and not be added/captured by later directives. Parallel regions
       // will likely want the same captures to be shared and for SIMD it's
       // illegal to have firstprivate clauses.
+      //
+      // Likewise, an implicit private clause should only be applied to the
+      // target construct and the leaf where it is explicitly applied. For,
+      // example for the combined construct `target teams distribute private(a)`
+      // we mark OmpImplicit+OmpPrivate in semantics, and this verification step
+      // makes sure we only apply the privatization to target, and distribute,
+      // target implicitly and distribute explicitly.
+      //
+      // Realistically this just prevents extra redundant intermediate
+      // allocations and assignments (in the firstprivate case) that would be
+      // generated between the different directive regions. As technically it
+      // is OpenMP compliant to have private/firstprivate or any other clause
+      // on a combined construct apply on all directives that can legally have
+      // it.
       if (isConstructWithTopLevelTarget(eval) && !isTargetPrivatization &&
-          sym->test(semantics::Symbol::Flag::OmpFirstPrivate)) {
+          (sym->test(semantics::Symbol::Flag::OmpFirstPrivate) ||
+           sym->test(semantics::Symbol::Flag::OmpPrivate))) {
         return false;
       }
 

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2751,13 +2751,45 @@ void OmpAttributeVisitor::CreateImplicitSymbols(
     }
 
     if (dsa.any()) {
-      if (parallelDir || taskGenDir || teamsDir) {
+      bool isParTaskOrTeams = parallelDir || taskGenDir || teamsDir;
+      // NOTE As `dsa` will match that of the symbol in the current scope
+      //      (if any), we won't override the DSA of any existing symbol.
+      bool dsaAny = (dsa & dataSharingAttributeFlags).any();
+      Symbol::Flags flags{dsa};
+
+      // Make sure that we mark components implicitly private so that
+      // later in lowering the DataSharingProcessor can correctly assess
+      // that the target directive must also be privatized for composite
+      // directives, rather than just the leaf construct. For example,
+      // in "!$omp target teams distribute private(s)" we wish to have
+      // target privatize (s) as well, not just the distribute.
+      // However, for a combined/composite construct it is correct from an
+      // OpenMP specification to reflect these flags on all composite
+      // components, not just the leaf as the clauses in theory apply
+      // at all levels. But, for this case we try to be as restrictive
+      // as possible while maintaining correctness, as reflecting
+      // individual private across everything will result in unrequired
+      // extra allocations.
+      // NOTE: This is separate to the usual isParTaskOrTeams as we need to
+      // cover all the parallel set when coupled with target, not just
+      // the top set.
+      if (dsaAny &&
+          (isParTaskOrTeams ||
+              llvm::omp::allParallelSet.test(dirContext.directive)) &&
+          targetDir && dsa.test(Symbol::Flag::OmpPrivate)) {
+        flags.set(Symbol::Flag::OmpImplicit);
+        // Will be executed below if we fall into isParTaskOrTeams, but
+        // we should cover the cases when we do not.
+        if (!isParTaskOrTeams)
+          makeSymbol(flags);
+      }
+
+      if (isParTaskOrTeams) {
         Symbol *prevDeclSymbol{lastDeclSymbol};
-        // NOTE As `dsa` will match that of the symbol in the current scope
-        //      (if any), we won't override the DSA of any existing symbol.
-        if ((dsa & dataSharingAttributeFlags).any()) {
-          makeSymbol(dsa);
-        }
+
+        if (dsaAny)
+          makeSymbol(flags);
+
         // Fix host association of explicit symbols, as they can be created
         // before implicit ones in enclosing scope.
         if (prevDeclSymbol && prevDeclSymbol != lastDeclSymbol &&

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-teams-private-implicit-scalar-map.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-teams-private-implicit-scalar-map.f90
@@ -4,10 +4,10 @@
 ! RUN: %flang_fc1 -emit-mlir -fopenmp -mmlir --enable-delayed-privatization-staging \
 ! RUN:   -o - %s 2>&1 | FileCheck %s
 
+!CHECK:   omp.private {type = firstprivate} @[[SYM_XDGFX:.*]] : i32 copy {
 !CHECK:   omp.private {type = private} @[[SYM_K:.*]] : i32
 !CHECK:   omp.private {type = private} @[[SYM_J:.*]] : i32
 !CHECK:   omp.private {type = private} @[[SYM_I:.*]] : i32
-!CHECK:   omp.private {type = firstprivate} @[[SYM_XDGFX:.*]] : i32 copy {
 !CHECK:   omp.private {type = firstprivate} @[[SYM_XFPVX:.*]] : i32 copy {
 
 program test_default_implicit_firstprivate
@@ -23,9 +23,6 @@ program test_default_implicit_firstprivate
 !CHECK:           %[[VAL_4:.*]] = fir.declare %{{.*}} {uniq_name = "_QFEk"} : (!fir.ref<i32>) -> !fir.ref<i32>
 !CHECK:           %[[VAL_5:.*]] = fir.declare %{{.*}} {uniq_name = "_QFExdgfx"} : (!fir.ref<i32>) -> !fir.ref<i32>
 !CHECK:           %[[VAL_6:.*]] = fir.declare %{{.*}} {uniq_name = "_QFExfpvx"} : (!fir.ref<i32>) -> !fir.ref<i32>
-!CHECK:           %[[VAL_7:.*]] = omp.map.info var_ptr(%[[VAL_2]] : !fir.ref<i32>, i32) map_clauses(implicit) capture(ByCopy) -> !fir.ref<i32> {name = "i"}
-!CHECK:           %[[VAL_8:.*]] = omp.map.info var_ptr(%[[VAL_3]] : !fir.ref<i32>, i32) map_clauses(implicit) capture(ByCopy) -> !fir.ref<i32> {name = "j"}
-!CHECK:           %[[VAL_9:.*]] = omp.map.info var_ptr(%[[VAL_4]] : !fir.ref<i32>, i32) map_clauses(implicit) capture(ByCopy) -> !fir.ref<i32> {name = "k"}
 !CHECK:           %[[VAL_10:.*]] = fir.box_offset %[[VAL_0]] base_addr : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.llvm_ptr<!fir.ref<!fir.array<?x?x?xi32>>>
 !CHECK:           %[[VAL_11:.*]] = omp.map.info var_ptr(%[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.box<!fir.heap<!fir.array<?x?x?xi32>>>) map_clauses(implicit, tofrom) capture(ByRef) var_ptr_ptr(%[[VAL_10]] : !fir.llvm_ptr<!fir.ref<!fir.array<?x?x?xi32>>>, i32) bounds({{.*}}) -> !fir.llvm_ptr<!fir.ref<!fir.array<?x?x?xi32>>> {name = ""}
 !CHECK:           %[[VAL_12:.*]] = omp.map.info var_ptr(%[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.box<!fir.heap<!fir.array<?x?x?xi32>>>) map_clauses(always, implicit, to) capture(ByRef) members(%[[VAL_11]] : [0] : !fir.llvm_ptr<!fir.ref<!fir.array<?x?x?xi32>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>> {name = "allocarr"}
@@ -33,8 +30,8 @@ program test_default_implicit_firstprivate
 !CHECK:           %[[VAL_13:.*]] = omp.map.info var_ptr(%[[VAL_1]] : !fir.ref<!fir.array<10x10x10xi32>>, !fir.array<10x10x10xi32>) map_clauses(implicit, tofrom) capture(ByRef) bounds({{.*}}) -> !fir.ref<!fir.array<10x10x10xi32>> {name = "arr"}
 !CHECK:           %[[VAL_14:.*]] = omp.map.info var_ptr(%[[VAL_6]] : !fir.ref<i32>, i32) map_clauses(to) capture(ByCopy) -> !fir.ref<i32>
 !CHECK:           %[[VAL_15:.*]] = omp.map.info var_ptr(%[[VAL_5]] : !fir.ref<i32>, i32) map_clauses(to) capture(ByCopy) -> !fir.ref<i32>
-!CHECK:           omp.target kernel_type(spmd) host_eval({{.*}}) map_entries(%[[VAL_7]] -> %{{.*}}, %[[VAL_8]] -> %{{.*}}, %[[VAL_9]] -> %{{.*}}, %[[VAL_12]] -> %{{.*}}, %[[VAL_13]] -> %{{.*}}, %[[VAL_14]] -> %{{.*}}, %[[VAL_15]] -> %{{.*}}, %[[VAL_12_ATTACH]] -> %{{.*}}, %[[VAL_11]] -> %{{.*}} : {{.*}}) private(@[[SYM_XFPVX]] %[[VAL_6]] -> %{{.*}} [map_idx=5], @[[SYM_XDGFX]] %[[VAL_5]] -> %{{.*}} [map_idx=6] : {{.*}}) {
-!CHECK              omp.parallel private(@[[SYM_XFPVX]] %{{.*}} -> %{{.*}}, @[[SYM_XDGFX]] %{{.*}} -> %{{.*}}, @[[SYM_I]] %{{.*}} -> %{{.*}}, @[[SYM_J]] %{{.*}} -> %{{.*}}, @[[SYM_K]] %{{.*}} -> %{{.*}} : {{.*}}) {
+!CHECK:           omp.target kernel_type(spmd) host_eval({{.*}}) map_entries(%[[VAL_12]] -> %{{.*}}, %[[VAL_13]] -> %{{.*}}, %[[VAL_14]] -> %{{.*}}, %[[VAL_15]] -> %{{.*}}, %[[VAL_12_ATTACH]] -> %{{.*}}, %[[VAL_11]] -> %{{.*}} : {{.*}}) private(@[[SYM_XFPVX]] %[[VAL_6]] -> %{{.*}} [map_idx=2], @[[SYM_I]] %[[VAL_2]] -> %{{.*}}, @[[SYM_J]] %[[VAL_3]] -> %{{.*}}, @[[SYM_K]] %[[VAL_4]] -> %{{.*}}, @[[SYM_XDGFX]] %[[VAL_5]] -> %{{.*}} [map_idx=3] : {{.*}}) {
+!CHECK:             omp.parallel private(@[[SYM_XFPVX]] %{{.*}} -> %{{.*}}, @[[SYM_I]] %{{.*}} -> %{{.*}}, @[[SYM_J]] %{{.*}} -> %{{.*}}, @[[SYM_K]] %{{.*}} -> %{{.*}} : {{.*}}) {
   !$omp target teams distribute parallel do collapse(3) firstprivate(xfpvx)
     do i = 1, 10
         do j = 1, 10

--- a/flang/test/Lower/OpenMP/common-block-target-update.f90
+++ b/flang/test/Lower/OpenMP/common-block-target-update.f90
@@ -24,7 +24,7 @@ end program
 ! CHECK: omp.target_update map_entries(%[[MAP_TO]] : !fir.ref<!fir.array<800xi8>>)
 
 ! CHECK: %[[MAP_TOFROM:.*]] = omp.map.info var_ptr(%[[CB_ADDR]] : !fir.ref<!fir.array<800xi8>>, !fir.array<800xi8>) map_clauses(tofrom) capture(ByRef) -> !fir.ref<!fir.array<800xi8>> {name = "cb_array"}
-! CHECK: omp.target {{.*}} map_entries(%[[MAP_TOFROM]] -> %{{.*}}, %{{.*}} -> %{{.*}} : !fir.ref<!fir.array<800xi8>>, !fir.ref<i32>)
+! CHECK: omp.target {{.*}} map_entries(%[[MAP_TOFROM]] -> %{{.*}} : !fir.ref<!fir.array<800xi8>>) private({{.*}} %{{.*}} -> %{{.*}} : !fir.ref<i32>)
 
 ! CHECK: %[[MAP_FROM:.*]] = omp.map.info var_ptr(%[[CB_ADDR]] : !fir.ref<!fir.array<800xi8>>, !fir.array<800xi8>) map_clauses(from) capture(ByRef) -> !fir.ref<!fir.array<800xi8>> {name = "cb_array"}
 ! CHECK: omp.target_update map_entries(%[[MAP_FROM]] : !fir.ref<!fir.array<800xi8>>)

--- a/flang/test/Lower/OpenMP/optional-argument-map-3.f90
+++ b/flang/test/Lower/OpenMP/optional-argument-map-3.f90
@@ -34,7 +34,7 @@ end module
 ! CHECK:             %[[VAL_3:.*]] = fir.box_offset %[[VAL_0]] base_addr : (!fir.ref<!fir.box<!fir.array<?xf32>>>) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xf32>>>
 ! CHECK:             %[[VAL_4:.*]] = omp.map.info var_ptr(%[[VAL_0]] : !fir.ref<!fir.box<!fir.array<?xf32>>>, !fir.box<!fir.array<?xf32>>) map_clauses(implicit, tofrom) capture(ByRef) var_ptr_ptr(%[[VAL_3]] : !fir.llvm_ptr<!fir.ref<!fir.array<?xf32>>>, f32) bounds(%{{.*}}) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xf32>>> {name = ""}
 ! CHECK:             %[[VAL_5:.*]] = omp.map.info var_ptr(%[[VAL_0]] : !fir.ref<!fir.box<!fir.array<?xf32>>>, !fir.box<!fir.array<?xf32>>) map_clauses(implicit, target_param, private, attach) capture(ByRef) var_ptr_ptr(%[[VAL_3]] : !fir.llvm_ptr<!fir.ref<!fir.array<?xf32>>>, f32) members(%[[VAL_4]] : [0] : !fir.llvm_ptr<!fir.ref<!fir.array<?xf32>>>) -> !fir.ref<!fir.array<?xf32>> {name = "dt"}
-! CHECK:             omp.target kernel_type(spmd) host_eval({{.*}}) map_entries({{.*}}%[[VAL_5]] -> {{.*}}, %[[VAL_4]] -> {{.*}} : {{.*}}) {
+! CHECK:             omp.target kernel_type(spmd) host_eval({{.*}}) map_entries(%[[VAL_5]] -> {{.*}}, %{{.*}} -> {{.*}}, %[[VAL_4]] -> {{.*}} : {{.*}}) private({{.*}} -> %{{.*}} : !fir.ref<i32>) {
 ! CHECK:           } else {
 ! CHECK:             %[[VAL_6:.*]] = fir.is_present %[[VAL_1]]#1 : (!fir.box<!fir.array<?xf32>>) -> i1
 ! CHECK:             fir.if %[[VAL_6]] {
@@ -43,4 +43,4 @@ end module
 ! CHECK:             %[[VAL_7:.*]] = fir.box_offset %[[VAL_0]] base_addr : (!fir.ref<!fir.box<!fir.array<?xf32>>>) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xf32>>>
 ! CHECK:             %[[VAL_8:.*]] = omp.map.info var_ptr(%[[VAL_0]] : !fir.ref<!fir.box<!fir.array<?xf32>>>, !fir.box<!fir.array<?xf32>>) map_clauses(implicit, tofrom) capture(ByRef) var_ptr_ptr(%[[VAL_7]] : !fir.llvm_ptr<!fir.ref<!fir.array<?xf32>>>, f32) bounds(%{{.*}}) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xf32>>> {name = ""}
 ! CHECK:             %[[VAL_9:.*]] = omp.map.info var_ptr(%[[VAL_0]] : !fir.ref<!fir.box<!fir.array<?xf32>>>, !fir.box<!fir.array<?xf32>>) map_clauses(implicit, target_param, private, attach) capture(ByRef) var_ptr_ptr(%[[VAL_7]] : !fir.llvm_ptr<!fir.ref<!fir.array<?xf32>>>, f32) members(%[[VAL_8]] : [0] : !fir.llvm_ptr<!fir.ref<!fir.array<?xf32>>>) -> !fir.ref<!fir.array<?xf32>> {name = "dt"}
-! CHECK:             omp.target kernel_type(spmd) host_eval({{.*}}) map_entries({{.*}}, %[[VAL_9]] ->{{.*}}, %[[VAL_8]] -> {{.*}} : {{.*}}) {
+! CHECK:             omp.target kernel_type(spmd) host_eval({{.*}}) map_entries(%[[VAL_9]] -> {{.*}}, %{{.*}} -> {{.*}}, %[[VAL_8]] -> {{.*}} : {{.*}}) private({{.*}} -> %{{.*}} : !fir.ref<i32>) {

--- a/flang/test/Lower/OpenMP/target-combined-private-pointer.f90
+++ b/flang/test/Lower/OpenMP/target-combined-private-pointer.f90
@@ -1,0 +1,102 @@
+! RUN: bbc -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+
+! Test that a private variables on a combined/composite target construct
+! (e.g. `target teams distribute private(a)` or `target parallel do
+! private(a)`) is privatized at the target level so that:
+!   (1) no implicit map is emitted
+!   (2) We are appropriately creating a new private argument for the target
+!       region for IsolatedFromAbove and code correctness.
+
+! CHECK-LABEL: func.func @_QPcombined_ptr
+! CHECK: omp.target
+! CHECK-SAME: private(@_QFcombined_ptrEa_private_box_ptr_f32
+! CHECK: omp.teams
+! CHECK: omp.distribute
+! CHECK-SAME: private(@_QFcombined_ptrEa_private_box_ptr_f32
+subroutine combined_ptr()
+  real, pointer, contiguous :: a
+  integer :: i, n
+  n = 100
+  !$omp target teams distribute private(a)
+  do i = 1, n
+  end do
+  !$omp end target teams distribute
+end subroutine
+
+! CHECK-LABEL: func.func @_QPseparated_ptr
+! CHECK: omp.target
+! CHECK: omp.teams
+! CHECK: omp.distribute
+! CHECK-SAME: private(@_QFseparated_ptrEa_private_box_ptr_f32
+subroutine separated_ptr()
+  real, pointer, contiguous :: a
+  integer :: i, n
+  n = 100
+  !$omp target teams
+  !$omp distribute private(a)
+  do i = 1, n
+  end do
+  !$omp end distribute
+  !$omp end target teams
+end subroutine
+
+! CHECK-LABEL: func.func @_QPcombined_scalar
+! CHECK: omp.target
+! CHECK-SAME: private(@_QFcombined_scalarEs_private_f32
+! CHECK: omp.teams
+! CHECK: omp.distribute
+! CHECK-SAME: private(@_QFcombined_scalarEs_private_f32
+subroutine combined_scalar()
+  real :: s
+  integer :: i, n
+  n = 100
+  !$omp target teams distribute private(s)
+  do i = 1, n
+    s = real(i)
+  end do
+  !$omp end target teams distribute
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtarget_parallel_do_ptr
+! CHECK: omp.target
+! CHECK-SAME: private(@_QFtarget_parallel_do_ptrEa_private_box_ptr_f32
+! CHECK: omp.wsloop
+! CHECK-SAME: private(@_QFtarget_parallel_do_ptrEa_private_box_ptr_f32
+subroutine target_parallel_do_ptr()
+  real, pointer, contiguous :: a
+  integer :: i, n
+  n = 100
+  !$omp target parallel do private(a)
+  do i = 1, n
+  end do
+  !$omp end target parallel do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtarget_only_ptr
+! CHECK: omp.target
+! CHECK-SAME: private(@_QFtarget_only_ptrEa_private_box_ptr_f32
+subroutine target_only_ptr()
+  real, pointer, contiguous :: a
+  integer :: i, n
+  n = 100
+  !$omp target private(a)
+  do i = 1, n
+  end do
+  !$omp end target
+end subroutine
+
+! CHECK-LABEL: func.func @_QPcombined_firstprivate_ptr
+! CHECK: omp.target
+! CHECK-SAME: private(@_QFcombined_firstprivate_ptrEa_firstprivate_box_ptr_f32
+! CHECK: omp.teams
+! CHECK: omp.distribute
+! CHECK-SAME: private(@_QFcombined_firstprivate_ptrEa_firstprivate_box_ptr_f32
+subroutine combined_firstprivate_ptr()
+  real, pointer, contiguous :: a
+  integer :: i, n
+  n = 100
+  !$omp target teams distribute firstprivate(a)
+  do i = 1, n
+  end do
+  !$omp end target teams distribute
+end subroutine

--- a/flang/test/Lower/OpenMP/target.f90
+++ b/flang/test/Lower/OpenMP/target.f90
@@ -638,7 +638,7 @@ subroutine omp_target_parallel_do
    !CHECK: %[[SUB:.*]] = arith.subi %[[C1024]], %[[C1]] : index
    !CHECK: %[[BOUNDS:.*]] = omp.map.bounds   lower_bound(%[[C0]] : index) upper_bound(%[[SUB]] : index) extent(%[[C1024]] : index) stride(%[[C1]] : index) start_idx(%[[C1]] : index)
    !CHECK: %[[MAP:.*]] = omp.map.info var_ptr(%[[VAL_0_DECL]]#1 : !fir.ref<!fir.array<1024xi32>>, !fir.array<1024xi32>)   map_clauses(tofrom) capture(ByRef) bounds(%[[BOUNDS]]) -> !fir.ref<!fir.array<1024xi32>> {name = "a"}
-   !CHECK: omp.target kernel_type(spmd) host_eval({{.*}}) map_entries(%[[MAP]] -> %[[ARG_0:.*]], %{{.*}} -> %{{.*}} : !fir.ref<!fir.array<1024xi32>>, !fir.ref<i32>) {
+   !CHECK: omp.target kernel_type(spmd) host_eval({{.*}}) map_entries(%[[MAP]] -> %[[ARG_0:.*]] : !fir.ref<!fir.array<1024xi32>>) private({{.*}} %{{.*}}#0 -> %{{.*}} : !fir.ref<i32>) {
       !CHECK: %[[VAL_0_DECL:.*]]:2 = hlfir.declare %[[ARG_0]](%{{.*}}) {uniq_name = "_QFomp_target_parallel_doEa"} : (!fir.ref<!fir.array<1024xi32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<1024xi32>>, !fir.ref<!fir.array<1024xi32>>)
       !CHECK: omp.parallel
       !$omp target parallel do map(tofrom: a)

--- a/flang/test/Semantics/OpenMP/do05-positivecase.f90
+++ b/flang/test/Semantics/OpenMP/do05-positivecase.f90
@@ -43,7 +43,7 @@ program OMP_DO
   !$omp end parallel
 
   !$omp target teams distribute parallel do
-  !DEF:/OMP_DO/OtherConstruct4/i (OmpPrivate ,OmpPreDetermined) HostAssoc INTEGER(4)
+  !DEF:/OMP_DO/OtherConstruct4/i (OmpPrivate, OmpPreDetermined, OmpImplicit) HostAssoc INTEGER(4)
   do i=1,100
     !REF:/OMP_DO/OtherConstruct4/i
     if(i<10) cycle
@@ -59,7 +59,7 @@ program OMP_DO
   !$omp end target teams distribute parallel do simd
 
   !$omp target teams distribute
-  !DEF: /OMP_DO/OtherConstruct6/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+  !DEF: /OMP_DO/OtherConstruct6/i (OmpPrivate, OmpPreDetermined, OmpImplicit) HostAssoc INTEGER(4)
   do i=1,100
     !REF: /OMP_DO/OtherConstruct6/i
     if(i < 5) cycle

--- a/flang/test/Semantics/OpenMP/resolve07.f90
+++ b/flang/test/Semantics/OpenMP/resolve07.f90
@@ -16,10 +16,10 @@ subroutine f00
   !The i and j are predetermined private as loop induction variables nested
   !in a teams construct.
   !$omp target teams distribute default(none) shared(array)
-!DEF: /f00/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+!DEF: /f00/OtherConstruct1/i (OmpPrivate, OmpPreDetermined, OmpImplicit) HostAssoc INTEGER(4)
 !REF: /f00/n
   do i = 1, n
-!DEF: /f00/OtherConstruct1/j (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+!DEF: /f00/OtherConstruct1/j (OmpPrivate, OmpPreDetermined, OmpImplicit) HostAssoc INTEGER(4)
 !REF: /f00/n
     do j = 1, n
       !i and j are shared in parallel
@@ -36,6 +36,3 @@ subroutine f00
     enddo
   enddo
 end subroutine
-
-
-

--- a/flang/test/Semantics/OpenMP/target-combined-private-pointer.f90
+++ b/flang/test/Semantics/OpenMP/target-combined-private-pointer.f90
@@ -1,0 +1,82 @@
+! RUN: %flang_fc1 -fopenmp -fdebug-dump-symbols %s 2>&1 | FileCheck %s
+! Test the data-sharing attribute resolution for a private variable
+! on a combined/composite target construct. On a top-level combined target
+! construct, an explicitly private pointer/scalar is additionally marked
+! OmpImplicit so that lowering privatizes it at the target level (suppressing a
+! implicit map and keeping the isolated target region legal). The marker should
+! NOT fire for a separated (non-top-level-target) distribute.
+
+! CHECK-LABEL: Subprogram scope: combined_ptr
+! CHECK: a (OmpPrivate, OmpExplicit, OmpImplicit): HostAssoc
+subroutine combined_ptr()
+  real, pointer, contiguous :: a
+  integer :: i, n
+  n = 100
+  !$omp target teams distribute private(a)
+  do i = 1, n
+  end do
+  !$omp end target teams distribute
+end subroutine
+
+! CHECK-LABEL: Subprogram scope: separated_ptr
+! CHECK: a (OmpPrivate, OmpExplicit): HostAssoc
+subroutine separated_ptr()
+  real, pointer, contiguous :: a
+  integer :: i, n
+  n = 100
+  !$omp target teams
+  !$omp distribute private(a)
+  do i = 1, n
+  end do
+  !$omp end distribute
+  !$omp end target teams
+end subroutine
+
+! CHECK-LABEL: Subprogram scope: combined_scalar
+! CHECK: s (OmpPrivate, OmpExplicit, OmpImplicit): HostAssoc
+subroutine combined_scalar()
+  real :: s
+  integer :: i, n
+  n = 100
+  !$omp target teams distribute private(s)
+  do i = 1, n
+    s = real(i)
+  end do
+  !$omp end target teams distribute
+end subroutine
+
+! CHECK-LABEL: Subprogram scope: target_parallel_do_ptr
+! CHECK: a (OmpPrivate, OmpExplicit, OmpImplicit): HostAssoc
+subroutine target_parallel_do_ptr()
+  real, pointer, contiguous :: a
+  integer :: i, n
+  n = 100
+  !$omp target parallel do private(a)
+  do i = 1, n
+  end do
+  !$omp end target parallel do
+end subroutine
+
+! CHECK-LABEL: Subprogram scope: target_only_ptr
+! CHECK: a (OmpPrivate, OmpExplicit): HostAssoc
+subroutine target_only_ptr()
+  real, pointer, contiguous :: a
+  integer :: i, n
+  n = 100
+  !$omp target private(a)
+  do i = 1, n
+  end do
+  !$omp end target
+end subroutine
+
+! CHECK-LABEL: Subprogram scope: combined_firstprivate_ptr
+! CHECK: a (OmpFirstPrivate, OmpExplicit): HostAssoc
+subroutine combined_firstprivate_ptr()
+  real, pointer, contiguous :: a
+  integer :: i, n
+  n = 100
+  !$omp target teams distribute firstprivate(a)
+  do i = 1, n
+  end do
+  !$omp end target teams distribute
+end subroutine

--- a/offload/test/offloading/fortran/target-no-loop.f90
+++ b/offload/test/offloading/fortran/target-no-loop.f90
@@ -83,16 +83,16 @@ program main
 end program main
 
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD-No-Loop mode
-! CHECK:  info: #Args: 3 Teams x Thrds:   64x  16
+! CHECK:  info: #Args: 2 Teams x Thrds:   64x  16
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD mode
-! CHECK:  info: #Args: 3 Teams x Thrds:   3x  16 {{.*}}
+! CHECK:  info: #Args: 2 Teams x Thrds:   3x  16 {{.*}}
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD-No-Loop mode
-! CHECK:  info: #Args: 3 Teams x Thrds:   64x  16 {{.*}}
+! CHECK:  info: #Args: 2 Teams x Thrds:   64x  16 {{.*}}
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD mode
-! CHECK:  info: #Args: 3 Teams x Thrds:   1x  16
+! CHECK:  info: #Args: 2 Teams x Thrds:   1x  16
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} Generic mode
-! CHECK:  info: #Args: 3 Teams x Thrds:   16x  16 {{.*}}
+! CHECK:  info: #Args: 2 Teams x Thrds:   16x  16 {{.*}}
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD mode
-! CHECK:  info: #Args: 4 Teams x Thrds:   16x  16 {{.*}}
+! CHECK:  info: #Args: 3 Teams x Thrds:   16x  16 {{.*}}
 ! CHECK:  number of errors: 0
 


### PR DESCRIPTION
Currently we are emitting implicit maps for private variables on composite directives, these maps are unrequired as the private clause does not require filling from the original clause item. They're default allocated and a user must assign to them.

The problem is that at the point we are processing implicit maps on the target region, the private symbol has not been marked appropriately for the DataSharingProcessor to connect the dots that it belongs to the target region (and technically other components of the composite directive) and not just the leaf construct. So, the DataSharingProcessor doesn't gather the symbol, and the implicit mapper generates a map as the symbol isn't in the privatized symbol list gathered for the directive.

The approach taken in this patch to avoid these extra maps follows the same method used for firstprivate, which is to mark the private symbol as implicit, which the DataSharingProcessor picks up for the target regions private symbol set when it is part of a composite directive, it does not prevent it being picked up and handled appropriately by the leaf node. This is a bit of a workaround originally implemented for firstprivate, due to the fact that symbols for composites are shared across the directives/combined.

An alternative approach would be to handle it at the target region's implicit map handling level, sifting through leaf constructs for private clauses to check against and then resolving the IsolatedFromAbove constraints by making sure we generate private arguments at the target boundaries to connect to the inner private clauses. However, handling this at a different level than we do for firstprivate seemed like the incorrect way to do things and doesn't provide the information required at the earliest possible point. This way things flow (mostly) naturally.


