### PR TITLE
[CMake][CI] Drop LLVM_MAIN_REVISION

### DIFF
--- a/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
+++ b/.github/workflows/multiarch-parameterised-sha-rockci-amd-staging.yml
@@ -7,9 +7,6 @@
 # It mirrors ci.yml but uses multi_arch_build_portable_linux.yml instead of
 # ci_linux.yml. Once validated, ci.yml will be updated to use the multi-arch
 # sub-workflows directly.
-#
-# Same `ci:skip` rules as rockci-amd-staging.yml: only automated LLVM_MAIN_REVISION PRs
-# (matching title/body) skip presubmit; label alone is not enough. 
 
 name: Multi Arch Parameterised CI amd-staging
 

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -12,16 +12,7 @@ jobs:
   code_formatter:
     if: >-
       !contains(github.event.pull_request.head.ref, 'upstream_merge')
-      && !(
-        contains(github.event.pull_request.labels.*.name, 'ci:skip') ||
-        (
-          contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
-          (
-            contains(github.event.pull_request.body, 'Automated update of') &&
-            contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
-          )
-        )
-      )
+      && !contains(github.event.pull_request.labels.*.name, 'ci:skip')
     runs-on: ubuntu-24.04
     container:
       image: 'ghcr.io/llvm/ci-ubuntu-24.04-format'

--- a/.github/workflows/rockci-amd-staging.yml
+++ b/.github/workflows/rockci-amd-staging.yml
@@ -11,10 +11,6 @@
 # For push to main branch, all AMD families will built and tested from `amdgpu_family_matrix.py`.
 #
 # Note: If a test machine is not available for a specific AMD GPU family in `amdgpu_family_matrix.py`, tests will be skipped.
-#
-# Presubmit is skipped only when ALL apply: label `ci:skip` AND the PR matches the
-# automated LLVM_MAIN_REVISION bump (title starts with that phrase OR body contains
-# the automation marker). Arbitrary PRs with only `ci:skip` still run full CI.
 
 name: CI amd-staging
 
@@ -71,19 +67,6 @@ concurrency:
 
 jobs:
   setup:
-    if: >-
-      github.event_name != 'pull_request' ||
-      (github.event.pull_request &&
-       !(
-         contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
-         (
-           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
-           (
-             contains(github.event.pull_request.body, 'Automated update of') &&
-             contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
-           )
-         )
-       ))
     uses: ./.github/workflows/setup.yml
     with:
       build_variant: "release"

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -8,8 +8,7 @@
 # ci_linux.yml. Once validated, ci.yml will be updated to use the multi-arch
 # sub-workflows directly.
 #
-# Same `ci:skip` rules as rockci-amd-staging.yml: only automated LLVM_MAIN_REVISION PRs
-# (matching title/body) skip presubmit; label alone is not enough. 
+# Presubmit is skipped for PRs labelled `ci:skip`.
 
 name: Multi-Arch CI amd-staging
 
@@ -82,16 +81,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       (github.event.pull_request &&
-       !(
-         contains(github.event.pull_request.labels.*.name, 'ci:skip') ||
-         (
-           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
-           (
-             contains(github.event.pull_request.body, 'Automated update of') &&
-             contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
-           )
-         )
-       ))
+       !contains(github.event.pull_request.labels.*.name, 'ci:skip'))
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
       build_variant: "release"

--- a/.github/workflows/spirv-ci.yml
+++ b/.github/workflows/spirv-ci.yml
@@ -1,8 +1,7 @@
 # Top-level dispatcher for the SPIRV-focused CI on amd-staging.
 # Dispatches to per-platform reusable workflows.
 #
-# SPIRV presubmit skips only for automated LLVM_MAIN_REVISION PRs: `ci:skip` plus
-# matching title/body (same rules as rockci-amd-staging.yml).
+# SPIRV presubmit skips for PRs labelled `ci:skip`.
 
 name: SPIRV Compiler CI - amd-staging
 
@@ -25,16 +24,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       (github.event.pull_request &&
-       !(
-         contains(github.event.pull_request.labels.*.name, 'ci:skip') ||
-         (
-           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
-           (
-             contains(github.event.pull_request.body, 'Automated update of') &&
-             contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
-           )
-         )
-       ))
+       !contains(github.event.pull_request.labels.*.name, 'ci:skip'))
     uses: ./.github/workflows/spirv-ci-linux-amd-staging.yml
 
   windows_release:
