### PR TITLE
[Offload] Remove OMPX_FORCE_SYNC_REGIONS

### DIFF
--- a/offload/include/Shared/APITypes.h
+++ b/offload/include/Shared/APITypes.h
@@ -93,8 +93,6 @@ struct __tgt_async_info {
   /// happening.
   KernelLaunchEnvironmentTy KernelLaunchEnvironment;
 
-  /// Use for sync interface. When false => synchronous execution
-  bool ExecAsync = true;
   /// Maintain the actal data for OMPT.
   void *ProfilerData = nullptr;
 };

--- a/offload/include/device.h
+++ b/offload/include/device.h
@@ -53,12 +53,6 @@ struct DeviceTy {
   /// This field is used by ompx_get_team_procs(devid).
   int32_t TeamProcs;
 
-
-  /// Flag to force synchronous data transfers
-  /// Controlled via environment flag OMPX_FORCE_SYNC_REGIONS
-  bool ForceSynchronousTargetRegions = false;
-
-
   DeviceTy(GenericPluginTy *RTL, int32_t DeviceID, int32_t RTLDeviceID);
   // DeviceTy is not copyable
   DeviceTy(const DeviceTy &D) = delete;

--- a/offload/libomptarget/device.cpp
+++ b/offload/libomptarget/device.cpp
@@ -74,7 +74,7 @@ int HostDataToTargetTy::addEventIfNecessary(DeviceTy &Device,
 
 DeviceTy::DeviceTy(GenericPluginTy *RTL, int32_t DeviceID, int32_t RTLDeviceID)
     : DeviceID(DeviceID), RTL(RTL), RTLDeviceID(RTLDeviceID),
-      ForceSynchronousTargetRegions(false), MappingInfo(*this) {}
+      MappingInfo(*this) {}
 
 DeviceTy::~DeviceTy() {
   if (DeviceID == -1 || !(getInfoLevel() & OMP_INFOTYPE_DUMP_TABLE))
@@ -82,12 +82,6 @@ DeviceTy::~DeviceTy() {
 
   ident_t Loc = {0, 0, 0, 0, ";libomptarget;libomptarget;0;0;;"};
   dumpTargetPointerMappings(&Loc, *this);
-}
-
-/// Used to set the asynchronous execution mode
-inline void setAsyncInfoSynchronous(__tgt_async_info *AI, bool SetSynchronous) {
-  if (SetSynchronous)
-    AI->ExecAsync = false;
 }
 
 llvm::Error DeviceTy::init() {
@@ -333,7 +327,6 @@ int32_t DeviceTy::submitData(void *TgtPtrBegin, void *HstPtrBegin, int64_t Size,
           HstPtrBegin, DeviceID, TgtPtrBegin, Size,
           /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);)
 
-  setAsyncInfoSynchronous(AsyncInfo, ForceSynchronousTargetRegions);
   return RTL->data_submit_async(RTLDeviceID, TgtPtrBegin, HstPtrBegin, Size,
                                 AsyncInfo);
 }
@@ -363,7 +356,6 @@ int32_t DeviceTy::retrieveData(void *HstPtrBegin, void *TgtPtrBegin,
           omp_initial_device, HstPtrBegin, Size,
           /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);)
 
-  setAsyncInfoSynchronous(AsyncInfo, ForceSynchronousTargetRegions);
   return RTL->data_retrieve_async(RTLDeviceID, HstPtrBegin, TgtPtrBegin, Size,
                                   AsyncInfo);
 }
@@ -392,7 +384,6 @@ int32_t DeviceTy::dataExchange(void *SrcPtr, DeviceTy &DstDev, void *DstPtr,
           DstDev.RTLDeviceID, DstPtr, Size,
           /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);)
 
-  setAsyncInfoSynchronous(AsyncInfo, ForceSynchronousTargetRegions);
   return RTL->data_exchange_async(RTLDeviceID, SrcPtr, DstDev.RTLDeviceID,
                                   DstPtr, Size, AsyncInfo);
 }
@@ -452,8 +443,6 @@ int32_t DeviceTy::launchKernel(void *TgtEntryPtr, void **TgtVarsPtr,
                                ptrdiff_t *TgtOffsets, KernelArgsTy &KernelArgs,
                                KernelReplayOutcomeTy *ReplayOutcome,
                                AsyncInfoTy &AsyncInfo) {
-  setAsyncInfoSynchronous(AsyncInfo, ForceSynchronousTargetRegions);
-
   llvm::SmallVector<void *> Args, Ptrs;
   llvm::SmallVector<int64_t> ArgSizes;
 

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -3319,7 +3319,6 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
                                64 * 1024),
         OMPX_InitialNumSignals("LIBOMPTARGET_AMDGPU_NUM_INITIAL_HSA_SIGNALS",
                                64),
