### PR TITLE
[offload] Re-enable InfoIdToODT static_assert, dropping #if FIXME guard

### DIFF
--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -698,9 +698,7 @@ template <uint32_t InfoId> static constexpr const char *InfoIdToODT() {
   };
 
   constexpr const char *result = getId();
-#if FIXME
   static_assert(result != nullptr, "Unknown InfoId being used");
-#endif
   return result;
 }
 


### PR DESCRIPTION
`InfoIdToODT()` in `offload/include/Shared/Debug.h` guards its `static_assert` with `#if FIXME`. `FIXME` is never defined anywhere in the tree, so the preprocessor evaluates it as `0` and the assertion has been dead code rather than a check. Anything that instantiates the template with an unhandled `InfoId` silently gets a null debug-type string instead of the intended build error.

Upstream `llvm/llvm-project` carries this function character-for-character identically except that the `static_assert` is live. Dropping the two guard lines is the entire difference, so this removes a downstream-only delta in `Debug.h` and restores the diagnostic.

Filed as part of the amd-staging upstream-divergence reduction effort.

If CI surfaces an amd-staging-only `INFO()` call site that passes an `InfoId` the switch does not handle, that call site is the actual bug the assertion was written to catch, and the fix is to add the missing case rather than to re-disable the assert.