### PR TITLE
[OpenMP] Remove stale support for multi-device allocation.

### DIFF
--- a/offload/libomptarget/OpenMP/API.cpp
+++ b/offload/libomptarget/OpenMP/API.cpp
@@ -188,25 +188,6 @@ EXTERN void *llvm_omp_target_alloc_shared(size_t Size, int DeviceNum) {
   return targetAllocExplicit(Size, DeviceNum, TARGET_ALLOC_SHARED, __func__);
 }
 
-EXTERN void *llvm_omp_target_alloc_multi_devices(size_t size, int num_devices,
-                                                 int DeviceNums[]) {
-  if (num_devices < 1)
-    return nullptr;
-
-  DeviceTy &Device = *PM->getDevice(DeviceNums[0]);
-  if (!Device.RTL->is_system_supporting_managed_memory(Device.DeviceID))
-    return nullptr;
-
-  // disregard device ids for now and allocate shared memory that can be
-  // accessed by any device and host under xnack+ mode
-  void *ptr =
-      targetAllocExplicit(size, DeviceNums[0], TARGET_ALLOC_DEFAULT, __func__);
-  // TODO: not implemented yet
-  // if (Device.RTL->enable_access_to_all_agents)
-  //   Device.RTL->enable_access_to_all_agents(DeviceNums[0], ptr);
-  return ptr;
-}
-
 EXTERN void omp_target_free(void *Ptr, int DeviceNum) {
   TIMESCOPE();
   OMPT_IF_BUILT(ReturnAddressSetterRAII RA(__builtin_return_address(0)));

--- a/offload/libomptarget/exports
+++ b/offload/libomptarget/exports
@@ -65,7 +65,6 @@ VERS1.0 {
     llvm_omp_target_alloc_host;
     llvm_omp_target_alloc_shared;
     llvm_omp_target_alloc_device;
-    llvm_omp_target_alloc_multi_devices;
     llvm_omp_target_lock_mem;
     llvm_omp_target_unlock_mem;
     llvm_omp_get_dynamic_shared;

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -6063,17 +6063,6 @@ struct AMDGPUPluginTy final : public GenericPluginTy {
   /// Get the ELF code for recognizing the compatible image binary.
   uint16_t getMagicElfBits() const override { return ELF::EM_AMDGPU; }
 
-  bool IsSystemSupportingManagedMemory() override final {
-    bool HasManagedMemorySupport = false;
-    hsa_status_t Status = hsa_system_get_info(HSA_AMD_SYSTEM_INFO_SVM_SUPPORTED,
-                                              &HasManagedMemorySupport);
-
-    if (Status != HSA_STATUS_SUCCESS)
-      return false;
-
-    return HasManagedMemorySupport;
-  }
-
   void checkInvalidImage(__tgt_device_image *TgtImage) override final {
     hsa_utils::checkImageCompatibilityWithSystemXnackMode(TgtImage,
                                                       IsXnackEnabled());

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1844,9 +1844,6 @@ struct GenericPluginTy {
   /// Get the number of active devices.
   int32_t getNumDevices() const { return NumDevices; }
 
-  /// Returns true if the system supports managed memory (SVN in AMD GPUs).
-  virtual bool IsSystemSupportingManagedMemory() { return false; }
-
   /// Get the plugin-specific device identifier.
   int32_t getUserId(int32_t DeviceId) const {
     assert(UserDeviceIds.contains(DeviceId) && "No user-id registered");
@@ -2025,9 +2022,6 @@ public:
   /// variables is enabled under unified shared memory.
   bool is_gfx90a_coarse_grain_usm_map_enabled(int32_t DeviceId);
 
-  /// Returns if managed memory is supported.
-  bool is_system_supporting_managed_memory(int32_t DeviceId);
-
   /// Returns non-zero if the data can be exchanged between the two devices.
   int32_t is_data_exchangable(int32_t SrcDeviceId, int32_t DstDeviceId);
 
@@ -2168,9 +2162,6 @@ public:
 
   /// Returns if we can use automatic zero copy.
   int32_t use_auto_zero_copy(int32_t DeviceId);
-
-  /// Make sure a pointer can be accessed by all agents.
-  int32_t enable_access_to_all_agents(int32_t DeviceId, void *ptr);
 
   /// Perform some checks when using automatic zero copy.
   int32_t zero_copy_sanity_checks_and_diag(int32_t DeviceId,

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1688,13 +1688,6 @@ bool GenericPluginTy::is_gfx90a_coarse_grain_usm_map_enabled(int32_t DeviceId) {
   return R;
 }
 
-bool GenericPluginTy::is_system_supporting_managed_memory(int32_t DeviceId) {
-  auto T = logger::log<bool>(__func__, DeviceId);
-  auto R = [&]() { return IsSystemSupportingManagedMemory(); }();
-  T.res(R);
-  return R;
-}
-
 int32_t GenericPluginTy::is_data_exchangable(int32_t SrcDeviceId,
                                              int32_t DstDeviceId) {
   auto T = logger::log<int32_t>(__func__, SrcDeviceId, DstDeviceId);
@@ -2301,17 +2294,6 @@ int32_t GenericPluginTy::get_function(__tgt_device_binary Binary,
 int32_t GenericPluginTy::use_auto_zero_copy(int32_t DeviceId) {
   auto T = logger::log<int32_t>(__func__, DeviceId);
   auto R = [&]() { return getDevice(DeviceId).useAutoZeroCopy(); }();
-  T.res(R);
-  return R;
-}
-
-int32_t GenericPluginTy::enable_access_to_all_agents(int32_t DeviceId,
-                                                     void *ptr) {
-  auto T = logger::log<int32_t>(__func__, DeviceId, ptr);
-  auto R = [&]() {
-    // Not implemented yet.
-    return OFFLOAD_FAIL;
-  }();
   T.res(R);
   return R;
 }

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -1804,24 +1804,6 @@ struct CUDAPluginTy final : public GenericPluginTy {
     // revision.
     return Major == ImageMajor && Minor >= ImageMinor;
   }
-  bool IsSystemSupportingManagedMemory() override final {
-    assert(getNumDevices());
-
-    CUdevice Device;
-    CUresult Res = cuDeviceGet(&Device, 0);
-
-    if (Res != CUDA_SUCCESS)
-      return false;
-
-    int HasManagedMemorySupport = false;
-    Res = cuDeviceGetAttribute(&HasManagedMemorySupport,
-                               CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY, Device);
-
-    if (Res != CUDA_SUCCESS)
-      return false;
-
-    return HasManagedMemorySupport;
-  }
 };
 
 Error CUDADeviceTy::dataExchangeImpl(const void *SrcPtr,

--- a/openmp/runtime/src/dllexports
+++ b/openmp/runtime/src/dllexports
@@ -534,8 +534,6 @@ kmp_set_disp_num_buffers                    890
     omp_get_device_num                      896
     omp_init_allocator                      897
     omp_destroy_allocator                   898
-    omp_get_memory_space                    900
-    omp_destroy_memory_space                901
     omp_get_devices_memspace                810
     omp_get_device_memspace                 811
     omp_get_devices_and_host_memspace       812
@@ -558,8 +556,6 @@ kmp_set_disp_num_buffers                    890
         __kmpc_calloc
         __kmpc_realloc
         __kmpc_free
-        __kmpc_get_memory_space
-        __kmpc_destroy_memory_space
         __kmpc_init_allocator
         __kmpc_destroy_allocator
     %endif

--- a/openmp/runtime/src/include/omp.h.var
+++ b/openmp/runtime/src/include/omp.h.var
@@ -479,8 +479,6 @@
       KMP_MEMSPACE_MAX_HANDLE = UINTPTR_MAX
     } omp_memspace_handle_t;
 #   endif
-    extern omp_memspace_handle_t __KAI_KMPC_CONVENTION omp_get_memory_space(size_t num_devices, int device_ids[], omp_memspace_handle_t base_memory_space);
-    extern void omp_destroy_memory_space(omp_memspace_handle_t ms);
     extern omp_allocator_handle_t __KAI_KMPC_CONVENTION omp_init_allocator(omp_memspace_handle_t m,
                                                        int ntraits, omp_alloctrait_t traits[]);
     extern void __KAI_KMPC_CONVENTION omp_destroy_allocator(omp_allocator_handle_t allocator);

--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -1064,7 +1064,6 @@ extern omp_memspace_handle_t const llvm_omp_target_host_mem_space;
 extern omp_memspace_handle_t const llvm_omp_target_shared_mem_space;
 extern omp_memspace_handle_t const llvm_omp_target_device_mem_space;
 extern omp_memspace_handle_t const kmp_max_mem_space;
-extern omp_memspace_handle_t __kmp_def_mem_space;
 
 typedef struct {
   omp_alloctrait_key_t key;
@@ -1098,8 +1097,6 @@ extern bool __kmp_hwloc_available;
 /// Memory space informaition is shared with offload runtime.
 typedef struct kmp_memspace_t {
   omp_memspace_handle_t memspace; // predefined input memory space
-  int num_devs;
-  int *devids;
   int num_resources = 0; // number of available resources
   int *resources = nullptr; // available resources
   kmp_memspace_t *next = nullptr; // next memory space handle
@@ -1126,10 +1123,6 @@ typedef struct kmp_allocator_t {
 #endif // KMP_HWLOC_ENABLED
 } kmp_allocator_t;
 
-extern omp_memspace_handle_t
-__kmpc_get_memory_space(size_t num_devices, int device_ids[],
-                        omp_memspace_handle_t base_memory_space);
-void __kmpc_destroy_memory_space(omp_memspace_handle_t ms);
 extern omp_allocator_handle_t __kmpc_init_allocator(int gtid,
                                                     omp_memspace_handle_t,
                                                     int ntraits,

--- a/openmp/runtime/src/kmp_alloc.cpp
+++ b/openmp/runtime/src/kmp_alloc.cpp
@@ -1261,8 +1261,6 @@ static void **mk_dax_kmem_preferred;
 static void *(*kmp_target_alloc_host)(size_t size, int device);
 static void *(*kmp_target_alloc_shared)(size_t size, int device);
 static void *(*kmp_target_alloc_device)(size_t size, int device);
-static void *(*kmp_target_alloc_multi_devices)(size_t size, int num_devices,
-                                               int device_nums[]);
 static void *(*kmp_target_lock_mem)(void *ptr, size_t size, int device);
 static void *(*kmp_target_unlock_mem)(void *ptr, int device);
 static void *(*kmp_target_free_host)(void *ptr, int device);
@@ -1626,8 +1624,6 @@ void __kmp_init_target_mem() {
       KMP_DLSYM("llvm_omp_target_alloc_device");
   *(void **)(&kmp_target_lock_mem) = KMP_DLSYM("llvm_omp_target_lock_mem");
   *(void **)(&kmp_target_unlock_mem) = KMP_DLSYM("llvm_omp_target_unlock_mem");
-  *(void **)(&kmp_target_alloc_multi_devices) =
-      KMP_DLSYM("llvm_omp_target_alloc_multi_devices");
 
   *(void **)(&kmp_target_free_host) = KMP_DLSYM("llvm_omp_target_free_host");
   *(void **)(&kmp_target_free_shared) =
@@ -1645,42 +1641,6 @@ void __kmp_init_target_mem() {
   __kmp_tgt_memspace_list.init();
 }
 
-omp_memspace_handle_t
-__kmpc_get_memory_space(size_t num_devices, int device_ids[],
-                        omp_memspace_handle_t base_memory_space) {
-  KMP_DEBUG_ASSERT(base_memory_space == omp_default_mem_space ||
-                   base_memory_space == omp_low_lat_mem_space ||
-                   base_memory_space == omp_large_cap_mem_space ||
-                   base_memory_space == omp_const_mem_space ||
-                   base_memory_space == omp_high_bw_mem_space ||
-                   KMP_IS_TARGET_MEM_SPACE(base_memory_space));
-  KMP_DEBUG_ASSERT(num_devices > 0);
-
-  // when using a struct for memory space, instead of a predefined memory space,
-  // we will always call the corresponding libomptarget allocator, and disregard
-  // the predefined memory allocator
-  kmp_memspace_t *ms_t =
-      (kmp_memspace_t *)__kmp_allocate(sizeof(kmp_memspace_t)); // zeroed
-  ms_t->memspace = llvm_omp_target_shared_mem_alloc;
-  ms_t->num_devs = num_devices;
-  ms_t->devids = (int *)__kmp_allocate(num_devices * sizeof(int));
-  for (int i = 0; i < num_devices; i++)
-    ms_t->devids[i] = device_ids[i];
-  return (omp_memspace_handle_t)ms_t;
-}
-
-void __kmpc_destroy_memory_space(omp_memspace_handle_t ms) {
-  if (ms < kmp_max_mem_space)
-    return; // predefined memory space does not need to be destroyed
-  kmp_memspace_t *ms_t = RCAST(kmp_memspace_t *, ms);
-  __kmp_free(ms_t->devids);
-  __kmp_free(ms_t);
-
-  // lock/pin and unlock/unpin target calls
-  *(void **)(&kmp_target_lock_mem) = KMP_DLSYM("llvm_omp_target_lock_mem");
-  *(void **)(&kmp_target_unlock_mem) = KMP_DLSYM("llvm_omp_target_unlock_mem");
-}
-
 /// Finalize target memory support
 void __kmp_fini_target_mem() { __kmp_tgt_memspace_list.fini(); }
 
@@ -1696,7 +1656,7 @@ omp_allocator_handle_t __kmpc_init_allocator(int gtid, omp_memspace_handle_t ms,
         ms == omp_high_bw_mem_space || KMP_IS_TARGET_MEM_SPACE(ms));
     actual_ms = ms;
   } else {
-    // memory space object obtained via omp_get_memory_space call
+    // memory space object obtained via omp_get_devices_memspace call
     kmp_memspace_t *ms_t = RCAST(kmp_memspace_t *, ms);
     actual_ms = ms_t->memspace;
     KMP_DEBUG_ASSERT(actual_ms == omp_default_mem_space ||

--- a/openmp/runtime/src/kmp_ftn_entry.h
+++ b/openmp/runtime/src/kmp_ftn_entry.h
@@ -399,21 +399,6 @@ int FTN_STDCALL FTN_CONTROL_TOOL(int command, int modifier, void *arg) {
 }
 
 /* OpenMP 5.0 Memory Management support */
-omp_memspace_handle_t FTN_STDCALL FTN_GET_MEMSPACE(
-    int ndevs, int device_ids[], omp_memspace_handle_t KMP_DEREF m) {
-#ifdef KMP_STUB
-  return NULL;
-#else
-  return __kmpc_get_memory_space(ndevs, device_ids, KMP_DEREF m);
-#endif
-}
-
-void FTN_STDCALL FTN_DESTROY_MEMSPACE(omp_memspace_handle_t ms) {
-#ifndef KMP_STUB
-  __kmpc_destroy_memory_space(ms);
-#endif
-}
-
 omp_allocator_handle_t FTN_STDCALL
 FTN_INIT_ALLOCATOR(omp_memspace_handle_t KMP_DEREF m, int KMP_DEREF ntraits,
                    omp_alloctrait_t tr[]) {

--- a/openmp/runtime/src/kmp_ftn_os.h
+++ b/openmp/runtime/src/kmp_ftn_os.h
@@ -130,8 +130,6 @@
 #define FTN_GET_MASTER_THREAD_ID omp_ext_get_master_thread_id
 #define FTN_GET_ACTIVE_THREAD_MASK omp_ext_get_active_threads_mask
 #define FTN_CONTROL_TOOL omp_control_tool
-#define FTN_GET_MEMSPACE omp_get_memory_space
-#define FTN_DESTROY_MEMSPACE omp_destroy_memory_space
 #define FTN_INIT_ALLOCATOR omp_init_allocator
 #define FTN_DESTROY_ALLOCATOR omp_destroy_allocator
 #define FTN_SET_DEFAULT_ALLOCATOR omp_set_default_allocator
@@ -288,8 +286,6 @@
 #define FTN_GET_MASTER_THREAD_ID omp_ext_get_master_thread_id_
 #define FTN_GET_ACTIVE_THREAD_MASK omp_ext_get_active_threads_mask_
 #define FTN_CONTROL_TOOL omp_control_tool_
-#define FTN_GET_MEMSPACE omp_get_memory_space_
-#define FTN_DESTROY_MEMSPACE omp_destroy_memory_space_
 #define FTN_INIT_ALLOCATOR omp_init_allocator_
 #define FTN_DESTROY_ALLOCATOR omp_destroy_allocator_
 #define FTN_SET_DEFAULT_ALLOCATOR omp_set_default_allocator_

--- a/openmp/runtime/src/kmp_global.cpp
+++ b/openmp/runtime/src/kmp_global.cpp
@@ -346,7 +346,6 @@ omp_memspace_handle_t const llvm_omp_target_device_mem_space =
     (omp_memspace_handle_t const)102;
 omp_memspace_handle_t const kmp_max_mem_space =
     (omp_memspace_handle_t const)1024;
-omp_allocator_handle_t __kmp_def_mem_space = omp_default_mem_alloc;
 
 /* This check ensures that the compiler is passing the correct data type for the
    flags formal parameter of the function kmpc_omp_task_alloc(). If the type is


### PR DESCRIPTION
The new APi implementation requires implementing __tgt_get_mem_resources, __tgt_omp_alloc, and __tgt_omp_free. This implementation was done before such a facility was available and it is currently untested and non-functional.


