### PR TITLE
[Infra] Add permission for the teams_notifier workflow call

### DIFF
--- a/.github/workflows/rockci_multi_arch_nightly.yml
+++ b/.github/workflows/rockci_multi_arch_nightly.yml
@@ -127,6 +127,9 @@ jobs:
     needs:
       - windows_build_and_test
       - linux_build_and_test
+    permissions:
+      contents: read
+      actions: read        
     with:
         JOB_NAME_TO_MATCH: "Linux::release / Build Multi-Arch Stages / math-libs (gfx94X-dcgpu, gfx942, linux-gfx942-1gpu-ccs-csp-ossci-rocm, false) / Stage - Math Libs (gfx94X-dcgpu)"
     secrets: inherit


### PR DESCRIPTION
Follow-up to https://github.com/ROCm/llvm-project/pull/3689, which added a top-level permissions block to teams_notifier.yml (contents: read, actions: read).

Callers that only declare contents: read now pass actions: none into that reusable workflow, so GitHub rejects the call. Add actions: read on the invoke-teams-notifier jobs in rockci_multi_arch_nightly.yml