### PR TITLE
[OpenMP][MLIR] Use op local instead of getOperation() in TeamsOp::verify

### DIFF
--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -3131,7 +3131,7 @@ LogicalResult TeamsOp::verify() {
                      "in any OpenMP dialect operations");
 
   // Check for num_teams clause restrictions
-  if (failed(verifyNumTeamsClause(getOperation(), this->getNumTeamsLower(),
+  if (failed(verifyNumTeamsClause(op, this->getNumTeamsLower(),
                                   this->getNumTeamsUpperVars())))
     return failure();
 
@@ -3147,7 +3147,7 @@ LogicalResult TeamsOp::verify() {
     return failure();
 
   if (failed(verifyDynGroupprivateClause(
-          getOperation(), getDynGroupprivateAccessGroupAttr(),
+          op, getDynGroupprivateAccessGroupAttr(),
           getDynGroupprivateFallbackAttr(), getDynGroupprivateSize())))
     return failure();
 


### PR DESCRIPTION
Reuse the existing op local for the `verifyNumTeamsClause` and `verifyDynGroupprivateClause` calls to match upstream. NFC.