### PR TITLE
[SPIRV][CI] Install ninja from GitHub release instead of chocolatey

### DIFF
--- a/.github/workflows/spirv-ci-windows-amd-staging.yml
+++ b/.github/workflows/spirv-ci-windows-amd-staging.yml
@@ -34,6 +34,7 @@ jobs:
       # feed 504s intermittently and takes the whole job down with it. Install
       # dir must be the same in every job — the build tree's CMakeCache bakes in
       # CMAKE_MAKE_PROGRAM as an absolute path and the test jobs untar it.
+      # Extracted with System32 tar (bsdtar, reads zip) — Git bash's tar is GNU.
       - name: Install ninja
         run: |
           ninja_dir="$(cygpath -u "$GITHUB_WORKSPACE")/.ninja"
@@ -41,7 +42,7 @@ jobs:
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
             -O https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip
           echo "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a  ninja-win.zip" | sha256sum -c -
-          tar -xf ninja-win.zip && rm ninja-win.zip
+          "$(cygpath -u "$SYSTEMROOT")/System32/tar.exe" -xf ninja-win.zip && rm ninja-win.zip
           cygpath -w "$ninja_dir" >> "$GITHUB_PATH"
           ./ninja --version
 
@@ -196,7 +197,7 @@ jobs:
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
             -O https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip
           echo "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a  ninja-win.zip" | sha256sum -c -
-          tar -xf ninja-win.zip && rm ninja-win.zip
+          "$(cygpath -u "$SYSTEMROOT")/System32/tar.exe" -xf ninja-win.zip && rm ninja-win.zip
           cygpath -w "$ninja_dir" >> "$GITHUB_PATH"
           ./ninja --version
 
@@ -334,7 +335,7 @@ jobs:
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
             -O https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip
           echo "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a  ninja-win.zip" | sha256sum -c -
-          tar -xf ninja-win.zip && rm ninja-win.zip
+          "$(cygpath -u "$SYSTEMROOT")/System32/tar.exe" -xf ninja-win.zip && rm ninja-win.zip
           cygpath -w "$ninja_dir" >> "$GITHUB_PATH"
           ./ninja --version
 
@@ -418,7 +419,7 @@ jobs:
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
             -O https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip
           echo "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a  ninja-win.zip" | sha256sum -c -
-          tar -xf ninja-win.zip && rm ninja-win.zip
+          "$(cygpath -u "$SYSTEMROOT")/System32/tar.exe" -xf ninja-win.zip && rm ninja-win.zip
           cygpath -w "$ninja_dir" >> "$GITHUB_PATH"
           ./ninja --version
 

--- a/.github/workflows/spirv-ci-windows-amd-staging.yml
+++ b/.github/workflows/spirv-ci-windows-amd-staging.yml
@@ -30,8 +30,20 @@ jobs:
           git config --global core.eol lf
 
       # Pinned ninja 1.12.1 — TheRock pins this version because 1.13.0 has a bug.
+      # Fetched from the GitHub release instead of chocolatey: the community
+      # feed 504s intermittently and takes the whole job down with it. Install
+      # dir must be the same in every job — the build tree's CMakeCache bakes in
+      # CMAKE_MAKE_PROGRAM as an absolute path and the test jobs untar it.
       - name: Install ninja
-        run: choco install -y ninja --version 1.12.1
+        run: |
+          ninja_dir="$(cygpath -u "$GITHUB_WORKSPACE")/.ninja"
+          mkdir -p "$ninja_dir" && cd "$ninja_dir"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+            -O https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip
+          echo "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a  ninja-win.zip" | sha256sum -c -
+          tar -xf ninja-win.zip && rm ninja-win.zip
+          cygpath -w "$ninja_dir" >> "$GITHUB_PATH"
+          ./ninja --version
 
       # MSVC environment so cmake -GNinja can find cl.exe + link.exe.
       - name: Configure MSVC
@@ -178,7 +190,15 @@ jobs:
           git config --global core.eol lf
 
       - name: Install ninja
-        run: choco install -y ninja --version 1.12.1
+        run: |
+          ninja_dir="$(cygpath -u "$GITHUB_WORKSPACE")/.ninja"
+          mkdir -p "$ninja_dir" && cd "$ninja_dir"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+            -O https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip
+          echo "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a  ninja-win.zip" | sha256sum -c -
+          tar -xf ninja-win.zip && rm ninja-win.zip
+          cygpath -w "$ninja_dir" >> "$GITHUB_PATH"
+          ./ninja --version
 
       - name: Configure MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -308,7 +328,15 @@ jobs:
           git config --global core.eol lf
 
       - name: Install ninja
