### PR TITLE
[Offload][AMDGPU] Remove runtime autotuning

### DIFF
--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -886,10 +886,6 @@ struct AMDGPUKernelTy : public GenericKernelTy {
   /// Indicates whether or not we need to set up our own private segment size.
   bool usesDynamicStack() const { return DynamicStack; }
 
-  bool isValidBlockSize(uint32_t BlockSize) const override {
-    return BlockSize <= ConstWGSize;
-  }
-
   uint32_t getKernelLaunchId() const { return KernelLaunchId; }
 
   void setKernelLaunchId(uint32_t Id) const { KernelLaunchId = Id; }
@@ -1778,21 +1774,6 @@ private:
     double TicksToTime;
   };
 
-  /// Utility struct holding arguments for post kernel run processing.
-  struct PostKernelRunProcessingArgsTy {
-    hsa_agent_t Agent;
-    AMDGPUSignalTy *Signal;
-    double TicksToTime;
-    std::string KernelName;
-    uint32_t NumTeams;
-    uint32_t NumThreads;
-    KernelRunRecordTy *KernelRunRecords;
-
-    PostKernelRunProcessingArgsTy()
-        : Agent{0}, Signal(nullptr), TicksToTime(setTicksToTime()), NumTeams(0),
-          NumThreads(0), KernelRunRecords(nullptr) {}
-  };
-
   struct KernelDurationTracingArgsTy {
     hsa_agent_t Agent;
     AMDGPUSignalTy *Signal;
@@ -1986,9 +1967,6 @@ private:
   /// When copying data from one host buffer to another, only do it
   /// asynchronously if `MinHostToHostAsyncCopySize <= size`.
   UInt32Envar OMPX_MinHostToHostAsyncCopySize;
-
-  /// Arguments for the callback function.
-  PostKernelRunProcessingArgsTy PostKernelRunProcessingArgs;
 
   /// Arguments for callback function to collect kernel duration.
   KernelDurationTracingArgsTy KernelDurationTracingArgs;
@@ -2209,30 +2187,6 @@ private:
     return EndTime - StartTime;
   }
 
-  /// Callback funtion to process the data for each kernel run.
-  static Error postKernelRunProcessingAction(void *Data) {
-    assert(Data && "Invalid data pointer for post kernel run processing");
-    PostKernelRunProcessingArgsTy *Args =
-        reinterpret_cast<PostKernelRunProcessingArgsTy *>(Data);
-
-    KernelRunRecordTy *KernelRecord = Args->KernelRunRecords;
-    assert(KernelRecord && "KernelRunRecord is null!");
-
-    uint64_t KernelDuration =
-        getKernelDuration<PostKernelRunProcessingArgsTy>(Args);
-    KernelRecord->addEntry(Args->KernelName, Args->NumTeams, Args->NumThreads,
-                           KernelDuration);
-
-    if (getInfoLevel() & OMP_INFOTYPE_AMD_KERNEL_TRACE) {
-      fprintf(stderr,
-              "[Autotuning run] Kernel %s with %u teams and %u threads "
-              "completed in %lu ns.\n",
-              Args->KernelName.c_str(), Args->NumTeams, Args->NumThreads,
-              KernelDuration);
-    }
-    return Plugin::success();
-  }
-
   /// Callback function to generate traces for kernel runtime.
   static Error KernelDurationTracingAction(void *Data) {
     assert(Data && "Invalid data pointer for tracing kernel duration");
@@ -2320,29 +2274,6 @@ public:
         return Err;
     }
 #endif
