### PR TITLE
[offload] Prune dead entries and duplicates from libomptarget exports

### DIFF
--- a/offload/libomptarget/exports
+++ b/offload/libomptarget/exports
@@ -57,16 +57,9 @@ VERS1.0 {
     omp_target_memset_async;
     omp_target_associate_ptr;
     omp_target_disassociate_ptr;
-    __kmpc_push_target_tripcount;
-    printf_allocate;
-    printf_execute;
-    global_allocate;
-    global_free;
     llvm_omp_target_alloc_host;
     llvm_omp_target_alloc_shared;
     llvm_omp_target_alloc_device;
-    llvm_omp_target_lock_mem;
-    llvm_omp_target_unlock_mem;
     llvm_omp_get_dynamic_shared;
     llvm_omp_target_free_host;
     llvm_omp_target_free_shared;


### PR DESCRIPTION
Fixes the remaining `offload/libomptarget/exports` problems from #4216.

## Dead entries

Four entries name symbols that exist nowhere in `offload/` — grepping the tree, each appears **only** in this file, with no definition, declaration or use:

```
printf_allocate   → offload/libomptarget/exports:61   (only hit)
printf_execute    → offload/libomptarget/exports:62   (only hit)
global_allocate   → offload/libomptarget/exports:63   (only hit)
global_free       → offload/libomptarget/exports:64   (only hit)
```

They are silently ignored today because `amd-staging` defaults lld to `--undefined-version`. Under upstream's `--no-undefined-version` they are hard link errors, as seen in Multi-Arch CI on #4065:

```
ld.lld: error: version script assignment of 'VERS1.0' to symbol 'printf_allocate' failed: symbol not defined
```

`global_allocate` / `global_free` are exported by a shipped ROCm 7.12 `libomptarget.so`, which is misleading — that is older source where they still existed. Current `amd-staging` has neither, and CI fails on all four.

## Duplicates

Three entries repeat lines already present earlier in the same version node:

| Entry | Duplicated at | Already at |
|---|---|---|
| `__kmpc_push_target_tripcount` | 60 | 36 |
| `llvm_omp_target_lock_mem` | 68 | 75 |
| `llvm_omp_target_unlock_mem` | 69 | 76 |

Harmless to lld, but removing them is how the block stops accumulating — the dead entries above sit in the middle of exactly this duplicated run, which is plausibly how they went unnoticed.

## Not an ABI change

The four removed symbols were never defined, so nothing could ever have resolved against them. Comparing the exported set before and after: 100 unique symbols → 96, removing exactly those four and nothing else. The duplicate removals do not change the set at all.

## Scope

`omp_get_device_num`, the fifth symbol failing in CI, is fixed separately in #4217 — it was a typo (`omp_get_DeviceNum`) rather than a stale entry. With both merged, #4216 is resolved and #4065 unblocks.
