### PR TITLE
[Offload][AMDGPU] Remove unused HeapV1Ptr from AMDGPUImplicitArgsTy to match upstream

### DIFF
--- a/offload/plugins-nextgen/amdgpu/utils/UtilitiesRTL.h
+++ b/offload/plugins-nextgen/amdgpu/utils/UtilitiesRTL.h
@@ -46,11 +46,9 @@ struct alignas(alignof(void *)) AMDGPUImplicitArgsTy {
   uint16_t GroupSizeZ;
   uint8_t Unused0[46]; // 46 byte offset.
   uint16_t GridDims;
-  uint8_t Unused1[30]; // 30 byte offset.
-  uint64_t HeapV1Ptr;
-  uint8_t Unused2[16]; // 16 byte offset.
+  uint8_t Unused1[54]; // 54 byte offset
   uint32_t DynamicLdsSize;
-  uint8_t Unused3[132]; // 132 byte offset.
+  uint8_t Unused2[132]; // 132 byte offset.
 };
 // Dummy struct for COV4 implicitargs.
 struct AMDGPUImplicitArgsTyCOV4 {


### PR DESCRIPTION
HeapV1Ptr field is never used and is not present upstream. Fold it back into reserved padding. NFC.