-
-    // If runtime autotuning is enabled, setup the callback functions to process
-    // the data after kernel completed.
-    if (Device.enableRuntimeAutotuning() && Kernel.isSPMDMode()) {
-      std::string KernelName(Kernel.getName());
-      KernelRunRecordTy *KernelRecords = Device.getKernelRunRecords();
-      assert(KernelRecords && "No KernelRecords!");
-
-      // If this kernel has reached the run limit,
-      // skip registering the callback function.
-      if (!KernelRecords->reachedRunLimitForKernel(KernelName)) {
-        PostKernelRunProcessingArgs.Agent = Agent;
-        PostKernelRunProcessingArgs.Signal = OutputSignal;
-        PostKernelRunProcessingArgs.KernelName = KernelName;
-        PostKernelRunProcessingArgs.NumTeams = NumBlocks[0];
-        PostKernelRunProcessingArgs.NumThreads = NumThreads[0];
-        PostKernelRunProcessingArgs.KernelRunRecords = KernelRecords;
-
-        if (auto Err = Slots[Curr].schedCallback(postKernelRunProcessingAction,
-                                                 &PostKernelRunProcessingArgs))
-          return Err;
-      }
-    }
 
     // When LIBOMPTARGET_KERNEL_EXE_TIME is set, register the callback function
     // to get the kernel duration.
