### PR TITLE
[Comgr] Fix libc++ header tracing on Windows path separators

### DIFF
--- a/amd/comgr/cmake/trace_headers.py
+++ b/amd/comgr/cmake/trace_headers.py
@@ -22,7 +22,7 @@ def to_posix(path):
     manifest consumed by CMake, and the relative paths used as virtual
     filesystem keys at runtime all assume '/'.
     """
-    return path.replace(os.sep, '/')
+    return path.replace(os.sep, "/")
 
 
 def trace_headers(clang, libcxx_dir, config_site, target, headers):
@@ -61,7 +61,7 @@ def trace_headers(clang, libcxx_dir, config_site, target, headers):
         for line in non_trace:
             print(f'  {line}', file=sys.stderr)
 
-    libcxx_real = to_posix(os.path.realpath(libcxx_dir)) + '/'
+    libcxx_real = to_posix(os.path.realpath(libcxx_dir)) + "/"
     libcxx_headers = set()
     clang_headers = set()
 
@@ -118,16 +118,22 @@ def main():
     entries = []
 
     # Custom __config_site for HIPRTC
-    entries.append(('libcxx', '__config_site',
-                    to_posix(os.path.abspath(args.config_site))))
+    entries.append(
+        ("libcxx", "__config_site", to_posix(os.path.abspath(args.config_site)))
+    )
 
     # __assertion_handler if it exists in the vendor directory
     assertion_handler = os.path.join(
         os.path.dirname(args.libcxx_dir),
         'vendor', 'llvm', 'default_assertion_handler.in')
     if os.path.exists(assertion_handler):
-        entries.append(('libcxx', '__assertion_handler',
-                        to_posix(os.path.abspath(assertion_handler))))
+        entries.append(
+            (
+                "libcxx",
+                "__assertion_handler",
+                to_posix(os.path.abspath(assertion_handler)),
+            )
+        )
 
     for path in libcxx_headers:
         rel = to_posix(os.path.relpath(path, libcxx_real))

--- a/amd/comgr/cmake/trace_headers.py
+++ b/amd/comgr/cmake/trace_headers.py
@@ -14,6 +14,17 @@ import sys
 import tempfile
 
 
+def to_posix(path):
+    """Convert OS-native separators to '/'.
+
+    No-op on POSIX. On Windows os.path.realpath() and os.path.relpath()
+    return '\\'-separated paths, but header classification below, the
+    manifest consumed by CMake, and the relative paths used as virtual
+    filesystem keys at runtime all assume '/'.
+    """
+    return path.replace(os.sep, '/')
+
+
 def trace_headers(clang, libcxx_dir, config_site, target, headers):
     """Run clang -E -H to discover all transitive header dependencies."""
     with tempfile.NamedTemporaryFile(mode='w', suffix='.cpp', delete=False) as f:
@@ -50,7 +61,7 @@ def trace_headers(clang, libcxx_dir, config_site, target, headers):
         for line in non_trace:
             print(f'  {line}', file=sys.stderr)
 
-    libcxx_real = os.path.realpath(libcxx_dir) + '/'
+    libcxx_real = to_posix(os.path.realpath(libcxx_dir)) + '/'
     libcxx_headers = set()
     clang_headers = set()
 
@@ -58,7 +69,7 @@ def trace_headers(clang, libcxx_dir, config_site, target, headers):
         m = re.match(r'^\.+ (.+)$', line)
         if not m:
             continue
-        path = os.path.realpath(m.group(1).strip())
+        path = to_posix(os.path.realpath(m.group(1).strip()))
         if path.startswith(libcxx_real):
             libcxx_headers.add(path)
         elif '/lib/clang/' in path and '/include/' in path:
@@ -107,7 +118,8 @@ def main():
     entries = []
 
     # Custom __config_site for HIPRTC
-    entries.append(('libcxx', '__config_site', os.path.abspath(args.config_site)))
+    entries.append(('libcxx', '__config_site',
+                    to_posix(os.path.abspath(args.config_site))))
 
     # __assertion_handler if it exists in the vendor directory
     assertion_handler = os.path.join(
@@ -115,15 +127,15 @@ def main():
         'vendor', 'llvm', 'default_assertion_handler.in')
     if os.path.exists(assertion_handler):
         entries.append(('libcxx', '__assertion_handler',
-                       os.path.abspath(assertion_handler)))
+                        to_posix(os.path.abspath(assertion_handler))))
 
     for path in libcxx_headers:
-        rel = os.path.relpath(path, libcxx_real)
+        rel = to_posix(os.path.relpath(path, libcxx_real))
         entries.append(('libcxx', rel, path))
 
     for path in clang_headers:
         if clang_resource_dir:
-            rel = os.path.relpath(path, clang_resource_dir)
+            rel = to_posix(os.path.relpath(path, clang_resource_dir))
         else:
             rel = os.path.basename(path)
         entries.append(('clang', rel, path))

--- a/amd/comgr/cmake/trace_headers.py
+++ b/amd/comgr/cmake/trace_headers.py
@@ -24,7 +24,6 @@ def to_posix(path):
     """
     return path.replace(os.sep, "/")
 
