### PR TITLE
[COMGR] Use amdgpu subarch triples in hotswap tests

### DIFF
--- a/amd/comgr/test-lit/hotswap/raiser/dump_meta.s
+++ b/amd/comgr/test-lit/hotswap/raiser/dump_meta.s
@@ -1,6 +1,6 @@
 ; REQUIRES: comgr-has-hotswap-transpile
 
-; RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx942 %s -o %t.o
+; RUN: %llvm-mc -triple=amdgpu9.42-amd-amdhsa -filetype=obj %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 ; RUN: %hotswap_transpile_cli %t.hsaco --dump-meta | %FileCheck %s
 

--- a/amd/comgr/test-lit/hotswap/raiser/dump_meta_alt_symbol.s
+++ b/amd/comgr/test-lit/hotswap/raiser/dump_meta_alt_symbol.s
@@ -1,6 +1,6 @@
 ; REQUIRES: comgr-has-hotswap-transpile
 
-; RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx942 %s -o %t.o
+; RUN: %llvm-mc -triple=amdgpu9.42-amd-amdhsa -filetype=obj %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 ; RUN: %hotswap_transpile_cli %t.hsaco --dump-meta | %FileCheck %s
 

--- a/amd/comgr/test-lit/hotswap/raiser/refuse_kernel_not_found.s
+++ b/amd/comgr/test-lit/hotswap/raiser/refuse_kernel_not_found.s
@@ -1,6 +1,6 @@
 ; REQUIRES: comgr-has-hotswap-transpile
 
-; RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx942 %s -o %t.o
+; RUN: %llvm-mc -triple=amdgpu9.42-amd-amdhsa -filetype=obj %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 ; A mode's value selects kernels by name; an absent name is reported rather
 ; than silently producing no output.

--- a/amd/comgr/test-lit/hotswap/raiser/refuse_missing_descriptor.s
+++ b/amd/comgr/test-lit/hotswap/raiser/refuse_missing_descriptor.s
@@ -1,6 +1,6 @@
 ; REQUIRES: comgr-has-hotswap-transpile
 
-; RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx942 %s -o %t.o
+; RUN: %llvm-mc -triple=amdgpu9.42-amd-amdhsa -filetype=obj %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 ; RUN: not %hotswap_transpile_cli %t.hsaco --dump-meta 2>&1 | %FileCheck %s
 

--- a/amd/comgr/test-lit/hotswap/raiser/refuse_stripped.s
+++ b/amd/comgr/test-lit/hotswap/raiser/refuse_stripped.s
@@ -1,6 +1,6 @@
 ; REQUIRES: comgr-has-hotswap-transpile
 
-; RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx942 %s -o %t.o
+; RUN: %llvm-mc -triple=amdgpu9.42-amd-amdhsa -filetype=obj %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 ; RUN: %llvm-objcopy --strip-all %t.hsaco %t.stripped
 ; RUN: not %hotswap_transpile_cli %t.stripped --dump-meta 2>&1 | %FileCheck %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-absolute-call.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-absolute-call.s
@@ -2,7 +2,7 @@
 // COM: address inside .text to a text-relative direct target so the second of
 // COM: two adjacent far patch sites retains an independently callable entry.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   -Wl,--section-start=.text=0x1000 %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-barrier-isfirst.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-barrier-isfirst.s
@@ -3,7 +3,7 @@
 // COM: when the barrier ID names a user cluster barrier; the non-isfirst
 // COM: variant shares encoding size and operand layout but does not write SCC.
 
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-barrier-mixed.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-barrier-mixed.s
@@ -6,7 +6,7 @@
 // COM: non-isfirst mnemonic (e.g. via prefix or contains() rather than
 // COM: equality) and documents the intentional _M0 passthrough.
 
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-barrier-no-isfirst.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-barrier-no-isfirst.s
@@ -4,7 +4,7 @@
 // COM: the patched output, and the original s_barrier_signal sites must
 // COM: remain in place with their original operands.
 
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-bounded-return-scaling.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-bounded-return-scaling.s
@@ -1,7 +1,7 @@
 // COM: Exercise bounded-return analysis with enough local functions and
 // COM: decoded instructions to expose repeated whole-object scans.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf --entry-trampolines --strict-mode \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-control-flow-index-scale.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-control-flow-index-scale.s
@@ -2,7 +2,7 @@
 // COM: set-PC functions. Control-flow proof must remain fail-closed without
 // COM: forming the Cartesian product of every set-PC and function range.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-f32-fp8.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-f32-fp8.s
@@ -11,7 +11,7 @@
 // COM:   hotswap-cvt-fp8-nosled.s   — trampoline fallback path
 // COM:   hotswap-cvt-fp8-multi.s    — multi-site stacking
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-fp8-bytesel.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-fp8-bytesel.s
@@ -14,7 +14,7 @@
 // COM:   hotswap-cvt-sr-fp8.s   - base SR conversion (byte_sel=0 and 2)
 // COM:   hotswap-cvt-f32-fp8.s  - base unpack conversion (byte_sel=0 and 2)
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-fp8-modifiers.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-fp8-modifiers.s
@@ -14,7 +14,7 @@
 // COM:   hotswap-cvt-pk-fp8.s  — base pack conversion (no modifiers)
 // COM:   hotswap-cvt-sr-fp8.s  — base SR conversion (no modifiers)
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-fp8-multi.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-fp8-multi.s
@@ -8,7 +8,7 @@
 // COM:   hotswap-cvt-sr-fp8.s   — v_cvt_sr_fp8_f32  (stochastic round F32->E5M3)
 // COM:   hotswap-cvt-f32-fp8.s  — v_cvt_f32_fp8     (unpack E5M3->F32)
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-fp8-nosled.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-fp8-nosled.s
@@ -11,7 +11,7 @@
 // COM:   hotswap-cvt-sr-fp8.s   — v_cvt_sr_fp8_f32  base (NOP sled path)
 // COM:   hotswap-cvt-f32-fp8.s  — v_cvt_f32_fp8     base (NOP sled path)
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-pk-fp8-zero-fill-in-function.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-pk-fp8-zero-fill-in-function.s
@@ -5,7 +5,7 @@
 // COM: STT_FUNC range, so the rewriter must leave it alone and append a
 // COM: trampoline instead of branching into the zero bytes.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-pk-fp8-zero-fill-sled.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-pk-fp8-zero-fill-sled.s
@@ -5,7 +5,7 @@
 // COM: source function. The rewriter should leave them alone and append a
 // COM: trampoline instead of branching into the zero bytes.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-pk-fp8.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-pk-fp8.s
