### PR TITLE
[OpenMP][AMDGPU] Take the kernel execution mode from the kernel environment

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -848,13 +848,17 @@ void CGOpenMPRuntimeGPU::emitNonSPMDKernel(const OMPExecutableDirective &D,
   GenerateMetaData(CGM, D, OutlinedFn, /*Generic*/ true);
 }
 
+static llvm::omp::OMPTgtExecModeFlags
+computeExecutionMode(bool Mode, const Stmt *DirectiveStmt, CodeGenModule &CGM);
+
 void CGOpenMPRuntimeGPU::emitKernelInit(const OMPExecutableDirective &D,
                                         CodeGenFunction &CGF,
                                         EntryFunctionState &EST, bool IsSPMD) {
   llvm::OpenMPIRBuilder::TargetKernelDefaultAttrs Attrs;
-  Attrs.ExecFlags =
-      IsSPMD ? llvm::omp::OMPTgtExecModeFlags::OMP_TGT_EXEC_MODE_SPMD
-             : llvm::omp::OMPTgtExecModeFlags::OMP_TGT_EXEC_MODE_GENERIC;
+  // The kernel environment carries the full mode, including the AMD-only
+  // no-loop, big-jump-loop and xteam-reduction variants, so that the plugin
+  // does not need a second copy of it in a separate global.
+  Attrs.ExecFlags = computeExecutionMode(IsSPMD, CGM.getOptKernelKey(D), CGM);
   computeMinAndMaxThreadsAndTeams(D, CGF, Attrs);
 
   CGBuilderTy &Bld = CGF.Builder;
@@ -950,21 +954,6 @@ void CGOpenMPRuntimeGPU::emitSPMDKernel(const OMPExecutableDirective &D,
   GenerateMetaData(CGM, D, OutlinedFn, /*SPMD*/ false);
 }
 
-// Create a unique global variable to indicate the execution mode of this target
-// region. The execution mode is either 'generic', or 'spmd' depending on the
-// target directive. This variable is picked up by the offload library to setup
-// the device appropriately before kernel launch. If the execution mode is
-// 'generic', the runtime reserves one warp for the master, otherwise, all
-// warps participate in parallel work.
-static void setPropertyExecutionMode(CodeGenModule &CGM, StringRef Name,
-                                     OMPTgtExecModeFlags Mode) {
-  auto *GVMode = new llvm::GlobalVariable(
-      CGM.getModule(), CGM.Int8Ty, /*isConstant=*/true,
-      llvm::GlobalValue::WeakAnyLinkage,
-      llvm::ConstantInt::get(CGM.Int8Ty, Mode), Twine(Name, "_exec_mode"));
-  CGM.addCompilerUsedGlobal(GVMode);
-}
-
 // Create a global variable to indicate whether fast reduction is enabled for
 // this file. This variable is read by the runtime while determining the launch
 // bounds.
@@ -1037,11 +1026,6 @@ void CGOpenMPRuntimeGPU::emitTargetOutlinedFunction(
                     CGM.emitNxResult("[No-Loop/Big-Jump-Loop/Xteam]", D,
                                      CodeGenModule::NxNonSPMD));
   }
-  setPropertyExecutionMode(
-      CGM, OutlinedFn->getName(),
-      IsBareKernel ? OMP_TGT_EXEC_MODE_BARE
-                   : computeExecutionMode(Mode, DirectiveStmt, CGM));
-
   if (Mode && DirectiveStmt)
     CGM.resetOptKernelMetadata(DirectiveStmt);
 
