### PR TITLE
comgr: Fix hotswap tests failing on a macOS host

### DIFF
--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-long-branch.s
@@ -64,7 +64,7 @@
 // COM: A live VCC can instead use an already-allocated numbered pair after
 // COM: CFG liveness proves that neither half is consumed by the replacement or
 // COM: continuation before being redefined.
-// RUN: sed '/^  tensor_load_to_lds/a\  s_cbranch_vccz 0' %t.full-sgpr.s \
+// RUN: sed 's|^// VCCZ-ONLY:|  |' %t.full-sgpr.s \
 // RUN:   > %t.local-pair.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.local-pair.s -o %t.local-pair.elf
@@ -78,7 +78,7 @@
 // COM: Search every aligned pair, not just the highest eight. Every pair above
 // COM: s[30:31] has a reachable incoming-value read; s[30:31] is overwritten
 // COM: first and is therefore the highest locally dead pair.
-// RUN: sed -e '/^  tensor_load_to_lds/a\  s_cbranch_vccz 0' \
+// RUN: sed -e 's|^// VCCZ-ONLY:|  |' \
 // RUN:   -e 's|^// LOW-PAIR-ONLY:|  |' %t.full-sgpr.s > %t.low-pair.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.low-pair.s -o %t.low-pair.elf
@@ -193,6 +193,7 @@
 test_far:
   s_mov_b64 vcc, -1
   tensor_load_to_lds s[0:3], s[4:11]
+// VCCZ-ONLY:s_cbranch_vccz 0
 // LOW-PAIR-ONLY:s_mov_b64 s[30:31], 0
 // LOW-PAIR-ONLY:.irp live_reg, s32, s34, s36, s38, s40, s42, s44, s46, s48, s50, s52, s54, s56, s58, s60, s62, s64, s66, s68, s70, s72, s74, s76, s78, s80, s82, s84, s86, s88, s90, s92, s94, s96, s98, s100, s102, s104
 // LOW-PAIR-ONLY:s_mov_b32 s1, \live_reg

--- a/amd/comgr/test/utils/test_hotswap_reduce.py
+++ b/amd/comgr/test/utils/test_hotswap_reduce.py
@@ -1570,7 +1570,7 @@ class EndToEndTests(unittest.TestCase):
                 source: str | bytes | os.PathLike[str] | os.PathLike[bytes],
                 destination: str | bytes | os.PathLike[str] | os.PathLike[bytes],
             ) -> None:
-                if Path(os.fsdecode(destination)) == output:
+                if Path(os.fsdecode(destination)) == output.resolve():
                     raise KeyboardInterrupt()
                 real_replace(source, destination)
 


### PR DESCRIPTION
- "sed '/re/a\ text'" one-line append form is a GNU extension that BSD/macOS sed rejects ("extra characters after \"). Rather than append s_cbranch_vccz after tensor_load_to_lds via sed, embed the instruction as a commented "// VCCZ-ONLY:" template line right after tensor_load_to_lds and uncomment it with a portable substitution, matching the idiom already used in this file (LIVE-ONLY, LOW-PAIR-ONLY, etc.). The assembled input is unchanged: tensor_load_to_lds is still emitted, now immediately followed by the uncommented s_cbranch_vccz 0.

- atomic_publish() resolves the output path, so on macOS the temp dir under /var (a symlink to /private/var) makes the test's unresolved comparison path never match the mocked os.replace destination, and the expected KeyboardInterrupt never fires. Compare against the resolved path.


