### PR TITLE
[llvm] Change the implementation of isValidFeatureListFormat

### DIFF
--- a/llvm/lib/MC/TargetRegistry.cpp
+++ b/llvm/lib/MC/TargetRegistry.cpp
@@ -16,7 +16,6 @@
 #include "llvm/MC/MCLFI.h"
 #include "llvm/MC/MCObjectStreamer.h"
 #include "llvm/MC/MCObjectWriter.h"
-#include "llvm/Support/Regex.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <vector>
@@ -29,8 +28,17 @@ bool Target::isValidFeatureListFormat(StringRef Features) {
   if (Features.empty())
     return true;
 
-  static const llvm::Regex pattern("^([+-][^,]+)(,[+-][^,]+)*,?$");
-  return pattern.match(Features);
+  // Each feature starts with '+'/'-' followed by at least one non-comma
+  // character. Features are comma-separated with an optional trailing comma.
+  for (size_t I = 0, E = Features.size(); I != E; ++I) {
+    if (I == 0 || Features[I - 1] == ',') {
+      // At the start of a feature: must have a sign and a non-empty name.
+      if ((Features[I] != '+' && Features[I] != '-') ||
+          I + 1 == Features.size() || Features[I + 1] == ',')
+        return false;
+    }
+  }
+  return true;
 }
 
 MCStreamer *Target::createMCObjectStreamer(


### PR DESCRIPTION
Cherry-picks https://github.com/llvm/llvm-project/pull/219266 into `amd-staging` ahead of the normal upstream merge, because we need it sooner than the merge cadence would deliver it.

Upstream PR summary: `Target::isValidFeatureListFormat` used a function-local `static const llvm::Regex`, which causes static initialization order problems for some programs (and the LLVM coding standards advise against statics with ctors/dtors). The replacement is a plain scan loop, which also drops the `llvm/Support/Regex.h` dependency from this TU.

### Cherry-pick details

The upstream PR is still open and has 4 commits (1 substantive + 3 review fixups), so this is the squashed PR diff against its merge-base, applied as a single commit and attributed to the upstream author. There is no upstream commit SHA to reference yet, so the trailer cites the PR URL and head SHA (`71557a8849ba35fdf1723f208ffcf179be90bde9`) rather than the usual `cherry picked from commit` line.

`amd-staging`'s copy of `llvm/lib/MC/TargetRegistry.cpp` is byte-identical to the PR's base, so the diff applied cleanly with no adaptation.

### Verification

- Behavioral equivalence against the regex it replaces (`^([+-][^,]+)(,[+-][^,]+)*,?$`): exhaustively compared over all 19,531 strings of length <= 6 drawn from `{+, -, ',', a, b}` -- no differences.
- The existing `llvm/unittests/MC/TargetRegistry.cpp` `IsValidFeatureListFormat` test already covers this function on `amd-staging`; all 23 assertions pass against the new implementation, including the whitespace cases outside the fuzzing alphabet.

### Follow-up

When #219266 lands upstream and the next `main` -> `amd-staging` merge runs, both sides will have modified this hunk. If the landed version matches what is picked here, the merge resolves cleanly; if the implementation changes during review, that merge will conflict and should be resolved in favor of the upstream version.