@@ -12,7 +12,7 @@
 // COM:   hotswap-cvt-fp8-nosled.s    - trampoline fallback path
 // COM:   hotswap-cvt-fp8-multi.s     - multi-site stacking
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-sr-fp8.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-cvt-sr-fp8.s
@@ -11,7 +11,7 @@
 // COM:   hotswap-cvt-fp8-nosled.s    - trampoline fallback path
 // COM:   hotswap-cvt-fp8-multi.s     - multi-site stacking
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-data-only-empty-text.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-data-only-empty-text.s
@@ -4,7 +4,7 @@
 // COM: instructions or kernel revision tags to transform, so return a
 // COM: byte-identical successful output after validating that shape.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: %llvm-readobj --sections --symbols --notes %t.elf \
 // RUN:   | %FileCheck --check-prefix=SHAPE --implicit-check-not=.kd %s
 // SHAPE: Name: .text
@@ -40,7 +40,7 @@
 
 // RUN: sed 's/^\.set claimed_function, 0$/.set claimed_function, 1/' \
 // RUN:   %s > %t.function.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.function.s -o %t.function.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.function.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -51,7 +51,7 @@
 
 // RUN: sed 's/^\.set claimed_other_function, 0$/.set claimed_other_function, 1/' \
 // RUN:   %s > %t.other-function.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.other-function.s -o %t.other-function.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
 // RUN:   hotswap-rewrite %t.other-function.elf \
@@ -63,7 +63,7 @@
 
 // RUN: sed 's/^\.set executable_section, 0$/.set executable_section, 1/' \
 // RUN:   %s > %t.executable.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.executable.s -o %t.executable.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.executable.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -74,7 +74,7 @@
 
 // RUN: sed 's/^\.set claimed_descriptor, 0$/.set claimed_descriptor, 1/' \
 // RUN:   %s > %t.descriptor.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.descriptor.s -o %t.descriptor.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.descriptor.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -85,7 +85,7 @@
 
 // RUN: sed 's/^\.set claimed_kernel, 0$/.set claimed_kernel, 1/' \
 // RUN:   %s > %t.kernel.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.kernel.s -o %t.kernel.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.kernel.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -95,7 +95,7 @@
 
 // RUN: sed 's/^\.set malformed_metadata, 0$/.set malformed_metadata, 1/' \
 // RUN:   %s > %t.malformed.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.malformed.s -o %t.malformed.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.malformed.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-device-function-vgpr.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-device-function-vgpr.s
@@ -2,7 +2,7 @@
 // COM: caller kernels without reachability information. Keep the original
 // COM: instruction until device-function call-graph accounting is implemented.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-ds2-entry-local-offset.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-ds2-entry-local-offset.s
@@ -9,7 +9,7 @@
 // COM: With semantic splitting mandatory, fail closed on the unavailable
 // COM: gateway instead of retaining an A0-unsafe DS2 instruction.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-ds2-far-external-padding.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-ds2-far-external-padding.s
@@ -2,7 +2,7 @@
 // COM: audited external padding with local DS2 bodies. Preserve every slot for
 // COM: routing unless maximum matching actually places a registerless site.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-elf-growth.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-elf-growth.s
@@ -4,7 +4,7 @@
 // COM: kernel contains no patchable instructions), but the rewrite pipeline
 // COM: must accept the ELF rather than returning an error.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // COM: Confirm .dynamic exists after .text in the input ELF.
 // RUN: %llvm-readelf --section-headers %t.elf | %FileCheck --check-prefix=LAYOUT %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-finite-external-call.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-finite-external-call.s
@@ -3,7 +3,7 @@
 // COM: facts permits a far required rewrite to use the code-end gateway while
 // COM: preserving the external call's return point.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-finite-materialized-call-closure.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-finite-materialized-call-closure.s
@@ -4,7 +4,7 @@
 // COM: call, canonical return, and call continuation together without falling
 // COM: back to an object-wide unknown indirect-entry assumption.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-indirect-call-far.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-indirect-call-far.s
@@ -5,7 +5,7 @@
 // COM: far trampoline pool, so it must fail closed instead of returning a
 // COM: successful object whose register call lands on rewritten padding.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-indirect-call.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-indirect-call.s
@@ -6,7 +6,7 @@
 // COM: Keep a real DS two-address patch in this reduced object so the rewrite
 // COM: creates a trampoline and exercises the production failure path.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-inplace-async.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-inplace-async.s
@@ -1,7 +1,7 @@
 // COM: Test HotSwap in-place patch: cluster_load_async_to_lds_{b8,b32,b64,b128}
 // COM: -> global_load_async_to_lds_{b8,b32,b64,b128}.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-inplace-b64.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-inplace-b64.s
@@ -1,6 +1,6 @@
 // COM: Test HotSwap in-place patch: cluster_load_b64 -> global_load_b64.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-inplace-mixed.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-inplace-mixed.s
@@ -1,7 +1,7 @@
 // COM: Test HotSwap in-place cluster_load -> global_load and blanket
 // COM: s_clause -> s_nop 0 patches.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-inplace-noop.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-inplace-noop.s
@@ -1,7 +1,7 @@
 // COM: A kernel requiring no instruction rewrite still needs its gfx1250
 // COM: revision metadata retagged from B0 to A0.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-inplace-saddr.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-inplace-saddr.s
@@ -7,7 +7,7 @@
 // COM: then the trampoline pass must wrap that remaining cluster_load with
 // COM: the A0 M0 wg_mask save/clear/restore sequence.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-fastpath.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-fastpath.s
@@ -4,7 +4,7 @@
 // COM: descriptor SGPR reservation to cover it, and adds no debug-only .stub
 // COM: symbols. A prologue that already carries the workaround is skipped.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-gfx125x.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-gfx125x.s
@@ -1,6 +1,6 @@
 // COM: Direct HotSwap entry displacement is supported across gfx125x.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1251 -nostdlib %s -o %t.gfx1251.elf
+// RUN: %clang --target=amdgpu12.51-amd-amdhsa -nostdlib %s -o %t.gfx1251.elf
 // RUN: hotswap-rewrite %t.gfx1251.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1251 amdgcn-amd-amdhsa--gfx1251 \
 // RUN:   --entry-trampolines --output %t.gfx1251.out.elf \
@@ -10,7 +10,7 @@
 // COM: Direct displacement does not need scratch SGPRs, so it remains valid at
 // COM: the architectural SGPR limit.
 // RUN: sed 's/.sgpr_count: 1/.sgpr_count: 105/' %s > %t.highsgpr.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1251 -nostdlib \
+// RUN: %clang --target=amdgpu12.51-amd-amdhsa -nostdlib \
 // RUN:   %t.highsgpr.s -o %t.highsgpr.elf
 // RUN: hotswap-rewrite %t.highsgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1251 amdgcn-amd-amdhsa--gfx1251 \
