### PR TITLE
[offload] Fix omp_get_device_num typo

### DIFF
--- a/offload/libomptarget/OpenMP/API.cpp
+++ b/offload/libomptarget/OpenMP/API.cpp
@@ -73,7 +73,7 @@ EXTERN int omp_get_num_devices(void) {
   return NumDevices;
 }
 
-EXTERN int omp_get_DeviceNum(void) {
+EXTERN int omp_get_device_num(void) {
   TIMESCOPE();
   OMPT_IF_BUILT(ReturnAddressSetterRAII RA(__builtin_return_address(0)));
   int HostDevice = omp_get_initial_device();


### PR DESCRIPTION
`offload/libomptarget/OpenMP/API.cpp:76` defines `omp_get_DeviceNum`, so `libomptarget` does not define the OpenMP API `omp_get_device_num()` at all:

```diff
-EXTERN int omp_get_device_num(void) {
+EXTERN int omp_get_DeviceNum(void) {
```

Both the declaration in `offload/include/omptarget.h:292` and the entry in `offload/libomptarget/exports:43` still use the correct name — so the header declares a function that does not exist, and the version script names a symbol that is never defined. Anything linking `libomptarget` and calling `omp_get_device_num` fails to resolve unless it happens to pick the symbol up from `libomp`.

Looks like collateral from a naming cleanup: `DeviceNum` is the local-variable convention throughout that file, so a find/replace on `device_num` would have caught the function name too.

## Why the rename is safe

- **No callers.** The only occurrences of `omp_get_DeviceNum` are this definition and `ROCm/rocMLIR`'s vendored copy of the same file.
- **Not exported.** It is absent from the `exports` global list, so `local: *` hides it — confirmed absent from the dynamic symbol table of a shipped `libomptarget.so.22.0git`.

So the misspelled symbol is dead code and the rename cannot break ABI. It restores the file to upstream for this symbol.

## Context

Found via #4216, while restoring upstream's `--no-undefined-version` lld default in #4065 — the strict default surfaces this as a hard link error:

```
ld.lld: error: version script assignment of 'VERS1.0' to symbol 'omp_get_device_num' failed: symbol not defined
```

which is also a decent argument for that default. This does not close #4216 on its own; the remaining `exports` entries there are AMD-added and handled separately.
