### PR TITLE
[MLIR][OpenMP] Replace target-data assert with error

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -8411,8 +8411,10 @@ convertOmpTargetData(Operation *op, llvm::IRBuilderBase &builder,
   llvm::OpenMPIRBuilder::TargetDataInfo info(
       /*RequiresDevicePointerInfo=*/true,
       /*SeparateBeginEndCalls=*/true);
-  assert(!ompBuilder->Config.isTargetDevice() &&
-         "target data/enter/exit/update are host ops");
+
+  if (ompBuilder->Config.isTargetDevice())
+    return op->emitOpError() << "not allowed in a target device";
+
   bool isOffloadEntry = !ompBuilder->Config.TargetTriples.empty();
 
   auto getDeviceID = [&](mlir::Value dev) -> llvm::Value * {


### PR DESCRIPTION
If a user incorrectly puts a `target data`, `target enter data`, `target exit data` or `target update` directive inside of target device code, this will get lowered to MLIR and trigger an assert while translating the corresponding operations to LLVM IR.

Part of the issue is that there are no semantics checks to prevent this but, even if they were added, they wouldn't be able to incorporate implicit `declare target` information, as that is added later. This patch replaces the assert with a more informative compile error during MLIR to LLVM IR translation to catch any of these cases that make it past semantics.