@@ -21,7 +21,7 @@
 
 // RUN: sed -e '/^\.amdgcn_target/d' \
 // RUN:   -e 's/gfx1251/gfx12-5-generic/g' %s > %t.generic.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx12-5-generic -nostdlib \
+// RUN: %clang --target=amdgpu12.5-amd-amdhsa -nostdlib \
 // RUN:   %t.generic.s -o %t.generic.elf
 // RUN: hotswap-rewrite %t.generic.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx12-5-generic \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-mixed-existing.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-mixed-existing.s
@@ -5,7 +5,7 @@
 
 // COM: First create an object where the pre-fixed first kernel is skipped and
 // COM: the second kernel receives a fast-path appended stub.
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s \
 // RUN:   -o %t.prefixed.elf
 // RUN: env AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS=1 hotswap-rewrite \
 // RUN:   %t.prefixed.elf \
@@ -19,7 +19,7 @@
 // COM: the workaround.
 // RUN: sed 's/^\.set raw_entry, 0$/.set raw_entry, 1/' \
 // RUN:   %s > %t.raw.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %t.raw.s \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %t.raw.s \
 // RUN:   -o %t.raw.elf
 // RUN: %llvm-objcopy --dump-section .text=%t.raw.text %t.raw.elf
 // RUN: %llvm-objcopy --update-section .text=%t.raw.text %t.seed.elf \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-multi.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-multi.s
@@ -2,7 +2,7 @@
 // COM: second kernel. HotSwap must retain the ABI's 256-byte entry alignment by
 // COM: falling back to aligned appended stubs for the whole object.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-precompiled-workaround.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-precompiled-workaround.s
@@ -2,7 +2,7 @@
 // COM: the workaround, so HotSwap skips its entry trampoline; a kernel without
 // COM: it still gets one.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-relocation.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline-relocation.s
@@ -2,7 +2,7 @@
 // COM: references displaced code. Direct displacement must decline this input
 // COM: and use an appended entry stub so the relocation remains valid.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --entry-trampolines --output %t.out.elf \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-kernel-entry-trampoline.s
@@ -2,7 +2,7 @@
 // COM: enabled. This multi-kernel layout uses aligned appended stubs because a
 // COM: direct prefix would misalign later kernel entries.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -72,7 +72,7 @@
 
 // COM: The alignment fallback needs a scratch SGPR pair for its appended stubs.
 // RUN: sed 's/.sgpr_count: 8/.sgpr_count: 105/' %s > %t.highsgpr.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.highsgpr.s -o %t.highsgpr.elf
 // RUN: hotswap-rewrite %t.highsgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-large-sgpr-usage-cache.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-large-sgpr-usage-cache.s
@@ -4,7 +4,7 @@
 // COM: second site reuses both cached results. Non-NOP straight-line windows
 // COM: let each far site carry its set-PC sequence without a gateway.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-mask-a0-noop.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-mask-a0-noop.s
@@ -1,7 +1,7 @@
 // COM: Explicit A0-to-A0 rewriting must not select the B0-to-A0 A0 mask
 // COM: workarounds, even when the kernel contains mask-sensitive instructions.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-materialized-call-joint-gateway.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-materialized-call-joint-gateway.s
@@ -6,7 +6,7 @@
 // COM: finite. Closing the component keeps external zero padding available as
 // COM: a gateway for an otherwise-stranded far eight-byte DS2 patch.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-nop-sled-function-scope.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-nop-sled-function-scope.s
@@ -1,7 +1,7 @@
 // COM: A NOP sled belongs to its containing kernel. The patchable DS
 // COM: instruction in second_kernel must not borrow first_kernel padding.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call-declared-entry.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call-declared-entry.s
@@ -3,7 +3,7 @@
 // COM: The register call must remain unresolved, which disables every rewrite
 // COM: that could consume an unknown original .text destination.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call-external-alias.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call-external-alias.s
@@ -2,7 +2,7 @@
 // COM: alias and kernel descriptor expose the same entry. Kernel dispatch
 // COM: does not define the helper's link pair, so the rewrite must fail closed.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call-fallthrough-entry.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call-fallthrough-entry.s
@@ -2,7 +2,7 @@
 // COM: the helper by fallthrough without defining its link pair. The return
 // COM: cannot be bounded even when its explicit caller is canonical.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call-interior-entry.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call-interior-entry.s
@@ -3,7 +3,7 @@
 // COM: function interior bypasses the entry and must keep the rewrite
 // COM: fail-closed, even when another canonical call targets the entry.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call-nested-clobber.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call-nested-clobber.s
@@ -3,7 +3,7 @@
 // COM: clobber proof, the outer s_set_pc_i64 must remain unresolved and the
 // COM: rewrite must use the existing fail-closed path.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-pc-materialized-call.s
@@ -5,7 +5,7 @@
 // COM: independently callable entry while safe external gateways remain
 // COM: available for both patches.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-reusable-pc-call-targets.s
@@ -5,7 +5,7 @@
 // COM: padding. A selector bypass would leave the target unknown and must
 // COM: continue to fail closed.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
@@ -20,7 +20,7 @@
 
 // RUN: sed 's/^\.set unsafe_selector, 0$/.set unsafe_selector, 1/' \
 // RUN:   %s > %t.bypass.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.bypass.s -o %t.bypass.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.bypass.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -50,7 +50,7 @@
 
 // RUN: sed 's/^\.set overlap_delta, 0$/.set overlap_delta, 1/' \
 // RUN:   %s > %t.overlap.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.overlap.s -o %t.overlap.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.overlap.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -59,7 +59,7 @@
 
 // RUN: sed 's/^\.set clobber_target, 0$/.set clobber_target, 1/' \
 // RUN:   %s > %t.clobber.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.clobber.s -o %t.clobber.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.clobber.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -68,7 +68,7 @@
 
 // RUN: sed 's/^\.set clobber_bootstrap, 0$/.set clobber_bootstrap, 1/' \
 // RUN:   %s > %t.bootstrap-clobber.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.bootstrap-clobber.s -o %t.bootstrap-clobber.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
 // RUN:   %t.bootstrap-clobber.elf amdgcn-amd-amdhsa--gfx1250 \