@@ -42,14 +32,5 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       (github.event.pull_request &&
-       !(
-         contains(github.event.pull_request.labels.*.name, 'ci:skip') ||
-         (
-           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
-           (
-             contains(github.event.pull_request.body, 'Automated update of') &&
-             contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
-           )
-         )
-       ))
+       !contains(github.event.pull_request.labels.*.name, 'ci:skip'))
     uses: ./.github/workflows/spirv-ci-windows-amd-staging.yml

--- a/llvm/include/llvm/Config/llvm-config.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config.h.cmake
@@ -14,11 +14,6 @@
 #ifndef LLVM_CONFIG_H
 #define LLVM_CONFIG_H
 
-/* The number of commits in the linear history from the
- * start of the universe up to the latest llvm main commit
- * that has been merged */
-#define LLVM_MAIN_REVISION 594793
-
 /* Define if LLVM_ENABLE_DUMP is enabled */
 #cmakedefine LLVM_ENABLE_DUMP
 


### PR DESCRIPTION
> [!IMPORTANT]
> Needs the **`z1-cciauto` bump job retired in tandem** — it has been pushing `Update LLVM_MAIN_REVISION to NNNNNN` daily (most recently #4206) and will have nothing to update once this lands.

`LLVM_MAIN_REVISION` is an AMD-private commit counter in `llvm-config.h`. It has no consumer inside this repository — its only occurrence in the tree is its own definition.

## Downstream consumers

All of them already handle the macro being absent. The one that did not was kfdtest's `Assemble.cpp`, which gated an MC API change on a bare `#if LLVM_MAIN_REVISION >= N`; an undefined identifier evaluates to `0` in `#if`, so it silently selected the wrong branch and failed to compile. Fixed by ROCm/rocm-systems#10563, which is present in the tree this repo's CI builds (`THEROCK_CI_MAIN_REF` → TheRock `a465d780902ff392` → `rocm-systems` `79f87b8238f0`).

Searching for the unsafe pattern (`#if LLVM_MAIN_REVISION >=`) finds no remaining consumer. Everything else uses the absent-means-newest form:

- `GPUOpen-Drivers/llpc` — 42 of 43 guards use `#if !defined(...) || ...`, and its CMake falls back to `999999999` when the macro is missing. It also reads the macro from **its own** llvm fork (`GPUOpen-Drivers/llvm-project`, own value `533774`), not this one.
- Other AMD tooling that consults the macro uses the guarded `#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < N` form, which selects the modern path when it is undefined.
- `ROCm/aiter` — probes by compiling a test snippet rather than reading the macro.

The macro is in an installed public header, so external consumers are not fully enumerable by search — flagging that explicitly for reviewers.

## CI guards

Removing the macro also retires the four presubmit guards that skipped CI for the automated bump PRs. **`ci:skip` behaviour is preserved exactly:**

| Workflow | Old rule | Change |
|---|---|---|
| `pr-code-format.yml` | `ci:skip` **OR** bump | drop bump term; `ci:skip` still skips |
| `rockci_multi_arch_amd_staging.yml` | `ci:skip` **OR** bump | drop bump term; `ci:skip` still skips |
| `spirv-ci.yml` (both jobs) | `ci:skip` **OR** bump | drop bump term; `ci:skip` still skips |
| `rockci-amd-staging.yml` | `ci:skip` **AND** bump | guard removed entirely — see below |

`rockci-amd-staging.yml` is the one that differs. Because it required *both*, `ci:skip` alone never skipped there. With bump PRs gone the condition is unsatisfiable, so dropping only the bump term would have made `ci:skip` start skipping — a behaviour change. The whole guard is removed instead, so the job always runs, which is its current behaviour for every PR except the bot's.

Three stale comments describing the old rules are updated. Note the `spirv-ci.yml` comment was already wrong — it described `ci:skip` *plus* a matching title/body while the code used `OR`.

## Result

`llvm/include/llvm/Config/llvm-config.h.cmake` is now byte-identical to `upstream/main`.
