### PR TITLE
[Comgr][Hotswap] Rename OpResolver to OperandResolver

### DIFF
--- a/amd/comgr/src/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/raiser/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(hotswap-raiser OBJECT
   user-sgpr-layout.cpp
   register-state.cpp
   raise-context.cpp
-  op-resolver.cpp
+  operand-resolver.cpp
   flat-addr.cpp
   handle-flat.cpp
   handle-smem.cpp

--- a/amd/comgr/src/hotswap/raiser/handle-flat.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-flat.cpp
@@ -13,7 +13,7 @@
 #include "hotswap/decoder/decoded-inst.h"
 #include "hotswap/decoder/parsed-reg.h"
 #include "hotswap/raiser/flat-addr.h"
-#include "hotswap/raiser/op-resolver.h"
+#include "hotswap/raiser/operand-resolver.h"
 #include "hotswap/raiser/raise-context.h"
 
 #include "llvm/IR/Instructions.h"
@@ -29,7 +29,7 @@ namespace COMGR::hotswap {
 static constexpr Align DwordGlobalAccessAlignment = Align::Constant<4>();
 
 static Error emitGlobalLoad(RaiseContext &Ctx, const DecodedInst &Di,
-                            OpResolver &Op) {
+                            OperandResolver &Op) {
   Expected<ParsedReg> Destination = Op.dst();
   if (!Destination)
     return Destination.takeError();
@@ -69,7 +69,8 @@ static Error emitGlobalStore(RaiseContext &Ctx, const DecodedInst &Di) {
   return Error::success();
 }
 
-Error handleFLAT(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op) {
+Error handleFLAT(RaiseContext &Ctx, const DecodedInst &Di,
+                 OperandResolver &Op) {
   switch (Di.CanonOp) {
   case CanonicalOp::GLOBAL_LOAD_B32:
     return emitGlobalLoad(Ctx, Di, Op);

--- a/amd/comgr/src/hotswap/raiser/handle-smem.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-smem.cpp
@@ -14,7 +14,7 @@
 #include "hotswap/decoder/decoded-inst.h"
 #include "hotswap/decoder/mc-state.h"
 #include "hotswap/decoder/parsed-reg.h"
-#include "hotswap/raiser/op-resolver.h"
+#include "hotswap/raiser/operand-resolver.h"
 #include "hotswap/raiser/raise-context.h"
 
 #include "llvm/IR/Constants.h"
@@ -98,7 +98,7 @@ static std::optional<unsigned> scalarLoadWidthInDwords(CanonicalOp Operation) {
   }
 }
 
-Error handleSMEM(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &) {
+Error handleSMEM(RaiseContext &Ctx, const DecodedInst &Di, OperandResolver &) {
   std::optional<unsigned> LoadWidthInDwords =
       scalarLoadWidthInDwords(Di.CanonOp);
   if (!LoadWidthInDwords)

--- a/amd/comgr/src/hotswap/raiser/handle-sop1.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-sop1.cpp
@@ -12,7 +12,8 @@ using namespace llvm;
 
 namespace COMGR::hotswap {
 
-Error handleSOP1(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op) {
+Error handleSOP1(RaiseContext &Ctx, const DecodedInst &Di,
+                 OperandResolver &Op) {
   if (Di.CanonOp == CanonicalOp::S_MOV_B32) {
     Expected<ParsedReg> Dst = Op.dst();
     if (!Dst)

--- a/amd/comgr/src/hotswap/raiser/handle-sop2.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-sop2.cpp
@@ -17,7 +17,7 @@ namespace COMGR::hotswap {
 namespace {
 
 // Read the destination, a 64-bit source, and a 32-bit source.
-Expected<BinaryOperands> readBinary64x32(OpResolver &Op) {
+Expected<BinaryOperands> readBinary64x32(OperandResolver &Op) {
   Expected<ParsedReg> Dst = Op.dst();
   if (!Dst)
     return Dst.takeError();
@@ -87,7 +87,7 @@ Value *emitBitOp(IRBuilder<> &B, BitOp Op, Value *A, Value *Bv,
 }
 
 // Raise a bitwise instruction and preserve wave-mask and SCC state.
-Error handleBitOp(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op,
+Error handleBitOp(RaiseContext &Ctx, const DecodedInst &Di, OperandResolver &Op,
                   BitOp Kind, bool Is64, const Twine &Name) {
   Expected<Value *> SrcMask0 = Op.srcWaveMaskI1(0);
   if (!SrcMask0)
@@ -131,7 +131,7 @@ Error handleBitOp(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op,
 }
 
 // Raise a 32-bit shift and set SCC if its result is nonzero.
-Error handleShift32(RaiseContext &Ctx, OpResolver &Op,
+Error handleShift32(RaiseContext &Ctx, OperandResolver &Op,
                     Instruction::BinaryOps Opcode, const Twine &Name) {
   Expected<BinaryOperands> Args = Op.readBinary32();
   if (!Args)
@@ -144,7 +144,7 @@ Error handleShift32(RaiseContext &Ctx, OpResolver &Op,
 }
 
 // Raise a 64-bit shift and set SCC if its result is nonzero.
-Error handleShift64(RaiseContext &Ctx, OpResolver &Op,
+Error handleShift64(RaiseContext &Ctx, OperandResolver &Op,
                     Instruction::BinaryOps Opcode, const Twine &Name) {
   Expected<BinaryOperands> Args = readBinary64x32(Op);
   if (!Args)
@@ -159,7 +159,7 @@ Error handleShift64(RaiseContext &Ctx, OpResolver &Op,
 }
 
 // Raise a shifted 32-bit addition and set SCC on unsigned overflow.
-Error handleLshlAdd(RaiseContext &Ctx, OpResolver &Op, unsigned Shift,
+Error handleLshlAdd(RaiseContext &Ctx, OperandResolver &Op, unsigned Shift,
                     const Twine &Name) {
   Expected<BinaryOperands> Args = Op.readBinary32();
   if (!Args)
@@ -178,7 +178,7 @@ Error handleLshlAdd(RaiseContext &Ctx, OpResolver &Op, unsigned Shift,
 
 // Raise a 32-bit binary instruction, writing the intrinsic result and overflow
 // flag to the destination and SCC.
-Error handleOverflowingBinary32(RaiseContext &Ctx, OpResolver &Op,
+Error handleOverflowingBinary32(RaiseContext &Ctx, OperandResolver &Op,
                                 Intrinsic::ID IntrinsicID,
                                 const Twine &ResultName,
                                 const Twine &OverflowName) {
@@ -197,7 +197,8 @@ Error handleOverflowingBinary32(RaiseContext &Ctx, OpResolver &Op,
 } // namespace
 
 // Raise one SOP2 instruction and preserve its SCC side effects.
-Error handleSOP2(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op) {
+Error handleSOP2(RaiseContext &Ctx, const DecodedInst &Di,
+                 OperandResolver &Op) {
   switch (Di.CanonOp) {
   case CanonicalOp::S_AND_B32:
     return handleBitOp(Ctx, Di, Op, BitOp::And, false, "and");

--- a/amd/comgr/src/hotswap/raiser/handle-sopc.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-sopc.cpp
@@ -126,7 +126,7 @@ bool isFloat16Compare(CanonicalOp Opcode) {
 }
 
 // Raise a 32-bit integer comparison and write its result to SCC.
-Error handleIntegerCompare(RaiseContext &Ctx, OpResolver &Op,
+Error handleIntegerCompare(RaiseContext &Ctx, OperandResolver &Op,
                            CmpInst::Predicate Pred) {
   Expected<Value *> Src0 = Op.src(0);
   if (!Src0)
@@ -140,7 +140,7 @@ Error handleIntegerCompare(RaiseContext &Ctx, OpResolver &Op,
 }
 
 // Raise a 64-bit integer comparison and write its result to SCC.
-Error handleInteger64Compare(RaiseContext &Ctx, OpResolver &Op,
+Error handleInteger64Compare(RaiseContext &Ctx, OperandResolver &Op,
                              CmpInst::Predicate Pred) {
   Expected<Value *> Src0 = Op.src64(0);
   if (!Src0)
@@ -154,7 +154,7 @@ Error handleInteger64Compare(RaiseContext &Ctx, OpResolver &Op,
 }
 
 // Raise a floating-point comparison and write its result to SCC.
-Error handleFloatCompare(RaiseContext &Ctx, OpResolver &Op,
+Error handleFloatCompare(RaiseContext &Ctx, OperandResolver &Op,
                          CmpInst::Predicate Pred, bool IsF16) {
   Expected<Value *> Src0 = Op.src(0);
   if (!Src0)
@@ -181,7 +181,7 @@ Error handleFloatCompare(RaiseContext &Ctx, OpResolver &Op,
 }
 
 // Raise a 32-bit bit test and write the requested bit value to SCC.
-Error handleBitCompare32(RaiseContext &Ctx, OpResolver &Op,
+Error handleBitCompare32(RaiseContext &Ctx, OperandResolver &Op,
                          CmpInst::Predicate Pred) {
   Expected<Value *> Src0 = Op.src(0);
   if (!Src0)
@@ -200,7 +200,7 @@ Error handleBitCompare32(RaiseContext &Ctx, OpResolver &Op,
 }
 
 // Raise a 64-bit bit test and write the requested bit value to SCC.
-Error handleBitCompare64(RaiseContext &Ctx, OpResolver &Op,
+Error handleBitCompare64(RaiseContext &Ctx, OperandResolver &Op,
                          CmpInst::Predicate Pred) {
   Expected<Value *> Src0 = Op.src64(0);
   if (!Src0)
@@ -223,7 +223,8 @@ Error handleBitCompare64(RaiseContext &Ctx, OpResolver &Op,
 } // namespace
 
 // Raise one SOPC instruction and write its comparison result to SCC.
-Error handleSOPC(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op) {
+Error handleSOPC(RaiseContext &Ctx, const DecodedInst &Di,
+                 OperandResolver &Op) {
   if (std::optional<CmpInst::Predicate> Pred = integerPredicate(Di.CanonOp))
     return handleIntegerCompare(Ctx, Op, *Pred);
 

--- a/amd/comgr/src/hotswap/raiser/handle-sopk.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-sopk.cpp
@@ -146,8 +146,8 @@ void updateImmediateModeVgprMsb(RaiseContext &Ctx, uint64_t Value) {
 
 // Raise a hardware-register read according to Policy.
 Error handleGetreg(RaiseContext &Ctx, const DecodedInst &Di,
-                   OperandResolver &Op,
-                   unsigned Id, HardwareRegisterPolicy Policy) {
+                   OperandResolver &Op, unsigned Id,
+                   HardwareRegisterPolicy Policy) {
   if (Policy.Read == HardwareRegisterReadAction::Reject)
     return unsupportedInstruction(
         Ctx, Di,
@@ -162,9 +162,9 @@ Error handleGetreg(RaiseContext &Ctx, const DecodedInst &Di,
 
 // Raise a hardware-register write according to Policy.
 Error handleSetreg(RaiseContext &Ctx, const DecodedInst &Di,
-                   OperandResolver &Op,
-                   unsigned Selector, unsigned Id, unsigned BitOffset,
-                   unsigned BitWidth, HardwareRegisterPolicy Policy) {
+                   OperandResolver &Op, unsigned Selector, unsigned Id,
+                   unsigned BitOffset, unsigned BitWidth,
+                   HardwareRegisterPolicy Policy) {
   if (Policy.Write == HardwareRegisterWriteAction::Reject)
     return unsupportedInstruction(
         Ctx, Di,

--- a/amd/comgr/src/hotswap/raiser/handle-sopk.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-sopk.cpp
@@ -145,7 +145,8 @@ void updateImmediateModeVgprMsb(RaiseContext &Ctx, uint64_t Value) {
 }
 
 // Raise a hardware-register read according to Policy.
-Error handleGetreg(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op,
+Error handleGetreg(RaiseContext &Ctx, const DecodedInst &Di,
+                   OperandResolver &Op,
                    unsigned Id, HardwareRegisterPolicy Policy) {
   if (Policy.Read == HardwareRegisterReadAction::Reject)
     return unsupportedInstruction(
@@ -160,7 +161,8 @@ Error handleGetreg(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op,
 }
 
 // Raise a hardware-register write according to Policy.
-Error handleSetreg(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op,
+Error handleSetreg(RaiseContext &Ctx, const DecodedInst &Di,
+                   OperandResolver &Op,
                    unsigned Selector, unsigned Id, unsigned BitOffset,
                    unsigned BitWidth, HardwareRegisterPolicy Policy) {
   if (Policy.Write == HardwareRegisterWriteAction::Reject)
@@ -201,7 +203,8 @@ Error handleSetreg(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op,
 } // namespace
 
 // Raise a hardware-register SOPK instruction.
-Error handleSOPK(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op) {
+Error handleSOPK(RaiseContext &Ctx, const DecodedInst &Di,
+                 OperandResolver &Op) {
   switch (Di.CanonOp) {
   case CanonicalOp::S_GETREG_B32:
   case CanonicalOp::S_SETREG_B32:

--- a/amd/comgr/src/hotswap/raiser/handle-sopp.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-sopp.cpp
@@ -78,7 +78,7 @@ Error raiseWavePriority(RaiseContext &Ctx, const DecodedInst &Di) {
 
 } // namespace
 
-Error handleSOPP(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &) {
+Error handleSOPP(RaiseContext &Ctx, const DecodedInst &Di, OperandResolver &) {
   switch (Di.CanonOp) {
   case CanonicalOp::S_ENDPGM:
     Ctx.B.CreateRetVoid();

--- a/amd/comgr/src/hotswap/raiser/handle-vop2.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-vop2.cpp
@@ -11,7 +11,7 @@
 #include "hotswap/decoder/canonical-op.h"
 #include "hotswap/decoder/decoded-inst.h"
 #include "hotswap/decoder/parsed-reg.h"
-#include "hotswap/raiser/op-resolver.h"
+#include "hotswap/raiser/operand-resolver.h"
 #include "hotswap/raiser/raise-context.h"
 
 #include "llvm/ADT/STLFunctionalExtras.h"
@@ -33,7 +33,8 @@ namespace COMGR::hotswap {
 using BinaryBuilder = function_ref<Value *(IRBuilder<> &, Value *, Value *)>;
 
 static Error raiseFloatBinary(RaiseContext &Ctx, const DecodedInst &Di,
-                              OpResolver &Op, Instruction::BinaryOps Opcode,
+                              OperandResolver &Op,
+                              Instruction::BinaryOps Opcode,
                               bool ReverseOperands) {
   if (Di.NumDefs != 1 || Di.numOperands() == 0 || !Di.isReg(0) ||
       Op.nSrcs() != 2) {
@@ -62,7 +63,7 @@ static Error raiseFloatBinary(RaiseContext &Ctx, const DecodedInst &Di,
 
 // Build a 32-bit result from two integer sources and write it to the
 // destination.
-static Error raiseBinary32(RaiseContext &Ctx, OpResolver &Op,
+static Error raiseBinary32(RaiseContext &Ctx, OperandResolver &Op,
                            BinaryBuilder Build) {
   Expected<BinaryOperands> Args = Op.readBinary32();
   if (!Args) {
@@ -73,7 +74,7 @@ static Error raiseBinary32(RaiseContext &Ctx, OpResolver &Op,
 }
 
 // Raise a low-16-bit binary operation and zero-extend its result to 32 bits.
-static Error raiseBinary16(RaiseContext &Ctx, OpResolver &Op,
+static Error raiseBinary16(RaiseContext &Ctx, OperandResolver &Op,
                            BinaryBuilder Build) {
   return raiseBinary32(Ctx, Op, [&](IRBuilder<> &B, Value *Src0, Value *Src1) {
     Type *I16Ty = B.getInt16Ty();
@@ -94,7 +95,7 @@ static void writeResultAndVCC(RaiseContext &Ctx, ParsedReg Dst, Value *Result,
 }
 
 // Raise a binary operation that writes carry or borrow to VCC.
-static Error raiseBinary32WriteVCC(RaiseContext &Ctx, OpResolver &Op,
+static Error raiseBinary32WriteVCC(RaiseContext &Ctx, OperandResolver &Op,
                                    Intrinsic::ID IntrinsicID,
                                    bool ReverseOperands) {
   Expected<BinaryOperands> Args = Op.readBinary32();
@@ -113,7 +114,7 @@ static Error raiseBinary32WriteVCC(RaiseContext &Ctx, OpResolver &Op,
 
 // Raise a binary operation that reads carry or borrow from VCC and writes the
 // updated carry or borrow back to VCC.
-static Error raiseBinary32ReadWriteVCC(RaiseContext &Ctx, OpResolver &Op,
+static Error raiseBinary32ReadWriteVCC(RaiseContext &Ctx, OperandResolver &Op,
                                        Intrinsic::ID IntrinsicID,
                                        bool ReverseOperands) {
   Expected<BinaryOperands> Args = Op.readBinary32();
@@ -138,7 +139,7 @@ static Error raiseBinary32ReadWriteVCC(RaiseContext &Ctx, OpResolver &Op,
 }
 
 // Select src1 when the current lane's VCC bit is set, otherwise src0.
-static Error raiseCndMask(RaiseContext &Ctx, OpResolver &Op) {
+static Error raiseCndMask(RaiseContext &Ctx, OperandResolver &Op) {
   Expected<BinaryOperands> Args = Op.readBinary32();
   if (!Args) {
     return Args.takeError();
@@ -151,7 +152,7 @@ static Error raiseCndMask(RaiseContext &Ctx, OpResolver &Op) {
 
 // Accumulate signed products of packed source elements, using the destination's
 // incoming value as the accumulator.
-static Error raiseSignedDotAccumulate(RaiseContext &Ctx, OpResolver &Op,
+static Error raiseSignedDotAccumulate(RaiseContext &Ctx, OperandResolver &Op,
                                       unsigned ElementWidthInBits) {
   assert(Op.nSrcs() == 3 && "dot accumulate must have three sources");
   Expected<BinaryOperands> Args = Op.readBinary32();
@@ -187,7 +188,7 @@ static Error raiseSignedDotAccumulate(RaiseContext &Ctx, OpResolver &Op,
 
 // Build a 64-bit result from two integer sources and write it to the
 // destination.
-static Error raiseBinary64(RaiseContext &Ctx, OpResolver &Op,
+static Error raiseBinary64(RaiseContext &Ctx, OperandResolver &Op,
                            BinaryBuilder Build) {
   Expected<BinaryOperands> Args = Op.readBinary64();
   if (!Args) {
@@ -216,7 +217,7 @@ static Value *extendLow24(IRBuilder<> &B, Value *Source, Type *Ty,
 }
 
 // Raise a 24-bit multiply returning the low 32 bits of the product.
-static Error raiseMul24(RaiseContext &Ctx, OpResolver &Op, bool IsSigned) {
+static Error raiseMul24(RaiseContext &Ctx, OperandResolver &Op, bool IsSigned) {
   return raiseBinary32(Ctx, Op,
                        [IsSigned](IRBuilder<> &B, Value *Src0, Value *Src1) {
                          Type *I32Ty = B.getInt32Ty();
@@ -228,7 +229,8 @@ static Error raiseMul24(RaiseContext &Ctx, OpResolver &Op, bool IsSigned) {
 
 // Raise a 24-bit multiply returning bits [63:32] of the sign- or
 // zero-extended 64-bit product.
-static Error raiseMulHi24(RaiseContext &Ctx, OpResolver &Op, bool IsSigned) {
+static Error raiseMulHi24(RaiseContext &Ctx, OperandResolver &Op,
+                          bool IsSigned) {
   return raiseBinary32(
       Ctx, Op, [IsSigned](IRBuilder<> &B, Value *Src0, Value *Src1) {
         Type *I64Ty = B.getInt64Ty();
@@ -243,7 +245,7 @@ static Error raiseMulHi24(RaiseContext &Ctx, OpResolver &Op, bool IsSigned) {
 
 // Raise `v_lshlrev_b64`, whose src0 is a 32-bit shift amount while its src1
 // and destination are 64 bits.
-static Error raiseShiftLeft64(RaiseContext &Ctx, OpResolver &Op) {
+static Error raiseShiftLeft64(RaiseContext &Ctx, OperandResolver &Op) {
   Expected<ParsedReg> Dst = Op.dst();
   if (!Dst) {
     return Dst.takeError();
@@ -262,7 +264,8 @@ static Error raiseShiftLeft64(RaiseContext &Ctx, OpResolver &Op) {
   return Error::success();
 }
 
-Error handleVOP2(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op) {
+Error handleVOP2(RaiseContext &Ctx, const DecodedInst &Di,
+                 OperandResolver &Op) {
   switch (Di.CanonOp) {
   case CanonicalOp::V_ADD_F32:
     return raiseFloatBinary(Ctx, Di, Op, Instruction::FAdd,

--- a/amd/comgr/src/hotswap/raiser/handle-vopc.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-vopc.cpp
@@ -10,7 +10,7 @@
 
 #include "hotswap/decoder/canonical-op.h"
 #include "hotswap/decoder/decoded-inst.h"
-#include "hotswap/raiser/op-resolver.h"
+#include "hotswap/raiser/operand-resolver.h"
 #include "hotswap/raiser/raise-context.h"
 #include "hotswap/raiser/register-state.h"
 
@@ -24,7 +24,8 @@ using namespace llvm;
 
 namespace COMGR::hotswap {
 
-Error handleVOPC(RaiseContext &Ctx, const DecodedInst &Di, OpResolver &Op) {
+Error handleVOPC(RaiseContext &Ctx, const DecodedInst &Di,
+                 OperandResolver &Op) {
   ICmpInst::Predicate Pred;
   switch (Di.CanonOp) {
   case CanonicalOp::V_CMP_LT_I32:

--- a/amd/comgr/src/hotswap/raiser/handlers.h
+++ b/amd/comgr/src/hotswap/raiser/handlers.h
@@ -12,7 +12,7 @@
 #include "hotswap/decoder/amdgpu-formats.h"
 #include "hotswap/decoder/decoded-inst.h"
 #include "hotswap/decoder/mc-state.h"
-#include "hotswap/raiser/op-resolver.h"
+#include "hotswap/raiser/operand-resolver.h"
 #include "hotswap/raiser/raise-context.h"
 #include "hotswap/raiser/raise_failure.h"
 
@@ -36,31 +36,31 @@ inline llvm::Error unsupported(const RaiseContext &Ctx, const DecodedInst &Di,
 // does not recognize the opcode returns a `RaiseFailure` rather than declining:
 // no later handler gets the chance to claim it.
 llvm::Error handleSOP1(RaiseContext &Ctx, const DecodedInst &Di,
-                       OpResolver &Op);
+                       OperandResolver &Op);
 llvm::Error handleSOP2(RaiseContext &Ctx, const DecodedInst &Di,
-                       OpResolver &Op);
+                       OperandResolver &Op);
 llvm::Error handleSOPC(RaiseContext &Ctx, const DecodedInst &Di,
-                       OpResolver &Op);
+                       OperandResolver &Op);
 llvm::Error handleSOPK(RaiseContext &Ctx, const DecodedInst &Di,
-                       OpResolver &Op);
+                       OperandResolver &Op);
 llvm::Error handleSOPP(RaiseContext &Ctx, const DecodedInst &Di,
-                       OpResolver &Op);
+                       OperandResolver &Op);
 // Translate supported SMEM loads or return a structured refusal.
 llvm::Error handleSMEM(RaiseContext &Ctx, const DecodedInst &Di,
-                       OpResolver &Op);
+                       OperandResolver &Op);
 // Translate supported GLOBAL memory accesses, or return a structured refusal.
 // The format covers flat, global and scratch addressing; only the global forms
 // are recognized and the rest are refused.
 llvm::Error handleFLAT(RaiseContext &Ctx, const DecodedInst &Di,
-                       OpResolver &Op);
+                       OperandResolver &Op);
 /// Translate a supported plain VOP2 instruction, or return a structured
 /// refusal.
 llvm::Error handleVOP2(RaiseContext &Ctx, const DecodedInst &Di,
-                       OpResolver &Op);
+                       OperandResolver &Op);
 /// Translate a supported plain VOPC comparison into the condition registers
 /// the opcode writes, or return a structured refusal.
 llvm::Error handleVOPC(RaiseContext &Ctx, const DecodedInst &Di,
-                       OpResolver &Op);
+                       OperandResolver &Op);
 
 } // namespace COMGR::hotswap
 

--- a/amd/comgr/src/hotswap/raiser/operand-resolver.cpp
+++ b/amd/comgr/src/hotswap/raiser/operand-resolver.cpp
@@ -1,4 +1,4 @@
-//===- op-resolver.cpp - Hotswap transpiler -------------------------------===//
+//===- operand-resolver.cpp - Hotswap transpiler --------------------------===//
 //
 // Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
 // amd/comgr/LICENSE.TXT in this repository for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "hotswap/raiser/op-resolver.h"
+#include "hotswap/raiser/operand-resolver.h"
 
 #include "llvm/IR/Intrinsics.h"
 
@@ -16,7 +16,7 @@ using namespace llvm;
 
 namespace COMGR::hotswap {
 
-unsigned OpResolver::srcMod(unsigned I) const {
+unsigned OperandResolver::srcMod(unsigned I) const {
   assert(I < Di.ModMap.size() && "source modifier index out of range");
   unsigned ModIdx = Di.ModMap[I];
   if (ModIdx == UINT_MAX)
@@ -25,7 +25,7 @@ unsigned OpResolver::srcMod(unsigned I) const {
   return static_cast<unsigned>(Di.getImm(ModIdx) & 0xF);
 }
 
-Value *OpResolver::applyMods(unsigned I, Value *V) {
+Value *OperandResolver::applyMods(unsigned I, Value *V) {
   unsigned Mods = srcMod(I);
   if (Mods == 0)
     return V;
@@ -41,14 +41,14 @@ Value *OpResolver::applyMods(unsigned I, Value *V) {
   return V;
 }
 
-Expected<Value *> OpResolver::srcF(unsigned I) {
+Expected<Value *> OperandResolver::srcF(unsigned I) {
   Expected<Value *> V = Ctx.registers().readOp32(Di, srcIdx(I));
   if (!V)
     return V.takeError();
   return applyMods(I, *V);
 }
 
-Expected<std::optional<ParsedReg>> OpResolver::srcReg(unsigned I) {
+Expected<std::optional<ParsedReg>> OperandResolver::srcReg(unsigned I) {
   unsigned Index = srcIdx(I);
   if (!Di.isReg(Index))
     return std::optional<ParsedReg>();
@@ -58,7 +58,7 @@ Expected<std::optional<ParsedReg>> OpResolver::srcReg(unsigned I) {
   return std::optional<ParsedReg>(*Reg);
 }
 
-Expected<BinaryOperands> OpResolver::readBinary32() {
+Expected<BinaryOperands> OperandResolver::readBinary32() {
   Expected<ParsedReg> Dst = dst();
   if (!Dst)
     return Dst.takeError();
@@ -71,7 +71,7 @@ Expected<BinaryOperands> OpResolver::readBinary32() {
   return BinaryOperands{*Dst, *Src0, *Src1};
 }
 
-Expected<BinaryOperands> OpResolver::readBinary64() {
+Expected<BinaryOperands> OperandResolver::readBinary64() {
   Expected<ParsedReg> Dst = dst();
   if (!Dst)
     return Dst.takeError();

--- a/amd/comgr/src/hotswap/raiser/operand-resolver.h
+++ b/amd/comgr/src/hotswap/raiser/operand-resolver.h
@@ -1,4 +1,4 @@
-//===- op-resolver.h - Hotswap transpiler ---------------------------------===//
+//===- operand-resolver.h - Hotswap transpiler ----------------------------===//
 //
 // Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
 // amd/comgr/LICENSE.TXT in this repository for license information.
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef HOTSWAP_TRANSPILER_OP_RESOLVER_H
-#define HOTSWAP_TRANSPILER_OP_RESOLVER_H
+#ifndef HOTSWAP_TRANSPILER_OPERAND_RESOLVER_H
+#define HOTSWAP_TRANSPILER_OPERAND_RESOLVER_H
 
 #include "hotswap/decoder/decoded-inst.h"
 #include "hotswap/decoder/parsed-reg.h"
@@ -33,7 +33,7 @@ struct BinaryOperands {
 // reads through the decoded srcMap at 32-bit, 64-bit or EXEC width, register
 // names for sources and destinations, and immediates. Float source reads apply
 // the neg/abs modifiers.
-struct OpResolver {
+struct OperandResolver {
   // Context the operands are read through.
   RaiseContext &Ctx;
   // Instruction whose operands are being read.

--- a/amd/comgr/src/hotswap/raiser/raiser.cpp
+++ b/amd/comgr/src/hotswap/raiser/raiser.cpp
@@ -27,7 +27,7 @@
 #include "hotswap/decoder/mc-state.h"
 #include "hotswap/decoder/opcode-map.h"
 #include "hotswap/raiser/handlers.h"
-#include "hotswap/raiser/op-resolver.h"
+#include "hotswap/raiser/operand-resolver.h"
 #include "hotswap/raiser/raise-context.h"
 #include "hotswap/raiser/raise_failure.h"
 #include "hotswap/raiser/wave-projection.h"
@@ -195,7 +195,7 @@ static Function *declareKernel(Module &M, StringRef KernelName,
 // lowered as something else.
 static Error raiseInst(RaiseContext &Ctx, const DecodedInst &Di) {
   using namespace AmdgpuFormat;
-  OpResolver Op{Ctx, Di};
+  OperandResolver Op{Ctx, Di};
 
   if (Di.TargetSpecificFlags & SOP1)
     return handleSOP1(Ctx, Di, Op);

--- a/amd/comgr/test-lit/hotswap/raiser/f32_vop2_modes_and_forms.s
+++ b/amd/comgr/test-lit/hotswap/raiser/f32_vop2_modes_and_forms.s
@@ -1,6 +1,6 @@
 ; REQUIRES: comgr-has-hotswap-transpile
 
-; RUN: %llvm-mc -triple=amdgpu9.42-amd-amdhsa -filetype=obj %s -o %t.o
+; RUN: %llvm-mc -triple=amdgpu10.10-amd-amdhsa -filetype=obj %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 
 ; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=fp_mode_kernel \
@@ -24,7 +24,7 @@
 ; IEEE-OFF-REFUSE-SAME: source IEEE_MODE=0 is not representable on a target
 ; IEEE-OFF-REFUSE-SAME: with fixed IEEE mode
 
-; RUN: %hotswap_transpile_cli %t.hsaco --target-isa=gfx942 \
+; RUN: %hotswap_transpile_cli %t.hsaco --target-isa=gfx1010 \
 ; RUN:   --emit-ir=ieee_off_kernel \
 ; RUN:   | %FileCheck %s --check-prefix=IEEE-OFF-SAME-ISA
 
@@ -49,7 +49,7 @@
 ; RUN:   | %FileCheck %s --check-prefix=SDWA
 ; SDWA: unsupported-instruction-form: v_add_f32 [SDWA]
 
-	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx1010"
 	.amdhsa_code_object_version 6
 	.text
 	.globl	fp_mode_kernel
@@ -128,7 +128,6 @@ sdwa_kernel:
 	.amdhsa_kernel fp_mode_kernel
 		.amdhsa_next_free_vgpr 3
 		.amdhsa_next_free_sgpr 1
-		.amdhsa_accum_offset 4
 		.amdhsa_float_round_mode_32 0
 		.amdhsa_float_denorm_mode_32 2
 		.amdhsa_float_denorm_mode_16_64 1
@@ -138,7 +137,6 @@ sdwa_kernel:
 	.amdhsa_kernel fixed_mode_kernel
 		.amdhsa_next_free_vgpr 3
 		.amdhsa_next_free_sgpr 1
-		.amdhsa_accum_offset 4
 		.amdhsa_dx10_clamp 1
 		.amdhsa_ieee_mode 1
 	.end_amdhsa_kernel
@@ -147,37 +145,31 @@ sdwa_kernel:
 	.amdhsa_kernel ieee_off_kernel
 		.amdhsa_next_free_vgpr 3
 		.amdhsa_next_free_sgpr 1
-		.amdhsa_accum_offset 4
 		.amdhsa_dx10_clamp 1
 		.amdhsa_ieee_mode 0
 	.end_amdhsa_kernel
 	.amdhsa_kernel integer_modes_off_kernel
 		.amdhsa_next_free_vgpr 1
 		.amdhsa_next_free_sgpr 1
-		.amdhsa_accum_offset 4
 		.amdhsa_dx10_clamp 0
 		.amdhsa_ieee_mode 0
 	.end_amdhsa_kernel
 	.amdhsa_kernel rounding_kernel
 		.amdhsa_next_free_vgpr 3
 		.amdhsa_next_free_sgpr 1
-		.amdhsa_accum_offset 4
 		.amdhsa_float_round_mode_32 1
 	.end_amdhsa_kernel
 	.amdhsa_kernel e64_kernel
 		.amdhsa_next_free_vgpr 3
 		.amdhsa_next_free_sgpr 1
-		.amdhsa_accum_offset 4
 	.end_amdhsa_kernel
 	.amdhsa_kernel dpp_kernel
 		.amdhsa_next_free_vgpr 3
 		.amdhsa_next_free_sgpr 1
-		.amdhsa_accum_offset 4
 	.end_amdhsa_kernel
 	.amdhsa_kernel sdwa_kernel
 		.amdhsa_next_free_vgpr 3
 		.amdhsa_next_free_sgpr 1
-		.amdhsa_accum_offset 4
 	.end_amdhsa_kernel
 	.text
 	.amdgpu_metadata
@@ -192,7 +184,7 @@ amdhsa.kernels:
     .sgpr_count:     1
     .symbol:         fp_mode_kernel.kd
     .vgpr_count:     3
-    .wavefront_size: 64
+    .wavefront_size: 32
   - .group_segment_fixed_size: 0
     .kernarg_segment_align: 8
     .kernarg_segment_size: 0
@@ -202,7 +194,7 @@ amdhsa.kernels:
     .sgpr_count:     1
     .symbol:         fixed_mode_kernel.kd
     .vgpr_count:     3
-    .wavefront_size: 64
+    .wavefront_size: 32
   - .group_segment_fixed_size: 0
     .kernarg_segment_align: 8
     .kernarg_segment_size: 0
@@ -212,7 +204,7 @@ amdhsa.kernels:
     .sgpr_count:     1
     .symbol:         ieee_off_kernel.kd
     .vgpr_count:     3
-    .wavefront_size: 64
+    .wavefront_size: 32
   - .group_segment_fixed_size: 0
     .kernarg_segment_align: 8
     .kernarg_segment_size: 0
@@ -222,7 +214,7 @@ amdhsa.kernels:
     .sgpr_count:     1
     .symbol:         integer_modes_off_kernel.kd
     .vgpr_count:     1
-    .wavefront_size: 64
+    .wavefront_size: 32
   - .group_segment_fixed_size: 0
     .kernarg_segment_align: 8
     .kernarg_segment_size: 0
@@ -232,7 +224,7 @@ amdhsa.kernels:
     .sgpr_count:     1
     .symbol:         rounding_kernel.kd
     .vgpr_count:     3
-    .wavefront_size: 64
+    .wavefront_size: 32
   - .group_segment_fixed_size: 0
     .kernarg_segment_align: 8
     .kernarg_segment_size: 0
@@ -242,7 +234,7 @@ amdhsa.kernels:
     .sgpr_count:     1
     .symbol:         e64_kernel.kd
     .vgpr_count:     3
-    .wavefront_size: 64
+    .wavefront_size: 32
   - .group_segment_fixed_size: 0
     .kernarg_segment_align: 8
     .kernarg_segment_size: 0
@@ -252,7 +244,7 @@ amdhsa.kernels:
     .sgpr_count:     1
     .symbol:         dpp_kernel.kd
     .vgpr_count:     3
-    .wavefront_size: 64
+    .wavefront_size: 32
   - .group_segment_fixed_size: 0
     .kernarg_segment_align: 8
     .kernarg_segment_size: 0
@@ -262,7 +254,7 @@ amdhsa.kernels:
     .sgpr_count:     1
     .symbol:         sdwa_kernel.kd
     .vgpr_count:     3
-    .wavefront_size: 64
+    .wavefront_size: 32
 amdhsa.version: [1, 2]
 ...
 	.end_amdgpu_metadata

--- a/amd/comgr/test-unit/hotswap/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/CMakeLists.txt
@@ -20,7 +20,7 @@ if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   add_subdirectory(decoder)
   list(APPEND COMGR_HOTSWAP_TEST_TARGETS
     RaiserScaffoldingTests WaveProjectionTests RaiseFailureTests RegFileTests
-    RegisterStateTests RaiseContextTests OpResolverTests UserSgprLayoutTests
+    RegisterStateTests RaiseContextTests OperandResolverTests UserSgprLayoutTests
     DecoderTests)
 endif()
 

--- a/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/raiser/CMakeLists.txt
@@ -161,15 +161,15 @@ target_include_directories(RaiseContextTests PRIVATE
 
 comgr_configure_test_target(RaiseContextTests)
 
-# -- OpResolverTests ----------------------------------------------------------
+# -- OperandResolverTests -----------------------------------------------------
 #
 # Covers the per-instruction operand accessor: the failures it propagates out of
 # the register reads it resolves through.
 
-add_executable(OpResolverTests
-  OpResolverTest.cpp)
+add_executable(OperandResolverTests
+  OperandResolverTest.cpp)
 
-target_link_libraries(OpResolverTests PRIVATE
+target_link_libraries(OperandResolverTests PRIVATE
   ${COMGR_GTEST_LIBS}
   hotswap::raiser
   hotswap::decoder
@@ -178,13 +178,13 @@ target_link_libraries(OpResolverTests PRIVATE
   ${COMGR_HOTSWAP_TEST_LLVM_LIBS}
   ${LLVM_PTHREAD_LIB})
 
-target_include_directories(OpResolverTests PRIVATE
+target_include_directories(OperandResolverTests PRIVATE
   ${LLVM_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}/src
   ${COMGR_GTEST_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
 
-comgr_configure_test_target(OpResolverTests)
+comgr_configure_test_target(OperandResolverTests)
 
 # -- UserSgprLayoutTests ------------------------------------------------------
 #

--- a/amd/comgr/test-unit/hotswap/raiser/OperandResolverTest.cpp
+++ b/amd/comgr/test-unit/hotswap/raiser/OperandResolverTest.cpp
@@ -1,4 +1,4 @@
-//===- OpResolverTest.cpp - operand resolver unit tests -------------------===//
+//===- OperandResolverTest.cpp - operand resolver unit tests --------------===//
 //
 // Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
 // amd/comgr/LICENSE.TXT in this repository for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "hotswap/raiser/op-resolver.h"
+#include "hotswap/raiser/operand-resolver.h"
 
 #include "hotswap/common/kernel-meta.h"
 #include "hotswap/decoder/decoded-inst.h"
@@ -50,7 +50,7 @@ MCRegister findRegister(const MCRegisterInfo &MRI, StringRef Name) {
   return MCRegister();
 }
 
-class OpResolverTest : public ::testing::Test {
+class OperandResolverTest : public ::testing::Test {
 protected:
   void SetUp() override {
     Expected<MCState> State = initMCState("gfx942");
@@ -69,7 +69,7 @@ protected:
     std::optional<RaiseContext> Ctx;
 
     explicit ContextEnvironment(const MCState &Mc)
-        : Mod("op_resolver_test", LLVMCtx), B(LLVMCtx),
+        : Mod("operand_resolver_test", LLVMCtx), B(LLVMCtx),
           Isa(ISAProfile::fromSubtarget(*Mc.SubtargetInfo)),
           Projection(Isa, Isa, B.getInt32Ty(), B.getInt64Ty()),
           Kernel(Function::Create(
@@ -86,7 +86,7 @@ protected:
   std::unique_ptr<ContextEnvironment> Env;
 };
 
-TEST_F(OpResolverTest, ReportsRegisterFailures) {
+TEST_F(OperandResolverTest, ReportsRegisterFailures) {
   unsigned Opc = findOpcode(*Mc.InstrInfo, "S_MOV_B32_vi");
   ASSERT_NE(Opc, Mc.InstrInfo->getNumOpcodes());
   MCRegister Reg = findRegister(*Mc.RegInfo, "XNACK_MASK_LO");
@@ -96,7 +96,7 @@ TEST_F(OpResolverTest, ReportsRegisterFailures) {
   Di.Inst.setOpcode(Opc);
   Di.Inst.addOperand(MCOperand::createReg(Reg));
 
-  OpResolver Resolver{*Env->Ctx, Di};
+  OperandResolver Resolver{*Env->Ctx, Di};
   Expected<ParsedReg> Destination = Resolver.dst();
   ASSERT_FALSE(static_cast<bool>(Destination));
   EXPECT_NE(toString(Destination.takeError()).find("register-decode"),


### PR DESCRIPTION
Rename `OpResolver` to `OperandResolver` to avoid confusion between "operation" and "operand".

Makes progress on #4129