@@ -77,7 +77,7 @@
 
 // RUN: sed 's/^\.set tail_escape, 0$/.set tail_escape, 1/' \
 // RUN:   %s > %t.tail.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.tail.s -o %t.tail.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.tail.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -86,7 +86,7 @@
 
 // RUN: sed 's/^\.set indirect_escape, 0$/.set indirect_escape, 1/' \
 // RUN:   %s > %t.indirect.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.indirect.s -o %t.indirect.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.indirect.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -95,7 +95,7 @@
 
 // RUN: sed 's/^\.set external_entry, 0$/.set external_entry, 1/' \
 // RUN:   %s > %t.external.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.external.s -o %t.external.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.external.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -104,7 +104,7 @@
 
 // RUN: sed 's/^\.set outside_selector, 0$/.set outside_selector, 1/' \
 // RUN:   %s > %t.outside.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.outside.s -o %t.outside.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.outside.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -127,7 +127,7 @@
 // resolve: its bytes could clobber the target pair or divert control flow.
 // RUN: sed 's/^\.set undecoded_gap, 0$/.set undecoded_gap, 1/' \
 // RUN:   %s > %t.undecoded.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.undecoded.s -o %t.undecoded.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.undecoded.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -139,7 +139,7 @@
 // visit must not survive.
 // RUN: sed 's/^\.set reconverge_reload, 0$/.set reconverge_reload, 1/' \
 // RUN:   %s > %t.reconverge.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.reconverge.s -o %t.reconverge.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.reconverge.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-addtid-nosled.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-addtid-nosled.s
@@ -20,7 +20,7 @@
 // COM: regressions in the math sequence, the 20-bit mask, or the operand
 // COM: order of ds_load_b32 are caught.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-addtid.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-addtid.s
@@ -21,7 +21,7 @@
 // COM: every instruction inside the trampoline body is then chained with
 // COM: 'DISASM-NEXT:' so the body itself is verified bit-for-bit.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-branch-islands.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-branch-islands.s
@@ -2,7 +2,7 @@
 // COM: branches through safe alignment holes. Each hop preserves SCC and the
 // COM: trampoline return uses the accepted SGPR-backed set-PC sequence.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-cluster-scc.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-cluster-scc.s
@@ -2,7 +2,7 @@
 // COM: cluster load. The M0 wg_mask clear must not clobber SCC before the
 // COM: following s_cbranch_scc1.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-cluster-scratch.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-cluster-scratch.s
@@ -2,7 +2,7 @@
 // COM: through the wrapped instruction. If metadata under-reports SGPR usage,
 // COM: scratch allocation must skip that tuple.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-cluster.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-cluster.s
@@ -3,7 +3,7 @@
 // COM: bits [15:0] cleared on A0, while preserving the incoming M0 value for
 // COM: surrounding code.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -73,7 +73,7 @@
 // COM: emitted, so the API reports ERROR instead of returning unsafe code.
 // RUN: sed -e 's/.amdhsa_next_free_sgpr 16/.amdhsa_next_free_sgpr 106/' \
 // RUN:     -e 's/.sgpr_count: 16/.sgpr_count: 106/' %s > %t.highsgpr.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.highsgpr.s -o %t.highsgpr.elf
 // RUN: hotswap-rewrite %t.highsgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-compact-gateway.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-compact-gateway.s
@@ -3,7 +3,7 @@
 // COM: for this forward displacement, so planning must use its MC-encoded
 // COM: size instead of requiring the 20-byte worst-case reservation.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-device-function-long-branch.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-device-function-long-branch.s
@@ -4,7 +4,7 @@
 // COM: missing .size directive exercises zero-size function-range inference on
 // COM: the far path.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-direct-target-sled.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-direct-target-sled.s
@@ -3,7 +3,7 @@
 // COM: run before patch emission so emitReplacementCode cannot place a
 // COM: relocated replacement at the branch target.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-long-branch.s
@@ -13,7 +13,7 @@
 // COM: NOP padding.
 // COM: No path emits the broken instruction.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-multi.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-multi.s
@@ -4,7 +4,7 @@
 // COM: own s_wait_dscnt 0x0 drain). Non-drain wait preservation is covered by
 // COM: hotswap-trampoline-ds-pipelined.s.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-nosled.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-nosled.s
@@ -4,7 +4,7 @@
 // COM: emitToTrampoline. The trampoline body (expanded DS instructions +
 // COM: branch-back) is appended after .text via growWithTrampolines.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-nostride64-multi.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-nostride64-multi.s
@@ -11,7 +11,7 @@
 // COM:     exchange b64, and a load+store+xchg combination kernel) drain
 // COM:     forms.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-nostride64.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-nostride64.s
@@ -18,7 +18,7 @@
 // COM:   hotswap-trampoline-ds-pipelined.s -- non-drain downstream wait
 // COM:     preserved while each split adds its own drain.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-nowait.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-nowait.s
@@ -4,7 +4,7 @@
 // COM: after the two single-address ops, so both halves complete even though
 // COM: the original kernel had no wait before s_endpgm.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-overlap-cyclic.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-overlap-cyclic.s
@@ -2,7 +2,7 @@
 // COM: sequential exchanges without scratch VGPRs. Returning the original B0
 // COM: DS2 instruction in an A0 object would be unsafe, so rewriting must fail.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-overlap.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-overlap.s
@@ -4,7 +4,7 @@
 // COM: trampoline/growth path. Its cyclic exchange is the intentional no-op
 // COM: case: the original instruction must remain byte-stable.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-pipelined.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-pipelined.s
@@ -5,7 +5,7 @@
 // COM: downstream wait must NOT be relaxed (relaxing it would let a consumer
 // COM: read a not-yet-landed half; see the patchDs2Addr rationale).
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-storexchg-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-storexchg-vgpr-msb.s
@@ -5,7 +5,7 @@
 // bank 0. Rebasing every role from a single assumed bank would silently
 // redirect the address or the data.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-vgpr-msb-local-closed.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-vgpr-msb-local-closed.s
@@ -3,7 +3,7 @@
 // recovery. The cross-bank DS2 still has a locally provable mode because its
 // exact setter is adjacent and no control-flow or declared entry bypasses it.
 
-// RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 \
+// RUN: %llvm-mc -triple=amdgpu12.50-amd-amdhsa \
 // RUN:   --amdhsa-code-object-version=6 -filetype=obj %s -o %t.local.o
 // RUN: %ld.lld -flavor gnu -m elf64_amdgpu %t.local.o -o %t.local.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.local.elf \
@@ -37,7 +37,7 @@
 // that site even though DirectControlFlow remains closed.
 // RUN: sed 's/^\.set bypass_setter, 0$/.set bypass_setter, 1/' \
 // RUN:   %s > %t.bypass.s
-// RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 \
+// RUN: %llvm-mc -triple=amdgpu12.50-amd-amdhsa \
 // RUN:   --amdhsa-code-object-version=6 -filetype=obj %t.bypass.s \
 // RUN:   -o %t.bypass.o
 // RUN: %ld.lld -flavor gnu -m elf64_amdgpu %t.bypass.o -o %t.bypass.elf

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds-vgpr-msb.s
@@ -2,7 +2,7 @@
 // the active VGPR bank rebases that half to v0 under a temporary destination
 // VGPR-MSB mode without losing the nonzero source or destination bank.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds.s
