### PR TITLE
[Comgr][Cache] Disable the Cache's default directory if it is mounted on an NFS

### DIFF
--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -195,6 +195,9 @@ By default, the cache is enabled.
   it is directed to "$XDG_CACHE_HOME/comgr" (which defaults to
   "$USER/.cache/comgr" on Linux, and "%LOCALAPPDATA%\cache\comgr"
   on Microsoft Windows).
+  When resolving this default location, if the system's cache directory resides
+  on a remote filesystem (e.g. NFS), the cache is disabled to avoid concurrency
+  issues on shared storage.
 * `AMD_COMGR_CACHE_POLICY`: If assigned a value, the string is interpreted and
   applied to the cache pruning policy. The cache is pruned only upon program
   termination. The string format aligns with [Clang's ThinLTO cache pruning policy](https://clang.llvm.org/docs/ThinLTO.html#cache-pruning).

--- a/amd/comgr/src/comgr-cache.cpp
+++ b/amd/comgr/src/comgr-cache.cpp
@@ -172,8 +172,9 @@ void CommandCache::prune() {
 }
 
 std::unique_ptr<CommandCache> CommandCache::get(raw_ostream &LogS) {
-  StringRef CacheDir = env::getCacheDirectory();
-  if (CacheDir.empty())
+  static std::optional<SmallString<256>> CacheDir =
+      env::getCacheDirectory(LogS);
+  if (CacheDir)
     return nullptr;
 
   std::optional<CachePruningPolicy> Policy =
@@ -182,7 +183,7 @@ std::unique_ptr<CommandCache> CommandCache::get(raw_ostream &LogS) {
     return nullptr;
 
   return std::unique_ptr<CommandCache>(
-      new CommandCache(CacheDir, *Policy, LogS));
+      new CommandCache(*CacheDir, *Policy, LogS));
 }
 
 CommandCache::CommandCache(StringRef CacheDir, const CachePruningPolicy &Policy,

--- a/amd/comgr/src/comgr-cache.cpp
+++ b/amd/comgr/src/comgr-cache.cpp
@@ -174,7 +174,7 @@ void CommandCache::prune() {
 std::unique_ptr<CommandCache> CommandCache::get(raw_ostream &LogS) {
   static std::optional<SmallString<256>> CacheDir =
       env::getCacheDirectory(LogS);
-  if (CacheDir)
+  if (!CacheDir)
     return nullptr;
 
   std::optional<CachePruningPolicy> Policy =

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -219,6 +219,11 @@ StringRef getCacheDirectory() {
     return Result;
 
   if (sys::path::cache_directory(Result)) {
+    // If the cache directory is mounted on a remote filesystem, disable the
+    // cache due to concurrency issues. We saw some issues where a SIGBUS was
+    // thrown when there was contention on the cache.
+    if (!sys::fs::is_local(Result))
+      return "";
     sys::path::append(Result, "comgr");
     return Result;
   }

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -17,6 +17,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <cstdlib>
 
@@ -202,33 +203,33 @@ StringRef getCachePolicy() {
   return EnvCachePolicy ? EnvCachePolicy : "";
 }
 
-StringRef getCacheDirectory() {
+std::optional<SmallString<256>> getCacheDirectory(raw_ostream &LogS) {
   // By default the cache is enabled
   static const char *Enable = COMGR_GETENV("AMD_COMGR_CACHE");
   bool CacheDisabled = StringRef(Enable) == "0";
   if (CacheDisabled)
-    return "";
+    return std::nullopt;
 
   StringRef EnvCacheDirectory = COMGR_GETENV("AMD_COMGR_CACHE_DIR");
   if (!EnvCacheDirectory.empty())
-    return EnvCacheDirectory;
+    return {EnvCacheDirectory};
 
-  // mark Result as static to keep it cached across calls
-  static SmallString<256> Result;
-  if (!Result.empty())
-    return Result;
+  SmallString<256> Result;
+  if (!sys::path::cache_directory(Result))
+    return std::nullopt;
 
-  if (sys::path::cache_directory(Result)) {
-    // If the cache directory is mounted on a remote filesystem, disable the
-    // cache due to concurrency issues. We saw some issues where a SIGBUS was
-    // thrown when there was contention on the cache.
-    if (!sys::fs::is_local(Result))
-      return "";
-    sys::path::append(Result, "comgr");
-    return Result;
+  // If the cache directory is mounted on a remote filesystem, disable the
+  // cache due to concurrency issues. We saw some issues where a SIGBUS was
+  // thrown when there was contention on the cache.
+  if (!sys::fs::is_local(Result)) {
+    if (shouldEmitVerboseLogs())
+      LogS << "Comgr cache: default directory '" << Result
+           << "' is not on a local filesystem; disabling cache.\n";
+    return std::nullopt;
   }
 
-  return "";
+  sys::path::append(Result, "comgr");
+  return {std::move(Result)};
 }
 
 StringRef getDriverOptionsAppend() {

--- a/amd/comgr/src/comgr-env.h
+++ b/amd/comgr/src/comgr-env.h
@@ -9,7 +9,12 @@
 #ifndef COMGR_ENV_H
 #define COMGR_ENV_H
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
+
+namespace llvm {
+class raw_ostream;
+} // namespace llvm
 
 namespace COMGR {
 namespace env {
@@ -71,7 +76,8 @@ llvm::StringRef getCachePolicy();
 /// If environment variable AMD_COMGR_CACHE_DIR is set, return the environment
 /// variable, otherwise return the default path: On Linux it's typically
 /// $HOME/.cache/comgr_cache (depends on XDG_CACHE_HOME)
-llvm::StringRef getCacheDirectory();
+std::optional<llvm::SmallString<256>>
+getCacheDirectory(llvm::raw_ostream &LogS);
 
 /// If environment variable AMD_COMGR_DRIVER_OPTIONS_APPEND is set, return the
 /// space-separated options to append to clang driver invocations.


### PR DESCRIPTION
When the cache directory is on an NFS, we may hit a SIGBUS signal when there is contention on the cache.

This happens typically with MPI jobs running on an NFS mounted $HOME directory.

This conservative approach totally disabled the cache default directory if it is mounted on an NFS.

The user can still override this by manually setting the cache's directory.

Related to [LCOMPILER-2307](https://amd-hub.atlassian.net/browse/LCOMPILER-2307) and [ROCM-30356](https://amd-hub.atlassian.net/browse/ROCM-30356).

This is a conservative alternative to https://github.com/ROCm/llvm-project/pull/3049




[LCOMPILER-2307]: https://amd-hub.atlassian.net/browse/LCOMPILER-2307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROCM-30356]: https://amd-hub.atlassian.net/browse/ROCM-30356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