-
 def trace_headers(clang, libcxx_dir, config_site, target, headers):
     """Run clang -E -H to discover all transitive header dependencies."""
     with tempfile.NamedTemporaryFile(mode='w', suffix='.cpp', delete=False) as f:

--- a/amd/comgr/test-lit/compile-hip-embedded-libcxx-headers.hip
+++ b/amd/comgr/test-lit/compile-hip-embedded-libcxx-headers.hip
@@ -1,0 +1,44 @@
+// COM: The embedded libc++ header set must be non-empty and usable on every
+// COM: host platform. The set is built at configure time by
+// COM: cmake/trace_headers.py from clang -E -H output. When that script
+// COM: mishandled host path separators the set came out empty,
+// COM: EmbedLibcxxHeaders.cmake still emitted a valid
+// COM: getLibcxxHeaderFiles() { return {}; }, the build succeeded, and the
+// COM: failure only surfaced at runtime as "'type_traits' file not found".
+// COM:
+// COM: This test is deliberately not gated on a host platform. The embedded
+// COM: header path is platform independent, and the lack of coverage on
+// COM: non-Linux hosts is what allowed that failure to ship.
+// RUN: compile-hip-cxx-headers --mode=distroless %s | %FileCheck %s
+
+// A zero count means trace_headers.py produced a manifest with no libc++
+// entries, so hasEmbeddedLibcxxHeaders() is false and nothing is mounted into
+// the VFS. Match a non-zero count explicitly rather than just the log line,
+// which reports the skip decision and not whether any headers exist.
+// CHECK-DAG: Embedded {{[1-9][0-9]*}} libc++ headers at:
+// CHECK-DAG: Embedded libc++ headers: active
+// CHECK: RESULT: PASS
+
+// Include libc++ detail headers rather than <type_traits> itself. The embedded
+// set is added with -idirafter, so on a host that has a system C++ library the
+// top-level names resolve to it instead, and mixing the two breaks the
+// #include_next chain. Only the __-prefixed names are guaranteed to come from
+// the embedded set. These are transitive dependencies of <type_traits>, which
+// is what MIOpen includes and what trace_headers.py must discover; 171 of the
+// 181 entries in a current manifest are detail headers like these.
+#include <__config>
+#include <__type_traits/integral_constant.h>
+#include <__type_traits/is_same.h>
+#include <__type_traits/remove_cv.h>
+
+#ifndef _LIBCPP_VERSION
+#error "expected the embedded libc++ headers"
+#endif
+
+static_assert(std::is_same<std::remove_cv<const int>::type, int>::value,
+              "remove_cv/is_same");
+static_assert(std::integral_constant<int, 7>::value == 7, "integral_constant");
+
+extern "C" __attribute__((global)) void test_kernel(int *out) {
+  out[0] = std::is_same<int, int>::value ? 1 : 0;
+}

--- a/amd/comgr/test-lit/compile-hip-embedded-libcxx-headers.hip
+++ b/amd/comgr/test-lit/compile-hip-embedded-libcxx-headers.hip
@@ -1,35 +1,24 @@
-// COM: The embedded libc++ header set must be non-empty and usable on every
-// COM: host platform. The set is built at configure time by
-// COM: cmake/trace_headers.py from clang -E -H output. When that script
-// COM: mishandled host path separators the set came out empty,
-// COM: EmbedLibcxxHeaders.cmake still emitted a valid
-// COM: getLibcxxHeaderFiles() { return {}; }, the build succeeded, and the
-// COM: failure only surfaced at runtime as "'type_traits' file not found".
+// COM: The embedded libc++ header set must be non-empty on every host. When
+// COM: cmake/trace_headers.py mishandled host path separators the set came out
+// COM: empty, the build still succeeded, and the failure only surfaced at
+// COM: runtime as "'type_traits' file not found". Not gated on a platform: the
+// COM: missing coverage on non-Linux hosts is what let that ship.
 // COM:
