### PR TITLE
[CI][Linux] Enable Profiler Apps build stage

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -281,34 +281,29 @@ jobs:
       id-token: write
 
   # ==========================================================================
-  # STAGE: profiler-apps (generic, parallel to math-libs) - DISABLED
+  # STAGE: profiler-apps (generic, parallel to math-libs)
   # ==========================================================================
-  # Temporarily disabled: the rocprofiler-systems examples build hangs while
-  # compiling/linking transferBench/AllToAll.cpp, causing the stage to run for
-  # the full 3h timeout (first seen in upstream-merge PR #3391). No other stage
-  # depends on profiler-apps, so disabling it is safe. Re-enable by uncommenting
-  # once the upstream compiler/lld regression is fixed.
-  # profiler-apps:
-  #   needs: compiler-runtime
-  #   if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'profiler-apps') }}
-  #   uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
-  #   secrets: inherit
-  #   with:
-  #     stage_name: profiler-apps
-  #     stage_display_name: "Stage - Profiler Apps"
-  #     timeout_minutes: 180  # 3 hours
-  #     dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
-  #     rocm_package_version: ${{ inputs.rocm_package_version }}
-  #     build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
-  #     build_runs_on: ${{ inputs.build_runs_on }}
-  #     release_type: ${{ inputs.release_type }}
-  #     test_type: ${{ inputs.test_type }}
-  #     repository: ${{ inputs.repository }}
-  #     ref: ${{ inputs.ref }}
-  #     external_repo_config: ${{ inputs.external_repo_config }}
-  #   permissions:
-  #     contents: read
-  #     id-token: write
+  profiler-apps:
+    needs: compiler-runtime
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'profiler-apps') }}
+    uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+    secrets: inherit
+    with:
+      stage_name: profiler-apps
+      stage_display_name: "Stage - Profiler Apps"
+      timeout_minutes: 180  # 3 hours
+      dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
+      rocm_package_version: ${{ inputs.rocm_package_version }}
+      build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      build_runs_on: ${{ inputs.build_runs_on }}
+      release_type: ${{ inputs.release_type }}
+      test_type: ${{ inputs.test_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
+    permissions:
+      contents: read
+      id-token: write
 
   # ==========================================================================
   # STAGE: media-libs (generic)


### PR DESCRIPTION
## Summary
Enable Profiler Apps build stage in Linux CI.

## Test plan
- [ ] Verify CI pipeline includes Profiler Apps build stage
- [ ] Confirm build completes successfully on Linux CI

