### PR TITLE
Pass `-O0` by default for HIP no-RDC compilations

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10138,6 +10138,12 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         }
       }
 
+      // If no optimization level was requested we default to `-O0` for no-RDC
+      // mode compilations. Others default to `lto<O2>` as standard in ld.lld.
+      if (JA.getType() == types::TY_HIP_FATBIN &&
+          !ToolChainArgs.getLastArg(OPT_O_Group))
+        CompilerArgs.emplace_back("-O0");
+
       // If the user explicitly requested it via `--offload-arch` we should
       // extract it from any static libraries if present.
       for (StringRef Arg : ToolChainArgs.getAllArgValues(OPT_offload_arch_EQ))


### PR DESCRIPTION
Summary:
The change to the new driver used LTO. Clang defaults to O0 while LTO defaults to lto<O2>. The reason for this is because most people do not pass optimizations to the linker step and when linking libraries we will have some that need optimizations and some that don't. In RDC-mode, we only have a single <logical> TU, so we suppress optimizations.

Fixes: https://github.com/ROCm/ROCgdb/pull/231