@@ -13,7 +13,7 @@
 // COM:   hotswap-trampoline-ds-nosled.s    -- true trampoline fallback (no NOP sled)
 // COM:   hotswap-trampoline-ds-nowait.s    -- split drain when no downstream wait
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds2-offset-overflow.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-ds2-offset-overflow.s
@@ -18,7 +18,7 @@
 // COM:   test_ds_load_b64_inrange  : raw 1/2 -> scaled 512/1024
 // COM:                               (control: in-range stride64_b64 IS rewritten)
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // COM: Capture the verbose log on stderr to confirm the overflow message
 // COM: fires for the out-of-range kernel. AMD_COMGR_EMIT_VERBOSE_LOGS=1

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-fragmented-gateway.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-fragmented-gateway.s
@@ -4,7 +4,7 @@
 // COM: live across this required DS2 rewrite and provide exactly one 20-byte
 // COM: gateway. The pool is beyond s_branch range and no island chain exists.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-live-vcc-deferred.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-live-vcc-deferred.s
@@ -5,7 +5,7 @@
 // COM: source dword is the owner-reserved final return relay, so it branches
 // COM: to the continuation instead of remaining padding.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-long-branch.s
@@ -3,7 +3,7 @@
 // COM: directly. A large non-NOP .rept filler (~160 KB) pushes the pool past
 // COM: s_branch's reach to force the far case.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -44,7 +44,7 @@
 // RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s104, 0/' \
 // RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 105/' \
 // RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 105/' %s > %t.full-sgpr.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.full-sgpr.s -o %t.full-sgpr.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.full-sgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -66,7 +66,7 @@
 // COM: continuation before being redefined.
 // RUN: sed 's|^// VCCZ-ONLY:|  |' %t.full-sgpr.s \
 // RUN:   > %t.local-pair.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.local-pair.s -o %t.local-pair.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.local-pair.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -80,7 +80,7 @@
 // COM: first and is therefore the highest locally dead pair.
 // RUN: sed -e 's|^// VCCZ-ONLY:|  |' \
 // RUN:   -e 's|^// LOW-PAIR-ONLY:|  |' %t.full-sgpr.s > %t.low-pair.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.low-pair.s -o %t.low-pair.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.low-pair.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -99,7 +99,7 @@
 // COM: a save/set-PC gateway, and its tail becomes the restore landing pad.
 // RUN: sed 's|^// LIVE-ONLY:|  |' %t.full-sgpr.s \
 // RUN:   > %t.live-vcc.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.live-vcc.s -o %t.live-vcc.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.live-vcc.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -126,7 +126,7 @@
 // RUN: sed -e 's|^// LIVE-ONLY:|  |' \
 // RUN:   -e 's/\.fill 32, 1, 0/.fill 16, 1, 0/g' \
 // RUN:   %t.full-sgpr.s > %t.split-vcc.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.split-vcc.s -o %t.split-vcc.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.split-vcc.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -166,7 +166,7 @@
 // RUN:   -e 's|^// EXACT20-ONLY:|  |' \
 // RUN:   -e 's/\.fill 32, 1, 0/.fill 20, 1, 0/g' \
 // RUN:   %t.full-sgpr.s > %t.exact20.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.exact20.s -o %t.exact20.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.exact20.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -178,7 +178,7 @@
 // COM: A metadata-less object also fails closed because scratch usage cannot
 // COM: be charged to its owning kernel.
 // RUN: sed '/^.amdgpu_metadata$/,/^.end_amdgpu_metadata$/d' %s > %t.nometa.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.nometa.s -o %t.nometa.elf
 // RUN: hotswap-rewrite %t.nometa.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-mirrored-stub-gateway.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-mirrored-stub-gateway.s
@@ -2,7 +2,7 @@
 // COM: already reserved for their return edge. The source PC plus one shared
 // COM: relocation-neutral delta selects a sparse branch stub in the pool.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
@@ -27,7 +27,7 @@
 // COM: foreign run is branch-reachable from every source below, the affine
 // COM: planner must not use it as a gateway for a different function.
 // RUN: sed 's|^// FOREIGN-ONLY:|  |' %s > %t.foreign.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.foreign.s -o %t.foreign.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.foreign.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-pair-backed-promotion.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-pair-backed-promotion.s
@@ -5,7 +5,7 @@
 // COM: spans. The forward branch allocator must promote safe straight-line
 // COM: source windows even though the owner has an SGPR-backed set-PC return.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-registerless-owner-tail.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-registerless-owner-tail.s
@@ -7,7 +7,7 @@
 // COM: reuses the same source window's second slot. All numbered SGPRs are live
 // COM: after every window, so both promotions must use proven-dead VCC.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-shared-gateway-ownership.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-shared-gateway-ownership.s
@@ -2,7 +2,7 @@
 // COM: the same function. An otherwise reachable NOP run in a foreign function
 // COM: is not a legal gateway.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=GOOD %s
@@ -10,7 +10,7 @@
 // GOOD: RESULT: SUCCESS
 
 // RUN: sed 's|^// FOREIGN-ONLY:|  |' %s > %t.foreign.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.foreign.s -o %t.foreign.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.foreign.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-shared-relay-chain.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-shared-relay-chain.s
@@ -2,7 +2,7 @@
 // COM: member's second dword. Each newly admitted member must publish its
 // COM: source+4 tail, never its source s_call at source+0, as the next relay.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-source-tail-islands.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-source-tail-islands.s
@@ -2,7 +2,7 @@
 // COM: functions. Their unreachable second dwords form a registerless relay
 // COM: chain to the appended trampoline pool.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-b0-known.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-b0-known.s
@@ -1,7 +1,7 @@
 // COM: Test HotSwap B0 tensor_load_to_lds masking when fixed .cluster_dims
 // COM: metadata proves the dispatch is non-cluster or size-one.
 
-// RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 \
+// RUN: %llvm-mc -triple=amdgpu12.50-amd-amdhsa \
 // RUN:   --amdhsa-code-object-version=6 -filetype=obj %s -o %t.o
 // RUN: %ld.lld -flavor gnu -m elf64_amdgpu %t.o -o %t.elf
 

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-b0-scc.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-b0-scc.s
@@ -2,7 +2,7 @@
 // COM: live across the tensor load. The B0 runtime cluster-id guard must save
 // COM: and restore SCC around its injected s_cmp_eq_u32.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-b0-scratch.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-b0-scratch.s
@@ -2,7 +2,7 @@
 // COM: the kernel descriptor under-reports SGPR use. Scratch must not be
 // COM: allocated inside the tensor descriptor tuple s[4:11].
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-b0.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-b0.s
@@ -2,7 +2,7 @@
 // COM: D# Group 1 wg_mask bits [15:0] only when IB_STS2.CLUSTER_ID == 0.
 // COM: Cluster loads do not need the A0 M0 workaround on a B0 target.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
