### PR TITLE
[docs][AMDGPU] DMA scopes and containment-based memory model

### DIFF
--- a/llvm/docs/AMDGPUDMAOperations.md
+++ b/llvm/docs/AMDGPUDMAOperations.md
@@ -141,3 +141,165 @@ Despite the absence of `.async` in their names, these intrinsics are
 asynchronous.
 
 All arguments must be wave-uniform.
+
+(amdgpu-dma-scopes)=
+
+## DMA Scopes
+
+A DMA operation initiated by a thread does not belong to the corresponding
+instance of "singlethread" scope. Instead the DMA operation belongs to a
+corresponding DMA scope determined by the target. The following intrinsics
+return the {ref}`scope<amdgpu-scope-type>` at which each kind of DMA operation
+observes memory on the current target:
+
+```llvm
+target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
+target("amdgcn.scope") @llvm.amdgcn.scope.tensor.dma()
+```
+
+These scope identifiers can be passed to any intrinsic that accepts a
+{ref}`amdgpu-scope-type` argument:
+
+```llvm
+%lds_dma_scope = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
+call void @llvm.amdgcn.make.available(target("amdgcn.scope") %lds_dma_scope)
+call void @llvm.amdgcn.make.ptr.visible(ptr %p, target("amdgcn.scope") %lds_dma_scope)
+```
+
+(amdgpu-dma-memory-model)=
+
+## Memory Model
+
+**TODO:** Need to carefully thread *location-order* and *happens-before*.
+
+Each dynamic instance of a DMA *instruction* ``X`` *initiates* a DMA
+*operation* ``D``. The DMA operation is performed in an instance of the
+corresponding DMA scope ``S``. In addition, the user may specify a scope
+``S'`` such that ``S`` is a subscope of ``S'``.
+
+The effect of ``D`` can be modeled as the following pseudo-expansion in LLVM IR:
+
+```llvm
+; M = max(S, S')
+;
+%tmp = load-visible ptr %src, M     ; non-atomic
+store-available ptr %dst, %tmp, M   ; non-atomic
+```
+
+(amdgpu-dma-visibility)=
+
+### Explicit Visibility Required
+
+[This section is informational.]
+
+A DMA operation ``D`` is performed in an instance ``I`` of scope ``S``, but it
+is not included in any subscope instances of ``I``. This means that the
+{ref}`amdgpu-availability-visibility` operations performed by ``D`` **cannot**
+form an *inclusive scope* relationship with those subscopes. This requires
+threads to perform additional availability and visibility operations that ensure
+{ref}`amdgpu-location-order` in certain cases shown below.
+
+#### Wavefront Scope
+
+Consider a thread that writes to global memory and then initiates a DMA
+operation that reads from the same location. The two operations are related in
+*happens-before*, but the DMA operation is not contained in the thread's
+"singlethread" scope instance. The global write is not visible from the DMA
+read; an explicit ``make.available`` at the DMA scope is needed.
+
+```llvm
+%dma_scope = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
+
+store %val, ptr %global
+call @llvm.amdgcn.make.ptr.available(ptr %global, target("amdgcn.scope") %dma_scope) ; <---
+call @llvm.amdgcn.global.load.async.to.lds(%global, %lds)
+call @llvm.amdgcn.asyncmark()
+call @llvm.amdgcn.wait.asyncmark(0)
+%val_lds = load addrspace(3) %lds
+```
+
+The same result can be achieved using a {ref}`amdgpu-store-available` operation:
+
+```llvm
+%dma_scope = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
+
+call @llvm.amdgcn.global.store.available(%global, %val, target("amdgcn.scope") %dma_scope)
+call @llvm.amdgcn.global.load.async.to.lds(%global, %lds)
+call @llvm.amdgcn.asyncmark()
+call @llvm.amdgcn.wait.asyncmark(0)
+%val_lds = load addrspace(3) %lds
+```
+
+A similar pattern is required when storing to global using DMA:
+
+```llvm
+%dma_scope = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
+
+call @llvm.amdgcn.global.store.async.from.lds(%global, %lds)
+call @llvm.amdgcn.asyncmark()
+call @llvm.amdgcn.wait.asyncmark(0)
+call @llvm.amdgcn.make.ptr.visible(ptr %global, target("amdgcn.scope") %dma_scope) ; <---
+%val = load ptr %global
+```
+
+The ``make.ptr.visible`` at the DMA scope is necessary because the DMA write is
+not automatically visible to the subsequent global read.
+
+#### Workgroup Scope
+
+Consider the case where one wave writes to global memory and a different wave in
+the same workgroup initiates a DMA operation that reads from the same location.
+A workgroup-scope fence can provide *happens-before* between the waves but does
+not make the write available at the DMA scope. The DMA operation is not
+contained in the workgroup scope instance, so the fence's *MakeAvailable* and
+the DMA do not have inclusive scopes. An explicit ``make.available`` at the DMA
+scope is needed.
+
+```llvm
+%dma_scope = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
+
+; wave 1
+store %val, ptr addrspace(1) %global
+call @llvm.amdgcn.make.ptr.available(ptr %global, target("amdgcn.scope") %dma_scope) ; <---
+fence release syncscope("workgroup")
+
+; wave 2
+fence acquire syncscope("workgroup")
+call @llvm.amdgcn.global.load.async.to.lds(%global, %lds)
+call @llvm.amdgcn.asyncmark()
+call @llvm.amdgcn.wait.asyncmark(0)
+%val_lds = load addrspace(3) %lds
+```
+
+Similarly, when one wave stores to global memory using a DMA operation and a
+different wave reads from the same location, an explicit ``make.visible`` at the
+DMA scope is needed. The workgroup fence's *MakeVisible* cannot observe the DMA
+write because the DMA is not contained in the workgroup scope instance.
+
+```llvm
+%dma_scope = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
+
+; wave 1
+call @llvm.amdgcn.global.store.async.from.lds(%global, %lds)
+call @llvm.amdgcn.asyncmark()
+call @llvm.amdgcn.wait.asyncmark(0)
+fence release syncscope("workgroup")
+
+; wave 2
+fence acquire syncscope("workgroup")
+call @llvm.amdgcn.make.ptr.visible(ptr %global, target("amdgcn.scope") %dma_scope) ; <---
+%val = load ptr addrspace(1) %global
+```
+
+### Implementation Details
+
+[This section is informational.]
+
+1. On GFX9, ``@llvm.amdgcn.scope.lds.dma()`` returns a value equivalent to
+   "wavefront" scope. The LDS DMA implementation on GFX9 sees the same state of
+   memory as the requesting thread, so ``make.available`` and ``make.visible``
+   at this scope are no-ops.
+2. On GFX1250, ``@llvm.amdgcn.scope.lds.dma()`` returns a value equivalent to
+   "cluster" scope. The compiler emits a cache write-back or invalidate at
+   ``SCOPE_SE`` for ``make.available`` and ``make.visible`` at this scope
+   respectively.

