### PR TITLE
[Comgr] Correct gfx950 LDS metadata

### DIFF
--- a/amd/comgr/src/comgr-isa-metadata.def
+++ b/amd/comgr/src/comgr-isa-metadata.def
@@ -48,7 +48,7 @@ HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx909",          EF_AMDGPU_MACH_AMDGCN_GFX909
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx90a",          EF_AMDGPU_MACH_AMDGCN_GFX90A,          true, true,   65536,   32,   4,    40, 1024,     8,  512,  512)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx90c",          EF_AMDGPU_MACH_AMDGCN_GFX90C,          true, true,   65536,   32,   4,    40, 1024,     4,  256,  256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx942",          EF_AMDGPU_MACH_AMDGCN_GFX942,          true, false,  65536,   32,   4,    40, 1024,     8,  512,  512)
-HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx950",          EF_AMDGPU_MACH_AMDGCN_GFX950,          true, false,  65536,   32,   4,    40, 1024,     8,  512,  512)
+HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx950",          EF_AMDGPU_MACH_AMDGCN_GFX950,          true, false, 163840,   64,   4,    40, 1024,     8,  512,  512)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1010",         EF_AMDGPU_MACH_AMDGCN_GFX1010,         true, true,   65536,   32,   4,    40, 1024,     8, 1024,  256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1011",         EF_AMDGPU_MACH_AMDGCN_GFX1011,         true, true,   65536,   32,   4,    40, 1024,     8, 1024,  256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1012",         EF_AMDGPU_MACH_AMDGCN_GFX1012,         true, true,   65536,   32,   4,    40, 1024,     8, 1024,  256)

--- a/amd/comgr/test/metadata_tp_test.c
+++ b/amd/comgr/test/metadata_tp_test.c
@@ -12,8 +12,40 @@
 #include <stdlib.h>
 #include <string.h>
 
+static void checkMetadataString(amd_comgr_metadata_node_t Meta, const char *Key,
+                                const char *Expected) {
+  amd_comgr_metadata_node_t Value;
+  amd_comgr_status_t Status = amd_comgr_metadata_lookup(Meta, Key, &Value);
+  checkError(Status, "amd_comgr_metadata_lookup");
+
+  size_t Size;
+  Status = amd_comgr_get_metadata_string(Value, &Size, NULL);
+  checkError(Status, "amd_comgr_get_metadata_string");
+
+  char *Actual = (char *)malloc(Size);
+  if (!Actual)
+    fail("malloc");
+  Status = amd_comgr_get_metadata_string(Value, &Size, Actual);
+  checkError(Status, "amd_comgr_get_metadata_string");
+
+  if (strcmp(Actual, Expected) != 0)
+    fail("%s: expected %s, got %s", Key, Expected, Actual);
+
+  free(Actual);
+  Status = amd_comgr_destroy_metadata(Value);
+  checkError(Status, "amd_comgr_destroy_metadata");
+}
+
 int main(int argc, char *argv[]) {
   amd_comgr_status_t Status;
+
+  amd_comgr_metadata_node_t Gfx950Meta;
+  Status = amd_comgr_get_isa_metadata("amdgcn-amd-amdhsa--gfx950", &Gfx950Meta);
+  checkError(Status, "amd_comgr_get_isa_metadata");
+  checkMetadataString(Gfx950Meta, "LocalMemorySize", "163840");
+  checkMetadataString(Gfx950Meta, "LDSBankCount", "64");
+  Status = amd_comgr_destroy_metadata(Gfx950Meta);
+  checkError(Status, "amd_comgr_destroy_metadata");
 
   // how many isa_names do we support?
   size_t IsaCounts;


### PR DESCRIPTION
## Summary

- correct gfx950 LDS metadata to report 163840 bytes
- correct the gfx950 LDS bank count to 64
- add public API regression coverage for both values

## Motivation

Consumers of `amd_comgr_get_isa_metadata` use its resource limits to
describe and configure a target. For gfx950, Comgr currently reports only
64 KiB of LDS and 32 banks.

Section 2.2.1 of the AMD Instinct CDNA4 ISA Reference Guide documents 64
banks with 640 four-byte entries per bank, giving 163840 bytes of LDS:

https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/instruction-set-architectures/amd-instinct-cdna4-instruction-set-architecture.pdf

## Testing

- `check-comgr` (32 CTest tests and 178 supported lit tests passed; 30 lit
  tests unsupported)
