### PR TITLE
[openmp] - Update openmp-config.cmake install location

### DIFF
--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -62,7 +62,7 @@ else()
       "Path where built OpenMP libraries should be installed.")
 endif()
 
-set(OPENMP_INSTALL_CFGDIR "lib/cmake" CACHE STRING
+set(OPENMP_INSTALL_CFGDIR "lib${LLVM_LIBDIR_SUFFIX}/cmake" CACHE STRING
       "Path where OpenMP config should be installed")
 
 set(OPENMP_TEST_C_COMPILER_default "${LLVM_TOOLS_BINARY_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}")


### PR DESCRIPTION
When the debug, perf, and asan standalone builds are enabled they are all installing/overriding the config in lib/llvm/lib/cmake/openmp. They should install their config in the lib directory instead. For example, lib-debug/cmake.

Eventually these standalone builds will be replaced by multilib versions. This is just correcting an existing issue, until the replacements manifest.


