### PR TITLE
[Comgr] Accept both amdgcn and amdgpu subarch triples in lit

### DIFF
--- a/amd/comgr/test-lit/cache-tests/unbundle-cached.hip
+++ b/amd/comgr/test-lit/cache-tests/unbundle-cached.hip
@@ -32,7 +32,7 @@
 // RUN: COUNT=$(ls "%t.cache" | wc -l)
 // RUN: [ 3 -eq $COUNT ]
 
-// BOTH: target triple = "amdgcn-amd-amdhsa"
+// BOTH: target triple = "amd{{gcn|gpu[0-9.]+}}-amd-amdhsa"
 // GFX9: "target-cpu"="gfx900"
 // GFX10: "target-cpu"="gfx1030"
 

--- a/amd/comgr/test-lit/device-lib-linking.cl
+++ b/amd/comgr/test-lit/device-lib-linking.cl
@@ -6,7 +6,7 @@
 // RUN: %llvm-dis %t-with-dev-libs.bc -o - | %FileCheck %s
 
 // COM: Verify LLVM IR text file
-// CHECK: target triple = "amdgcn-amd-amdhsa"
+// CHECK: target triple = "amd{{gcn|gpu[0-9.]+}}-amd-amdhsa"
 // CHECK: define internal float @_Z4powrff
 // CHECK: define internal float @_Z6sincosfPU3AS5f
 // CHECK: define internal float @_Z4cbrtf

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-rewrite-e2e.hip
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-rewrite-e2e.hip
@@ -21,7 +21,7 @@
 // RUN: %llvm-readelf -h %t.input.elf | %FileCheck --check-prefix=INPUT-FLAGS %s
 // INPUT-FLAGS: Flags:{{.*}}gfx1250
 // RUN: %llvm-readelf --notes %t.input.elf | %FileCheck --check-prefix=INPUT-META %s
-// INPUT-META: amdhsa.target: amdgcn-amd-amdhsa{{--|-unknown-}}gfx1250
+// INPUT-META: amdhsa.target: amd{{gcn|gpu[0-9.]+}}-amd-amdhsa{{--|-unknown-}}gfx1250
 
 // COM: Run hotswap-rewrite; save the output so we can inspect it.
 // RUN: hotswap-rewrite %t.input.elf \
@@ -36,7 +36,7 @@
 // RUN: %llvm-readelf -h %t.output.elf | %FileCheck --check-prefix=OUTPUT-FLAGS %s
 // OUTPUT-FLAGS: Flags:{{.*}}gfx1250
 // RUN: %llvm-readelf --notes %t.output.elf | %FileCheck --check-prefix=OUTPUT-META %s
-// OUTPUT-META: amdhsa.target: amdgcn-amd-amdhsa{{--|-unknown-}}gfx1250
+// OUTPUT-META: amdhsa.target: amd{{gcn|gpu[0-9.]+}}-amd-amdhsa{{--|-unknown-}}gfx1250
 
 // COM: .text section is still present and marked executable.
 // RUN: %llvm-readelf --section-headers %t.output.elf \

--- a/amd/comgr/test-lit/unbundle.hip
+++ b/amd/comgr/test-lit/unbundle.hip
@@ -18,7 +18,7 @@
 // RUN: unbundle %t.compressed-bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx1030 %t.compressed.gfx1030.bc
 // RUN: %llvm-dis %t.compressed.gfx1030.bc -o - | %FileCheck --check-prefixes=BOTH,GFX10 %s
 //
-// BOTH: target triple = "amdgcn-amd-amdhsa"
+// BOTH: target triple = "amd{{gcn|gpu[0-9.]+}}-amd-amdhsa"
 // GFX9: "target-cpu"="gfx900"
 // GFX10: "target-cpu"="gfx1030"
 

--- a/amd/comgr/test-lit/unpackage-test.hip
+++ b/amd/comgr/test-lit/unpackage-test.hip
@@ -42,7 +42,7 @@
 // RUN: unpackage --expect-fail \
 // RUN: %t.corrupt.bc amdgcn-amd-amdhsa gfx900 %t.corrupt.output.bc
 //
-// BOTH: target triple = "amdgcn-amd-amdhsa"
+// BOTH: target triple = "amd{{gcn|gpu[0-9.]+}}-amd-amdhsa"
 // GFX9: "target-cpu"="gfx900"
 // GFX10: "target-cpu"="gfx1030"
 


### PR DESCRIPTION
Upstream [#206482](https://github.com/llvm/llvm-project/pull/206482) ("clang: Start using new amdgpu subarch triples") renames `Triple::amdgcn` to `Triple::amdgpu` and adds a subarch dimension, so the driver emits subarch-qualified triples — `amdgpu9.00-amd-amdhsa`, `amdgpu10.30-amd-amdhsa`, `amdgpu12.50-amd-amdhsa` — where it previously emitted `amdgcn-amd-amdhsa`.

Five Comgr lit tests hard-code the legacy spelling in their FileCheck patterns and fail when that change is in effect:

| Test | Surface |
|---|---|
| `unbundle.hip` | module `target triple` |
| `unpackage-test.hip` | module `target triple` |
| `cache-tests/unbundle-cached.hip` | module `target triple` |
| `device-lib-linking.cl` | module `target triple` |
| `hotswap/rewriter/hotswap-rewrite-e2e.hip` | `amdhsa.target` in the `NT_AMDGPU_METADATA` note |

#206482 and its follow-up [#217640](https://github.com/llvm/llvm-project/pull/217640) are currently reverted on `amd-staging` (c84607fa4212, cfe526a2271c), so these tests pass today. `revert_patches.txt` lists three blockers for re-applying them: *"breaks comgr, device-libs, hip-test"*. This PR clears the first one. It is inert against the tree as it stands — the relaxed patterns still match the legacy-only output — so it can land ahead of the un-revert.

### What changed

Only FileCheck patterns, 6 lines across 5 files:

```
-// BOTH: target triple = "amdgcn-amd-amdhsa"
+// BOTH: target triple = "amd{{gcn|gpu[0-9.]+}}-amd-amdhsa"

-// INPUT-META: amdhsa.target: amdgcn-amd-amdhsa{{--|-unknown-}}gfx1250
+// INPUT-META: amdhsa.target: amd{{gcn|gpu[0-9.]+}}-amd-amdhsa{{--|-unknown-}}gfx1250
```

The patterns stay specific: the trailing `-amd-amdhsa` anchors the match, so an unrelated arch such as `amdgcnspirv-amd-amdhsa` is still rejected.

Test-*supplied* strings are deliberately left alone — bundle entry IDs (`hip-amdgcn-amd-amdhsa-unknown-gfx900`), `unpackage` / `hotswap-rewrite` arguments, and `llvm-offload-binary --image=...,triple=amdgcn-amd-amdhsa`. Those are inputs, and `amdgcn-amd-amdhsa` still parses to `amdgpu` + `NoSubArch`.

### No Comgr source change needed

Comgr does not read the triple string to identify a target. `getElfIsaNameFromElfHeader()` (`comgr-metadata.cpp`) reconstructs the ISA name from `e_ident` / `e_machine` / `e_flags`, and the hotswap rewriter's `amdgcn-amd-amdhsa` `Triple` is only used for `TargetRegistry::lookupTarget()`, which still resolves. The same holds downstream — ROCr and clr derive the ISA from `e_flags`, and no consumer of the `amdhsa.target` string was found in either.