-        OMPX_ForceSyncRegions("OMPX_FORCE_SYNC_REGIONS", 0),
         OMPX_StreamBusyWait("LIBOMPTARGET_AMDGPU_STREAM_BUSYWAIT", 2000000),
         OMPX_UseMultipleSdmaEngines(
             // setting default to true here appears to solve random sdma problem
@@ -4144,7 +4143,7 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
     //        work. So for now, skip async copy for non-x86 for dataSubmit
     //        and dataRetrive only.
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86)
-    if (OMPX_ForceSyncRegions || Size >= OMPX_MaxAsyncCopyBytes) {
+    if (Size >= OMPX_MaxAsyncCopyBytes) {
 #else
     if (false) {
 #endif
@@ -4230,13 +4229,12 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
     }
 
     // For large transfers use synchronous behavior.
-    // If OMPT is enabled or synchronous behavior is explicitly requested:
     // FIXME: Currently hsa async copy fails to see completion signal for
     //        non-x86 dataSubmit/Retrieve. Other non-x86 calls to asyncMemCopy
     //        work. So for now, skip async copy for non-x86 for dataSubmit
     //        and dataRetrive only.
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86)
-    if (OMPX_ForceSyncRegions || Size >= OMPX_MaxAsyncCopyBytes) {
+    if (Size >= OMPX_MaxAsyncCopyBytes) {
 #else
     if (false) {
 #endif
@@ -4330,8 +4328,7 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
     auto ProfilerSpecificData = getOrNullProfilerSpecificData(AsyncInfoWrapper);
 
     // For large transfers use synchronous behavior.
-    // If OMPT is enabled or synchronous behavior is explicitly requested:
-    if (OMPX_ForceSyncRegions || Size >= OMPX_MaxAsyncCopyBytes) {
+    if (Size >= OMPX_MaxAsyncCopyBytes) {
       if (AsyncInfoWrapper.hasQueue())
         if (auto Err = synchronize(AsyncInfoWrapper))
           return Err;
@@ -5358,10 +5355,6 @@ private:
   /// These signals are mainly used by AMDGPU streams. If needed, more signals
   /// will be created.
   UInt32Envar OMPX_InitialNumSignals;
-
-  /// Envar to force synchronous target regions. The default 0 uses an
-  /// asynchronous implementation.
-  UInt32Envar OMPX_ForceSyncRegions;
   /// switching to blocked state. The default 2000000 busywaits for 2 seconds
   /// before going into a blocking HSA wait state. The unit for these variables
   /// are microseconds.

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -64,27 +64,16 @@ Error AsyncInfoWrapperTy::synchronize() {
 void AsyncInfoWrapperTy::finalize(Error &Err) {
   assert(AsyncInfoPtr && "AsyncInfoWrapperTy already finalized");
 
-  // If we used a local async info object we want synchronous behavior. (No need
-  // to check the env-var OMPX_FORCE_SYNC_REGIONS since that was done by
-  // libomptarget.) In that case, and assuming the current status code is
-  // correct, we will synchronize explicitly when the object is deleted. Update
-  // the error with the result of the synchronize operation.
+  // If we used a local async info object we want synchronous behavior. In that
+  // case, and assuming the current status code is correct, we will synchronize
+  // explicitly when the object is deleted. Update the error with the result of
+  // the synchronize operation.
   if (AsyncInfoPtr == &LocalAsyncInfo && LocalAsyncInfo.Queue && !Err) {
-     ODBG(ODT_Init) << "Synchronizing Operation for LOCAL";
+    ODBG(ODT_Init) << "Synchronizing Operation for LOCAL";
     Err = Device.synchronize(&LocalAsyncInfo);
-    // Invalidate the wrapper object.
   }
 
-  // This case is used to transfer information about OMPT down from libomptarget
-  // to the plugins / other parts of the runtime for asynchronous profiling.
-  // Since we want to maintain the possibility to enforce synchronous mode,
-  // This was introduced.
-  else if (AsyncInfoPtr && !AsyncInfoPtr->ExecAsync && AsyncInfoPtr->Queue &&
-           !Err) {
-    ODBG(ODT_Init) << "Synchronizing Operation for EXECASYNC";
-    Err = Device.synchronize(AsyncInfoPtr);
-  }
-
+  // Invalidate the wrapper object.
   AsyncInfoPtr = nullptr;
 }
 


### PR DESCRIPTION
Remove the AMDGPU environment variable and its dead synchronous-execution plumbing. Keep size-based synchronous copies unchanged.

Part of an effort to reduce delta to upstream.
This used to be relevant for OMPT but is no longer. Given its limited use, good candidate to remove.