-        run: choco install -y ninja --version 1.12.1
+        run: |
+          ninja_dir="$(cygpath -u "$GITHUB_WORKSPACE")/.ninja"
+          mkdir -p "$ninja_dir" && cd "$ninja_dir"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+            -O https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip
+          echo "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a  ninja-win.zip" | sha256sum -c -
+          tar -xf ninja-win.zip && rm ninja-win.zip
+          cygpath -w "$ninja_dir" >> "$GITHUB_PATH"
+          ./ninja --version
 
       - name: Configure MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -384,7 +412,15 @@ jobs:
           git config --global core.eol lf
 
       - name: Install ninja
-        run: choco install -y ninja --version 1.12.1
+        run: |
+          ninja_dir="$(cygpath -u "$GITHUB_WORKSPACE")/.ninja"
+          mkdir -p "$ninja_dir" && cd "$ninja_dir"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+            -O https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip
+          echo "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a  ninja-win.zip" | sha256sum -c -
+          tar -xf ninja-win.zip && rm ninja-win.zip
+          cygpath -w "$ninja_dir" >> "$GITHUB_PATH"
+          ./ninja --version
 
       - name: Configure MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0


### PR DESCRIPTION
Both Windows test jobs on ROCm/SPIRV-LLVM-Translator#288 failed at the **"Install ninja"** step — step 3 of 4 identically-structured jobs — when the chocolatey community feed returned a 504:

```
Unable to connect to source 'https://community.chocolatey.org/api/v2/':
 Failed to fetch results from V2 feed at
 'https://community.chocolatey.org/api/v2/Packages(Id='ninja',Version='1.12.1')'
 with following message : Response status code does not indicate success:
 504 (Gateway Timeout).
ninja not installed. The package was not found with the source(s) listed.
```

Every subsequent step was skipped. The third Windows test job started ~2 min later and installed ninja fine, so the feed was flapping rather than down; a rerun of the failed jobs went green.

`spirv-ci-windows-amd-staging.yml` here is the sibling copy of that workflow and carries the same exposure: `choco install -y ninja --version 1.12.1` in all four Windows jobs with no retry, so a blip in a third-party package feed costs an entire job. This drops chocolatey from the dependency graph and pulls the pinned `ninja-win.zip` straight from the `ninja-build/ninja` GitHub release — GitHub is already a hard dependency of the run, `curl` retries, and the archive is checksum-verified.

```bash
ninja_dir="$(cygpath -u "$GITHUB_WORKSPACE")/.ninja"
mkdir -p "$ninja_dir" && cd "$ninja_dir"
curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
  -O https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip
echo "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a  ninja-win.zip" | sha256sum -c -
tar -xf ninja-win.zip && rm ninja-win.zip
cygpath -w "$ninja_dir" >> "$GITHUB_PATH"
./ninja --version
```

Notes on the details:

- **Install dir is `$GITHUB_WORKSPACE/.ninja`, not a global location.** The build job's `CMakeCache.txt` bakes `CMAKE_MAKE_PROGRAM` in as an absolute path, and `Test SPIRV translator lit` re-runs `cmake` against the untarred build tree — so the ninja path has to be identical in every job. The workspace is guaranteed writable and deterministic; `C:\tools` does not exist on this runner image. The build artifact only tars `build build-comgr build-device-libs`, so `.ninja` is not swept into it.
- **`tar -xf`, not `unzip`** — Git-for-Windows bash has no `unzip`; bsdtar reads zip.
- **`cygpath` both directions** — `$GITHUB_WORKSPACE` is backslashed, and `$GITHUB_PATH` needs Windows form. `$GITHUB_PATH` prepends, so this ninja takes precedence over the VS-bundled one at `...\CommonExtensions\Microsoft\CMake\Ninja`.
- **Inlined per job rather than a composite action** — no job checks out this repo at the workspace root (checkouts use `path: llvm-project`), so `uses: ./.github/actions/...` would need an extra root checkout in all four jobs.

Companion PR with the identical change to the translator repo's copy: ROCm/SPIRV-LLVM-Translator#289.

`vcpkg install zstd:x64-windows`, two steps later, is the same class of unprotected third-party fetch. Left alone here; worth a separate look.
