### PR TITLE
[docs][AMDGPU] non-transitive amdgpu-happens-before that includes DMA transfers

### DIFF
--- a/llvm/docs/AMDGPUAsyncOperations.md
+++ b/llvm/docs/AMDGPUAsyncOperations.md
@@ -7,9 +7,12 @@
 
 Asynchronous operations are operations whose completion is not tracked
 internally by the compiler. A thread that initiates one or more async operations can use
-*asyncmarks* to track their completion.
+execution synchronization mechanisms such as *asyncmarks* or
+{ref}`barriers<amdgpu-execution-synchronization>` to track their completion.
 
 - Most {ref}`DMA operations <amdgpu-dma-operations>` are asynchronous.
+
+(amdgpu-asyncmarks)=
 
 ## Asyncmarks
 
@@ -32,6 +35,11 @@ Produces an asyncmark and appends it to the current sequence.
 Ensures that the length of the current sequence is at most `N` by removing
 asyncmarks from the start of the sequence if it is more than `N`.
 
+This operation implicitly includes the semantics of a `fence acquire` at
+*system-scope*.
+
+(amdgpu-asyncmark-completed-at)=
+
 ### Completion of Asyncmarks
 
 An `asyncmark()` operation `X` that produces an asyncmark `M` is
@@ -42,26 +50,39 @@ if:
 - `M` is not in the current sequence at any operation `Z` that immediately
   follows `Y` in *program-order*.
 
+(amdgpu-async-completed-at)=
+
 ## Completion of Async Operations
 
 An async operation executes outside the thread that initiated it, i.e., it is
 not related in *program-order* with any other operations from that thread. But
-the thread can use an asyncmark to ensure that the async operation is
-*completed-at* some later operation.
+a thread that depends on the side-effects of `A` can use an asyncmark or barrier
+to ensure that `A` is *completed-at* some operation in that thread.
 
-An async operation `A` *initiated-by* an instruction `I` is *completed-at* some
+```{note}
+{ref}`DMA operations<amdgpu-dma-memmodel>` use the *completed-at* relation to
+establish a *happens-before* relation with threads that depend on their
+completion.
+```
+
+### Using Asyncmarks
+
+Some async operations use asyncmarks to notify completion. Such an async
+operation `A` *initiated-by* an instruction `I` is *completed-at* some
 `wait.asyncmark()` operation `Y` if there exists an `asyncmark()` operation `X`
 such that:
 - `I` is *program-ordered* before `X`, and
 - `X` is *completed-at* `Y`.
 
-### happens-before
+### Using Barriers
 
-When an instruction `I` initiates an async operation `A`, `I` *happens-before*
-`A`.
+Some async operations can take a {ref}`barrier
+<amdgpu-execution-synchronization>` as an argument. A thread that depends on the
+side-effects of `A` performs a {ref}`barrier wait <amdgpu-barrier-operations>`
+operation `W` on the barrier.
 
-If `A` is *completed-at* a `wait.asyncmark()` operation `Y`, then `A`
-*happens-before* `Y`.
+`A` is said to be *completed-at* `W` when it performs a {ref}`barrier arrive
+<amdgpu-barrier-operations>` operation on the barrier and the barrier completes.
 
 ## Examples
 

--- a/llvm/docs/AMDGPUDMAOperations.md
+++ b/llvm/docs/AMDGPUDMAOperations.md
@@ -8,8 +8,8 @@
 DMA (or "Direct Memory Access") operations transfer data between different kinds
 of memory directly without occupying registers in the invoking wave. They are
 usually {ref}`asynchronous<amdgpu-async-operations>` asynchronous, and require
-the user to explicitly track completion using
-{ref}`asyncmarks<amdgpu-async-operations>`.
+additional mechanisms to track completion such as {ref}`amdgpu-asyncmarks` or
+{ref}`barriers<amdgpu-execution-synchronization>`.
 
 All DMA operations support the same cache modifiers as ordinary load/store
 operations from registers. They cannot be performed atomically.
@@ -20,11 +20,12 @@ Each GFX9 DMA instruction has a synchronous counterpart (e.g.,
 `@llvm.amdgcn.load.to.lds` for `@llvm.amdgcn.load.async.to.lds`). The
 synchronous variants perform the same operation, but the compiler automatically
 ensures completion before their side-effects are used.
+The asynchronous variants use {ref}`amdgpu-asyncmarks` to track completion.
 
 GFX9 DMA instructions implement volatile (via `aux/cpol` bit 31) and
 nontemporal (via metadata) as if they were loads from the global address space.
 