--- a/llvm/docs/AMDGPUMemoryModel.md
+++ b/llvm/docs/AMDGPUMemoryModel.md
@@ -69,8 +69,7 @@ The LLVM Language Reference defines the following {ref}`scopes<syncscope>`:
 
 ### AMDGPU scopes
 
-The AMDGPU backend further refines the LLVM scopes with the following
-target-defined scopes and constraints:
+The AMDGPU target defines the following LLVM scopes:
 
 - *system scope* (same as LLVM)
 - "agent" scope
@@ -82,15 +81,35 @@ target-defined scopes and constraints:
 These are arranged from largest scope (*system scope*) to smallest scope
 ("singlethread").
 
-- Every instance `X` of some scope `S1` other than "singlethread" scope is
-  partitioned by the scope `S2` one level below it. Each subset defined by this
-  partition is an instance of `S2` and is called a *subscope instance* of `X`.
-- It follows that if two scope instances `X` and `Y` intersect, then their
-  intersection is the smaller of `X` and `Y`.
-- A scope `S1` is a *subscope* of a scope `S2` if every instance of `S1`
-  is a subscope instance of some instance of `S2`.
+- Every scope `S1` other than *system scope* is a *subscope* of the scopes
+  above it in this linear arrangement.
+- If `S1` is a subscope of `S2`, then an instance `I1` of `S1` is a
+  subset of some instance `I2` of `S2`, and `I1` is said to be a
+  *subscope instance* of `I2`.
+- If two scope instances `I1` and `I2` intersect, then their intersection is
+  the smaller of `I1` and `I2`.
 
