### PR TITLE
[flang][test] Un-XFAIL the AMDGPU debug integration tests

### DIFF
--- a/flang/test/Integration/amdgpu/debug-declare-target-function-var.f90
+++ b/flang/test/Integration/amdgpu/debug-declare-target-function-var.f90
@@ -1,5 +1,4 @@
 ! RUN: %flang_fc1 -triple amdgcn-amd-amdhsa -emit-llvm -fopenmp  -fopenmp-is-target-device -debug-info-kind=standalone %s -o - | FileCheck  %s
-! XFAIL: *
 function add(a, b) result(ret)
   real ret
   real a
@@ -12,9 +11,9 @@ function add(a, b) result(ret)
   end if
 end
 
-!CHECK: define float @add_({{.*}}){{.*}}!dbg ![[SP:[0-9]+]] {
-!CHECK: #dbg_declare({{.*}}, ![[A:[0-9]+]], !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpDeref(ptr), DIOpDeref(ptr)), !{{.*}})
-!CHECK: #dbg_declare({{.*}}, ![[B:[0-9]+]], !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpDeref(ptr), DIOpDeref(ptr)), !{{.*}})
+!CHECK: define{{.*}}float @add_({{.*}}){{.*}}!dbg ![[SP:[0-9]+]] {
+!CHECK: #dbg_declare({{.*}}, ![[A:[0-9]+]], !DIExpression(DIOpArg(0, ptr), DIOpDeref(ptr)), !{{.*}})
+!CHECK: #dbg_declare({{.*}}, ![[B:[0-9]+]], !DIExpression(DIOpArg(0, ptr), DIOpDeref(ptr)), !{{.*}})
 !CHECK: #dbg_declare({{.*}}, ![[RET:[0-9]+]], !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpDeref(float)), !{{.*}})
 !CHECK: }
 !CHECK: ![[SP]] = {{.*}}!DISubprogram(name: "add"{{.*}})

--- a/flang/test/Integration/amdgpu/debug-target-var.f90
+++ b/flang/test/Integration/amdgpu/debug-target-var.f90
@@ -1,5 +1,4 @@
 ! RUN: %flang_fc1 -triple amdgcn-amd-amdhsa -emit-llvm -fopenmp -fopenmp-is-target-device -debug-info-kind=standalone %s -o - | FileCheck  %s
-! XFAIL: *
 subroutine fff(x, y)
   implicit none
   integer :: y(:)
@@ -25,6 +24,6 @@ end subroutine fff
 
 ! CHECK-DAG: ![[SP]] = {{.*}}!DISubprogram(name: "[[FN]]"{{.*}})
 ! CHECK-DAG: ![[X]] = !DILocalVariable(name: "x", arg: 1, scope: ![[SP]]{{.*}}type: ![[INT:[0-9]+]])
-! CHECK-DAG: ![[INT]] = !DIBasicType(name: "integer", size: 32, encoding: DW_ATE_signed)
+! CHECK-DAG: ![[INT]] = !DIBasicType(name: "integer(kind=4)", size: 32, encoding: DW_ATE_signed)
 ! CHECK-DAG: ![[Y]] = !DILocalVariable(name: "y", arg: 2, scope: ![[SP]]{{.*}}type: ![[ARR:[0-9]+]])
 ! CHECK-DAG: ![[ARR]] = !DICompositeType(tag: DW_TAG_array_type, baseType: ![[INT]]{{.*}})


### PR DESCRIPTION
Both tests were failing only because their expectations had not kept up with intentional changes to the output, so the XFAIL was hiding nothing.

debug-declare-target-function-var.f90 expected the dummy arguments to be described through the extra alloca that declare target functions used to carry:

  DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpDeref(ptr), DIOpDeref(ptr))

f746817674bc removed those allocas, so the variables are now described directly on the incoming argument with one fewer indirection. That commit updated omptarget-decl-target-fn-debug-amdgpu.mlir, which asserts the same shape and was XFAILed for the same reason on the same day, but it did not touch this test. Since then 22e5273cc333 gave device declare target functions hidden visibility, which the literal 'define float' pattern did not allow for.

debug-target-var.f90 expected the name "integer" where flang now spells the type "integer(kind=4)". Its declares still go through allocas and still match, because those belong to a target kernel rather than to a declare target function.

The variables and their locations are checked as before; only the patterns that had gone stale are updated.


