### PR TITLE
[runtimes] - Remove downstream external rocr build

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -588,7 +588,7 @@ if(build_runtimes)
   string(JOIN "$<SEMICOLON>" escaped_cmake_prefix_path ${CMAKE_PREFIX_PATH})
   # Some projects require access to the LLVM lib/cmake directory, whether or not
   # the user provided a prefix path of their own.
-  if (OFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR OR DEFINED LIBOMPTARGET_EXTERNAL_PROJECT_ROCM_DEVICE_LIBS_PATH)
+  if (DEFINED LIBOMPTARGET_EXTERNAL_PROJECT_ROCM_DEVICE_LIBS_PATH)
     if(escaped_cmake_prefix_path)
       string(PREPEND escaped_cmake_prefix_path "${CMAKE_BINARY_DIR}/lib/cmake$<SEMICOLON>")
     else()
@@ -637,33 +637,6 @@ if(build_runtimes)
     endforeach()
   endif()
   if("openmp" IN_LIST LLVM_ENABLE_RUNTIMES OR "offload" IN_LIST LLVM_ENABLE_RUNTIMES)
-    # With ROCm 6.3 the ROCr runtime and the thunk layer share a single repository.
-    # No need to provide a separate path for ROCt.
-    if (OFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR)
-
-      set(rocr_extra_cmake_args "")
-      if(THEROCK_AMDGPU_TARGETS)
-        # Pass the list of AMDGPU targets to ROCr runtime
-        list(APPEND rocr_extra_cmake_args "-DTHEROCK_AMDGPU_TARGETS=${THEROCK_AMDGPU_TARGETS}")
-      endif()
-
-      if(NOT DEFINED LIBOMPTARGET_EXTERNAL_PROJECT_HSA_PATH)
-        message(SEND_ERROR "External ROCr requires setting LIBOMPTARGET_EXTERNAL_PROJECT_HSA_PATH")
-      endif()
-
-      message(STATUS "Add external unified ROCr: ${LIBOMPTARGET_EXTERNAL_PROJECT_HSA_PATH}")
-      ExternalProject_Add(rocr-runtime
-        SOURCE_DIR ${LIBOMPTARGET_EXTERNAL_PROJECT_HSA_PATH}
-        DEPENDS clang llvm-link lld opt llvm-objcopy
-        INSTALL_COMMAND ""
-        CMAKE_ARGS -DBUILD_SHARED_LIBS=ON
-                   -DIMAGE_SUPPORT=OFF
-                   -DLLVM_RUNTIME_OPENMP=ON
-                   ${rocr_extra_cmake_args}
-                   ${extra_cmake_args})
-      set(HSA_DEP rocr-runtime)
-    endif()
-
     # omptarget device RTL depends on device libs, leading to circular dependency in build scripts.
     # Providing path to the sources enables to build them as part of compiler build, which
     # removes the ciruclar dependency on the script-side.
@@ -689,7 +662,7 @@ if(build_runtimes)
       endif()
     endif()
 
-    foreach(dep opt llvm-link llvm-extract clang llvm-offload-binary clang-nvlink-wrapper rocm-device-libs offload-arch ${HSA_DEP})
+    foreach(dep opt llvm-link llvm-extract clang llvm-offload-binary clang-nvlink-wrapper rocm-device-libs offload-arch)
       if(TARGET ${dep})
         list(APPEND extra_deps ${dep})
       endif()


### PR DESCRIPTION
offload now resolves hsa symbols via dlopen like upstream. This is left over cleanup from https://github.com/ROCm/llvm-project/pull/2466.