-**Flat/Global Addressing**
+#### Flat/Global Addressing
 
 ```llvm
 void @llvm.amdgcn.load[.async].to.lds.pN(
@@ -59,7 +60,7 @@ void @llvm.amdgcn.global.load[.async].lds(
 
 This is identical to `@llvm.amdgcn.load[.async].to.lds.p1`.
 
-**Buffer Addressing**
+#### Buffer Addressing
 
 ```llvm
 void @llvm.amdgcn.{raw|struct}[.ptr].buffer.load[.async].lds(
@@ -85,13 +86,16 @@ The intrinsics differ in two orthogonal ways:
 - **ptr** vs non-ptr: The `ptr` variants use `ptr addrspace(8)` for the
   buffer resource descriptor; the non-ptr variants use `<4 x i32>`.
 
-### GFX1250
+### GFX1250 DMA Operations
+
+All GFX1250 DMA operations are asynchronous and use {ref}`amdgpu-asyncmarks` to
+track completion. There are no synchronous variants.
+
+#### LDS DMA Operations
 
 GFX1250 LDS DMA instructions implement nontemporal (via metadata) as if they
 were loads from the global address space. Tensor DMA instructions do not support
 volatile or nontemporal.
-
-**Global Addressing**
 
 ```llvm
 void @llvm.amdgcn.{global|cluster}.load.async.to.lds.b<N>(
@@ -120,7 +124,7 @@ void @llvm.amdgcn.global.store.async.from.lds.b<N>(
 
 Stores data from LDS to global memory.
 
-**Tensor Addressing**
+#### Tensor Operations
 
 ```llvm
 void @llvm.amdgcn.tensor.{load.to|store.from}.lds(
@@ -157,6 +161,24 @@ target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
 target("amdgcn.scope") @llvm.amdgcn.scope.tensor.dma()
 ```
 
+The scope returned by these intrinsics is at most **cluster** scope.
+
+```{attention}
+
+**A lot is hanging on this sentence.** The tail release of a DMA operation
+*synchronizes-with* a `fence acquire` with DMA scope, performed by the consuming
+thread. But since the DMA scope is a `target("amdgcn.scope")` value it cannot
+be passed to an LLVM `fence` instruction.
+
+We have the following options:
+
+1. Explain the upper bound on the DMA scope and let the programmer figure out
+   the rest. (`fence acquire` at cluster scope followed by `make-visible` at
+   DMA scope.)
+2. Augment `fence` instruction to support `target("amdgcn.scope")`. Eventually, yes.
+3. Introduce `amdgcn.fence` intrinsics with the right syntax. Definitely not?
+```
+
 These scope identifiers can be passed to any intrinsic that accepts a
 {ref}`amdgpu-scope-type` argument:
 
@@ -166,25 +188,78 @@ call void @llvm.amdgcn.make.available(target("amdgcn.scope") %lds_dma_scope)
 call void @llvm.amdgcn.make.ptr.visible(ptr %p, target("amdgcn.scope") %lds_dma_scope)
 ```
 
-(amdgpu-dma-memory-model)=
+(amdgpu-dma-memmodel)=
 
-## Memory Model
+## AMDGPU DMA Memory Model
 
-**TODO:** Need to carefully thread *location-order* and *happens-before*.
+Each DMA operation ``D`` is performed in an instance of the corresponding DMA
+scope ``S``. In addition, the user may specify a scope ``S'`` as an argument.
+The internal operations are made available/visible at the larger of these two
+scopes:
 
-Each dynamic instance of a DMA *instruction* ``X`` *initiates* a DMA
-*operation* ``D``. The DMA operation is performed in an instance of the
-corresponding DMA scope ``S``. In addition, the user may specify a scope
-``S'`` such that ``S`` is a subscope of ``S'``.
-
-The effect of ``D`` can be modeled as the following pseudo-expansion in LLVM IR:
-
-```llvm
-; M = max(S, S')
-;
-%tmp = load-visible ptr %src, M     ; non-atomic
-store-available ptr %dst, %tmp, M   ; non-atomic
 ```
+Availability/Visibility Scope M = max(S, S')
+```
+
+### `program-order`
+
+When the DMA operation is performed, control flow begins from an *entry*
+followed in *program-order* by various operations listed below.
+
+```{code-block} llvm
+:caption: Global to LDS Internal Sequence
+
+entry
+%tmp = load.visible ptr addrspace(1) %src, M      ; non-atomic
+store ptr addrspace(3) %dst, %tmp                 ; non-atomic
+fence release syncscope<"system"> !{!"amdgcn-av", !"none"}
+notify_completion
+```
+
+```{code-block} llvm
+:caption: LDS to Global Internal Sequence
+
+entry
+%tmp = load ptr addrspace(3) %src                ; non-atomic
+store-available ptr addrspace(1) %dst, %tmp, M   ; non-atomic
+fence release syncscope<"system"> !{!"amdgcn-av", !"none"}
+notify_completion
+```
+
+### `completed-at`
+
+A DMA operation `D` *initiated* by an instruction `X` is *completed-at* an
+operation `Y` if:
+
+- `D` is a synchronous operation and `X` is *program-ordered* before
+  `Y`, or,
+- `D` is an asynchronous operation and a {ref}`completion
+  mechanism<amdgpu-async-completed-at>` ensures that `D` is *completed-at* `Y`.
+
+### `synchronizes-with`
+
+If a DMA operation `D` is *completed-at* a `wait.asyncmark()` operation
+`Y`, then the *tail release* `Rel` inside `D` *synchronizes-with* `Y`.
+
+If a DMA operation `D` is *completed-at* a
+{ref}`barrier wait<amdgpu-barrier-operations>` operation `Y` then the *tail
+release* operation `Rel` in `D` *synchronizes-with* a `fence acquire` operation
+`Acq` if:
+
+- `Y` is *program-ordered* before `Acq`, and
+- `D` is included in the scope instance of `Acq`.
+
+### `happens-before`
+
+Since the internal operations in a DMA operation participate in *program-order*
+and *synchronize-with*, they also participate in the base *happens-before* order
+defined in the {ref}`LLVM Memory Model<memmodel>`. In particular,
+*happens-before* relates the operations performed by the DMA operation to
+threads that are waiting for it to complete.
+
+Operations in the initiating thread are **not** related in *happens-before* to
+the internal DMA operations. Instead they are related through the non-transitive
+{ref}`amdgpu-amdgpu-happens-before` order.
 
 (amdgpu-dma-visibility)=
 
@@ -201,11 +276,10 @@ threads to perform additional availability and visibility operations that ensure
 
 #### Wavefront Scope
 
-Consider a thread that writes to global memory and then initiates a DMA
-operation that reads from the same location. The two operations are related in
-*happens-before*, but the DMA operation is not contained in the thread's
-"singlethread" scope instance. The global write is not visible from the DMA
-read; an explicit ``make.available`` at the DMA scope is needed.
+Consider a thread that writes to global memory and then *initiates* a DMA
+operation that reads from the same location. An explicit ``make.available`` at
+the LDS DMA scope is needed to ensure that the write is *location-ordered*
+before the DMA instruction.
 
 ```llvm
 %dma_scope = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
@@ -218,19 +292,20 @@ call @llvm.amdgcn.wait.asyncmark(0)
 %val_lds = load addrspace(3) %lds
 ```
 
-The same result can be achieved using a {ref}`amdgpu-store-available` operation:
+Alternatively, the global store can be upgraded to a
+{ref}`amdgpu-store-available` operation to achieve the same ordering.
 
 ```llvm
 %dma_scope = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
 
-call @llvm.amdgcn.global.store.available(%global, %val, target("amdgcn.scope") %dma_scope)
+call @llvm.amdgcn.global.store.available(%global, %val, target("amdgcn.scope") %dma_scope) ; <--
 call @llvm.amdgcn.global.load.async.to.lds(%global, %lds)
 call @llvm.amdgcn.asyncmark()
 call @llvm.amdgcn.wait.asyncmark(0)
 %val_lds = load addrspace(3) %lds
 ```
 
-A similar pattern is required when storing to global using DMA:
+A similar pattern is required with a DMA operation that writes to global memory.
 
 ```llvm
 %dma_scope = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
@@ -242,18 +317,20 @@ call @llvm.amdgcn.make.ptr.visible(ptr %global, target("amdgcn.scope") %dma_scop
 %val = load ptr %global
 ```
 
-The ``make.ptr.visible`` at the DMA scope is necessary because the DMA write is
-not automatically visible to the subsequent global read.
+The actual DMA operation was performed in the LDS DMA scope. Although the DMA
+operation *happens-before* the global load, the ``make.ptr.visible`` at the LDS
+DMA scope is necessary to ensure that it is *location-ordered* before the global
+read.
 
 #### Workgroup Scope
 
 Consider the case where one wave writes to global memory and a different wave in
-the same workgroup initiates a DMA operation that reads from the same location.
-A workgroup-scope fence can provide *happens-before* between the waves but does
-not make the write available at the DMA scope. The DMA operation is not
-contained in the workgroup scope instance, so the fence's *MakeAvailable* and
-the DMA do not have inclusive scopes. An explicit ``make.available`` at the DMA
-scope is needed.
+the same workgroup *initiates* a DMA operation that reads from the same
+location. A workgroup-scope fence can provide *happens-before* between the waves
+but does not make the write available at the DMA scope. If the DMA scope is not
+contained in the workgroup-scope, the fence's *MakeAvailable* and the DMA do not
+have inclusive scopes. An explicit ``make.available`` at the DMA scope is
+needed.
 
 ```llvm
 %dma_scope = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()
@@ -272,9 +349,10 @@ call @llvm.amdgcn.wait.asyncmark(0)
 ```
 
 Similarly, when one wave stores to global memory using a DMA operation and a
-different wave reads from the same location, an explicit ``make.visible`` at the
-DMA scope is needed. The workgroup fence's *MakeVisible* cannot observe the DMA
-write because the DMA is not contained in the workgroup scope instance.
+different wave reads from the same location, an explicit ``make.visible`` at
+the DMA scope is needed. The workgroup fence's *MakeVisible* cannot observe
+the DMA write because the DMA is not contained in the workgroup scope
+instance.
 
 ```llvm
 %dma_scope = call target("amdgcn.scope") @llvm.amdgcn.scope.lds.dma()

--- a/llvm/docs/AMDGPUExecutionSynchronization.md
+++ b/llvm/docs/AMDGPUExecutionSynchronization.md
@@ -51,7 +51,7 @@ Each barrier *object* has the following state:
 Barrier *objects* exist within a *scope* instance (see {ref}`amdgpu-amdhsa-llvm-sync-scopes-table`),
 and thus can only be accessed by threads in the same *scope* instance.
 
-(amdgpu-execution-synchronization-barriers-execution-model-barrier-operations)=
+(amdgpu-barrier-operations)=
 
 :::{rubric} Barrier Operations
 :::
@@ -321,7 +321,7 @@ Not all barrier *objects* are *named barrier objects*, and both types can coexis
 :::
 
 The entirety of the
-{ref}`barrier operations section<amdgpu-execution-synchronization-barriers-execution-model-barrier-operations>`
+{ref}`barrier operations section<amdgpu-barrier-operations>`
 applies, with the following barrier operation being added:
 
 - Barrier *join*.

--- a/llvm/docs/AMDGPUMemoryModel.md
+++ b/llvm/docs/AMDGPUMemoryModel.md
@@ -416,6 +416,23 @@ eventually make that a parameter similar to the storage class parameter on
 operations and orders in Vulkan.
 :::
 
+(amdgpu-amdgpu-happens-before)=
+
+### `amdgpu-happens-before`
+
+An operation `A` *amdgpu-happens-before* an operation `B` if:
+
+- `A` *happens-before* `B`, or,
+- `B` is the *entry* of some DMA operation `D` such that:
+
+  - `A` *initiates* `D`, or,
+  - `A` *happens-before* some operation `X` and `X` *initiates* `D`.
+
+:::{note}
+*happens-before* also includes the completion of DMA operations as described in
+the {ref}`amdgpu-dma-memmodel`.
+:::
+
 ### Availability Operation
 
 An operation `X` is an *availability operation* on a write `W` if one of the
@@ -432,7 +449,7 @@ following holds:
 - `X` is a *make-available* operation whose scope instance includes `W`,
   and there is an availability operation `Z` on `W` such that:
 
-  - `Z` happens-before `X`, and,
+  - `Z` *amdgpu-happens-before* `X`, and,
   - `Z`'s scope instance includes `X`.
 
 Then `X` makes `W` available in its own scope instance `S` and every
@@ -446,15 +463,15 @@ An operation `Y` is a *visibility operation* on a write `W` if `Y` is a
 
 - There exists an *availability* operation `X` on write `W` such that:
 
-  - `X` happens-before `Y`, and,
-  - `X` and `Y` have inclusive scopes.
+  - `X` *amdgpu-happens-before* `Y`, and,
+  - `X` and `Y` specify inclusive scopes.
 
   Then `Y` makes `W` visible in the common scope instance `S` of `X` and
   `Y`, and every subscope instance of `S` that includes `Y`.
 
 - There exists a *visibility* operation `X` on write `W` such that:
 
-  - `X` happens-before `Y`, and,
+  - `X` *amdgpu-happens-before* `Y`, and,
   - `X` makes `W` visible in a scope instance `S1` that includes `Y`, and,
   - `X` is included in the scope instance `S2` of `Y`.
 
@@ -471,7 +488,7 @@ if `W` is program-ordered before `Y`.
 A write `W` is *location-ordered* before a write `W1` to the same address if
 there exists an availability operation `Z` on `W` such that:
 
-- `Z` happens-before `W1`, and,
+- `Z` *amdgpu-happens-before* `W1`, and,
 - `W1` is included in `Z`'s scope instance.
 
 A write `W` is *location-ordered* before a read `R` to the same address if
@@ -495,7 +512,7 @@ For each byte of a read `R`, `R` may see any write to the same byte, except:
 
 - If a write `W1` is *location-ordered* before a write `W2`, and `W2` is
   *location-ordered* before a read `R`, then `R` may not see `W1`.
-- If a read `R` is *location-ordered* before a write `W3`, then `R` may not see
+- If a read `R` *amdgpu-happens-before* a write `W3`, then `R` may not see
   `W3`.
 
 The value returned by `R` is then defined as follows:
@@ -519,11 +536,12 @@ This section is informational.
 
 The following properties follow from the definitions above:
 
-1. **Happens-before is necessary for location-order.** An access `X` is
-   *location-ordered* before an access `Y` only if `X` happens-before `Y`.
+1. **amdgpu-happens-before is necessary for location-order.** A write `W` is
+   *location-ordered* before a read `R` only if `W`
+   *amdgpu-happens-before* `R`.
    This follows from the definition of availability and visibility operations,
-   which always require a happens-before link with the preceding operation in
-   the chain.
+   which always require an *amdgpu-happens-before* link with the preceding
+   operation in the chain.
 2. **A write cannot be made available in a scope that does not contain it.** The
    definition of an availability operation `X` requires that `X`'s scope
    instance includes `W` as a precondition. Since every scope instance that
@@ -550,9 +568,61 @@ The following properties follow from the definitions above:
    operation with inclusive scopes, such that their common scope includes both
    `W` and `R`.
 
+(amdgpu-ordering-comparison)=
+
+## Comparison of Ordering Relations
+
+[This section is informational.]
+
+```{list-table}
+:header-rows: 1
+:widths: 30 20 25 25
+
+   * - Purpose
+     - C++
+     - Vulkan
+     - AMDGPU
+   * - Intra-thread ordering
+     - sequenced-before<br>(transitive)
+     - program-order<br>(transitive)
+     - program-order<br>(transitive)
+   * - Inter-thread synchronization
+     - synchronizes-with
+     - synchronizes-with
+     - synchronizes-with
+   * - Transitive inter-thread ordering
+     - happens-before
+     - inter-thread-happens-before
+     - happens-before
+   * - Basis for visibility
+     - happens-before<br>(transitive)
+     - happens-before<br>(**not** transitive)
+     - amdgpu-happens-before<br>(**not** transitive)
+```
+
+The above table lines up roughly equivalent ordering relations across the
+C++, Vulkan, and AMDGPU memory models.
+
+- In C++, *happens-before* is transitive and serves directly as the basis of
+  *visible side effects*.
+- In Vulkan, the non-transitive *happens-before* serves as the basis of
+  *location-order*.
+- In AMDGPU, the non-transitive *amdgpu-happens-before* serves the same role.
+
+The Vulkan and AMDGPU models achieve non-transitivity differently:
+
+- Vulkan defines *happens-before* as the union of *program-order* and
+  *inter-thread-happens-before*, which are each individually transitive but whose
+  union is not.
+- AMDGPU defines *amdgpu-happens-before* as the union of the transitive
+  *happens-before* and *initiate DMA* edges. *happens-before* additionally
+  contains *dma-program-order* and *synchronizes-with* edges from DMA operations.
+
 (amdgcn-av-vulkan)=
 
 ## The Vulkan Memory Model
+
+[This section is informational.]
 
 The AMDGPU memory model draws heavily on the Vulkan memory model. In
 particular, the following instructions are equivalent.


### PR DESCRIPTION
Changes to the AMDGPU memory model:

- _completed-at_ for asyncmarks and for barriers
- Advertise that "cluster" is the upper bound on DMA scopes. We need this because the consuming thread needs to perform a `fence acquire` instruction, which does not support numerical scopes from #3396.
- DMA "internal" operations that are performed in _dma-program-order_ terminating in a `non-av release fence`.
- Allow DMA operations to establish _synchronize-with_ relations with the consuming thread.
- _amgpu-happens-before_ is a non-transitive order
  - allows _happens-before_ to enter a DMA operation but not continue beyond
  - separately allows _happens-before_ to start from the exit of a DMA operation
- A comparison table at the end of the memory model, lining up the transitive/non-transitive variations of _happens-before_ from C++, Vulkan and AMDGPU

Part of a stack:

- #4135
- #4134
- #4133
- #3396 
- main

Assisted-By: Claude Opus 4.8