### PR TITLE
[Clang] Reapply "Enable -Wunused-template under -Wall"

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1376,7 +1376,7 @@ def Conversion
 def Unused : DiagGroup<"unused",
                        [UnusedArgument, UnusedFunction, UnusedLabel,
                         // UnusedParameter, (matches GCC's behavior)
-                        // UnusedTemplate, (clean-up libc++ before enabling)
+                        UnusedTemplate,
                         // UnusedMemberFunction, (clean-up llvm before enabling)
                         UnusedPrivateField, UnusedLambdaCapture,
                         UnusedLocalTypedef, UnusedValue, UnusedVariable,

--- a/clang/test/Misc/warning-wall.c
+++ b/clang/test/Misc/warning-wall.c
@@ -73,6 +73,8 @@ CHECK-NEXT:      -Wunused-argument
 CHECK-NEXT:      -Wunused-function
 CHECK-NEXT:        -Wunneeded-internal-declaration
 CHECK-NEXT:      -Wunused-label
+CHECK-NEXT:      -Wunused-template
+CHECK-NEXT:        -Wunneeded-internal-declaration
 CHECK-NEXT:      -Wunused-private-field
 CHECK-NEXT:      -Wunused-lambda-capture
 CHECK-NEXT:      -Wunused-local-typedef

--- a/clang/test/SemaCXX/warn-func-not-needed.cpp
+++ b/clang/test/SemaCXX/warn-func-not-needed.cpp
@@ -10,7 +10,7 @@ void foo() {
 }
 
 namespace test1_template {
-template <typename T> static void f() {}
+template <typename T> static void f() {} // expected-warning {{unused function template}}
 template <> void f<int>() {} // expected-warning {{function 'f<int>' is not needed and will not be emitted}}
 template <typename T>
 void foo() {

--- a/clang/test/SemaCXX/warn-variable-not-needed.cpp
+++ b/clang/test/SemaCXX/warn-variable-not-needed.cpp
@@ -4,7 +4,7 @@ namespace test1 {
   static int abc = 42; // expected-warning {{variable 'abc' is not needed and will not be emitted}}
 
   namespace {
-  template <typename T> int abc_template = 0;
+  template <typename T> int abc_template = 0; // expected-warning {{unused variable template}}
   template <> int abc_template<int> = 0; // expected-warning {{variable 'abc_template<int>' is not needed and will not be emitted}}
   }                                      // namespace
   template <typename T>

--- a/revert_patches.txt
+++ b/revert_patches.txt
@@ -11,9 +11,6 @@ breaks rocgdb UT
 breaks windows build: [amd-llvm] terminate called after throwing an instance of 'std::bad_alloc'
 Make][CodeGen] Add PCH for Clang CodeGen (#206018)
 ---
-hipDMM build warns as errors
-Revert "Reland "[Clang] Enable -Wunused-template under -Wall" (#208001)
----
 needs SPIRv changes
 [DebugMetadata][DwarfDebug][CodeView] Support function-local static variables in lexical block scopes 
 ---


### PR DESCRIPTION
Reverts `a06d76ec59bc`, restoring upstream `1529d35adbd6` ("Reland "[Clang] Enable -Wunused-template under -Wall" (#208001)").

## Why it was reverted

`a06d76ec59bc` was a same-day downstream revert on 2026-07-08 to unblock CI. hipDNN built with `-Werror` and hit three unused internal-linkage function templates:

```
ShapeUtilities.hpp:348:13: error: unused function template 'iterateAlongDimensions' [-Werror,-Wunused-template]
CpuFpReferenceUtilities.hpp:141:5: error: unused function template 'callFuncUnpackArgsImpl' [-Werror,-Wunused-template]
CpuFpReferenceUtilities.hpp:147:13: error: unused function template 'callFuncUnpackArgs' [-Werror,-Wunused-template]
```

Tracked as ALMIOPEN-2293.

## Why it can go back in

[ROCm/rocm-libraries#10193](https://github.com/ROCm/rocm-libraries/pull/10193) fixed all of them — nine files, the three above plus six more `cpu_graph_executor` headers — and merged 2026-08-04 (`1aa8a6f6afa8`).

It also added the diagnostic to hipdnn's own warning flags:

```cmake
$<$<CXX_COMPILER_ID:Clang>:-Wunused-template> # Clang: catch unused internal-linkage templates (matches llvm-project CI)
```

so hipdnn enforces it independently of whether it is in `-Wall`, and will catch regressions on its own.

The fix is reachable from TheRock's pinned `rocm-libraries` submodule (`416eae89dcee`, 0 commits behind `1aa8a6f6afa8`), so it is present in the tree `amd-staging` CI builds. Verified at that pin: the `-Wunused-template` flag is on line 261 of `projects/hipdnn/CMakeLists.txt`, and `iterateAlongDimensions` is no longer `static`.

## Result

The four affected files now match `upstream/main` exactly (`git diff upstream/main` over them is empty).

Note that `clang/docs/ReleaseNotes.md` already documents `-Wunused-template` as part of `-Wunused` — a later upstream merge restored that paragraph, so the docs and the code have been inconsistent since the revert. This change makes them agree again.

The stale `revert_patches.txt` entry is removed.
