### PR TITLE
[WaveTransform] Fix simplifyMachinePHI for all-same-value PHIs

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
@@ -165,11 +165,11 @@ static Register simplifyMachinePHI(MachineInstr &PHI, MachineRegisterInfo &MRI,
   // originally carried IMPLICIT_DEF.
   if (HasImplicitDefInput) {
     MachineInstr *DefCommonReg = MRI.getVRegDef(CommonReg);
-    if (DefCommonReg && MDT.dominates(DefCommonReg, &PHI))
-      return CommonReg;
+    if (!DefCommonReg || !MDT.dominates(DefCommonReg, &PHI))
+      return Register();
   }
 
-  return Register();
+  return CommonReg;
 }
 
 /// Walk every PHI in the function and try to replace uniform (SGPR) PHIs that

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/global-atomic-fadd.f32-rtn.ll
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/global-atomic-fadd.f32-rtn.ll
@@ -229,7 +229,7 @@ define amdgpu_ps float @global_atomic_fadd_f32_saddr_rtn_atomicrmw(ptr addrspace
   ; ITERATE-NEXT:   successors: %bb.3(0x80000000)
   ; ITERATE-NEXT: {{  $}}
   ; ITERATE-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-  ; ITERATE-NEXT:   [[COPY6:%[0-9]+]]:vgpr_32 = COPY %12
+  ; ITERATE-NEXT:   [[COPY6:%[0-9]+]]:vgpr_32 = COPY %9
   ; ITERATE-NEXT:   [[GLOBAL_ATOMIC_ADD_F32_SADDR_RTN:%[0-9]+]]:vgpr_32 = GLOBAL_ATOMIC_ADD_F32_SADDR_RTN killed [[V_MOV_B32_e32_]], [[COPY6]], [[COPY3]], 0, 1, implicit $exec :: (load store syncscope("wavefront") monotonic (s32) on %ir.ptr, addrspace 1)
   ; ITERATE-NEXT: {{  $}}
   ; ITERATE-NEXT: bb.3 (%ir-block.6):
@@ -268,7 +268,6 @@ define amdgpu_ps float @global_atomic_fadd_f32_saddr_rtn_atomicrmw(ptr addrspace
   ; ITERATE-NEXT:   successors: %bb.2(0x30000000), %bb.3(0x50000000)
   ; ITERATE-NEXT: {{  $}}
   ; ITERATE-NEXT:   [[PHI5:%[0-9]+]]:vgpr_32 = PHI [[V_WRITELANE_B32_]], %bb.5
-  ; ITERATE-NEXT:   [[PHI6:%[0-9]+]]:sgpr_32 = PHI [[S_ADD_F32_]], %bb.5
   ; ITERATE-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; ITERATE-NEXT:   [[V_MBCNT_LO_U32_B32_e64_:%[0-9]+]]:vgpr_32 = V_MBCNT_LO_U32_B32_e64 [[COPY5]], [[S_MOV_B32_3]], implicit $exec
   ; ITERATE-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_EQ_U32_e64 killed [[V_MBCNT_LO_U32_B32_e64_]], [[S_MOV_B32_3]], implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/simplify-uniform-phi.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/simplify-uniform-phi.mir
@@ -203,3 +203,180 @@ body: |
     $sgpr0 = COPY %5
     S_ENDPGM 0
 ...
+
+---
+# SGPR PHI with two incoming edges both carrying the same register value,
+# no IMPLICIT_DEF inputs. The PHI should be simplified to the common register.
+# This is the case that was previously missed (all-same-value without undefs).
+name: simplify_sgpr_phi_all_same_two_inputs
+tracksRegLiveness: true
+body: |
+  ; CHECK-LABEL: name: simplify_sgpr_phi_all_same_two_inputs
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; CHECK-NEXT:   liveins: $sgpr0, $vgpr0
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr0
+  ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
+  ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 [[COPY1]], [[S_MOV_B32_]], implicit $exec
+  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NE_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
+  ; CHECK-NEXT:   S_BRANCH %bb.2
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   successors: %bb.3(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   S_BRANCH %bb.3
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   successors: %bb.3(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   S_BRANCH %bb.3
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.3:
+  ; CHECK-NEXT:   $sgpr0 = COPY [[COPY]]
+  ; CHECK-NEXT:   S_ENDPGM 0
+  bb.0:
+    liveins: $sgpr0, $vgpr0
+
+    %0:sreg_32 = COPY $sgpr0
+    %1:vgpr_32 = COPY $vgpr0
+    %2:sreg_32 = S_MOV_B32 0
+    %3:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 %1, %2, implicit $exec
+    SI_BRCOND %bb.1, killed %3, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.2
+
+  bb.1:
+    S_BRANCH %bb.3
+
+  bb.2:
+    S_BRANCH %bb.3
+
+  bb.3:
+    %4:sreg_32 = PHI %0, %bb.1, %0, %bb.2
+    $sgpr0 = COPY %4
+    S_ENDPGM 0
+...
+
+---
+# SGPR PHI with three incoming edges all carrying the same register value.
+# The PHI should be simplified to the common register.
+name: simplify_sgpr_phi_all_same_three_inputs
+tracksRegLiveness: true
+body: |
+  ; CHECK-LABEL: name: simplify_sgpr_phi_all_same_three_inputs
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; CHECK-NEXT:   liveins: $sgpr0, $vgpr0, $vgpr1
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr0
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:vgpr_32 = COPY $vgpr1
+  ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
+  ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 [[COPY1]], [[S_MOV_B32_]], implicit $exec
+  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NE_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
+  ; CHECK-NEXT:   S_BRANCH %bb.2
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   successors: %bb.3(0x40000000), %bb.4(0x40000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 [[COPY2]], [[S_MOV_B32_]], implicit $exec
+  ; CHECK-NEXT:   SI_BRCOND %bb.3, killed [[V_CMP_NE_U32_e64_1]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
+  ; CHECK-NEXT:   S_BRANCH %bb.4
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   successors: %bb.4(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   S_BRANCH %bb.4
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.3:
+  ; CHECK-NEXT:   successors: %bb.4(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   S_BRANCH %bb.4
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.4:
+  ; CHECK-NEXT:   $sgpr0 = COPY [[COPY]]
+  ; CHECK-NEXT:   S_ENDPGM 0
+  bb.0:
+    liveins: $sgpr0, $vgpr0, $vgpr1
+
+    %0:sreg_32 = COPY $sgpr0
+    %1:vgpr_32 = COPY $vgpr0
+    %2:vgpr_32 = COPY $vgpr1
+    %3:sreg_32 = S_MOV_B32 0
+    %4:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 %1, %3, implicit $exec
+    SI_BRCOND %bb.1, killed %4, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.2
+
+  bb.1:
+    %5:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 %2, %3, implicit $exec
+    SI_BRCOND %bb.3, killed %5, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.4
+
+  bb.2:
+    S_BRANCH %bb.4
+
+  bb.3:
+    S_BRANCH %bb.4
+
+  bb.4:
+    %6:sreg_32 = PHI %0, %bb.1, %0, %bb.2, %0, %bb.3
+    $sgpr0 = COPY %6
+    S_ENDPGM 0
+...
+
+---
+# SGPR PHI with two different register values from two predecessors.
+# This PHI should NOT be simplified.
+name: no_simplify_sgpr_phi_different_values
+tracksRegLiveness: true
+body: |
+  ; CHECK-LABEL: name: no_simplify_sgpr_phi_different_values
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; CHECK-NEXT:   liveins: $sgpr0, $vgpr0
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr0
+  ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
+  ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 [[COPY1]], [[S_MOV_B32_]], implicit $exec
+  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NE_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
+  ; CHECK-NEXT:   S_BRANCH %bb.2
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   successors: %bb.3(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 42
+  ; CHECK-NEXT:   S_BRANCH %bb.3
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   successors: %bb.3(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   S_BRANCH %bb.3
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.3:
+  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:sreg_32 = PHI [[S_MOV_B32_1]], %bb.1, [[COPY]], %bb.2
+  ; CHECK-NEXT:   $sgpr0 = COPY [[PHI]]
+  ; CHECK-NEXT:   S_ENDPGM 0
+  bb.0:
+    liveins: $sgpr0, $vgpr0
+
+    %0:sreg_32 = COPY $sgpr0
+    %1:vgpr_32 = COPY $vgpr0
+    %2:sreg_32 = S_MOV_B32 0
+    %3:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 %1, %2, implicit $exec
+    SI_BRCOND %bb.1, killed %3, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.2
+
+  bb.1:
+    %4:sreg_32 = S_MOV_B32 42
+    S_BRANCH %bb.3
+
+  bb.2:
+    S_BRANCH %bb.3
+
+  bb.3:
+    %5:sreg_32 = PHI %4, %bb.1, %0, %bb.2
+    $sgpr0 = COPY %5
+    S_ENDPGM 0
+...

--- a/llvm/test/CodeGen/AMDGPU/si-lower-sgpr-spills-cycle-header.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-lower-sgpr-spills-cycle-header.ll
@@ -42,9 +42,9 @@ define amdgpu_kernel void @loop_sgpr_spill_implicit_def_in_preheader(
   ; CHECK-NEXT: bb.1.loop.header:
   ; CHECK-NEXT:   successors: %bb.2(0x40000000), %bb.3(0x40000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   $sgpr6 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 3
+  ; CHECK-NEXT:   $sgpr4 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 3
   ; CHECK-NEXT:   $sgpr5 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 4
-  ; CHECK-NEXT:   $sgpr4 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 5
+  ; CHECK-NEXT:   $sgpr6 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 5
   ; CHECK-NEXT:   $sgpr7 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 6
   ; CHECK-NEXT:   $sgpr8 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 7
   ; CHECK-NEXT:   $sgpr9 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 8
@@ -57,13 +57,11 @@ define amdgpu_kernel void @loop_sgpr_spill_implicit_def_in_preheader(
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR killed $sgpr9, 15, [[DEF]]
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR killed $sgpr8, 16, [[DEF]]
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR killed $sgpr7, 17, [[DEF]]
-  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR $sgpr4, 18, [[DEF]]
-  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR $sgpr5, 19, [[DEF]]
-  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR $sgpr6, 20, [[DEF]]
-  ; CHECK-NEXT:   renamable $sgpr7 = S_MOV_B32 0
-  ; CHECK-NEXT:   S_CMP_EQ_U32 renamable $sgpr6, killed renamable $sgpr7, implicit-def $scc
-  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR killed $sgpr5, 21, [[DEF]]
-  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR killed $sgpr4, 22, [[DEF]]
+  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR killed $sgpr6, 18, [[DEF]]
+  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR killed $sgpr5, 19, [[DEF]]
+  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR $sgpr4, 20, [[DEF]]
+  ; CHECK-NEXT:   renamable $sgpr5 = S_MOV_B32 0
+  ; CHECK-NEXT:   S_CMP_EQ_U32 renamable $sgpr4, killed renamable $sgpr5, implicit-def $scc
   ; CHECK-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit killed $scc
   ; CHECK-NEXT:   S_BRANCH %bb.3
   ; CHECK-NEXT: {{  $}}
@@ -80,7 +78,7 @@ define amdgpu_kernel void @loop_sgpr_spill_implicit_def_in_preheader(
   ; CHECK-NEXT:   $sgpr10 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 18
   ; CHECK-NEXT:   $sgpr11 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 19
   ; CHECK-NEXT:   renamable $sgpr13 = S_MOV_B32 1
-  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR $sgpr13, 23, [[DEF]]
+  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR $sgpr13, 21, [[DEF]]
   ; CHECK-NEXT:   renamable $sgpr11 = S_ADD_I32 renamable $sgpr11, renamable $sgpr13, implicit-def dead $scc
   ; CHECK-NEXT:   renamable $sgpr10 = S_ADD_I32 renamable $sgpr10, renamable $sgpr13, implicit-def dead $scc
   ; CHECK-NEXT:   renamable $sgpr9 = S_ADD_I32 renamable $sgpr9, renamable $sgpr13, implicit-def dead $scc
@@ -104,8 +102,8 @@ define amdgpu_kernel void @loop_sgpr_spill_implicit_def_in_preheader(
   ; CHECK-NEXT: bb.3.exit:
   ; CHECK-NEXT:   $sgpr4 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 0, implicit-def $sgpr4_sgpr5
   ; CHECK-NEXT:   $sgpr5 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 1
-  ; CHECK-NEXT:   $sgpr7 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 22
-  ; CHECK-NEXT:   $sgpr6 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 21
+  ; CHECK-NEXT:   $sgpr6 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 19
+  ; CHECK-NEXT:   $sgpr7 = SI_RESTORE_S32_FROM_VGPR [[DEF]], 18
   ; CHECK-NEXT:   renamable $sgpr6 = S_ADD_I32 killed renamable $sgpr6, killed renamable $sgpr7, implicit-def dead $scc
   ; CHECK-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY killed renamable $sgpr6


### PR DESCRIPTION
simplifyMachinePHI was only returning CommonReg inside the HasImplicitDefInput branch, so PHIs whose incoming edges all carry the same SGPR value but have no IMPLICIT_DEF inputs were never folded. Invert the dominance check to an early return for the IMPLICIT_DEF case and fall through to return CommonReg unconditionally.

Add test cases for two-input and three-input all-same-value PHI simplification, plus a negative test for different-value PHIs.