@@ -56,7 +56,7 @@
 
 // RUN: sed -e 's/.amdhsa_next_free_sgpr 16/.amdhsa_next_free_sgpr 106/' \
 // RUN:     -e 's/.sgpr_count: 16/.sgpr_count: 106/' %s > %t.highsgpr.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.highsgpr.s -o %t.highsgpr.elf
 // RUN: hotswap-rewrite %t.highsgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-liveness.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-liveness.s
@@ -4,7 +4,7 @@
 // COM: the SGPR is live, producing save/restore even though the use may
 // COM: not execute on all paths.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-already-zero.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-already-zero.s
@@ -5,7 +5,7 @@
 // COM: tensor. A variant with one nonzero seed must reject the no-op proof and
 // COM: use the save/clear/tensor/restore fallback.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 \
@@ -19,7 +19,7 @@
 // COM: modeled zero path cannot prove anything about s4 on that hidden edge.
 // RUN: sed 's/^\.set opaque_tensor_entry, 0$/.set opaque_tensor_entry, 1/' \
 // RUN:   %s > %t.opaque.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.opaque.s -o %t.opaque.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.opaque.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -28,7 +28,7 @@
 
 // RUN: sed 's/^\.set nonzero_path, 0$/.set nonzero_path, 1/' \
 // RUN:   %s > %t.nonzero.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.nonzero.s -o %t.nonzero.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nonzero.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-bounded-return.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-bounded-return.s
@@ -4,7 +4,7 @@
 // COM: proof succeeds. The variant's proven return target is outside the
 // COM: tensor function, which this local CFG rejects conservatively.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOCAL %s
@@ -15,7 +15,7 @@
 
 // RUN: sed 's/^\.set outside_return, 0$/.set outside_return, 1/' \
 // RUN:   %s > %t.outside.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.outside.s -o %t.outside.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.outside.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-cfg-live-scc.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-cfg-live-scc.s
@@ -3,7 +3,7 @@
 // COM: scan sees the redefine and misses the use; CFG analysis must choose the
 // COM: at-site fallback.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-cfg-scc-dead.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-cfg-scc-dead.s
@@ -4,7 +4,7 @@
 // COM: clears the SCC bit on both join paths, so the definition-time clear is
 // COM: safe and applies rather than deferring to the at-site fallback.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-cfg-sor.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-cfg-sor.s
@@ -2,7 +2,7 @@
 // COM: writes the descriptor again after its mask-set, so neither definition
 // COM: can be changed safely and the tensor must use the at-site fallback.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-cross-kernel.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-cross-kernel.s
@@ -3,7 +3,7 @@
 // COM: bare tensor on the same SGPR. The scan is confined to each function, so
 // COM: B does not see A's mask-set and falls back to the at-site rewrite.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def-alt-base.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def-alt-base.s
@@ -2,7 +2,7 @@
 // COM: SReg_256 range (s[16:23]). Verifies getDescriptorBaseSgpr extracts s16
 // COM: and the mask-set for that base is cleared, not a fixed s4.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def-highbits.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def-highbits.s
@@ -4,7 +4,7 @@
 // COM: cannot restore a nonzero workgroup_mask. The mask-set is still cleared
 // COM: in place and the high-bit s_or is left intact.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def-multi.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def-multi.s
@@ -2,7 +2,7 @@
 // COM: one descriptor base built once. The single mask-set is cleared and every
 // COM: tensor that reads the base is covered; the clear is applied once.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def-saturated.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def-saturated.s
@@ -4,7 +4,7 @@
 // COM: clear applies because both consumers require the cleared descriptor.
 // COM: There is no NOP sled or spare SGPR.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def-wave.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def-wave.s
@@ -3,7 +3,7 @@
 // COM: The backward reaching-definition scan covers both construction regions,
 // COM: so the mask-set s_and of each is cleared.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-def.s
@@ -5,7 +5,7 @@
 // COM: (0xNNNNffff -> 0xNNNN0000), forcing workgroup_mask to zero, and leaves
 // COM: the PC-sensitive tensor instruction untouched.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-failclosed.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-failclosed.s
@@ -4,7 +4,7 @@
 // COM: and its SGPR is live after the tensor while the kernel's SGPR budget is
 // COM: saturated to s106, so the at-site fallback has no scratch register.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-fallback-bare.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-fallback-bare.s
@@ -3,7 +3,7 @@
 // COM: back to the at-site s_pack_hh rewrite. The descriptor SGPR is dead after
 // COM: the tensor, so no save/restore is needed.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-fallback-live.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-fallback-live.s
@@ -3,7 +3,7 @@
 // COM: the at-site rewrite, which saves and restores the base through a scratch
 // COM: SGPR so the temporary normalization is not visible to the later use.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-killed-def.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-killed-def.s
@@ -4,7 +4,7 @@
 // COM: normalized descriptor. The definition clear is not applicable and the
 // COM: pass falls back to the at-site rewrite.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-live-scc.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-live-scc.s
@@ -3,7 +3,7 @@
 // COM: so the definition clear is not applicable and the pass falls back to the
 // COM: at-site rewrite, which does not touch the construction s_and.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-local-setpc.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-local-setpc.s
@@ -4,7 +4,7 @@
 // COM: the jump target kill s4 after the tensor mask definition, so the
 // COM: definition-time low16 clear is safe.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 \
@@ -34,7 +34,7 @@
 // COM: and uses the at-site fallback.
 // RUN: sed 's/^\.set wrong_pair, 0$/.set wrong_pair, 1/' \
 // RUN:   %s > %t.wrong-pair.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.wrong-pair.s -o %t.wrong-pair.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.wrong-pair.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -42,7 +42,7 @@
 // RUN:   | %FileCheck --check-prefix=OPAQUE %s
 // RUN: sed 's/^\.set intervening_def, 0$/.set intervening_def, 1/' \
 // RUN:   %s > %t.intervening.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.intervening.s -o %t.intervening.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.intervening.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -50,7 +50,7 @@
 // RUN:   | %FileCheck --check-prefix=OPAQUE %s
 // RUN: sed 's/^\.set outside_target, 0$/.set outside_target, 1/' \
 // RUN:   %s > %t.outside.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.outside.s -o %t.outside.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.outside.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -58,7 +58,7 @@
 // RUN:   | %FileCheck --check-prefix=OPAQUE %s
 // RUN: sed 's/^\.set interior_entry, 0$/.set interior_entry, 1/' \
 // RUN:   %s > %t.interior.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.interior.s -o %t.interior.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.interior.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -66,7 +66,7 @@
 // RUN:   | %FileCheck --check-prefix=OPAQUE %s
 // RUN: sed 's/^\.set declared_entry, 0$/.set declared_entry, 1/' \
 // RUN:   %s > %t.declared.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.declared.s -o %t.declared.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.declared.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-post-use.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-post-use.s
