### PR TITLE
[Comgr][hotswap] Compile every comgr target at the same C++ standard

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -471,6 +471,7 @@ endforeach()
 set_target_properties(comgr-object-utils PROPERTIES
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS No
   POSITION_INDEPENDENT_CODE ON)
 target_include_directories(comgr-object-utils
   PRIVATE

--- a/amd/comgr/src/hotswap/common/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/common/CMakeLists.txt
@@ -5,9 +5,6 @@ cmake_minimum_required(VERSION 3.20)
 # and re-imports LLVM, which links a second copy of the AMDGPU static libraries
 # into amd_comgr and double-registers their cl::opts under a non-folding linker.
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # --- LLVM ---------------------------------------------------------------------
 if(NOT TARGET LLVMSupport)
   find_package(LLVM REQUIRED CONFIG)
@@ -47,7 +44,11 @@ if(NOT LLVM_ENABLE_RTTI)
     target_compile_options(hotswap-common PRIVATE -fno-rtti)
   endif()
 endif()
-set_target_properties(hotswap-common PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(hotswap-common PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS No
+  POSITION_INDEPENDENT_CODE ON)
 
 # Match LLVM's RTTI setting explicitly. llvm_update_compile_flags only adds
 # -fno-rtti when it detects a GCC-compatible compiler, which is not set in this

--- a/amd/comgr/src/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/decoder/CMakeLists.txt
@@ -4,8 +4,6 @@ cmake_minimum_required(VERSION 3.20)
 # standalone build. A nested project() re-runs the superbuild dependency provider
 # and re-imports LLVM, which links a second copy of the AMDGPU static libraries
 # into amd_comgr and double-registers their cl::opts under a non-folding linker.
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # --- LLVM ---------------------------------------------------------------------
 if(NOT TARGET LLVMSupport)
@@ -82,7 +80,11 @@ if(NOT LLVM_ENABLE_RTTI)
     target_compile_options(hotswap-decoder PRIVATE -fno-rtti)
   endif()
 endif()
-set_target_properties(hotswap-decoder PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(hotswap-decoder PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS No
+  POSITION_INDEPENDENT_CODE ON)
 
 # Public include root (src/) so consumers can `#include "hotswap/..."`.
 target_include_directories(hotswap-decoder PUBLIC

--- a/amd/comgr/src/hotswap/loader/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/loader/CMakeLists.txt
@@ -5,9 +5,6 @@ cmake_minimum_required(VERSION 3.20)
 # and re-imports LLVM, which links a second copy of the AMDGPU static libraries
 # into amd_comgr and double-registers their cl::opts under a non-folding linker.
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # --- LLVM ---------------------------------------------------------------------
 if(NOT TARGET LLVMSupport)
   find_package(LLVM REQUIRED CONFIG)
@@ -78,7 +75,11 @@ if(NOT LLVM_ENABLE_RTTI)
     target_compile_options(hotswap-loader PRIVATE -fno-rtti)
   endif()
 endif()
-set_target_properties(hotswap-loader PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(hotswap-loader PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS No
+  POSITION_INDEPENDENT_CODE ON)
 
 # Match LLVM's RTTI setting explicitly. llvm_update_compile_flags only adds
 # -fno-rtti when it detects a GCC-compatible compiler, which is not set in this

--- a/amd/comgr/src/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/raiser/CMakeLists.txt
@@ -5,9 +5,6 @@ cmake_minimum_required(VERSION 3.20)
 # and re-imports LLVM, which links a second copy of the AMDGPU static libraries
 # into amd_comgr and double-registers their cl::opts under a non-folding linker.
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # --- LLVM ---------------------------------------------------------------------
 if(NOT TARGET LLVMSupport)
   find_package(LLVM REQUIRED CONFIG)
@@ -64,7 +61,11 @@ if(NOT LLVM_ENABLE_RTTI)
   endif()
 endif()
 
-set_target_properties(hotswap-raiser PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(hotswap-raiser PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS No
+  POSITION_INDEPENDENT_CODE ON)
 
 # Public include root (src/) so consumers can `#include "hotswap/raiser/raiser.h"`.
 target_include_directories(hotswap-raiser PUBLIC

--- a/amd/comgr/src/hotswap/rewriter/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/rewriter/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # --- LLVM ---------------------------------------------------------------------
 if(NOT TARGET LLVMSupport)
   find_package(LLVM REQUIRED CONFIG)
@@ -50,7 +47,11 @@ endif()
 # on any class with a virtual method.
 llvm_update_compile_flags(hotswap-rewriter)
 
-set_target_properties(hotswap-rewriter PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(hotswap-rewriter PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS No
+  POSITION_INDEPENDENT_CODE ON)
 
 # These TUs land directly in amd_comgr and define exported amd_comgr_hotswap_*
 # API functions, so they must be built with AMD_COMGR_EXPORT for AMD_COMGR_API

--- a/amd/comgr/test-support/CMakeLists.txt
+++ b/amd/comgr/test-support/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(comgr-test-llvm-init OBJECT llvm-init.cpp)
 set_target_properties(comgr-test-llvm-init PROPERTIES
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS No
   POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(comgr-test-llvm-init PRIVATE

--- a/amd/comgr/test-unit/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/decoder/CMakeLists.txt
@@ -20,9 +20,3 @@ target_include_directories(DecoderTests PRIVATE
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
 
 comgr_configure_test_target(DecoderTests)
-
-# The decoder headers this test includes are built as C++20 by the
-# hotswap::decoder library; match it (comgr_configure_test_target pins C++17).
-set_target_properties(DecoderTests PROPERTIES
-  CXX_STANDARD 20
-  CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
The hotswap OBJECT libraries ask for C++20 where every other comgr target asks
for C++17, and they ask for it through a directory-scoped `CMAKE_CXX_STANDARD`
rather than the per-target property the rest of the build uses. That produces
three separate divergences, all of which this removes.

**The standard itself.** Five files set C++20, all under `src/hotswap`
(`common`, `decoder`, `loader`, `raiser`, `rewriter`), plus `DecoderTests`,
which pinned 20 to match them. Everything else in comgr is C++17: `amd_comgr`,
`comgr-object-utils`, the device-libs and libcxx-headers helpers, every lit
binary and the other thirteen unit binaries.

Nothing under `src/hotswap` reaches a C++20 feature. No `<span>`, `<ranges>`,
`<concepts>`, `<bit>`, `<format>` or `<compare>`; no `std::bit_cast`,
`popcount` or `erase_if`; no concepts, `consteval`, `constinit`, coroutines,
`<=>`, `using enum`, designated initializers or `[[likely]]`.

**The same sources at two standards in one build.** The rewriter unit tests
(`HotswapMCTests`, `HotswapElfTests`, `HotswapProfileTests`) list
`src/hotswap/rewriter/*.cpp` as sources rather than linking `hotswap::rewriter`,
so `elf.cpp`, `b0a0.cpp`, `profile.cpp` and the rest are compiled at C++17 into
the test binaries and at C++20 into the library, in the same build.

**`gnu++` versus plain.** A directory-scoped `set(CMAKE_CXX_STANDARD ...)` never
touches `CXX_EXTENSIONS`, which defaults on, so the hotswap libraries come out
as `gnu++20` in a standalone comgr build. In-tree this is invisible, because
`llvm/CMakeLists.txt` sets `CMAKE_CXX_EXTENSIONS NO` for the whole tree.
`comgr-object-utils` has the same gap at C++17.

Setting the standard per target, at 17, with extensions off, closes all three.
17 is also what `llvm/CMakeLists.txt` names as `LLVM_REQUIRED_CXX_STANDARD`, so
this is the tree's own floor rather than a number picked for comgr.

### Verification

Standalone Release build, before and after:

| | before | after |
|---|---|---|
| `-std=c++17` | 58 | 97 |
| `-std=gnu++17` | 3 | 0 |
| `-std=c++20` | 1 | 0 |
| `-std=gnu++20` | 35 | 0 |

`check-comgr` 32/32; lit 207 discovered, 194 passed, 13 unsupported, 0 failed;
all 14 unit binaries at unchanged counts (DecoderTests 20, OpResolverTests 1,
RaiseContextTests 1, RaiseFailureTests 5, RaiserScaffoldingTests 4, RegFileTests
10, RegisterStateTests 18, UserSgprLayoutTests 12, WaveProjectionTests 11,
HotswapElfTests 36, HotswapMCTests 217, HotswapProfileTests 9,
DemangleSymbolNameTest 27, LoggerTests 21).

Stacked on `users/ftynse/hotswap-test-llvm-init`; review that branch first.