@@ -2624,6 +2608,32 @@ llvm::Value *CGOpenMPRuntimeGPU::getGPUBlockID(CodeGenFunction &CGF) {
 llvm::Value *CGOpenMPRuntimeGPU::getGPUNumBlocks(CodeGenFunction &CGF) {
   return CGF.EmitRuntimeCall(OMPBuilder.getOrCreateRuntimeFunction(
       CGM.getModule(), OMPRTL___kmpc_get_hardware_num_blocks));
+}
+
+void CGOpenMPRuntimeGPU::emitSpecializedKernelEnvironment(
+    const OMPExecutableDirective &D, CodeGenFunction &CGF) {
+  // This runs while emitting the loop body, where the enclosing directive is
+  // not necessarily the target directive, so the launch bounds cannot be
+  // recomputed here. A specialized kernel is compiled for one fixed workgroup
+  // size anyway, which is the size the environment must report.
+  llvm::OpenMPIRBuilder::TargetKernelDefaultAttrs Attrs;
+  unsigned BlockSize = 0;
+  if (CGM.isXteamRedKernel(D)) {
+    Attrs.ExecFlags = llvm::omp::OMP_TGT_EXEC_MODE_XTEAM_RED;
+    BlockSize = CGM.getXteamRedBlockSize(D);
+  } else if (CGM.isBigJumpLoopKernel(D)) {
+    Attrs.ExecFlags = llvm::omp::OMP_TGT_EXEC_MODE_SPMD_BIG_JUMP_LOOP;
+    BlockSize = CGM.getBigJumpLoopBlockSize(D);
+  } else if (CGM.isNoLoopKernel(D)) {
+    Attrs.ExecFlags = llvm::omp::OMP_TGT_EXEC_MODE_SPMD_NO_LOOP;
+    BlockSize = CGM.getNoLoopBlockSize(D);
+  } else {
+    return;
+  }
+  if (BlockSize > 0)
+    Attrs.MaxThreads = {static_cast<int32_t>(BlockSize)};
+
+  OMPBuilder.createKernelEnvironment(CGF.Builder, Attrs);
 }
 
 llvm::Value *CGOpenMPRuntimeGPU::initSpecializedKernel(CodeGenFunction &CGF) {

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.h
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.h
@@ -168,6 +168,12 @@ public:
   /// Initialization for a specialized kernel.
   llvm::Value *initSpecializedKernel(CodeGenFunction &CGF);
 
+  /// Emit the kernel environment for a specialized kernel. Such a kernel does
+  /// not call kmpc_target_init, but the plugin still reads its execution mode
+  /// and launch bounds out of the environment.
+  void emitSpecializedKernelEnvironment(const OMPExecutableDirective &D,
+                                        CodeGenFunction &CGF);
+
   std::pair<llvm::Value *, llvm::Value *>
   getXteamRedFunctionPtrs(CodeGenFunction &CGF, llvm::Type *RedVarType,
                           CodeGenModule::XteamRedOpKind Opcode);

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -326,6 +326,7 @@ void CodeGenFunction::EmitNoLoopCode(const OMPExecutableDirective &D,
 
   // Initialize a specialized kernel.
   RT.initSpecializedKernel(*this);
+  RT.emitSpecializedKernelEnvironment(D, *this);
 
   auto IVPair = EmitNoLoopIV(LD);
   const VarDecl *IVDecl = IVPair.first;
@@ -562,6 +563,7 @@ void CodeGenFunction::EmitBigJumpLoopCode(const OMPExecutableDirective &D,
   auto &RT = static_cast<CGOpenMPRuntimeGPU &>(CGM.getOpenMPRuntime());
   // Initialize a specialized kernel.
   RT.initSpecializedKernel(*this);
+  RT.emitSpecializedKernelEnvironment(D, *this);
   EmitStmt(CapturedForStmt);
 }
 
@@ -577,6 +579,7 @@ void CodeGenFunction::EmitXteamRedCode(const OMPExecutableDirective &D,
 
   // Initialize a specialized kernel.
   RT.initSpecializedKernel(*this);
+  RT.emitSpecializedKernelEnvironment(D, *this);
 
   EmitXteamLocalAggregator(CapturedForStmt);
 

--- a/llvm/include/llvm/Frontend/OpenMP/OMPDeviceConstants.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPDeviceConstants.h
@@ -29,6 +29,21 @@ enum OMPTgtExecModeFlags : unsigned char {
   OMP_TGT_EXEC_MODE_XTEAM_RED = 1 << 3
 };
 
+/// Whether \p Mode runs every thread in the kernel body, so that no generic
+/// worker/dispatcher state machine is needed. Modes are not a bitmask that can
+/// be tested for the SPMD bit, so they are enumerated explicitly.
+constexpr bool isSPMDExecMode(OMPTgtExecModeFlags Mode) {
+  switch (Mode) {
+  case OMP_TGT_EXEC_MODE_SPMD:
+  case OMP_TGT_EXEC_MODE_SPMD_NO_LOOP:
+  case OMP_TGT_EXEC_MODE_SPMD_BIG_JUMP_LOOP:
+  case OMP_TGT_EXEC_MODE_XTEAM_RED:
+    return true;
+  default:
+    return false;
+  }
+}
+
 } // end namespace omp
 } // end namespace llvm
 

--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -3563,6 +3563,32 @@ public:
       const LocationDescription &Loc,
       const llvm::OpenMPIRBuilder::TargetKernelDefaultAttrs &Attrs);
 
+  /// Create the kernel environment global for the kernel containing \p Loc,
+  /// without emitting a kmpc_target_init call. Kernels that initialize
+  /// themselves with a specialized init still need the environment present in
+  /// the image, because the plugin reads the execution mode and the launch
+  /// bounds out of it as plain data.
+  ///
+  /// \param Loc The insert and source location description.
+  /// \param Attrs Structure containing the default attributes.
+  LLVM_ABI GlobalVariable *createKernelEnvironment(
+      const LocationDescription &Loc,
+      const llvm::OpenMPIRBuilder::TargetKernelDefaultAttrs &Attrs);
+
+private:
+  /// Emit the dynamic and kernel environment globals for the kernel containing
+  /// \p Loc. \p WriteLaunchBounds also manifests the launch configuration in
+  /// the kernel metadata.
+  GlobalVariable *emitKernelEnvironment(
+      const LocationDescription &Loc,
+      const llvm::OpenMPIRBuilder::TargetKernelDefaultAttrs &Attrs,
+      bool WriteLaunchBounds);
+
+  /// Emit the branch that sends non-user threads of a generic kernel to an
+  /// early return, given the result of kmpc_target_init.
+  InsertPointTy emitTargetInitBranch(CallInst *ThreadKind);
+
+public:
   /// Create a runtime call for kmpc_target_deinit
   ///
   /// \param Loc The insert and source location description.

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -349,7 +349,9 @@ getTargetKernelExecMode(Function &Kernel) {
 static bool isGenericKernel(Function &Fn) {
   std::optional<omp::OMPTgtExecModeFlags> ExecMode =
       getTargetKernelExecMode(Fn);
-  return !ExecMode || (*ExecMode & OMP_TGT_EXEC_MODE_GENERIC);
+  // Not a bit test: some modes set the generic bit without running generic.
+  return !ExecMode || *ExecMode == OMP_TGT_EXEC_MODE_GENERIC ||
+         *ExecMode == OMP_TGT_EXEC_MODE_GENERIC_SPMD;
 }
 
 /// Make \p Source branch to \p Target.
@@ -8615,9 +8617,8 @@ GlobalVariable *OpenMPIRBuilder::emitKernelEnvironment(
   Constant *SrcLocStr = getOrCreateSrcLocStr(Loc, SrcLocStrSize);
   Constant *Ident = getOrCreateIdent(SrcLocStr, SrcLocStrSize);
   Constant *IsSPMDVal = ConstantInt::getSigned(Int8, Attrs.ExecFlags);
-  Constant *UseGenericStateMachineVal = ConstantInt::getSigned(
-      Int8, Attrs.ExecFlags != omp::OMP_TGT_EXEC_MODE_SPMD &&
-                Attrs.ExecFlags != omp::OMP_TGT_EXEC_MODE_SPMD_NO_LOOP);
+  Constant *UseGenericStateMachineVal =
+      ConstantInt::getSigned(Int8, !omp::isSPMDExecMode(Attrs.ExecFlags));
   Constant *MayUseNestedParallelismVal = ConstantInt::getSigned(Int8, true);
   Constant *DebugIndentionLevelVal = ConstantInt::getSigned(Int16, 0);
 

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -8560,6 +8560,18 @@ CallInst *OpenMPIRBuilder::createCachedThreadPrivate(
   return createRuntimeFunctionCall(Fn, Args);
 }
 
+GlobalVariable *OpenMPIRBuilder::createKernelEnvironment(
+    const LocationDescription &Loc,
+    const llvm::OpenMPIRBuilder::TargetKernelDefaultAttrs &Attrs) {
+  assert(!Attrs.MaxThreads.empty() && !Attrs.MaxTeams.empty() &&
+         "expected num_threads and num_teams to be specified");
+
+  if (!updateToLocation(Loc))
+    return nullptr;
+
+  return emitKernelEnvironment(Loc, Attrs, /*WriteLaunchBounds=*/false);
+}
+
 OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTargetInit(
     const LocationDescription &Loc,
     const llvm::OpenMPIRBuilder::TargetKernelDefaultAttrs &Attrs) {
@@ -8569,6 +8581,36 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTargetInit(
   if (!updateToLocation(Loc))
     return Loc.IP;
 
+  GlobalVariable *KernelEnvironmentGV =
+      emitKernelEnvironment(Loc, Attrs, /*WriteLaunchBounds=*/true);
+
+  Function *DebugKernelWrapper = Builder.GetInsertBlock()->getParent();
+  Function *Fn = getOrCreateRuntimeFunctionPtr(
+      omp::RuntimeFunction::OMPRTL___kmpc_target_init);
+
+  Constant *KernelEnvironment =
+      KernelEnvironmentGV->getType() == KernelEnvironmentPtr
+          ? KernelEnvironmentGV
+          : ConstantExpr::getAddrSpaceCast(KernelEnvironmentGV,
+                                           KernelEnvironmentPtr);
+  Value *KernelLaunchEnvironment =
+      DebugKernelWrapper->getArg(DebugKernelWrapper->arg_size() - 1);
+  Type *KernelLaunchEnvParamTy = Fn->getFunctionType()->getParamType(1);
+  KernelLaunchEnvironment =
+      KernelLaunchEnvironment->getType() == KernelLaunchEnvParamTy
+          ? KernelLaunchEnvironment
+          : Builder.CreateAddrSpaceCast(KernelLaunchEnvironment,
+                                        KernelLaunchEnvParamTy);
+  CallInst *ThreadKind = createRuntimeFunctionCall(
+      Fn, {KernelEnvironment, KernelLaunchEnvironment});
+
+  return emitTargetInitBranch(ThreadKind);
+}
+
+GlobalVariable *OpenMPIRBuilder::emitKernelEnvironment(
+    const LocationDescription &Loc,
+    const llvm::OpenMPIRBuilder::TargetKernelDefaultAttrs &Attrs,
+    bool WriteLaunchBounds) {
   uint32_t SrcLocStrSize;
   Constant *SrcLocStr = getOrCreateSrcLocStr(Loc, SrcLocStrSize);
   Constant *Ident = getOrCreateIdent(SrcLocStr, SrcLocStrSize);
@@ -8596,8 +8638,10 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTargetInit(
     Config.setGridValue(getGridValue(T, Kernel));
 
   // Manifest the launch configuration in the metadata matching the kernel
-  // environment.
-  if (Attrs.MinTeams.front() > 1 || Attrs.MaxTeams.front() > 0)
+  // environment. A specialized kernel has already established its own bounds,
+  // so only the environment data is needed there.
+  if (WriteLaunchBounds &&
+      (Attrs.MinTeams.front() > 1 || Attrs.MaxTeams.front() > 0))
     writeTeamsForKernel(T, *Kernel, Attrs.MinTeams.front(),
                         Attrs.MaxTeams.front());
 
@@ -8614,7 +8658,7 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTargetInit(
     }
   }
 
-  if (MaxThreadsVal > 0)
+  if (WriteLaunchBounds && MaxThreadsVal > 0)
     writeThreadBoundsForKernel(T, *Kernel, Attrs.MinThreads.front(),
                                MaxThreadsVal);
 
@@ -8672,22 +8716,11 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTargetInit(
       DL.getDefaultGlobalsAddressSpace());
   KernelEnvironmentGV->setVisibility(GlobalValue::ProtectedVisibility);
 
-  Constant *KernelEnvironment =
-      KernelEnvironmentGV->getType() == KernelEnvironmentPtr
-          ? KernelEnvironmentGV
-          : ConstantExpr::getAddrSpaceCast(KernelEnvironmentGV,
-                                           KernelEnvironmentPtr);
-  Value *KernelLaunchEnvironment =
-      DebugKernelWrapper->getArg(DebugKernelWrapper->arg_size() - 1);
-  Type *KernelLaunchEnvParamTy = Fn->getFunctionType()->getParamType(1);
-  KernelLaunchEnvironment =
-      KernelLaunchEnvironment->getType() == KernelLaunchEnvParamTy
-          ? KernelLaunchEnvironment
-          : Builder.CreateAddrSpaceCast(KernelLaunchEnvironment,
-                                        KernelLaunchEnvParamTy);
-  CallInst *ThreadKind = createRuntimeFunctionCall(
-      Fn, {KernelEnvironment, KernelLaunchEnvironment});
+  return KernelEnvironmentGV;
+}
 
+OpenMPIRBuilder::InsertPointTy
+OpenMPIRBuilder::emitTargetInitBranch(CallInst *ThreadKind) {
   Value *ExecUserCode = Builder.CreateICmpEQ(
       ThreadKind, Constant::getAllOnesValue(ThreadKind->getType()),
       "exec_user_code");

--- a/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
+++ b/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
@@ -4388,33 +4388,6 @@ struct AAKernelInfoFunction : AAKernelInfo {
         ConstantInt::get(ExecModeC->getIntegerType(),
                          ExecModeVal | OMP_TGT_EXEC_MODE_GENERIC_SPMD));
 
-    // The global variable needs to be set too.
-    GlobalVariable *ExecMode = Kernel->getParent()->getGlobalVariable(
-        (Kernel->getName() + "_exec_mode").str());
-
-    if (!ExecMode) { // likely fortran missing exec mode
-      auto Remark = [&](OptimizationRemark OR) {
-        return OR << "Could not transform generic-mode kernel to SPMD-mode. Missing mode.";
-      };
-      A.emitRemark<OptimizationRemark>(KernelInitCB, "OMP122", Remark);
-    return false;
-    }
-    assert(ExecMode && "Kernel without exec mode?");
-    assert(ExecMode->getInitializer() && "ExecMode doesn't have initializer!");
-
-    // Set the global exec mode flag to indicate SPMD-Generic mode.
-    assert(isa<ConstantInt>(ExecMode->getInitializer()) &&
-           "ExecMode is not an integer!");
-
-    // Adjust the global exec mode flag that tells the runtime what mode this
-    // kernel is executed in.
-    assert(cast<ConstantInt>(ExecMode->getInitializer())->getSExtValue() ==
-               OMP_TGT_EXEC_MODE_GENERIC &&
-           "Initially non-SPMD kernel has SPMD exec mode!");
-    ExecMode->setInitializer(
-        ConstantInt::get(ExecMode->getInitializer()->getType(),
-                         ExecModeVal | OMP_TGT_EXEC_MODE_GENERIC_SPMD));
-
     ++NumOpenMPTargetRegionKernelsSPMD;
 
     // Record that this kernel now runs SPMD so post-Attributor cleanup can drop

--- a/llvm/test/Transforms/OpenMP/get_hardware_num_threads_in_block_fold.ll
+++ b/llvm/test/Transforms/OpenMP/get_hardware_num_threads_in_block_fold.ll
@@ -78,7 +78,7 @@ define weak ptx_kernel void @kernel2(ptr %dyn) "kernel" #0 {
 ; CHECK-NEXT:    call void @helper0() #[[ATTR1]]
 ; CHECK-NEXT:    call void @helper1() #[[ATTR1]]
 ; CHECK-NEXT:    call void @helper2() #[[ATTR1]]
-; CHECK-NEXT:    call void @__kmpc_parallel_60(ptr null, i32 [[TMP0]], i32 1, i32 -1, i32 -1, ptr @__omp_outlined__, ptr @__omp_outlined___wrapper, ptr [[CAPTURED_VARS_ADDRS]], i64 0, i32 0)
+; CHECK-NEXT:    call void @__kmpc_parallel_60(ptr null, i32 [[TMP0]], i32 1, i32 -1, i32 -1, ptr @__omp_outlined__, ptr null, ptr [[CAPTURED_VARS_ADDRS]], i64 0, i32 0)
 ; CHECK-NEXT:    call void @__kmpc_target_deinit()
 ; CHECK-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/OpenMP/is_spmd_exec_mode_fold.ll
+++ b/llvm/test/Transforms/OpenMP/is_spmd_exec_mode_fold.ll
@@ -49,7 +49,7 @@ define weak ptx_kernel void @will_be_spmd() "kernel" {
 ; CHECK:       user_code.entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = call i32 @__kmpc_global_thread_num(ptr null) #[[ATTR3:[0-9]+]]
 ; CHECK-NEXT:    call void @is_spmd_helper2()
-; CHECK-NEXT:    call void @__kmpc_parallel_60(ptr null, i32 [[TMP0]], i32 1, i32 -1, i32 -1, ptr @__omp_outlined__, ptr @__omp_outlined___wrapper, ptr [[CAPTURED_VARS_ADDRS]], i64 0, i32 0)
+; CHECK-NEXT:    call void @__kmpc_parallel_60(ptr null, i32 [[TMP0]], i32 1, i32 -1, i32 -1, ptr @__omp_outlined__, ptr null, ptr [[CAPTURED_VARS_ADDRS]], i64 0, i32 0)
 ; CHECK-NEXT:    call void @__kmpc_target_deinit()
 ; CHECK-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/OpenMP/spmd_parallel_wrapper_removal.ll
+++ b/llvm/test/Transforms/OpenMP/spmd_parallel_wrapper_removal.ll
@@ -38,7 +38,7 @@ define weak amdgpu_kernel void @generic_kernel() "kernel" {
 
 ; SPMD kernel: the wrapper (arg 6) is nulled.
 ; CHECK-LABEL: define internal void @spmd_outlined(
-; CHECK: call void @__kmpc_parallel_60(ptr @1, i32 0, i32 1, i32 -1, i32 -1, ptr @spmd_body, ptr @spmd_body_wrapper, ptr null, i64 0, i32 0)
+; CHECK: call void @__kmpc_parallel_60(ptr @1, i32 0, i32 1, i32 -1, i32 -1, ptr @spmd_body, ptr null, ptr null, i64 0, i32 0)
 define internal void @spmd_outlined(ptr %.global_tid., ptr %.bound_tid.) {
   call void @__kmpc_parallel_60(ptr @1, i32 0, i32 1, i32 -1, i32 -1, ptr @spmd_body, ptr @spmd_body_wrapper, ptr null, i64 0, i32 0)
   ret void

--- a/llvm/test/Transforms/OpenMP/spmdization_assumes.ll
+++ b/llvm/test/Transforms/OpenMP/spmdization_assumes.ll
@@ -55,7 +55,7 @@ define weak ptx_kernel void @__omp_offloading_fd02_404433c2_main_l5(ptr %dyn, pt
 ; CHECK-NEXT:    call void @__kmpc_barrier_simple_spmd(ptr @[[GLOB2]], i32 [[TMP2]])
 ; CHECK-NEXT:    br label %[[REGION_EXIT:.*]]
 ; CHECK:       [[REGION_EXIT]]:
-; CHECK-NEXT:    call void @__kmpc_parallel_60(ptr nonnull @[[GLOB1]], i32 [[TMP1]], i32 1, i32 -1, i32 -1, ptr @__omp_outlined__, ptr @__omp_outlined___wrapper, ptr nonnull [[CAPTURED_VARS_ADDRS]], i64 0, i32 0) #[[ATTR3]]
+; CHECK-NEXT:    call void @__kmpc_parallel_60(ptr nonnull @[[GLOB1]], i32 [[TMP1]], i32 1, i32 -1, i32 -1, ptr @__omp_outlined__, ptr null, ptr nonnull [[CAPTURED_VARS_ADDRS]], i64 0, i32 0) #[[ATTR3]]
 ; CHECK-NEXT:    call void @__kmpc_target_deinit() #[[ATTR3]]
 ; CHECK-NEXT:    br label %[[COMMON_RET]]
 ;

--- a/llvm/test/Transforms/OpenMP/spmdization_guarding_two_reaching_kernels.ll
+++ b/llvm/test/Transforms/OpenMP/spmdization_guarding_two_reaching_kernels.ll
@@ -167,7 +167,7 @@ define internal void @spmd_helper() #1 {
 ; CHECK-NEXT:    [[CAPTURED_VARS_ADDRS:%.*]] = alloca [0 x ptr], align 8
 ; CHECK-NEXT:    call void @leaf() #[[ATTR7]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = call i32 @__kmpc_global_thread_num(ptr @[[GLOB2]]) #[[ATTR3:[0-9]+]]
-; CHECK-NEXT:    call void @__kmpc_parallel_60(ptr @[[GLOB2]], i32 [[TMP0]], i32 1, i32 -1, i32 -1, ptr @__omp_outlined__, ptr @__omp_outlined___wrapper, ptr [[CAPTURED_VARS_ADDRS]], i64 0, i32 0)
+; CHECK-NEXT:    call void @__kmpc_parallel_60(ptr @[[GLOB2]], i32 [[TMP0]], i32 1, i32 -1, i32 -1, ptr @__omp_outlined__, ptr null, ptr [[CAPTURED_VARS_ADDRS]], i64 0, i32 0)
 ; CHECK-NEXT:    ret void
 ;
 ; CHECK-DISABLE-SPMDIZATION-LABEL: define {{[^@]+}}@spmd_helper

--- a/llvm/test/Transforms/OpenMP/spmdization_no_guarding_two_reaching_kernels.ll
+++ b/llvm/test/Transforms/OpenMP/spmdization_no_guarding_two_reaching_kernels.ll
@@ -161,7 +161,7 @@ define internal void @spmd_helper() #1 {
 ; CHECK-NEXT:    [[CAPTURED_VARS_ADDRS:%.*]] = alloca [0 x ptr], align 8
 ; CHECK-NEXT:    call void @leaf() #[[ATTR8:[0-9]+]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = call i32 @__kmpc_global_thread_num(ptr @[[GLOB2]]) #[[ATTR4:[0-9]+]]
-; CHECK-NEXT:    call void @__kmpc_parallel_60(ptr @[[GLOB2]], i32 [[TMP0]], i32 1, i32 -1, i32 -1, ptr @__omp_outlined__, ptr @__omp_outlined___wrapper, ptr [[CAPTURED_VARS_ADDRS]], i64 0, i32 0)
+; CHECK-NEXT:    call void @__kmpc_parallel_60(ptr @[[GLOB2]], i32 [[TMP0]], i32 1, i32 -1, i32 -1, ptr @__omp_outlined__, ptr null, ptr [[CAPTURED_VARS_ADDRS]], i64 0, i32 0)
 ; CHECK-NEXT:    ret void
 ;
 ; CHECK-DISABLE-SPMDIZATION-LABEL: define {{[^@]+}}@spmd_helper

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -108,31 +108,15 @@ Error GenericKernelTy::init(GenericDeviceTy &GenericDevice,
                       << "' Using default Bare (0) execution mode";
   }
 
-  // Create a metadata object for the exec mode global (auto-generated).
-  StaticGlobalTy<llvm::omp::OMPTgtExecModeFlags> ExecModeGlobal(getName(),
-                                                                "_exec_mode");
-
-  // Retrieve execution mode for the kernel. This may fail since some kernels
-  // may not have an execution mode.
-  if (auto Err =
-          GHandler.readGlobalFromImage(GenericDevice, Image, ExecModeGlobal)) {
-    // Consume the error since it is acceptable to fail.
-    [[maybe_unused]] std::string ErrStr = toString(std::move(Err));
-     ODBG(ODT_Init) << "Failed to read execution mode for "
-                    << getName()
-                    << ":"
-                    << ErrStr.data()
-                    << "Using default Bare (0) execution mode";
-
-    ExecutionMode = OMP_TGT_EXEC_MODE_BARE;
-  } else {
-    // Check that the retrieved execution mode is valid.
-    if (!GenericKernelTy::isValidExecutionMode(ExecModeGlobal.getValue()))
-      return Plugin::error(ErrorCode::UNKNOWN,
-                           "Invalid execution mode %d for '%s'",
-                           ExecModeGlobal.getValue(), getName());
-    ExecutionMode = ExecModeGlobal.getValue();
-  }
+  // The execution mode comes from the kernel environment. A kernel without an
+  // environment (a bare kernel) leaves the default zero, which is bare mode.
+  auto ImageExecutionMode = static_cast<llvm::omp::OMPTgtExecModeFlags>(
+      KernelEnvironment.Configuration.ExecMode);
+  if (!GenericKernelTy::isValidExecutionMode(ImageExecutionMode))
+    return Plugin::error(ErrorCode::UNKNOWN,
+                         "Invalid execution mode %d for '%s'",
+                         ImageExecutionMode, getName());
+  ExecutionMode = ImageExecutionMode;
 
   // Max = Config.Max > 0 ? min(Config.Max, Device.Max) : Device.Max;
   MaxNumThreads = KernelEnvironment.Configuration.MaxThreads > 0


### PR DESCRIPTION
# Take the kernel execution mode from the kernel environment

The execution mode of a target kernel is currently represented twice:

- in the **kernel environment**, where clang collapses it to either `SPMD` or
  `GENERIC`, and
- in a separate **`<kernel>_exec_mode` device global**, which contains the real
  mode, including the AMD-only `SPMD_NO_LOOP`, `SPMD_BIG_JUMP_LOOP` and
  `XTEAM_RED` variants.

The plugin reads the global, so the two copies have to be kept in agreement by
hand, and only one of them is ever right. This series deletes the global and
makes the environment the single source of truth, which is also what upstream
does.

## Why the global could not simply be deleted before

A specialized kernel — no-loop, big-jump-loop or xteam-reduction — does not call
`__kmpc_target_init`. It initializes itself with `__kmpc_specialized_kernel_init()`,
which takes no arguments, so no kernel environment is ever created for it and
the global is genuinely its only channel.

We add code to give the specialized kernels their own environment.

## What this also fixes

Now we can remove an (incorrect) section of divergent code from OpenMPOpt.cpp.
This was from commit f67639dddf3e in the Divergence spreadsheet. It could not have
been removed without the remnoval of the _exec_mode global.

Two mode tests were also wrong for the AMD-only modes, which mattered as soon as
those modes reached the environment. The values are not usable as a bitmask:
`SPMD_BIG_JUMP_LOOP` is `GENERIC | SPMD | 1 << 2`, so it has the generic bit set
even though it never runs a generic state machine, and `XTEAM_RED` is `1 << 3`,
which does not have the SPMD bit set at all.

## Commits

1. **`[OpenMPIRBuilder] Separate kernel environment creation from target init (NFC)`**
   — splits `createTargetInit` into environment creation and call emission, so
   the environment can be created on its own.
2. **`[OpenMP] Test the kernel execution mode explicitly, not as a bitmask`** —
   enumerates the modes in a helper next to the enum. A no-op for the modes that
   reach these tests today.
3. **`[OpenMP][AMDGPU] Take the kernel execution mode from the kernel environment`**
   — emits the environment for specialized kernels, points the plugin at it, and
   removes the global and its OpenMPOpt updater.

## Testing

On gfx90a:

| suite | with this series |
|---|---|
| `llvm/test/Transforms/OpenMP` + `clang/test/OpenMP` | 1680 passed, 0 failed |
| `check-offload` | 1141 passed, 14 failed |
| AOMP `smoke` | 325/325 |
| AOMP `smoke-fort` | 164/164 |

The 14 `check-offload` failures are pre-existing: the failure set is identical to
the one measured at the branch point without this series.

Six tests in `llvm/test/Transforms/OpenMP` hand-write the IR OpenMPOpt consumes,
so they never had the global and stopped early at the bail described above. They
now run the transform to completion and their expectations grow accordingly.
Four of the six become identical to their upstream counterparts.

## Not addressed here

`OpenMPIRBuilder::emitKernelExecutionMode` still emits an `_exec_mode` global for
kernels coming through the MLIR path. That code is identical in this tree and
upstream, so changing it would create divergence, and nothing reads the global
now. `setPropertyWorkGroupSize` writes a second legacy global of the same kind,
`<kernel>_wg_size`, which the environment's `MaxThreads` field also makes
redundant; that is a separate change.
