### PR TITLE
[AMDGPU] Enable kernel argument preloading by default

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPreloadKernelArguments.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPreloadKernelArguments.cpp
@@ -35,7 +35,7 @@ using namespace llvm;
 
 static cl::opt<unsigned> KernargPreloadCount(
     "amdgpu-kernarg-preload-count",
-    cl::desc("How many kernel arguments to preload onto SGPRs"), cl::init(0));
+    cl::desc("How many kernel arguments to preload onto SGPRs"), cl::init(10000));
 
 static cl::opt<bool>
     EnableKernargPreload("amdgpu-kernarg-preload",


### PR DESCRIPTION
For testing only.

(cherry picked from commit 40f9200bc74528bd9c11fc48fca7d51a2b7649ef)


