### PR TITLE
[Analysis] Raise the capture tracking use budget to 150

### DIFF
--- a/llvm/lib/Analysis/CaptureTracking.cpp
+++ b/llvm/lib/Analysis/CaptureTracking.cpp
@@ -45,7 +45,7 @@ STATISTIC(NumNotCapturedBefore, "Number of pointers not captured before");
 static cl::opt<unsigned>
     DefaultMaxUsesToExplore("capture-tracking-max-uses-to-explore", cl::Hidden,
                             cl::desc("Maximal number of uses to explore."),
-                            cl::init(100));
+                            cl::init(150));
 
 unsigned llvm::getDefaultMaxUsesToExploreForCaptureTracking() {
   return DefaultMaxUsesToExplore;


### PR DESCRIPTION
PointerMayBeCaptured walks the uses of a pointer. It gives up after capture-tracking-max-uses-to-explore use edges and then reports "may be captured". The default budget is 100.

The rocRAND threefry generator keeps its state in a private alloca. The walk over that alloca needs 105 use edges in the 32-bit kernel and 121 in the 64-bit kernel. The walk runs out of budget, so LICM does not promote the state out of the hot loop. The kernel then writes the state to scratch memory on every iteration. On MI300X this costs 11% on threefry4x32_20 and 25% on threefry4x64_20. None of the uses that consume the budget can capture the pointer.

I measured CTMark with perf, as retired instructions. Budget 150 costs 0.01% in O3, 0.02% in O0-g, 0.01% in ReleaseThinLTO and 0.03% in ReleaseLTO-g. The noise floor of the harness is 0.01%, so the cost is not measurable. CTMark has a cliff between budget 165 and 170. It sits in sqlite3.c and costs 3% on that benchmark. 150 stays below the cliff.

I open this pull request to run the AMDGPU compile time job. Do not merge it.