@@ -3001,10 +2932,8 @@ struct AMDGPUStreamManagerTy final
         OMPX_EnableQueueProfiling("LIBOMPTARGET_AMDGPU_ENABLE_QUEUE_PROFILING",
                                   false),
         NextQueue(0), Agent(HSAAgent) {
-    // If OMPX_ENABLE_RUNTIME_AUTOTUNING or LIBOMPTARGET_KERNEL_EXE_TIME is
-    // enabled, set queue profiling to true.
-    if (Device.enableRuntimeAutotuning() ||
-        Device.enableKernelDurationTracing()) {
+    // Enable queue profiling to collect kernel execution times.
+    if (Device.enableKernelDurationTracing()) {
       OMPX_EnableQueueProfiling = true;
     }
   }

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -68,7 +68,6 @@ namespace plugin {
 struct GenericPluginTy;
 struct GenericKernelTy;
 struct GenericDeviceTy;
-struct KernelRunRecordTy;
 struct PluginContextTy;
 template <typename ResourceRef> class GenericDeviceResourceManagerTy;
 
@@ -607,9 +606,6 @@ struct GenericKernelTy {
   bool isXTeamReductionsMode() const {
     return ExecutionMode == OMP_TGT_EXEC_MODE_XTEAM_RED;
   }
-
-  /// Indicate if the input block size is within the limit.
-  virtual bool isValidBlockSize(uint32_t BlockSize) const { return true; }
 
 protected:
   /// Get the execution mode name of the kernel.
@@ -1456,10 +1452,6 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
     return Error::success();
   }
 
-  bool enableRuntimeAutotuning() const { return OMPX_EnableRuntimeAutotuning; }
-
-  KernelRunRecordTy *getKernelRunRecords() const { return KernelRunRecords; }
-
   /// Returns true if the plugin can guarantee that the associated
   /// storage is accessible
   Expected<bool> isAccessiblePtr(const void *Ptr, size_t Size);
@@ -1629,9 +1621,6 @@ protected:
   UInt32Envar OMPX_InitialNumStreams;
   UInt32Envar OMPX_InitialNumEvents;
 
-  /// Envar to enable runtime tuning.
-  BoolEnvar OMPX_EnableRuntimeAutotuning;
-
   /// The identifier of the device within the plugin. Notice this is not a
   /// global device id and is not the device id visible to the OpenMP user.
   const int32_t DeviceId;
@@ -1668,9 +1657,6 @@ protected:
   /// This is used to run the RPC server during task synchronization.
   RPCServerTy *RPCServer;
 
-  /// Structs for functions and data used in runtime autotuning.
-  KernelRunRecordTy *KernelRunRecords;
-
   /// Variable to enable kernel duration tracing.
   BoolEnvar OMPX_KernelDurationTracing;
 
@@ -1682,119 +1668,6 @@ private:
   getKernelEnvironmentForKernel(StringRef Name, DeviceImageTy &Image);
 
   bool IsFastReductionEnabled = false;
-};
-
-/// Struct represents the metadata for each kernel run on the device.
-struct KernelRunRecordTy {
-
-  struct KernelRunEntryTy {
-    std::string KernelName;
-    uint32_t NumTeams = 0;
-    uint32_t NumThreads = 0;
-    uint64_t RunDuration = 0;
-  };
-
-  // Metadata used in tuning process.
-  struct TuningMetadataTy {
-    uint32_t IdxThread = 0;
-    uint32_t IdxCUMultiplier = 0;
-    // Run counters.
-    uint32_t RunCounters = 0;
-    // Entry with minimum running time.
-    KernelRunEntryTy MinEntry;
-  };
-
-  // Add a new entry
-  void addEntry(std::string KernelName, uint32_t NumTeams, uint32_t NumThreads,
-                uint64_t RunDuration) {
-    TuningData[KernelName].RunCounters++;
-
-    // Update min entries.
-    uint64_t MinDuration = 0;
-    auto It = TuningData.find(KernelName);
-    if (It != TuningData.end()) {
-      MinDuration = It->second.MinEntry.RunDuration;
-    }
-    if (MinDuration > RunDuration || MinDuration == 0) {
-      TuningData[KernelName].MinEntry = {KernelName, NumTeams, NumThreads,
-                                         RunDuration};
-    }
-  }
-
-  // Get parameters for next kernel launch.
-  std::pair<uint32_t, uint32_t>
-  getLaunchParamsForKernel(const GenericKernelTy &Kernel,
-                           GenericDeviceTy &GenericDevice) {
-    std::string KernelName = Kernel.getName();
-
-    // If the kernel reaches the run limit,
-    // return the current optimal launch parameters.
-    if (reachedRunLimitForKernel(KernelName)) {
-      auto MinEntry = TuningData[KernelName].MinEntry;
-      return {MinEntry.NumTeams, MinEntry.NumThreads};
-    }
-
-    // Pick new launch parameters.
-    uint32_t IdxCUMulti = TuningData[KernelName].IdxCUMultiplier;
-    uint32_t IdxThread = TuningData[KernelName].IdxThread;
-
-    if (IdxCUMulti >= CUMultiplierCandidate.size()) {
-      // No more element to search.
-      // Max run counter to stop further runs.
-      // Return current optimal launch parameters.
-      TuningData[KernelName].RunCounters = RunLimiter + 1;
-
-      return {TuningData[KernelName].MinEntry.NumTeams,
-              TuningData[KernelName].MinEntry.NumThreads};
-    }
-
-    // New team/thread pair for launch parameters.
-    uint32_t NumCU = GenericDevice.getNumComputeUnits();
-    std::pair<uint32_t, uint32_t> NewLaunchParams = {
-        CUMultiplierCandidate[IdxCUMulti] * NumCU, ThreadCandidate[IdxThread]};
-
-    // Update indices.
-    IdxThread++;
-    TuningData[KernelName].IdxThread = IdxThread;
-
-    // Threads should be within the limit.
-    if (IdxThread >= ThreadCandidate.size() ||
-        !Kernel.isValidBlockSize(ThreadCandidate[IdxThread])) {
-      TuningData[KernelName].IdxThread = 0;
-      TuningData[KernelName].IdxCUMultiplier++;
-    }
-
-    return NewLaunchParams;
-  }
-
-  bool reachedRunLimitForKernel(std::string KernelName) {
-    if (TuningData.find(KernelName) == TuningData.end()) {
-      // If no record for this kernel.
-      return false;
-    }
-
-    return TuningData[KernelName].RunCounters > RunLimiter;
-  }
-
-  uint32_t getRunCounterForKernel(std::string KernelName) {
-    if (TuningData.find(KernelName) == TuningData.end()) {
-      return 0;
-    }
-
-    return TuningData[KernelName].RunCounters;
-  }
-
-private:
-  // Candidates for thread and team.
-  std::vector<uint32_t> ThreadCandidate = {32, 64, 128, 256, 512, 1024};
-  std::vector<uint32_t> CUMultiplierCandidate = {4, 8, 16, 32, 64, 128};
-  // The max number of tuning runs for each kernel.
-  uint32_t RunLimiter = ThreadCandidate.size() * CUMultiplierCandidate.size();
-  // Used for keeping track of the metatdata used in tuning for each kernel.
-  std::unordered_map<std::string, TuningMetadataTy> TuningData;
-  /// Internal representation for OMPT device (initialize & finalize)
-  std::atomic<bool> OmptInitialized;
-
 };
 
 /// Class implementing common functionalities of offload plugins. Each plugin

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -351,25 +351,9 @@ Error GenericKernelTy::launch(GenericDeviceTy &GenericDevice,
 
   // Get max occupancy for this kernel
   computeMaxOccupancy(GenericDevice);
-  std::string KernelName = getName();
-  KernelRunRecordTy *KernelRecord = GenericDevice.getKernelRunRecords();
-  uint32_t KernelRunCounter = 0;
 
   // Calculate or adjust the effective number of threads and blocks if needed.
-  if (KernelRecord) {
-    KernelRunCounter = KernelRecord->getRunCounterForKernel(KernelName);
-  }
-  // If Autotuning is enabled and the kernel is not launched for the first time.
-  if (GenericDevice.enableRuntimeAutotuning() && isSPMDMode() &&
-      KernelRunCounter > 0) {
-    assert(KernelRecord &&
-           "Autotuning is enabled, but KernelRunRecord is not initialized!");
-
-    auto [Teams, Threads] =
-        KernelRecord->getLaunchParamsForKernel(*this, GenericDevice);
-    EffectiveNumBlocks[0] = Teams;
-    EffectiveNumThreads[0] = Threads;
-  } else if (!isBareMode()) {
+  if (!isBareMode()) {
     if (!LaunchArgs.Flags.StrictThreads) {
       EffectiveNumThreads[0] =
           getEffectiveNumThreads(GenericDevice, EffectiveNumThreads[0]);
@@ -571,11 +555,10 @@ GenericDeviceTy::GenericDeviceTy(GenericPluginTy &Plugin, int32_t DeviceId,
       // By default, the initial number of streams and events is 1.
       OMPX_InitialNumStreams("LIBOMPTARGET_NUM_INITIAL_STREAMS", 1),
       OMPX_InitialNumEvents("LIBOMPTARGET_NUM_INITIAL_EVENTS", 1),
-      OMPX_EnableRuntimeAutotuning("OMPX_ENABLE_RUNTIME_AUTOTUNING", false),
       OMPX_KernelDurationTracing("LIBOMPTARGET_KERNEL_EXE_TIME", false),
       DeviceId(DeviceId), GridValues(OMPGridValues),
       PeerAccesses(NumDevices, PeerAccessState::PENDING), PeerAccessesLock(),
-      PinnedAllocs(*this), RPCServer(nullptr), KernelRunRecords(nullptr) {
+      PinnedAllocs(*this), RPCServer(nullptr) {
   // Conservative fall-back to the plugin's device uid for the case that no real
   // vendor (u)uid will become available later.
   setDeviceUidFromVendorUid(std::to_string(static_cast<uint64_t>(DeviceId)));
@@ -659,11 +642,6 @@ Error GenericDeviceTy::init(GenericPluginTy &Plugin) {
     MemoryManager = new MemoryManagerTy(*this, ThresholdMM);
   }
 
-  // Allocate resources for autotuning if enabled.
-  if (OMPX_EnableRuntimeAutotuning) {
-    KernelRunRecords = new KernelRunRecordTy();
-  }
-
   return Plugin::success();
 }
 
@@ -716,14 +694,6 @@ Error GenericDeviceTy::deinit(GenericPluginTy &Plugin) {
       return Err;
     delete RecordReplay;
     RecordReplay = nullptr;
-  }
-
-  // Delete autotuning related resources if the option is on.
-  if (OMPX_EnableRuntimeAutotuning) {
-    if (KernelRunRecords) {
-      delete KernelRunRecords;
-      KernelRunRecords = nullptr;
-    }
   }
 
   if (auto Profiler = Plugin.getProfiler(); Profiler)


### PR DESCRIPTION
As discussed, removing the runtime autotuning to further reduce the code discrepancy between upstream/downstream. 

Passed local build and smoke tests.