### PR TITLE
Update LLVM_MAIN_REVISION to 593846

### DIFF
--- a/llvm/include/llvm/Config/llvm-config.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config.h.cmake
@@ -17,7 +17,7 @@
 /* The number of commits in the linear history from the
  * start of the universe up to the latest llvm main commit
  * that has been merged */
-#define LLVM_MAIN_REVISION 593794
+#define LLVM_MAIN_REVISION 593846
 
 /* Define if LLVM_ENABLE_DUMP is enabled */
 #cmakedefine LLVM_ENABLE_DUMP


### PR DESCRIPTION
Automated update of `LLVM_MAIN_REVISION` to match llvm/llvm-project `main` as merged into ROCm/amd-staging history.

Computed revision: **593846**