### PR TITLE
[DebugInfo] Remove dead heterogeneous DWARF extension scaffolding

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -393,11 +393,6 @@ protected:
   /// location is allowed.
   bool SupportsExtendedDwarfLocDirective = true;
 
-  /// True if the target supports the extensions defined at
-  /// https://llvm.org/docs/AMDGPUDwarfProposalForHeterogeneousDebugging.html.
-  /// Defaults to false.
-  bool SupportsHeterogeneousDebuggingExtensions = false;
-
   //===--- Prologue State ----------------------------------------------===//
 
   std::vector<MCCFIInstruction> InitialFrameState;
@@ -697,9 +692,6 @@ public:
   bool useParensForSpecifier() const { return UseParensForSpecifier; }
   bool supportsExtendedDwarfLocDirective() const {
     return SupportsExtendedDwarfLocDirective;
-  }
-  bool supportsHeterogeneousDebuggingExtensions() const {
-    return SupportsHeterogeneousDebuggingExtensions;
   }
 
   bool enableDwarfFileDirectoryDefault() const {

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -423,8 +423,6 @@ DwarfDebug::DwarfDebug(AsmPrinter *A)
   UseARangesSection = GenerateARangeSection || tuneForSCE();
 
   HasAppleExtensionAttributes = tuneForLLDB();
-  HasHeterogeneousExtensionAttributes =
-      Asm->MAI.supportsHeterogeneousDebuggingExtensions();
 
   // Handle split DWARF.
   HasSplitDwarf = !Asm->TM.Options.MCOptions.SplitDwarfFile.empty();

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
@@ -487,9 +487,6 @@ private:
   AccelTableKind TheAccelTableKind;
   bool HasAppleExtensionAttributes;
   bool HasSplitDwarf;
-  // Enables extensions defined at
-  // https://llvm.org/docs/AMDGPUDwarfProposalForHeterogeneousDebugging.html
-  bool HasHeterogeneousExtensionAttributes;
 
   /// Whether to generate the DWARF v5 string offsets table.
   /// It consists of a series of contributions, each preceded by a header.
@@ -885,13 +882,6 @@ public:
 
   bool useAppleExtensionAttributes() const {
     return HasAppleExtensionAttributes;
-  }
-
-  /// Returns whether extensions defined at
-  /// https://llvm.org/docs/AMDGPUDwarfProposalForHeterogeneousDebugging.html
-  /// are enabled.
-  bool useHeterogeneousExtensionAttributes() const {
-    return HasHeterogeneousExtensionAttributes;
   }
 
   /// Returns whether or not to change the current debug info for split DWARF.

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -1927,8 +1927,8 @@ const MCSymbol &FrameEmitterImpl::EmitCIE(const MCDwarfFrameInfo &Frame) {
   uint8_t CIEVersion = getCIEVersion(IsEH, context.getDwarfVersion());
   Streamer.emitInt8(CIEVersion);
 
-  SmallString<8> Augmentation;
   if (IsEH) {
+    SmallString<8> Augmentation;
     Augmentation += "z";
     if (Frame.Personality)
       Augmentation += "P";
@@ -1941,8 +1941,8 @@ const MCSymbol &FrameEmitterImpl::EmitCIE(const MCDwarfFrameInfo &Frame) {
       Augmentation += "B";
     if (Frame.IsMTETaggedFrame)
       Augmentation += "G";
+    Streamer.emitBytes(Augmentation);
   }
-  Streamer.emitBytes(Augmentation);
   Streamer.emitInt8(0);
 
   if (CIEVersion >= 4) {

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCAsmInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCAsmInfo.cpp
@@ -58,7 +58,6 @@ AMDGPUMCAsmInfo::AMDGPUMCAsmInfo(const Triple &TT,
   SupportsDebugInformation = true;
   UsesCFIWithoutEH = true;
   DwarfRegNumForCFI = true;
-  SupportsHeterogeneousDebuggingExtensions = true;
 
   UseIntegratedAssembler = false;
   initializeAtSpecifiers(atSpecifiers);


### PR DESCRIPTION
The CFI squash d02227fb8659 added an MCAsmInfo flag that told DwarfDebug to emit the DW_AT_LLVM_augmentation attribute. Commit 014f0975cc17 dropped that attribute and deleted its only use, but it kept the supporting code.

Nothing reads the flag today. The chain runs from
SupportsHeterogeneousDebuggingExtensions in MCAsmInfo, through HasHeterogeneousExtensionAttributes in DwarfDebug, to the unused accessor useHeterogeneousExtensionAttributes. Remove the whole chain.

Commit 473898f240d8 also left the augmentation string of EmitCIE outside the IsEH block. Restore the upstream form. The behavior does not change, because an empty augmentation string emits no bytes.

This removes the divergence caused by d02227fb8659, and by the remnants that 473898f240d8 left behind. MCDwarf.cpp and AMDGPUMCAsmInfo.cpp now match upstream/main byte-for-byte. MCAsmInfo.h keeps one unrelated difference, the doesSupportExceptionHandling accessor. DwarfDebug.cpp and DwarfDebug.h keep the live DIOp divergence.

Assisted-by: Claude Opus


