### PR TITLE
[AMDGPU][Scheduler] Restore upstream position of getStageTargetOccupancy

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -2316,10 +2316,6 @@ void GCNSchedStage::modifyRegionSchedule(unsigned RegionIdx,
   DAG.Regions[RegionIdx].first = MIOrder.front();
 }
 
-unsigned PreRARematStage::getStageTargetOccupancy() const {
-  return TargetOcc ? *TargetOcc : MFI.getMinWavesPerEU();
-}
-
 /// Returns true if reaching def \p RD will be in AGPR form after the rewrite
 /// and so needs no bridge copy: a candidate MFMA in \p RewriteSet, an
 /// AV_MOV_*_IMM_PSEUDO, or a copy from a candidate src2 reg in \p CandSrc2Regs.
@@ -2975,6 +2971,10 @@ bool RewriteMFMAFormStage::rewrite(
   DAG.Pressure[RegionIdx] = DAG.getRealRegPressure(RegionIdx);
 
   return true;
+}
+
+unsigned PreRARematStage::getStageTargetOccupancy() const {
+  return TargetOcc ? *TargetOcc : MFI.getMinWavesPerEU();
 }
 
 bool PreRARematStage::setObjective() {


### PR DESCRIPTION
The merge commit b734fd9c7866 placed the definition of PreRARematStage::getStageTargetOccupancy before isReachingDefAGPRForm. Upstream defines it between RewriteMFMAFormStage::rewrite and PreRARematStage::setObjective.

Move the definition back to the upstream position. This is a pure code motion.

This removes the divergence caused by the merge commit b734fd9c7866. GCNSchedStrategy.cpp and GCNSchedStrategy.h now match upstream/main byte-for-byte.

Assisted-by: Claude Opus