-// COM: This test is deliberately not gated on a host platform. The embedded
-// COM: header path is platform independent, and the lack of coverage on
-// COM: non-Linux hosts is what allowed that failure to ship.
-// RUN: compile-hip-cxx-headers --mode=distroless %s | %FileCheck %s
+// COM: --mode=distroless only forces the embedded set to be mounted; it does
+// COM: not remove the host's C++ headers, and Comgr injects the embedded
+// COM: directory with -idirafter (last). -nostdinc++ drops the host paths while
+// COM: leaving that -idirafter intact, so the embedded set is the only source.
+// RUN: env AMD_COMGR_DRIVER_OPTIONS_APPEND="-nostdinc++" \
+// RUN:     compile-hip-cxx-headers --mode=distroless %s | %FileCheck %s
 
-// A zero count means trace_headers.py produced a manifest with no libc++
-// entries, so hasEmbeddedLibcxxHeaders() is false and nothing is mounted into
-// the VFS. Match a non-zero count explicitly rather than just the log line,
-// which reports the skip decision and not whether any headers exist.
+// Match a non-zero count, not just the log line: that line reports the skip
+// decision and prints even when the set is empty.
 // CHECK-DAG: Embedded {{[1-9][0-9]*}} libc++ headers at:
 // CHECK-DAG: Embedded libc++ headers: active
 // CHECK: RESULT: PASS
 
-// Include libc++ detail headers rather than <type_traits> itself. The embedded
-// set is added with -idirafter, so on a host that has a system C++ library the
-// top-level names resolve to it instead, and mixing the two breaks the
-// #include_next chain. Only the __-prefixed names are guaranteed to come from
-// the embedded set. These are transitive dependencies of <type_traits>, which
-// is what MIOpen includes and what trace_headers.py must discover; 171 of the
-// 181 entries in a current manifest are detail headers like these.
-#include <__config>
-#include <__type_traits/integral_constant.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/remove_cv.h>
+// A seed header for trace_headers.py, so this exercises the full traced graph.
+#include <type_traits>
 
 #ifndef _LIBCPP_VERSION
 #error "expected the embedded libc++ headers"

--- a/amd/comgr/test-lit/compile-hip-embedded-libcxx-headers.hip
+++ b/amd/comgr/test-lit/compile-hip-embedded-libcxx-headers.hip
@@ -6,9 +6,10 @@
 // COM:
 // COM: --mode=distroless only forces the embedded set to be mounted; it does
 // COM: not remove the host's C++ headers, and Comgr injects the embedded
-// COM: directory with -idirafter (last). -nostdinc++ drops the host paths while
-// COM: leaving that -idirafter intact, so the embedded set is the only source.
-// RUN: env AMD_COMGR_DRIVER_OPTIONS_APPEND="-nostdinc++" \
+// COM: directory with -idirafter (last). -nostdlibinc drops the host paths
+// COM: while leaving that -idirafter and the clang resource dir intact, so the
+// COM: embedded set is the only source.
+// RUN: env AMD_COMGR_DRIVER_OPTIONS_APPEND="-nostdlibinc" \
 // RUN:     compile-hip-cxx-headers --mode=distroless %s | %FileCheck %s
 
 // Match a non-zero count, not just the log line: that line reports the skip


### PR DESCRIPTION
`trace_headers.py` classified headers from `clang -E -H` using hardcoded / separators, but `os.path.realpath()` returns \-separated paths on Windows, so every header was discarded and Comgr shipped with no embedded libc++ headers — surfacing at runtime as 'type_traits' file not found during MIOpen's HIPRTC compilation. 

This patch adds a `to_posix()` helper and applies it wherever a path enters the classification logic or the manifest, covering both the `realpath()` calls on input and the `abspath()/relpath()` calls on output (the latter matters because those paths land in generated C++ string literals, where \ is an escape character). 

`to_posix()` is a no-op on POSIX, so Linux behaviour is unchanged.