@@ -2,7 +2,7 @@
 // COM: clear. Reject that path and use the at-site save/restore fallback so the
 // COM: later consumer sees the original descriptor value.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-signed-setpc.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-mask-signed-setpc.s
@@ -3,7 +3,7 @@
 // COM: entry into the positive arm invalidates that target proof and forces
 // COM: the tensor's at-site fallback.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOCAL %s
@@ -17,7 +17,7 @@
 
 // RUN: sed 's/^\.set alternate_arm_entry, 0$/.set alternate_arm_entry, 1/' \
 // RUN:   %s > %t.alternate.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   %t.alternate.s -o %t.alternate.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.alternate.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-multi.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-multi.s
@@ -4,7 +4,7 @@
 // COM:   - Idempotency guard correctly handles back-to-back patches
 // COM:   - DS + tensor coexistence in the same kernel
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-nosled.s
@@ -4,7 +4,7 @@
 // COM:   live SGPR - save/pack/tensor/restore appended via growWithTrampolines
 // COM: Both force emitReplacementCode to use emitToTrampoline.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor.s
@@ -15,7 +15,7 @@
 // COM:   hotswap-trampoline-tensor-multi.s      - multi-site stacking
 // COM:   hotswap-trampoline-tensor-liveness.s   - isSgprLiveAfter edge cases
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-vgpr-workgroup-capacity.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-vgpr-workgroup-capacity.s
@@ -3,7 +3,7 @@
 // COM: when the kernel has occupancy headroom. Also verify that an applied
 // COM: bump updates runtime-visible .vgpr_count metadata.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-vop3px2-src2-noop.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-vop3px2-src2-noop.s
@@ -3,7 +3,7 @@
 // COM: unchanged: no bits are modified, and the disassembly must match the
 // COM: original layout.
 
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-vop3px2-src2.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-vop3px2-src2.s
@@ -4,7 +4,7 @@
 // COM: SALU stall. The patch sets this field to VGPR0 encoding (0x100).
 // COM: Applies to both A0 and B0 steppings.
 
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-hazard-partial.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-hazard-partial.s
@@ -1,7 +1,7 @@
 // COM: Test WMMA hazard with pre-existing v_nops: 3 v_nops already present
 // COM: between WMMA (needs 8) and overlapping VALU. Should insert 5 more.
 
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-hazard-safe.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-hazard-safe.s
@@ -2,7 +2,7 @@
 // COM: already present between WMMA (needs 8) and overlapping VALU.
 // COM: No additional padding should be inserted.
 
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-hazard.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-hazard.s
@@ -2,7 +2,7 @@
 // COM: instruction (A0 needs 8 v_nops vs B0's 4) followed by an
 // COM: overlapping VALU should get v_nop padding inserted.
 
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16-refuse.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16-refuse.s
@@ -2,7 +2,7 @@
 // COM: assembled into its own object so every rejection is exercised
 // COM: independently.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   -Wa,-defsym,CASE=1 %s -o %t.da.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.da.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
@@ -11,7 +11,7 @@
 // D-A: destination overlaps matrix A
 // D-A: RESULT: ERROR
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   -Wa,-defsym,CASE=2 %s -o %t.db.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.db.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
@@ -20,7 +20,7 @@
 // D-B: destination overlaps matrix B
 // D-B: RESULT: ERROR
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   -Wa,-defsym,CASE=3 %s -o %t.ab.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.ab.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
@@ -29,7 +29,7 @@
 // A-B: matrix A overlaps matrix B
 // A-B: RESULT: ERROR
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   -Wa,-defsym,CASE=4 %s -o %t.dc.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.dc.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
@@ -38,7 +38,7 @@
 // D-C: partial destination/src2 overlap
 // D-C: RESULT: ERROR
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   -Wa,-defsym,CASE=5 %s -o %t.ac.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.ac.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
@@ -47,7 +47,7 @@
 // A-C: matrix A overlaps src2
 // A-C: RESULT: ERROR
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   -Wa,-defsym,CASE=6 %s -o %t.scale-matrix.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
 // RUN:   %t.scale-matrix.elf \
@@ -57,7 +57,7 @@
 // SCALE: scale pair overlaps a staged matrix operand
 // SCALE: RESULT: ERROR
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   -Wa,-defsym,CASE=7 %s -o %t.scale-scale.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
 // RUN:   %t.scale-scale.elf \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16.s
@@ -6,7 +6,7 @@
 // COM: first save slot is reused as the reversible scale-pair permutation
 // COM: temporary.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-fp4.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-fp4.s
@@ -3,7 +3,7 @@
 // COM: split along the VGPR index, so the masked-A copy nulls the opposite
 // COM: subblock's VGPRs (v_mov ..., 0) instead of using a lane mask.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-large-vgpr-count.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-large-vgpr-count.s
@@ -4,7 +4,7 @@
 // The bump is occupancy-neutral (the original and rewritten allocations both
 // admit one wave/EU), despite the maximum-workgroup metadata asking for two.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-local-vgpr-msb-reject.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-local-vgpr-msb-reject.s
@@ -6,7 +6,7 @@
 // recovery path can prove the incoming mode, so the required lowering must
 // fail closed instead of assuming the ABI entry mode.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --expect-status ERROR 2>&1 | %FileCheck %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-local-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-local-vgpr-msb.s
@@ -10,7 +10,7 @@
 // same unresolved call with no local setter must fail closed. The pair is what
 // proves the local scan, rather than the CFG analysis, supplied the mode here.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-occupancy-boundary.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-occupancy-boundary.s
@@ -11,7 +11,7 @@
 // Reserving either one pushes the request to 134 logical / 144 allocated VGPRs,
 // which drops the kernel to 7 waves/EU and fails the required patch.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-scale-bank-zero.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-scale-bank-zero.s
@@ -3,7 +3,7 @@
 // COM: scale values must therefore be produced in the same low-bank registers
 // COM: consumed by each replacement WMMA.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf | %FileCheck --check-prefix=RESULT %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16.s
@@ -5,7 +5,7 @@
 // COM: the matching block-16 scales. When the scratch budget is unavailable it
 // COM: fails closed (see the 32x16 refuse test).
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-and-hazard.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-and-hazard.s
@@ -18,7 +18,7 @@
 // (dst v[16:23], src0 v[0:7], src1 v[8:15]) -- different VGPR set so the
 // two patches are operating on independent kernel state.
 
-// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-fp-imm.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-fp-imm.s
@@ -4,7 +4,7 @@
 // (242 vs 1 per the AMDGPU ISA), so emitting `1` would change the
 // instruction.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-int-imm.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-int-imm.s
@@ -3,7 +3,7 @@
 // inline-const slot 1). Verify the imm is preserved on the first
 // half and the second half uses dst as the carry.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-long-branch.s
@@ -3,7 +3,7 @@
 // COM: sequences on both edges and never executes s_add_pc_i64. External NOP
 // COM: space supplies the forward gateway; non-NOP filler forces the far case.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-matrix-a-reuse.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-matrix-a-reuse.s
@@ -7,7 +7,7 @@
 // splitter strips the modifier on both halves (no perf hint, but
 // correct semantics).
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-matrix-b-reuse.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-matrix-b-reuse.s
@@ -2,7 +2,7 @@
 // same rationale as matrix_a_reuse (the B matrix is sliced in half by
 // K, so the reuse-buffer assertion no longer holds after rewrite).
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-msplit-fp-imm.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-msplit-fp-imm.s
@@ -9,7 +9,7 @@
 // does not, and they must be set to MATRIX_FMT_FP4 so the f8f6f4
 // destination interprets the data as the source's f4 layout).
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-msplit-neg-lo.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-msplit-neg-lo.s
@@ -5,7 +5,7 @@
 // src2). The MATRIX_FMT_FP4 modifiers added by the splitter come BEFORE
 // the preserved neg_lo, mirroring how the printer orders them.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-multi-wmma.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-multi-wmma.s
@@ -8,7 +8,7 @@
 // landing pads carry the expected K=64 mnemonics is the smallest input that
 // exercises the >1-trampoline path.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-neg-hi-k.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-neg-hi-k.s
@@ -3,7 +3,7 @@
 // the NEG_HI bit (SISrcMods::NEG_HI = 1 << 1, vs NEG = 1 << 0) which
 // the splitter projects onto the same modifier-suffix synthesis path.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-neg-lo-k.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-neg-lo-k.s
@@ -9,7 +9,7 @@
 // neg_lo:[0,0,0] is the printer's omitted-default form, so the second
 // half ends up with no neg_lo suffix at all.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-src2-eq-dst.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-src2-eq-dst.s
@@ -8,7 +8,7 @@
 // had, but the splitter still has to emit it correctly via the
 // transformation rather than blindly reusing the printed src2.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-callable-entry-materialized.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-callable-entry-materialized.s
@@ -11,7 +11,7 @@
 // materialized call target, the analysis drops the mode-0 edge, converges on
 // the fallthrough mode, and patches the WMMA under a mode that is not provable.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-cfg.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-cfg.s
@@ -2,7 +2,7 @@
 // direct target. This covers a backedge loop, a nonzero fixed point, and a
 // non-MODE SETREG that must preserve the tracked fields.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-field-merge.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-field-merge.s
@@ -2,7 +2,7 @@
 // This guards the four-field CFG lattice independently of the dst/src0 facts
 // used by DS2 alignment.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-interior-call-absolute.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-interior-call-absolute.s
@@ -4,7 +4,7 @@
 // the rewrite uses, mark the callee as entered at a non-start offset, and fail
 // a mandatory WMMA split there closed rather than seed the wrong mode.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib \
 // RUN:   -Wl,--section-start=.text=0x1000 %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-interior-call-materialized.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-interior-call-materialized.s
@@ -4,7 +4,7 @@
 // from the symbol start, so a mandatory WMMA split there fails closed instead
 // of bracketing for the wrong incoming mode.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-interior-jump-setpc.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-interior-jump-setpc.s
@@ -9,7 +9,7 @@
 // CHECK-NOT verifies the decline comes from the interior-entry resolver, not
 // from the unresolved-call bail: no "unresolved call target" is logged here.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-k-src2-role.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-k-src2-role.s
@@ -2,7 +2,7 @@
 // slice crosses v255, the temporary src2 bank must therefore match the
 // incoming dst bank. Preserve and restore every other incoming mode field.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-kd-interior-entry.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-kd-interior-entry.s
@@ -8,7 +8,7 @@
 // correct split must bracket the crossing half for 0x60 (0x6050 / 0x5060). A
 // mode-0 misread would emit no bracket at all.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-long-branch.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-long-branch.s
@@ -2,7 +2,7 @@
 // the callable-entry VGPR-MSB setter only as the first copied instruction, so
 // every entry still establishes the original mode before either WMMA half.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-m-roles.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-m-roles.s
@@ -2,7 +2,7 @@
 // upper-half base into its operand's mode field, keep broadcast src1 unchanged,
 // and restore the exact nonzero incoming mode after the upper half.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-merge.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-merge.s
@@ -5,7 +5,7 @@
 // This also exercises s_call_i64's unusual target operand layout in the shared
 // direct-control-flow target index.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-setreg-unknown.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-setreg-unknown.s
@@ -1,7 +1,7 @@
 // A dynamic write to WAVE_MODE does not reveal the incoming VGPR-MSB fields.
 // Keep the required WMMA split fail-closed instead of assuming ABI entry mode.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-setreg.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-setreg.s
@@ -2,7 +2,7 @@
 // Immediate bits [19:12] are rotated into s_set_vgpr_msb order; 0x81 becomes
 // mode 0x60 and must be restored around the split WMMA's upper half.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-table-coverage.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-table-coverage.s
@@ -6,7 +6,7 @@
 // hotswap-wmma-split-vgpr-msb-m-roles.s (Split32x16to16x16F4); this test
 // guarantees no table entry is left unsplit.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-unreachable-cfg.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb-unreachable-cfg.s
@@ -5,7 +5,7 @@
 // but the A0-incompatible opcode must still be legalized. The first WMMA
 // follows an explicit dead MODE write; the second has no local MODE write.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split-vgpr-msb.s
@@ -1,7 +1,7 @@
 // Verify that a K-split whose upper source half crosses v255 changes the
 // gfx1250 VGPR-MSB mode around that half and restores the incoming mode.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-split.s
@@ -19,7 +19,7 @@
 // would be visible in the exact-operand DAGs at the bottom rather than
 // being hidden by an incidental textual identity.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang --target=amdgpu12.50-amd-amdhsa -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \


### PR DESCRIPTION
Switch the hotswap lit tests from the legacy amdgcn triple plus -mcpu to the amdgpu triple whose subarch encodes the ISA version, dropping the now redundant -mcpu. clang derives the processor from the subarch when -mcpu is absent, and the emitted code objects are unchanged.

The amdhsa OS component is retained: an empty OS field means unknown, and the AMDGPU assembler then rejects the HSA metadata directives these tests rely on.


