### PR TITLE
comgr: Fix mkdtemp build error in darwin build

### DIFF
--- a/amd/comgr/test/time_stat_symlink_test.c
+++ b/amd/comgr/test/time_stat_symlink_test.c
@@ -21,6 +21,9 @@
 // include, since common.h transitively pulls in <sys/stat.h>/<unistd.h>.
 #ifndef _WIN32
 #define _POSIX_C_SOURCE 200809L
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#endif
 #endif
 
 #include "amd_comgr.h"


### PR DESCRIPTION
mkdtemp is a BSD extension on Darwin and requires another macro to expose it.


