### PR TITLE
[Attributor] Count AAPointerInfo access cap per accessing function

### DIFF
--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -915,14 +915,22 @@ protected:
 private:
   /// State to track fixpoint and validity.
   BooleanState BS;
+
+  /// Number of tracked accesses per accessing function, for the per-scope cap.
+  DenseMap<const Function *, unsigned> PerScopeAccesses;
 };
 
 ChangeStatus AA::PointerInfo::State::addAccess(
     Attributor &A, const AAPointerInfo::RangeList &Ranges, Instruction &I,
     std::optional<Value *> Content, AAPointerInfo::AccessKind Kind, Type *Ty,
     Instruction *RemoteI) {
+  // The cap is per accessing function; interference reasoning is scoped, so
+  // many functions with few accesses each stay precise. The absolute ceiling
+  // bounds memory.
+  const Function *AccScope = I.getFunction();
   if (MaxAccessesPerAAPointerInfo > 0 &&
-      AccessList.size() >= MaxAccessesPerAAPointerInfo)
+      (PerScopeAccesses.lookup(AccScope) >= MaxAccessesPerAAPointerInfo ||
+       AccessList.size() >= 64 * MaxAccessesPerAAPointerInfo))
     return indicatePessimisticFixpoint();
 
   RemoteI = RemoteI ? RemoteI : &I;
@@ -956,6 +964,7 @@ ChangeStatus AA::PointerInfo::State::addAccess(
            "New Access should have been at AccIndex");
     LocalList.push_back(AccIndex);
     AddToBins(AccessList[AccIndex].getRanges());
+    ++PerScopeAccesses[AccScope];
     return ChangeStatus::CHANGED;
   }
 

--- a/llvm/test/Transforms/Attributor/pointer-info-access-cap.ll
+++ b/llvm/test/Transforms/Attributor/pointer-info-access-cap.ll
@@ -1,0 +1,57 @@
+; RUN: opt -aa-pipeline=basic-aa -passes=attributor -attributor-max-pi-accesses=4 -S < %s | FileCheck %s
+;
+; The access cap is per accessing function: @g has 7 accesses spread over 6
+; functions and must stay precise under a cap of 4, while @dense has 6 in one
+; function and must go pessimistic.
+
+@g = internal global i32 0, align 4
+@dense = internal global [8 x i32] zeroinitializer, align 4
+
+define i32 @writer() {
+; CHECK-LABEL: @writer(
+; CHECK: ret i32 7
+  store i32 7, ptr @g, align 4
+  %v = load i32, ptr @g, align 4
+  ret i32 %v
+}
+
+define i32 @r1() {
+  %v = load i32, ptr @g, align 4
+  ret i32 %v
+}
+
+define i32 @r2() {
+  %v = load i32, ptr @g, align 4
+  ret i32 %v
+}
+
+define i32 @r3() {
+  %v = load i32, ptr @g, align 4
+  ret i32 %v
+}
+
+define i32 @r4() {
+  %v = load i32, ptr @g, align 4
+  ret i32 %v
+}
+
+define i32 @r5() {
+  %v = load i32, ptr @g, align 4
+  ret i32 %v
+}
+
+define i32 @dense_fn() {
+; CHECK-LABEL: @dense_fn(
+; CHECK: load i32
+  store i32 1, ptr @dense, align 4
+  %p1 = getelementptr inbounds [8 x i32], ptr @dense, i64 0, i64 1
+  store i32 2, ptr %p1, align 4
+  %p2 = getelementptr inbounds [8 x i32], ptr @dense, i64 0, i64 2
+  store i32 3, ptr %p2, align 4
+  %p3 = getelementptr inbounds [8 x i32], ptr @dense, i64 0, i64 3
+  store i32 4, ptr %p3, align 4
+  %p4 = getelementptr inbounds [8 x i32], ptr @dense, i64 0, i64 4
+  store i32 5, ptr %p4, align 4
+  %v = load i32, ptr @dense, align 4
+  ret i32 %v
+}


### PR DESCRIPTION
Fixes #4070.

## Problem

The AAPointerInfo access cap added by PR1807 (`attributor-max-pi-accesses`, default 512) counts all accesses tracked for one object. In OpenMP device images each kernel's inlined `__kmpc_target_init` and parallel-protocol code adds about one access to each DeviceRTL state global (`TeamState`, `ThreadStates`, `IsSPMDMode`, `KernelEnvironmentPtr`, `KernelLaunchEnvironmentPtr`, `SharedMemVariableSharingSpace`), so those lists grow with kernel count and hit the cap in any large enough application.

Once `SharedMemVariableSharingSpace` goes pessimistic, store-to-load forwarding through `__kmpc_begin/get_sharing_variables` cannot be proven and OpenMPOpt's parallel-region cleanup fails module-wide: marshalling allocas reach codegen in nearly every kernel, and the by-then-dead 512 B sharing space is still referenced when `AMDGPULowerModuleLDS` builds the per-kernel LDS structs. On MFC (gfx90a, ~520 kernels) untouched kernels became 2.4-4.5x slower per dispatch and every kernel gained 512 B of LDS, triggered by adding a few unrelated `target` regions elsewhere in the application.

## Change

Count the cap per accessing function rather than per object. Interference reasoning is execution-scoped, so many functions with a few accesses each stay cheap and keep full precision, while a single function with a huge access list, the case the cap targets, is still cut off. A 64x absolute ceiling stays as a memory backstop.

## Validation

Built at `a830b4135bfc` with and without this change, run over the merged device-LTO module pair from a real MFC device link (module details and the bitcode are in #4070):

| module | unpatched | patched |
|---|---|---|
| below the cap (519 kernels) | 0 marshalling allocas, 0 dead LDS slots | 0, 0 (unchanged) |
| over the cap (523 kernels) | 8670 marshalling allocas, 515 dead LDS slots | **0, 0** |

The same module pair at the AFAR 23.2 base goes 22470 -> 0. Remaining cap hits after the change are only on genuinely dense single-function cases (llvm-libc `slab_cache`, Fortran runtime `ShallowCopy` specializations); LTO pipeline time is about 2x the default, against roughly 4x if the cap is simply raised.

`llvm/test/Transforms/Attributor/pointer-info-access-cap.ll` fails without the change and passes with it.