-**Inclusive Scopes**: Two operations `X` and `Y` are said to have *inclusive
+#### Containment
+
+Every operation *belongs to* an instance of a specific scope:
+
+- Operations executed by each thread (loads, stores, atomics, fences) *belong
+  to* the corresponding "singlethread" scope instance.
+- DMA operations *initiated by* each thread *belong to* an instance of the
+  corresponding {ref}`DMA scope<amdgpu-dma-scopes>`.
+
+Every operation is *contained* in the scope instance `I1` that it *belongs
+to*, as well as every scope instance `I2` such that `I1` is a *subscope
+instance* of `I2`.
+
+This affects how operations are related in *inclusive scopes* when determining
+availability and visibility. For example, DMA operations require
+{ref}`explicit availability and visibility<amdgpu-dma-visibility>`
+operations at scopes below the corresponding DMA scope.
+
+#### Inclusive Scopes
+
+Two operations `X` and `Y` are said to have *inclusive
 scopes* if the scope instance of each operation contains the other operation. In
 that case, the *common scope instance* `S'` of `X` and `Y` is the
 intersection of their scope instances. The scope corresponding to `S'` is also
@@ -130,12 +149,23 @@ target("amdgcn.scope") @llvm.amdgcn.scope.wavefront()
 target("amdgcn.scope") @llvm.amdgcn.scope.singlethread()
 ```
 
+Additional scope intrinsics for {ref}`DMA scopes<amdgpu-dma-scopes>`:
+
+```llvm
+target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
+target("amdgcn.scope") @llvm.amdgcn.scope.tensor.dma()
+```
+
 An example:
 
 ```llvm
 %wg = call target("amdgcn.scope") @llvm.amdgcn.scope.workgroup()
 call void @llvm.amdgcn.make.available(target("amdgcn.scope") %wg)
+%dma = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
+call void @llvm.amdgcn.make.available(target("amdgcn.scope") %dma)
 ```
+
+(amdgpu-availability-visibility)=
 
 ## Availability and Visibility
 
@@ -412,8 +442,7 @@ subscope instance of `S` that also includes `W`.
 
 An operation `Y` is a *visibility operation* on a write `W` if `Y` is a
 *load-visible* or *make-ptr-visible* operation to the same address, or a
-*make-visible* operation,
-and one of the following holds:
+*make-visible* operation, and one of the following holds:
 
 - There exists an *availability* operation `X` on write `W` such that:
 


### PR DESCRIPTION
Add DMA scope intrinsics (scope.lds.dma, scope.tensor.dma) that return the scope at which each kind of DMA operation observes memory. Document the DMA memory model with explicit visibility/availability patterns for wavefront and workgroup scopes, and implementation details per target.

Reformulate AMDGPU scope definitions to use containment-based descriptions: add Containment subsection defining how operations belong to scope instances, and promote Inclusive Scopes to its own subsection. This supports reasoning about DMA operations which are not contained in the initiating thread's singlethread scope.

Part of a stack:

- #4135
- #4134
- #4133
- #3396 
- main

Assisted-By: Claude Opus 4.6


