### PR TITLE
[Comgr][hotswap] Raise every kernel a raiser test needs in one command

### DIFF
--- a/amd/comgr/test-lit/comgr-sources/hotswap_transpile_cli.cpp
+++ b/amd/comgr/test-lit/comgr-sources/hotswap_transpile_cli.cpp
@@ -62,20 +62,22 @@ cl::opt<std::string>
 
 // The three modes are mutually exclusive and each names the kernels it runs
 // over the same way: bare selects every kernel in code-object order,
-// =<k>[,<k>...] selects those kernels in the order given.
-cl::opt<std::string> DumpMetaOpt(
+// =<k>[,<k>...] selects those kernels in the order given. Repeating the option
+// appends to that order, so a long selection can be spread over several
+// occurrences.
+cl::list<std::string> DumpMetaOpt(
     "dump-meta", cl::ValueOptional, cl::value_desc("kernel[,kernel...]"),
     cl::desc(
         "Print the metadata extracted from the code object (per-kernel ABI "
         "surface, kernel-descriptor fields, and .text extent) and exit."));
 
-cl::opt<std::string>
+cl::list<std::string>
     EmitIrOpt("emit-ir", cl::ValueOptional,
               cl::value_desc("kernel[,kernel...]"),
               cl::desc("Raise the selected kernels and print the LLVM IR on "
                        "stdout."));
 
-cl::opt<std::string> DumpDecodedOpt(
+cl::list<std::string> DumpDecodedOpt(
     "dump-decoded", cl::ValueOptional, cl::value_desc("kernel[,kernel...]"),
     cl::desc("Print the decoded instruction listing (offset, canonical op, "
              "disassembly) instead of raising."));
@@ -116,26 +118,29 @@ int dumpKernel(const CodeObjectInfo &Info, StringRef Name) {
   return 0;
 }
 
-// Resolve a mode's value into the ordered list of kernels to process: empty
-// selects every kernel in code-object order; a comma list selects the named
-// kernels in order. Reports unknown names on stderr.
-bool resolveTargets(StringRef Requested, ArrayRef<std::string> KernelNames,
-                    StringRef CoPath, SmallVectorImpl<std::string> &Targets) {
-  if (Requested.empty()) {
-    Targets.assign(KernelNames.begin(), KernelNames.end());
-    return true;
-  }
-  SmallVector<StringRef> RequestedNames;
-  Requested.split(RequestedNames, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
-  for (StringRef Name : RequestedNames) {
-    Name = Name.trim();
-    if (!is_contained(KernelNames, Name)) {
-      errs() << "hotswap_transpile_cli: kernel '" << Name << "' not found in "
-             << CoPath << "\n";
-      return false;
+// Resolve a mode's occurrences into the ordered list of kernels to process:
+// naming none selects every kernel in code-object order; the comma lists select
+// the named kernels in the order they were given. Reports unknown names on
+// stderr.
+bool resolveTargets(ArrayRef<std::string> Requested,
+                    ArrayRef<std::string> KernelNames, StringRef CoPath,
+                    SmallVectorImpl<std::string> &Targets) {
+  for (StringRef Occurrence : Requested) {
+    SmallVector<StringRef> RequestedNames;
+    Occurrence.split(RequestedNames, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+    for (StringRef Name : RequestedNames) {
+      Name = Name.trim();
+      if (!is_contained(KernelNames, Name)) {
+        errs() << "hotswap_transpile_cli: kernel '" << Name << "' not found in "
+               << CoPath << "\n";
+        return false;
+      }
+      Targets.push_back(Name.str());
     }
-    Targets.push_back(Name.str());
   }
+  // The mode was given without naming a kernel, which selects all of them.
+  if (Targets.empty())
+    Targets.assign(KernelNames.begin(), KernelNames.end());
   return true;
 }
 
@@ -240,9 +245,26 @@ int runEmitIr(const CodeObjectInfo &Info, const TextSection &Text,
       raiseToIR(Text, SourceIsa, TargetIsa, Kernels);
   if (!RaisedOrErr) {
     // The raiser only returns a module on success, so a failure has no partial
-    // IR to dump; report the structured reason on stderr.
-    errs() << "hotswap_transpile_cli: failed to raise: "
-           << toString(RaisedOrErr.takeError()) << "\n";
+    // IR to dump; report the structured reason on stderr. It also stops at the
+    // kernel it refuses, so raise the requested kernels one at a time to say
+    // what is wrong with each of them rather than only with the first.
+    bool Reported = false;
+    for (const KernelRequest &Kernel : Kernels) {
+      Expected<RaiseResult> OneOrErr =
+          raiseToIR(Text, SourceIsa, TargetIsa, Kernel);
+      if (OneOrErr)
+        continue;
+      errs() << "hotswap_transpile_cli: failed to raise: "
+             << toString(OneOrErr.takeError()) << "\n";
+      Reported = true;
+    }
+    // Nothing to attribute to a single kernel, so report what the whole
+    // request failed with.
+    if (!Reported)
+      errs() << "hotswap_transpile_cli: failed to raise: "
+             << toString(RaisedOrErr.takeError()) << "\n";
+    else
+      consumeError(RaisedOrErr.takeError());
     return 1;
   }
   RaisedOrErr->Module->print(outs(), nullptr);
@@ -296,9 +318,9 @@ int main(int Argc, char **Argv) {
 
   // Every mode names its kernels the same way, so the selection is resolved
   // once from whichever mode's value carries it.
-  StringRef Requested = DumpMeta      ? StringRef(DumpMetaOpt)
-                        : DumpDecoded ? StringRef(DumpDecodedOpt)
-                                      : StringRef(EmitIrOpt);
+  ArrayRef<std::string> Requested = DumpMeta      ? DumpMetaOpt
+                                    : DumpDecoded ? DumpDecodedOpt
+                                                  : EmitIrOpt;
   SmallVector<std::string> Targets;
   if (!resolveTargets(Requested, Info.kernelNames(), CoPathOpt, Targets))
     return 2;

--- a/amd/comgr/test-lit/hotswap/raiser/f32_vop2_modes_and_forms.s
+++ b/amd/comgr/test-lit/hotswap/raiser/f32_vop2_modes_and_forms.s
@@ -14,8 +14,8 @@
 ; DX10-OFF-REFUSE-SAME: with fixed DX10 clamp mode
 
 ; RUN: %hotswap_transpile_cli %t.hsaco --target-isa=gfx1250 \
-; RUN:   --emit-ir=fixed_mode_kernel \
-; RUN:   | %FileCheck %s --check-prefix=FIXED-MODE
+; RUN:   --emit-ir=fixed_mode_kernel,integer_modes_off_kernel \
+; RUN:   | %FileCheck %s --check-prefix=FIXED-TARGET
 
 ; RUN: not %hotswap_transpile_cli %t.hsaco --target-isa=gfx1250 \
 ; RUN:   --emit-ir=ieee_off_kernel 2>&1 \
@@ -28,26 +28,16 @@
 ; RUN:   --emit-ir=ieee_off_kernel \
 ; RUN:   | %FileCheck %s --check-prefix=IEEE-OFF-SAME-ISA
 
-; RUN: %hotswap_transpile_cli %t.hsaco --target-isa=gfx1250 \
-; RUN:   --emit-ir=integer_modes_off_kernel \
-; RUN:   | %FileCheck %s --check-prefix=INTEGER-MODES-OFF
-
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=rounding_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=ROUNDING
-; ROUNDING: unsupported-floating-point-mode: v_add_f32 [VOP2]
-; ROUNDING-SAME: f32 rounding mode 1 is unsupported
-
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=e64_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=E64
-; E64: unsupported-instruction-form: v_add_f32 [VOP3]
-
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=dpp_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=DPP
-; DPP: unsupported-instruction-form: v_add_f32 [DPP]
-
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=sdwa_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=SDWA
-; SDWA: unsupported-instruction-form: v_add_f32 [SDWA]
+; A mode the raise cannot carry over and an encoding outside the dispatched
+; VOP2 form are both refused rather than mislowered.
+; RUN: not %hotswap_transpile_cli %t.hsaco \
+; RUN:   --emit-ir=rounding_kernel,e64_kernel,dpp_kernel,sdwa_kernel 2>&1 \
+; RUN:   | %FileCheck %s --check-prefix=REFUSE
+; REFUSE:      unsupported-floating-point-mode: v_add_f32 [VOP2]
+; REFUSE-SAME: f32 rounding mode 1 is unsupported
+; REFUSE:      unsupported-instruction-form: v_add_f32 [VOP3]
+; REFUSE:      unsupported-instruction-form: v_add_f32 [DPP]
+; REFUSE:      unsupported-instruction-form: v_add_f32 [SDWA]
 
 	.amdgcn_target "amdgcn-amd-amdhsa--gfx1010"
 	.amdhsa_code_object_version 6
@@ -65,9 +55,9 @@ fp_mode_kernel:
 	.globl	fixed_mode_kernel
 	.p2align	8
 	.type	fixed_mode_kernel,@function
-; FIXED-MODE-LABEL: define amdgpu_kernel void @fixed_mode_kernel()
+; FIXED-TARGET-LABEL: define amdgpu_kernel void @fixed_mode_kernel()
 fixed_mode_kernel:
-; FIXED-MODE: fadd float
+; FIXED-TARGET: fadd float
 	v_add_f32_e32 v0, v1, v2
 	s_endpgm
 
@@ -84,10 +74,10 @@ ieee_off_kernel:
 	.globl	integer_modes_off_kernel
 	.p2align	8
 	.type	integer_modes_off_kernel,@function
-; INTEGER-MODES-OFF-LABEL: define amdgpu_kernel void @integer_modes_off_kernel()
+; FIXED-TARGET-LABEL: define amdgpu_kernel void @integer_modes_off_kernel()
 integer_modes_off_kernel:
 	s_mov_b32 s0, 0
-; INTEGER-MODES-OFF: ret void
+; FIXED-TARGET: ret void
 	s_endpgm
 
 	.globl	rounding_kernel

--- a/amd/comgr/test-lit/hotswap/raiser/global_loads.s
+++ b/amd/comgr/test-lit/hotswap/raiser/global_loads.s
@@ -6,19 +6,9 @@
 ; RUN: %hotswap_transpile_cli %t.hsaco --target-isa=gfx942 \
 ; RUN:   --emit-ir=global_loads | %FileCheck %s --check-prefix=IR
 ; RUN: not %hotswap_transpile_cli %t.hsaco --target-isa=gfx942 \
-; RUN:   --emit-ir=global_load_cache_policy 2>&1 | \
-; RUN:   %FileCheck %s --check-prefix=CACHE-POLICY
-; RUN: not %hotswap_transpile_cli %t.hsaco --target-isa=gfx942 \
-; RUN:   --emit-ir=global_load_unaligned_offset 2>&1 | \
-; RUN:   %FileCheck %s --check-prefix=UNALIGNED-OFFSET
-; RUN: not %hotswap_transpile_cli %t.hsaco --target-isa=gfx942 \
-; RUN:   --emit-ir=global_load_pair 2>&1 | \
-; RUN:   %FileCheck %s --check-prefix=PAIR
-; RUN: not %hotswap_transpile_cli %t.hsaco --target-isa=gfx942 \
-; RUN:   --emit-ir=global_load_flat 2>&1 | %FileCheck %s --check-prefix=FLAT
-; RUN: not %hotswap_transpile_cli %t.hsaco --target-isa=gfx942 \
-; RUN:   --emit-ir=global_load_scratch 2>&1 | \
-; RUN:   %FileCheck %s --check-prefix=SCRATCH
+; RUN:   --emit-ir=global_load_cache_policy,global_load_unaligned_offset \
+; RUN:   --emit-ir=global_load_pair,global_load_flat,global_load_scratch 2>&1 \
+; RUN:   | %FileCheck %s --check-prefix=REFUSE
 
 	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
 	.amdhsa_code_object_version 6
@@ -60,7 +50,8 @@ global_loads:
 	.p2align	8
 	.type	global_load_cache_policy,@function
 global_load_cache_policy:
-; CACHE-POLICY: non-default cache policy is not modeled
+; REFUSE:      in kernel 'global_load_cache_policy'
+; REFUSE-SAME: non-default cache policy is not modeled
 	global_load_dword v1, v[2:3], off sc0
 	s_endpgm
 
@@ -68,7 +59,8 @@ global_load_cache_policy:
 	.p2align	8
 	.type	global_load_unaligned_offset,@function
 global_load_unaligned_offset:
-; UNALIGNED-OFFSET: immediate offset does not preserve the alignment of the access
+; REFUSE:      in kernel 'global_load_unaligned_offset'
+; REFUSE-SAME: immediate offset does not preserve the alignment of the access
 	global_load_dword v1, v[2:3], off offset:1
 	s_endpgm
 
@@ -76,7 +68,8 @@ global_load_unaligned_offset:
 	.p2align	8
 	.type	global_load_pair,@function
 global_load_pair:
-; PAIR: unsupported flat memory operation
+; REFUSE:      in kernel 'global_load_pair'
+; REFUSE-SAME: unsupported flat memory operation
 	global_load_dwordx2 v[2:3], v[2:3], off
 	s_endpgm
 
@@ -84,7 +77,8 @@ global_load_pair:
 	.p2align	8
 	.type	global_load_flat,@function
 global_load_flat:
-; FLAT: unsupported flat memory operation
+; REFUSE:      in kernel 'global_load_flat'
+; REFUSE-SAME: unsupported flat memory operation
 	flat_load_dword v1, v[2:3]
 	s_endpgm
 
@@ -92,7 +86,8 @@ global_load_flat:
 	.p2align	8
 	.type	global_load_scratch,@function
 global_load_scratch:
-; SCRATCH: unsupported flat memory operation
+; REFUSE:      in kernel 'global_load_scratch'
+; REFUSE-SAME: unsupported flat memory operation
 	scratch_load_dword v1, v0, off
 	s_endpgm
 

--- a/amd/comgr/test-lit/hotswap/raiser/mov_endpgm.s
+++ b/amd/comgr/test-lit/hotswap/raiser/mov_endpgm.s
@@ -3,21 +3,19 @@
 ; RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx942 %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 
-; s0 is never read, so the moved value is dead and the lifted body is just the
-; terminator.
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=mov_endpgm_kernel | %FileCheck %s
+; Scalar and integer VOP1 moves both lift as register-file copies. Neither
+; destination is read again, so the moved value is dead in each and the lifted
+; body is just the terminator.
+; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=mov_endpgm_kernel,vmov_kernel \
+; RUN:   | %FileCheck %s
 ; CHECK-LABEL: define amdgpu_kernel void @mov_endpgm_kernel(
+; CHECK: ret void
+; CHECK-LABEL: define amdgpu_kernel void @vmov_kernel(
 ; CHECK: ret void
 
 ; The decoder maps the two instructions onto their canonical ops.
 ; RUN: %hotswap_transpile_cli %t.hsaco --dump-decoded=mov_endpgm_kernel \
 ; RUN:   | %FileCheck %s --check-prefix=DECODE
-
-; Integer VOP1 moves lift as register-file copies.
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=vmov_kernel \
-; RUN:   | %FileCheck %s --check-prefix=VMOV
-; VMOV-LABEL: define amdgpu_kernel void @vmov_kernel(
-; VMOV: ret void
 
 ; Raising the whole code object runs both kernels through one call.
 ; RUN: %hotswap_transpile_cli %t.hsaco --target-isa=gfx950 --emit-ir \

--- a/amd/comgr/test-lit/hotswap/raiser/movrel.s
+++ b/amd/comgr/test-lit/hotswap/raiser/movrel.s
@@ -3,50 +3,23 @@
 ; RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -filetype=obj -mcpu=gfx1250 %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 
-; RUN: %hotswap_transpile_cli %t.hsaco --dump-decoded=movrels_kernel \
-; RUN:   | %FileCheck %s --check-prefix=DECODE-MOVRELS
-; RUN: %hotswap_transpile_cli %t.hsaco --dump-decoded=movreld_kernel \
-; RUN:   | %FileCheck %s --check-prefix=DECODE-MOVRELD
-; RUN: %hotswap_transpile_cli %t.hsaco --dump-decoded=movrelsd_2_kernel \
-; RUN:   | %FileCheck %s --check-prefix=DECODE-MOVRELSD2
+; RUN: %hotswap_transpile_cli %t.hsaco \
+; RUN:   --dump-decoded=movrels_kernel,movreld_kernel,movrelsd_2_kernel \
+; RUN:   | %FileCheck %s --check-prefix=DECODE
 
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=movrels_kernel \
-; RUN:   | %FileCheck %s --check-prefix=MOVRELS
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=movreld_kernel \
-; RUN:   | %FileCheck %s --check-prefix=MOVRELD
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=movrelsd_2_kernel \
-; RUN:   | %FileCheck %s --check-prefix=MOVRELSD2
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=m0_reload_kernel \
-; RUN:   | %FileCheck %s --check-prefix=M0-RELOAD
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=last_sgpr_kernel \
-; RUN:   | %FileCheck %s --check-prefix=LAST-SGPR
+; RUN: %hotswap_transpile_cli %t.hsaco \
+; RUN:   --emit-ir=movrels_kernel,movreld_kernel,movrelsd_2_kernel \
+; RUN:   --emit-ir=m0_reload_kernel,last_sgpr_kernel \
+; RUN:   | %FileCheck %s
 
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=dynamic_m0_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=DYNAMIC
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=odd_index_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=ODD
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=odd_index_dst_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=ODD-DST
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=past_last_sgpr_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=PAST-LAST-SGPR
 ; RUN: not %hotswap_transpile_cli %t.hsaco \
-; RUN:   --emit-ir=past_last_sgpr_pair_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=PAST-LAST-PAIR
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=movreld_range_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=DRANGE
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=movrelsd_2_src_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=SDSRC
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=movrelsd_2_dst_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=SDDST
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=not_sgpr_src_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=NOT-SGPR-SRC
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=not_sgpr_dst_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=NOT-SGPR-DST
-; RUN: not %hotswap_transpile_cli %t.hsaco \
-; RUN:   --emit-ir=not_sgpr_sd_dst_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=NOT-SGPR-SD-DST
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=unhandled_sop1_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=UNHANDLED
+; RUN:   --emit-ir=past_last_sgpr_kernel,past_last_sgpr_pair_kernel \
+; RUN:   --emit-ir=dynamic_m0_kernel,odd_index_kernel,odd_index_dst_kernel \
+; RUN:   --emit-ir=movreld_range_kernel,movrelsd_2_src_kernel \
+; RUN:   --emit-ir=movrelsd_2_dst_kernel,not_sgpr_src_kernel \
+; RUN:   --emit-ir=not_sgpr_dst_kernel,not_sgpr_sd_dst_kernel \
+; RUN:   --emit-ir=unhandled_sop1_kernel 2>&1 \
+; RUN:   | %FileCheck %s --check-prefix=REFUSE
 
 	.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 	.text
@@ -58,7 +31,7 @@
 	.globl	movrels_kernel
 	.p2align	8
 	.type	movrels_kernel,@function
-; MOVRELS-LABEL: define amdgpu_kernel void @movrels_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @movrels_kernel(
 movrels_kernel:
 	s_mov_b32 s7, 7
 	s_mov_b32 s8, 8
@@ -69,32 +42,32 @@ movrels_kernel:
 	s_mov_b32 s19, 19
 	s_mov_b32 m0, 10
 ; s_movrels displaces its source index, so s7 with M0 = 10 reads s17.
-; DECODE-MOVRELS: S_MOVRELS_B32{{.+}}s_movrels_b32 s5, s7
+; DECODE: S_MOVRELS_B32{{.+}}s_movrels_b32 s5, s7
 	s_movrels_b32 s5, s7
-; MOVRELS: uitofp i32 17 to float
+; CHECK: uitofp i32 17 to float
 	s_cvt_f32_u32 s1, s5
 ; The pair based at s8 reads the pair based at s18. A 64-bit read pairs the two
 ; halves and the write splits them again, so the destination halves are the
 ; ends of that chain rather than plain constants.
-; DECODE-MOVRELS: S_MOVRELS_B64{{.+}}s_movrels_b64 s[2:3], s[8:9]
-; MOVRELS: [[S18:%.+]] = zext i32 18 to i64
-; MOVRELS: [[S19:%.+]] = zext i32 19 to i64
-; MOVRELS: [[HI:%.+]] = shl i64 [[S19]], 32
-; MOVRELS: [[PAIR:%.+]] = or i64 [[S18]], [[HI]]
-; MOVRELS: [[LOW:%.+]] = trunc i64 [[PAIR]] to i32
-; MOVRELS: [[SHIFTED:%.+]] = lshr i64 [[PAIR]], 32
-; MOVRELS: [[HIGH:%.+]] = trunc i64 [[SHIFTED]] to i32
+; DECODE: S_MOVRELS_B64{{.+}}s_movrels_b64 s[2:3], s[8:9]
+; CHECK: [[S18:%.+]] = zext i32 18 to i64
+; CHECK: [[S19:%.+]] = zext i32 19 to i64
+; CHECK: [[HI:%.+]] = shl i64 [[S19]], 32
+; CHECK: [[PAIR:%.+]] = or i64 [[S18]], [[HI]]
+; CHECK: [[LOW:%.+]] = trunc i64 [[PAIR]] to i32
+; CHECK: [[SHIFTED:%.+]] = lshr i64 [[PAIR]], 32
+; CHECK: [[HIGH:%.+]] = trunc i64 [[SHIFTED]] to i32
 	s_movrels_b64 s[2:3], s[8:9]
-; MOVRELS: uitofp i32 [[LOW]] to float
+; CHECK: uitofp i32 [[LOW]] to float
 	s_cvt_f32_u32 s1, s2
-; MOVRELS: uitofp i32 [[HIGH]] to float
+; CHECK: uitofp i32 [[HIGH]] to float
 	s_cvt_f32_u32 s1, s3
 	s_endpgm
 
 	.globl	movreld_kernel
 	.p2align	8
 	.type	movreld_kernel,@function
-; MOVRELD-LABEL: define amdgpu_kernel void @movreld_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @movreld_kernel(
 movreld_kernel:
 	s_mov_b32 s7, 7
 	s_mov_b32 s8, 8
@@ -105,37 +78,37 @@ movreld_kernel:
 	s_mov_b32 m0, 10
 ; s_movreld displaces its destination index, so s5 with M0 = 10 writes s15
 ; while its source stays at s7.
-; DECODE-MOVRELD: S_MOVRELD_B32{{.+}}s_movreld_b32 s5, s7
+; DECODE: S_MOVRELD_B32{{.+}}s_movreld_b32 s5, s7
 	s_movreld_b32 s5, s7
-; MOVRELD: uitofp i32 7 to float
+; CHECK: uitofp i32 7 to float
 	s_cvt_f32_u32 s1, s15
 ; The registers either side of the resolved destination keep their own values.
-; MOVRELD: uitofp i32 14 to float
+; CHECK: uitofp i32 14 to float
 	s_cvt_f32_u32 s1, s14
-; MOVRELD: uitofp i32 16 to float
+; CHECK: uitofp i32 16 to float
 	s_cvt_f32_u32 s1, s16
 ; The pair based at s2 is written through the pair based at s12. A 64-bit read
 ; pairs the two source halves and the write splits them again, so what lands in
 ; the destination halves is the end of that chain rather than a plain constant.
-; DECODE-MOVRELD: S_MOVRELD_B64{{.+}}s_movreld_b64 s[2:3], s[8:9]
-; MOVRELD: [[S8:%.+]] = zext i32 8 to i64
-; MOVRELD: [[S9:%.+]] = zext i32 9 to i64
-; MOVRELD: [[HI:%.+]] = shl i64 [[S9]], 32
-; MOVRELD: [[PAIR:%.+]] = or i64 [[S8]], [[HI]]
-; MOVRELD: [[LOW:%.+]] = trunc i64 [[PAIR]] to i32
-; MOVRELD: [[SHIFTED:%.+]] = lshr i64 [[PAIR]], 32
-; MOVRELD: [[HIGH:%.+]] = trunc i64 [[SHIFTED]] to i32
+; DECODE: S_MOVRELD_B64{{.+}}s_movreld_b64 s[2:3], s[8:9]
+; CHECK: [[S8:%.+]] = zext i32 8 to i64
+; CHECK: [[S9:%.+]] = zext i32 9 to i64
+; CHECK: [[HI:%.+]] = shl i64 [[S9]], 32
+; CHECK: [[PAIR:%.+]] = or i64 [[S8]], [[HI]]
+; CHECK: [[LOW:%.+]] = trunc i64 [[PAIR]] to i32
+; CHECK: [[SHIFTED:%.+]] = lshr i64 [[PAIR]], 32
+; CHECK: [[HIGH:%.+]] = trunc i64 [[SHIFTED]] to i32
 	s_movreld_b64 s[2:3], s[8:9]
-; MOVRELD: uitofp i32 [[LOW]] to float
+; CHECK: uitofp i32 [[LOW]] to float
 	s_cvt_f32_u32 s1, s12
-; MOVRELD: uitofp i32 [[HIGH]] to float
+; CHECK: uitofp i32 [[HIGH]] to float
 	s_cvt_f32_u32 s1, s13
 	s_endpgm
 
 	.globl	movrelsd_2_kernel
 	.p2align	8
 	.type	movrelsd_2_kernel,@function
-; MOVRELSD2-LABEL: define amdgpu_kernel void @movrelsd_2_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @movrelsd_2_kernel(
 movrelsd_2_kernel:
 	s_mov_b32 s7, 7
 	s_mov_b32 s8, 8
@@ -146,11 +119,11 @@ movrelsd_2_kernel:
 ; M0[25:16], so s7 reads s17 and s5 writes s8. Swapping the two fields would
 ; read s10 and write s15 instead.
 	s_mov_b32 m0, 0x3000a
-; DECODE-MOVRELSD2: S_MOVRELSD_2_B32{{.+}}s_movrelsd_2_b32 s5, s7
+; DECODE: S_MOVRELSD_2_B32{{.+}}s_movrelsd_2_b32 s5, s7
 	s_movrelsd_2_b32 s5, s7
-; MOVRELSD2: uitofp i32 17 to float
+; CHECK: uitofp i32 17 to float
 	s_cvt_f32_u32 s1, s8
-; MOVRELSD2: uitofp i32 15 to float
+; CHECK: uitofp i32 15 to float
 	s_cvt_f32_u32 s1, s15
 	s_endpgm
 
@@ -158,17 +131,17 @@ movrelsd_2_kernel:
 	.globl	m0_reload_kernel
 	.p2align	8
 	.type	m0_reload_kernel,@function
-; M0-RELOAD-LABEL: define amdgpu_kernel void @m0_reload_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @m0_reload_kernel(
 m0_reload_kernel:
 	s_mov_b32 s17, 17
 	s_mov_b32 s27, 27
 	s_mov_b32 m0, 10
 	s_movrels_b32 s5, s7
-; M0-RELOAD: uitofp i32 17 to float
+; CHECK: uitofp i32 17 to float
 	s_cvt_f32_u32 s1, s5
 	s_mov_b32 m0, 20
 	s_movrels_b32 s6, s7
-; M0-RELOAD: uitofp i32 27 to float
+; CHECK: uitofp i32 27 to float
 	s_cvt_f32_u32 s1, s6
 	s_endpgm
 
@@ -177,13 +150,13 @@ m0_reload_kernel:
 	.globl	last_sgpr_kernel
 	.p2align	8
 	.type	last_sgpr_kernel,@function
-; LAST-SGPR-LABEL: define amdgpu_kernel void @last_sgpr_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @last_sgpr_kernel(
 last_sgpr_kernel:
 	s_mov_b32 m0, 102
 	s_movrels_b32 s5, s5
 	s_mov_b32 m0, 100
 	s_movrels_b64 s[2:3], s[6:7]
-; LAST-SGPR: ret void
+; CHECK: ret void
 	s_endpgm
 
 ; One index past the last register is refused.
@@ -193,7 +166,7 @@ last_sgpr_kernel:
 past_last_sgpr_kernel:
 	s_mov_b32 m0, 103
 	s_movrels_b32 s5, s5
-; PAST-LAST-SGPR: unsupported-instruction-form: s_movrels_b32{{.+}}movrel: resolved SGPR index 108 is out of range
+; REFUSE: unsupported-instruction-form: s_movrels_b32{{.+}}movrel: resolved SGPR index 108 is out of range
 	s_endpgm
 
 ; A pair needs both its halves inside the file, so the last pair a 64-bit
@@ -204,7 +177,7 @@ past_last_sgpr_kernel:
 past_last_sgpr_pair_kernel:
 	s_mov_b32 m0, 102
 	s_movrels_b64 s[2:3], s[6:7]
-; PAST-LAST-PAIR: unsupported-instruction-form: s_movrels_b64{{.+}}movrel: resolved SGPR index 108 is out of range
+; REFUSE: unsupported-instruction-form: s_movrels_b64{{.+}}movrel: resolved SGPR index 108 is out of range
 	s_endpgm
 
 ; An M0 that is not a raise-time constant leaves the relative index unresolved.
@@ -214,7 +187,7 @@ past_last_sgpr_pair_kernel:
 dynamic_m0_kernel:
 	s_mov_b32 m0, s4
 	s_movrels_b32 s5, s7
-; DYNAMIC: unsupported-instruction-form: s_movrels_b32{{.+}}movrel: M0 does not hold a constant here
+; REFUSE: unsupported-instruction-form: s_movrels_b32{{.+}}movrel: M0 does not hold a constant here
 	s_endpgm
 
 ; A 64-bit relative access must land on an even index, whether the index comes
@@ -225,7 +198,7 @@ dynamic_m0_kernel:
 odd_index_kernel:
 	s_mov_b32 m0, 1
 	s_movrels_b64 s[6:7], s[8:9]
-; ODD: unsupported-instruction-form: s_movrels_b64{{.+}}movrel: 64-bit access resolves to odd SGPR index 9
+; REFUSE: unsupported-instruction-form: s_movrels_b64{{.+}}movrel: 64-bit access resolves to odd SGPR index 9
 	s_endpgm
 
 	.globl	odd_index_dst_kernel
@@ -234,7 +207,7 @@ odd_index_kernel:
 odd_index_dst_kernel:
 	s_mov_b32 m0, 1
 	s_movreld_b64 s[6:7], s[8:9]
-; ODD-DST: unsupported-instruction-form: s_movreld_b64{{.+}}movrel: 64-bit access resolves to odd SGPR index 7
+; REFUSE: unsupported-instruction-form: s_movreld_b64{{.+}}movrel: 64-bit access resolves to odd SGPR index 7
 	s_endpgm
 
 ; s_movreld displaces its destination index, so s5 with M0 = 200 names s205.
@@ -244,7 +217,7 @@ odd_index_dst_kernel:
 movreld_range_kernel:
 	s_mov_b32 m0, 200
 	s_movreld_b32 s5, s7
-; DRANGE: unsupported-instruction-form: s_movreld_b32{{.+}}movrel: resolved SGPR index 205 is out of range
+; REFUSE: unsupported-instruction-form: s_movreld_b32{{.+}}movrel: resolved SGPR index 205 is out of range
 	s_endpgm
 
 ; s_movrelsd_2 takes its source displacement from M0[9:0], so s7 names s207.
@@ -254,7 +227,7 @@ movreld_range_kernel:
 movrelsd_2_src_kernel:
 	s_mov_b32 m0, 200
 	s_movrelsd_2_b32 s5, s7
-; SDSRC: unsupported-instruction-form: s_movrelsd_2_b32{{.+}}movrel: resolved SGPR index 207 is out of range
+; REFUSE: unsupported-instruction-form: s_movrelsd_2_b32{{.+}}movrel: resolved SGPR index 207 is out of range
 	s_endpgm
 
 ; s_movrelsd_2 takes its destination displacement from M0[25:16], so s5 names
@@ -265,7 +238,7 @@ movrelsd_2_src_kernel:
 movrelsd_2_dst_kernel:
 	s_mov_b32 m0, 0xc80000
 	s_movrelsd_2_b32 s5, s7
-; SDDST: unsupported-instruction-form: s_movrelsd_2_b32{{.+}}movrel: resolved SGPR index 205 is out of range
+; REFUSE: unsupported-instruction-form: s_movrelsd_2_b32{{.+}}movrel: resolved SGPR index 205 is out of range
 	s_endpgm
 
 ; Only an SGPR carries an index the displacement can be added to. The scalar
@@ -277,7 +250,7 @@ movrelsd_2_dst_kernel:
 not_sgpr_src_kernel:
 	s_mov_b32 m0, 0
 	s_movrels_b32 s5, vcc_lo
-; NOT-SGPR-SRC: unsupported-instruction-form: s_movrels_b32{{.+}}movrel: relative operand is not an SGPR
+; REFUSE: unsupported-instruction-form: s_movrels_b32{{.+}}movrel: relative operand is not an SGPR
 	s_endpgm
 
 	.globl	not_sgpr_dst_kernel
@@ -286,7 +259,7 @@ not_sgpr_src_kernel:
 not_sgpr_dst_kernel:
 	s_mov_b32 m0, 0
 	s_movreld_b32 vcc_lo, s7
-; NOT-SGPR-DST: unsupported-instruction-form: s_movreld_b32{{.+}}movrel: relative operand is not an SGPR
+; REFUSE: unsupported-instruction-form: s_movreld_b32{{.+}}movrel: relative operand is not an SGPR
 	s_endpgm
 
 	.globl	not_sgpr_sd_dst_kernel
@@ -295,7 +268,7 @@ not_sgpr_dst_kernel:
 not_sgpr_sd_dst_kernel:
 	s_mov_b32 m0, 0
 	s_movrelsd_2_b32 vcc_lo, s7
-; NOT-SGPR-SD-DST: unsupported-instruction-form: s_movrelsd_2_b32{{.+}}movrel: relative operand is not an SGPR
+; REFUSE: unsupported-instruction-form: s_movrelsd_2_b32{{.+}}movrel: relative operand is not an SGPR
 	s_endpgm
 
 ; handleSOP1 still refuses every SOP1 opcode it does not lift.
@@ -304,7 +277,7 @@ not_sgpr_sd_dst_kernel:
 	.type	unhandled_sop1_kernel,@function
 unhandled_sop1_kernel:
 	s_rfe_i64 s[0:1]
-; UNHANDLED: unsupported-instruction-form: s_rfe_i64
+; REFUSE: unsupported-instruction-form: s_rfe_i64
 	s_endpgm
 
 	.section	.rodata,"a",@progbits

--- a/amd/comgr/test-lit/hotswap/raiser/refuse_sopk_hwreg_state.s
+++ b/amd/comgr/test-lit/hotswap/raiser/refuse_sopk_hwreg_state.s
@@ -2,12 +2,9 @@
 
 ; RUN: %llvm-mc -triple=amdgpu9.42-amd-amdhsa -filetype=obj %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=refuse_hwreg_read 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=READ
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=refuse_hwreg_write 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=WRITE
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=refuse_mode_read 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=MODE-READ
+; RUN: not %hotswap_transpile_cli %t.hsaco \
+; RUN:   --emit-ir=refuse_hwreg_read,refuse_hwreg_write,refuse_mode_read 2>&1 \
+; RUN:   | %FileCheck %s --check-prefix=REFUSE
 
 	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
 	.amdhsa_code_object_version 6
@@ -16,7 +13,8 @@
 	.p2align	8
 	.type	refuse_hwreg_read,@function
 refuse_hwreg_read:
-	; READ: unsupported-instruction-form
+	; REFUSE:      in kernel 'refuse_hwreg_read'
+	; REFUSE-SAME: cannot reproduce hardware-register read for id 20
 	; READ-SAME: s_getreg_b32
 	; READ-SAME: cannot reproduce hardware-register read for id 20
 	s_getreg_b32 s0, hwreg(20)
@@ -26,7 +24,8 @@ refuse_hwreg_read:
 	.p2align	8
 	.type	refuse_hwreg_write,@function
 refuse_hwreg_write:
-	; WRITE: unsupported-instruction-form
+	; REFUSE:      in kernel 'refuse_hwreg_write'
+	; REFUSE-SAME: cannot reproduce hardware-register write for id 16
 	; WRITE-SAME: s_setreg_imm32_b32
 	; WRITE-SAME: cannot reproduce hardware-register write for id 16
 	s_setreg_imm32_b32 hwreg(16), 1
@@ -36,7 +35,8 @@ refuse_hwreg_write:
 	.p2align	8
 	.type	refuse_mode_read,@function
 refuse_mode_read:
-	; MODE-READ: unsupported-instruction-form
+	; REFUSE:      in kernel 'refuse_mode_read'
+	; REFUSE-SAME: cannot reproduce hardware-register read for id 1
 	; MODE-READ-SAME: s_getreg_b32
 	; MODE-READ-SAME: cannot reproduce hardware-register read for id 1
 	s_setreg_imm32_b32 hwreg(HW_REG_MODE, 0, 4), 5

--- a/amd/comgr/test-lit/hotswap/raiser/scalar_float.s
+++ b/amd/comgr/test-lit/hotswap/raiser/scalar_float.s
@@ -4,11 +4,9 @@
 ; RUN: %llvm-mc -triple=amdgpu12.50-amd-amdhsa -filetype=obj %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=scalar_float_kernel | %FileCheck %s
-
-; None of the scalar float opcodes writes SCC.
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=scc_kernel \
-; RUN:   | %FileCheck %s --check-prefix=SCC
+; RUN: %hotswap_transpile_cli %t.hsaco \
+; RUN:   --emit-ir=scalar_float_kernel,scc_kernel \
+; RUN:   | %FileCheck %s
 
 ; s_rfe_i64 has no lowering, and SOP1 refuses an opcode it does not lift rather
 ; than letting it through unlowered.
@@ -114,12 +112,12 @@ scalar_float_kernel:
 ; s_not_b32 writes SCC and s_cmov_b32 reads it. Every scalar float opcode runs
 ; in between, so the select still taking the bit s_not_b32 produced is what
 ; says none of them touched SCC along the way.
-; SCC-LABEL: define amdgpu_kernel void @scc_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @scc_kernel(
 scc_kernel:
 ; The value s_cmov_b32 preserves when SCC is clear.
 	s_mov_b32 s2, 7
-; SCC: [[NOT:%.+]] = xor i32 {{.+}}, -1
-; SCC: [[SCC:%.+]] = icmp ne i32 [[NOT]], 0
+; CHECK: [[NOT:%.+]] = xor i32 {{.+}}, -1
+; CHECK: [[SCC:%.+]] = icmp ne i32 [[NOT]], 0
 	s_not_b32 s0, s1
 	s_ceil_f32 s3, s0
 	s_floor_f32 s3, s3
@@ -136,7 +134,7 @@ scc_kernel:
 	s_floor_f16 s3, s3
 	s_trunc_f16 s3, s3
 	s_rndne_f16 s3, s3
-; SCC: select i1 [[SCC]], i32 {{.+}}, i32 7
+; CHECK: select i1 [[SCC]], i32 {{.+}}, i32 7
 	s_cmov_b32 s2, s3
 	s_endpgm
 

--- a/amd/comgr/test-lit/hotswap/raiser/smem_loads.s
+++ b/amd/comgr/test-lit/hotswap/raiser/smem_loads.s
@@ -5,17 +5,14 @@
 ; RUN: %ld.lld -shared %t.gfx1250.o -o %t.gfx1250.hsaco
 
 ; RUN: %hotswap_transpile_cli %t.gfx1250.hsaco --target-isa=gfx942 \
-; RUN:   --emit-ir=smem_loads,smem_wide_loads,smem_wide_overlap,smem_register_offset,smem_wide_register_offset,smem_soffset_overlap,smem_scale_offset \
+; RUN:   --emit-ir=smem_loads,smem_wide_loads,smem_wide_overlap \
+; RUN:   --emit-ir=smem_register_offset,smem_wide_register_offset \
+; RUN:   --emit-ir=smem_soffset_overlap,smem_scale_offset \
 ; RUN:   | %FileCheck %s --check-prefix=IR
 ; RUN: not %hotswap_transpile_cli %t.gfx1250.hsaco --target-isa=gfx942 \
-; RUN:   --emit-ir=smem_cache_policy 2>&1 | \
-; RUN:   %FileCheck %s --check-prefix=CACHE-POLICY
-; RUN: not %hotswap_transpile_cli %t.gfx1250.hsaco --target-isa=gfx942 \
-; RUN:   --emit-ir=smem_buffer_load 2>&1 | \
-; RUN:   %FileCheck %s --check-prefix=BUFFER
-; RUN: not %hotswap_transpile_cli %t.gfx1250.hsaco --target-isa=gfx942 \
-; RUN:   --emit-ir=smem_negative_offset 2>&1 | \
-; RUN:   %FileCheck %s --check-prefix=NEGATIVE-OFFSET
+; RUN:   --emit-ir=smem_cache_policy,smem_buffer_load \
+; RUN:   --emit-ir=smem_negative_offset 2>&1 \
+; RUN:   | %FileCheck %s --check-prefix=REFUSE
 
 	.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 	.amdhsa_code_object_version 6
@@ -212,7 +209,7 @@ smem_scale_offset:
 	.p2align	8
 	.type	smem_cache_policy,@function
 smem_cache_policy:
-; CACHE-POLICY: scalar load cache-policy modifiers other than SCALE_OFFSET are not supported
+; REFUSE: scalar load cache-policy modifiers other than SCALE_OFFSET are not supported
 	s_load_b32 s2, s[0:1], 0x0 scope:SCOPE_SYS
 	s_endpgm
 
@@ -220,7 +217,7 @@ smem_cache_policy:
 	.p2align	8
 	.type	smem_buffer_load,@function
 smem_buffer_load:
-; BUFFER: unsupported scalar memory operation
+; REFUSE: unsupported scalar memory operation
 	s_buffer_load_b32 s4, s[0:3], 0x0
 	s_endpgm
 
@@ -228,7 +225,7 @@ smem_buffer_load:
 	.p2align	8
 	.type	smem_negative_offset,@function
 smem_negative_offset:
-; NEGATIVE-OFFSET: negative scalar load offsets are not supported
+; REFUSE: negative scalar load offsets are not supported
 	s_load_b32 s2, s[0:1], -4
 	s_endpgm
 

--- a/amd/comgr/test-lit/hotswap/raiser/sop1_bits.s
+++ b/amd/comgr/test-lit/hotswap/raiser/sop1_bits.s
@@ -5,22 +5,11 @@
 ; RUN: %llvm-mc -triple=amdgpu12.50-amd-amdhsa -filetype=obj %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=search_kernel \
-; RUN:   | %FileCheck %s --check-prefix=SEARCH
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=search_nothing_kernel \
-; RUN:   | %FileCheck %s --check-prefix=NOTHING
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=sext_kernel \
-; RUN:   | %FileCheck %s --check-prefix=SEXT
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=bitset_kernel \
-; RUN:   | %FileCheck %s --check-prefix=BITSET
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=bitreplicate_kernel \
-; RUN:   | %FileCheck %s --check-prefix=REPLICATE
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=abs_kernel \
-; RUN:   | %FileCheck %s --check-prefix=ABS
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=bcnt_kernel \
-; RUN:   | %FileCheck %s --check-prefix=BCNT
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=scc_kernel \
-; RUN:   | %FileCheck %s --check-prefix=SCC
+; RUN: %hotswap_transpile_cli %t.hsaco \
+; RUN:   --emit-ir=search_kernel,search_nothing_kernel,sext_kernel \
+; RUN:   --emit-ir=bitset_kernel \
+; RUN:   --emit-ir=bitreplicate_kernel,abs_kernel,bcnt_kernel,scc_kernel \
+; RUN:   | %FileCheck %s
 
 ; s_rfe_i64 has no lowering, and SOP1 refuses an opcode it does not lift rather
 ; than letting it through unlowered.
@@ -38,76 +27,76 @@
 	.globl	search_kernel
 	.p2align	8
 	.type	search_kernel,@function
-; SEARCH-LABEL: define amdgpu_kernel void @search_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @search_kernel(
 search_kernel:
 	s_mov_b32 s0, 0x10000
-; SEARCH: [[CTZ:%.+]] = call i32 @llvm.cttz.i32(i32 65536, i1 false)
-; SEARCH: [[CTZ_ANY:%.+]] = icmp ne i32 65536, 0
-; SEARCH: [[CTZ_POS:%.+]] = select i1 [[CTZ_ANY]], i32 [[CTZ]], i32 -1
+; CHECK: [[CTZ:%.+]] = call i32 @llvm.cttz.i32(i32 65536, i1 false)
+; CHECK: [[CTZ_ANY:%.+]] = icmp ne i32 65536, 0
+; CHECK: [[CTZ_POS:%.+]] = select i1 [[CTZ_ANY]], i32 [[CTZ]], i32 -1
 	s_ctz_i32_b32 s1, s0
-; SEARCH: uitofp i32 [[CTZ_POS]] to float
+; CHECK: uitofp i32 [[CTZ_POS]] to float
 	s_cvt_f32_u32 s30, s1
 ; s_clz counts from the other end of the same operand.
-; SEARCH: [[CLZ:%.+]] = call i32 @llvm.ctlz.i32(i32 65536, i1 false)
-; SEARCH: [[CLZ_ANY:%.+]] = icmp ne i32 65536, 0
-; SEARCH: [[CLZ_POS:%.+]] = select i1 [[CLZ_ANY]], i32 [[CLZ]], i32 -1
+; CHECK: [[CLZ:%.+]] = call i32 @llvm.ctlz.i32(i32 65536, i1 false)
+; CHECK: [[CLZ_ANY:%.+]] = icmp ne i32 65536, 0
+; CHECK: [[CLZ_POS:%.+]] = select i1 [[CLZ_ANY]], i32 [[CLZ]], i32 -1
 	s_clz_i32_u32 s2, s0
-; SEARCH: uitofp i32 [[CLZ_POS]] to float
+; CHECK: uitofp i32 [[CLZ_POS]] to float
 	s_cvt_f32_u32 s30, s2
 ; s_cls stops at the first bit unlike the sign rather than at the first set
 ; bit, so a negative source is complemented before the leading zeros of what is
 ; left are counted.
 	s_mov_b32 s3, 0xffff3333
-; SEARCH: [[SIGN:%.+]] = ashr i32 -52429, 31
-; SEARCH: [[CLS_IN:%.+]] = xor i32 -52429, [[SIGN]]
-; SEARCH: [[CLS:%.+]] = call i32 @llvm.ctlz.i32(i32 [[CLS_IN]], i1 false)
-; SEARCH: [[CLS_ANY:%.+]] = icmp ne i32 [[CLS_IN]], 0
-; SEARCH: [[CLS_POS:%.+]] = select i1 [[CLS_ANY]], i32 [[CLS]], i32 -1
+; CHECK: [[SIGN:%.+]] = ashr i32 -52429, 31
+; CHECK: [[CLS_IN:%.+]] = xor i32 -52429, [[SIGN]]
+; CHECK: [[CLS:%.+]] = call i32 @llvm.ctlz.i32(i32 [[CLS_IN]], i1 false)
+; CHECK: [[CLS_ANY:%.+]] = icmp ne i32 [[CLS_IN]], 0
+; CHECK: [[CLS_POS:%.+]] = select i1 [[CLS_ANY]], i32 [[CLS]], i32 -1
 	s_cls_i32 s4, s3
-; SEARCH: uitofp i32 [[CLS_POS]] to float
+; CHECK: uitofp i32 [[CLS_POS]] to float
 	s_cvt_f32_u32 s30, s4
 ; A non-negative source goes into the count as it stands.
 	s_mov_b32 s5, 0xcccc
-; SEARCH: [[PSIGN:%.+]] = ashr i32 52428, 31
-; SEARCH: [[PCLS_IN:%.+]] = xor i32 52428, [[PSIGN]]
-; SEARCH: [[PCLS:%.+]] = call i32 @llvm.ctlz.i32(i32 [[PCLS_IN]], i1 false)
-; SEARCH: [[PCLS_ANY:%.+]] = icmp ne i32 [[PCLS_IN]], 0
-; SEARCH: [[PCLS_POS:%.+]] = select i1 [[PCLS_ANY]], i32 [[PCLS]], i32 -1
+; CHECK: [[PSIGN:%.+]] = ashr i32 52428, 31
+; CHECK: [[PCLS_IN:%.+]] = xor i32 52428, [[PSIGN]]
+; CHECK: [[PCLS:%.+]] = call i32 @llvm.ctlz.i32(i32 [[PCLS_IN]], i1 false)
+; CHECK: [[PCLS_ANY:%.+]] = icmp ne i32 [[PCLS_IN]], 0
+; CHECK: [[PCLS_POS:%.+]] = select i1 [[PCLS_ANY]], i32 [[PCLS]], i32 -1
 	s_cls_i32 s6, s5
-; SEARCH: uitofp i32 [[PCLS_POS]] to float
+; CHECK: uitofp i32 [[PCLS_POS]] to float
 	s_cvt_f32_u32 s30, s6
 ; The 64-bit forms search a register pair and still write a single dword, so
 ; the count is narrowed before it reaches the destination.
 	s_mov_b32 s8, 0
 	s_mov_b32 s9, 0x10000
-; SEARCH: [[CTZ64_IN:%.+]] = or i64 {{.+}}, {{.+}}
-; SEARCH: [[CTZ64:%.+]] = call i64 @llvm.cttz.i64(i64 [[CTZ64_IN]], i1 false)
-; SEARCH: [[CTZ64_LO:%.+]] = trunc i64 [[CTZ64]] to i32
-; SEARCH: [[CTZ64_ANY:%.+]] = icmp ne i64 [[CTZ64_IN]], 0
-; SEARCH: [[CTZ64_POS:%.+]] = select i1 [[CTZ64_ANY]], i32 [[CTZ64_LO]], i32 -1
+; CHECK: [[CTZ64_IN:%.+]] = or i64 {{.+}}, {{.+}}
+; CHECK: [[CTZ64:%.+]] = call i64 @llvm.cttz.i64(i64 [[CTZ64_IN]], i1 false)
+; CHECK: [[CTZ64_LO:%.+]] = trunc i64 [[CTZ64]] to i32
+; CHECK: [[CTZ64_ANY:%.+]] = icmp ne i64 [[CTZ64_IN]], 0
+; CHECK: [[CTZ64_POS:%.+]] = select i1 [[CTZ64_ANY]], i32 [[CTZ64_LO]], i32 -1
 	s_ctz_i32_b64 s10, s[8:9]
-; SEARCH: uitofp i32 [[CTZ64_POS]] to float
+; CHECK: uitofp i32 [[CTZ64_POS]] to float
 	s_cvt_f32_u32 s30, s10
-; SEARCH: [[CLZ64_IN:%.+]] = or i64 {{.+}}, {{.+}}
-; SEARCH: [[CLZ64:%.+]] = call i64 @llvm.ctlz.i64(i64 [[CLZ64_IN]], i1 false)
-; SEARCH: [[CLZ64_LO:%.+]] = trunc i64 [[CLZ64]] to i32
-; SEARCH: [[CLZ64_ANY:%.+]] = icmp ne i64 [[CLZ64_IN]], 0
-; SEARCH: [[CLZ64_POS:%.+]] = select i1 [[CLZ64_ANY]], i32 [[CLZ64_LO]], i32 -1
+; CHECK: [[CLZ64_IN:%.+]] = or i64 {{.+}}, {{.+}}
+; CHECK: [[CLZ64:%.+]] = call i64 @llvm.ctlz.i64(i64 [[CLZ64_IN]], i1 false)
+; CHECK: [[CLZ64_LO:%.+]] = trunc i64 [[CLZ64]] to i32
+; CHECK: [[CLZ64_ANY:%.+]] = icmp ne i64 [[CLZ64_IN]], 0
+; CHECK: [[CLZ64_POS:%.+]] = select i1 [[CLZ64_ANY]], i32 [[CLZ64_LO]], i32 -1
 	s_clz_i32_u64 s11, s[8:9]
-; SEARCH: uitofp i32 [[CLZ64_POS]] to float
+; CHECK: uitofp i32 [[CLZ64_POS]] to float
 	s_cvt_f32_u32 s30, s11
 ; The sign of a pair is its bit 63.
 	s_mov_b32 s12, 0
 	s_mov_b32 s13, 0xffff3333
-; SEARCH: [[PAIR:%.+]] = or i64 {{.+}}, {{.+}}
-; SEARCH: [[SIGN64:%.+]] = ashr i64 [[PAIR]], 63
-; SEARCH: [[CLS64_IN:%.+]] = xor i64 [[PAIR]], [[SIGN64]]
-; SEARCH: [[CLS64:%.+]] = call i64 @llvm.ctlz.i64(i64 [[CLS64_IN]], i1 false)
-; SEARCH: [[CLS64_LO:%.+]] = trunc i64 [[CLS64]] to i32
-; SEARCH: [[CLS64_ANY:%.+]] = icmp ne i64 [[CLS64_IN]], 0
-; SEARCH: [[CLS64_POS:%.+]] = select i1 [[CLS64_ANY]], i32 [[CLS64_LO]], i32 -1
+; CHECK: [[PAIR:%.+]] = or i64 {{.+}}, {{.+}}
+; CHECK: [[SIGN64:%.+]] = ashr i64 [[PAIR]], 63
+; CHECK: [[CLS64_IN:%.+]] = xor i64 [[PAIR]], [[SIGN64]]
+; CHECK: [[CLS64:%.+]] = call i64 @llvm.ctlz.i64(i64 [[CLS64_IN]], i1 false)
+; CHECK: [[CLS64_LO:%.+]] = trunc i64 [[CLS64]] to i32
+; CHECK: [[CLS64_ANY:%.+]] = icmp ne i64 [[CLS64_IN]], 0
+; CHECK: [[CLS64_POS:%.+]] = select i1 [[CLS64_ANY]], i32 [[CLS64_LO]], i32 -1
 	s_cls_i32_i64 s14, s[12:13]
-; SEARCH: uitofp i32 [[CLS64_POS]] to float
+; CHECK: uitofp i32 [[CLS64_POS]] to float
 	s_cvt_f32_u32 s30, s14
 	s_endpgm
 
@@ -118,75 +107,75 @@ search_kernel:
 	.globl	search_nothing_kernel
 	.p2align	8
 	.type	search_nothing_kernel,@function
-; NOTHING-LABEL: define amdgpu_kernel void @search_nothing_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @search_nothing_kernel(
 search_nothing_kernel:
 	s_mov_b32 s0, 0
 	s_mov_b32 s1, 0
-; NOTHING: call i32 @llvm.cttz.i32(i32 0, i1 false)
-; NOTHING: [[CTZ_ANY:%.+]] = icmp ne i32 0, 0
-; NOTHING: [[CTZ_POS:%.+]] = select i1 [[CTZ_ANY]], i32 {{.+}}, i32 -1
+; CHECK: call i32 @llvm.cttz.i32(i32 0, i1 false)
+; CHECK: [[CTZ_ANY:%.+]] = icmp ne i32 0, 0
+; CHECK: [[CTZ_POS:%.+]] = select i1 [[CTZ_ANY]], i32 {{.+}}, i32 -1
 	s_ctz_i32_b32 s2, s0
-; NOTHING: uitofp i32 [[CTZ_POS]] to float
+; CHECK: uitofp i32 [[CTZ_POS]] to float
 	s_cvt_f32_u32 s30, s2
-; NOTHING: call i32 @llvm.ctlz.i32(i32 0, i1 false)
-; NOTHING: [[CLZ_ANY:%.+]] = icmp ne i32 0, 0
-; NOTHING: [[CLZ_POS:%.+]] = select i1 [[CLZ_ANY]], i32 {{.+}}, i32 -1
+; CHECK: call i32 @llvm.ctlz.i32(i32 0, i1 false)
+; CHECK: [[CLZ_ANY:%.+]] = icmp ne i32 0, 0
+; CHECK: [[CLZ_POS:%.+]] = select i1 [[CLZ_ANY]], i32 {{.+}}, i32 -1
 	s_clz_i32_u32 s3, s0
-; NOTHING: uitofp i32 [[CLZ_POS]] to float
+; CHECK: uitofp i32 [[CLZ_POS]] to float
 	s_cvt_f32_u32 s30, s3
-; NOTHING: [[Z_IN:%.+]] = xor i32 0, {{.+}}
-; NOTHING: [[Z_ANY:%.+]] = icmp ne i32 [[Z_IN]], 0
-; NOTHING: [[Z_POS:%.+]] = select i1 [[Z_ANY]], i32 {{.+}}, i32 -1
+; CHECK: [[Z_IN:%.+]] = xor i32 0, {{.+}}
+; CHECK: [[Z_ANY:%.+]] = icmp ne i32 [[Z_IN]], 0
+; CHECK: [[Z_POS:%.+]] = select i1 [[Z_ANY]], i32 {{.+}}, i32 -1
 	s_cls_i32 s4, s0
-; NOTHING: uitofp i32 [[Z_POS]] to float
+; CHECK: uitofp i32 [[Z_POS]] to float
 	s_cvt_f32_u32 s30, s4
 ; All ones is as uniformly signed as all zeros, so it too has no bit to find.
 	s_mov_b32 s5, -1
-; NOTHING: [[ONES_IN:%.+]] = xor i32 -1, {{.+}}
-; NOTHING: [[ONES_ANY:%.+]] = icmp ne i32 [[ONES_IN]], 0
-; NOTHING: [[ONES_POS:%.+]] = select i1 [[ONES_ANY]], i32 {{.+}}, i32 -1
+; CHECK: [[ONES_IN:%.+]] = xor i32 -1, {{.+}}
+; CHECK: [[ONES_ANY:%.+]] = icmp ne i32 [[ONES_IN]], 0
+; CHECK: [[ONES_POS:%.+]] = select i1 [[ONES_ANY]], i32 {{.+}}, i32 -1
 	s_cls_i32 s6, s5
-; NOTHING: uitofp i32 [[ONES_POS]] to float
+; CHECK: uitofp i32 [[ONES_POS]] to float
 	s_cvt_f32_u32 s30, s6
-; NOTHING: [[CTZ64_IN:%.+]] = or i64 {{.+}}, {{.+}}
-; NOTHING: call i64 @llvm.cttz.i64(i64 [[CTZ64_IN]], i1 false)
-; NOTHING: [[CTZ64_ANY:%.+]] = icmp ne i64 [[CTZ64_IN]], 0
-; NOTHING: [[CTZ64_POS:%.+]] = select i1 [[CTZ64_ANY]], i32 {{.+}}, i32 -1
+; CHECK: [[CTZ64_IN:%.+]] = or i64 {{.+}}, {{.+}}
+; CHECK: call i64 @llvm.cttz.i64(i64 [[CTZ64_IN]], i1 false)
+; CHECK: [[CTZ64_ANY:%.+]] = icmp ne i64 [[CTZ64_IN]], 0
+; CHECK: [[CTZ64_POS:%.+]] = select i1 [[CTZ64_ANY]], i32 {{.+}}, i32 -1
 	s_ctz_i32_b64 s7, s[0:1]
-; NOTHING: uitofp i32 [[CTZ64_POS]] to float
+; CHECK: uitofp i32 [[CTZ64_POS]] to float
 	s_cvt_f32_u32 s30, s7
-; NOTHING: [[CLZ64_IN:%.+]] = or i64 {{.+}}, {{.+}}
-; NOTHING: call i64 @llvm.ctlz.i64(i64 [[CLZ64_IN]], i1 false)
-; NOTHING: [[CLZ64_ANY:%.+]] = icmp ne i64 [[CLZ64_IN]], 0
-; NOTHING: [[CLZ64_POS:%.+]] = select i1 [[CLZ64_ANY]], i32 {{.+}}, i32 -1
+; CHECK: [[CLZ64_IN:%.+]] = or i64 {{.+}}, {{.+}}
+; CHECK: call i64 @llvm.ctlz.i64(i64 [[CLZ64_IN]], i1 false)
+; CHECK: [[CLZ64_ANY:%.+]] = icmp ne i64 [[CLZ64_IN]], 0
+; CHECK: [[CLZ64_POS:%.+]] = select i1 [[CLZ64_ANY]], i32 {{.+}}, i32 -1
 	s_clz_i32_u64 s8, s[0:1]
-; NOTHING: uitofp i32 [[CLZ64_POS]] to float
+; CHECK: uitofp i32 [[CLZ64_POS]] to float
 	s_cvt_f32_u32 s30, s8
-; NOTHING: [[CLS64_IN:%.+]] = xor i64 {{.+}}, {{.+}}
-; NOTHING: [[CLS64_ANY:%.+]] = icmp ne i64 [[CLS64_IN]], 0
-; NOTHING: [[CLS64_POS:%.+]] = select i1 [[CLS64_ANY]], i32 {{.+}}, i32 -1
+; CHECK: [[CLS64_IN:%.+]] = xor i64 {{.+}}, {{.+}}
+; CHECK: [[CLS64_ANY:%.+]] = icmp ne i64 [[CLS64_IN]], 0
+; CHECK: [[CLS64_POS:%.+]] = select i1 [[CLS64_ANY]], i32 {{.+}}, i32 -1
 	s_cls_i32_i64 s9, s[0:1]
-; NOTHING: uitofp i32 [[CLS64_POS]] to float
+; CHECK: uitofp i32 [[CLS64_POS]] to float
 	s_cvt_f32_u32 s30, s9
 	s_endpgm
 
 	.globl	sext_kernel
 	.p2align	8
 	.type	sext_kernel,@function
-; SEXT-LABEL: define amdgpu_kernel void @sext_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @sext_kernel(
 sext_kernel:
 ; The source has bit 7 and bit 15 set, so the two widths disagree on the sign
 ; and a check on one of them cannot pass for the other.
 	s_mov_b32 s0, 0xff81
-; SEXT: [[BYTE:%.+]] = trunc i32 65409 to i8
-; SEXT: [[SEXT8:%.+]] = sext i8 [[BYTE]] to i32
+; CHECK: [[BYTE:%.+]] = trunc i32 65409 to i8
+; CHECK: [[SEXT8:%.+]] = sext i8 [[BYTE]] to i32
 	s_sext_i32_i8 s1, s0
-; SEXT: uitofp i32 [[SEXT8]] to float
+; CHECK: uitofp i32 [[SEXT8]] to float
 	s_cvt_f32_u32 s30, s1
-; SEXT: [[HALF:%.+]] = trunc i32 65409 to i16
-; SEXT: [[SEXT16:%.+]] = sext i16 [[HALF]] to i32
+; CHECK: [[HALF:%.+]] = trunc i32 65409 to i16
+; CHECK: [[SEXT16:%.+]] = sext i16 [[HALF]] to i32
 	s_sext_i32_i16 s2, s0
-; SEXT: uitofp i32 [[SEXT16]] to float
+; CHECK: uitofp i32 [[SEXT16]] to float
 	s_cvt_f32_u32 s30, s2
 	s_endpgm
 
@@ -196,55 +185,55 @@ sext_kernel:
 	.globl	bitset_kernel
 	.p2align	8
 	.type	bitset_kernel,@function
-; BITSET-LABEL: define amdgpu_kernel void @bitset_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @bitset_kernel(
 bitset_kernel:
 	s_mov_b32 s0, -1
 	s_mov_b32 s1, 5
-; BITSET: [[I0:%.+]] = and i32 5, 31
-; BITSET: [[B0:%.+]] = shl i32 1, [[I0]]
-; BITSET: [[N0:%.+]] = xor i32 [[B0]], -1
-; BITSET: [[CLEARED:%.+]] = and i32 -1, [[N0]]
+; CHECK: [[I0:%.+]] = and i32 5, 31
+; CHECK: [[B0:%.+]] = shl i32 1, [[I0]]
+; CHECK: [[N0:%.+]] = xor i32 [[B0]], -1
+; CHECK: [[CLEARED:%.+]] = and i32 -1, [[N0]]
 	s_bitset0_b32 s0, s1
-; BITSET: uitofp i32 [[CLEARED]] to float
+; CHECK: uitofp i32 [[CLEARED]] to float
 	s_cvt_f32_u32 s30, s0
 	s_mov_b32 s2, 0
-; BITSET: [[I1:%.+]] = and i32 5, 31
-; BITSET: [[B1:%.+]] = shl i32 1, [[I1]]
-; BITSET: [[SET:%.+]] = or i32 0, [[B1]]
+; CHECK: [[I1:%.+]] = and i32 5, 31
+; CHECK: [[B1:%.+]] = shl i32 1, [[I1]]
+; CHECK: [[SET:%.+]] = or i32 0, [[B1]]
 	s_bitset1_b32 s2, s1
-; BITSET: uitofp i32 [[SET]] to float
+; CHECK: uitofp i32 [[SET]] to float
 	s_cvt_f32_u32 s30, s2
 ; A pair takes six index bits, so index 32 reaches the high half of the
 ; destination instead of wrapping back to its bit 0.
 	s_mov_b32 s4, 0
 	s_mov_b32 s5, 0
 	s_mov_b32 s3, 32
-; BITSET: [[I2:%.+]] = and i32 32, 63
-; BITSET: [[I2W:%.+]] = zext i32 [[I2]] to i64
-; BITSET: [[B2:%.+]] = shl i64 1, [[I2W]]
-; BITSET: [[SET64:%.+]] = or i64 {{.+}}, [[B2]]
-; BITSET: [[SET64_LO:%.+]] = trunc i64 [[SET64]] to i32
-; BITSET: [[SET64_SHIFTED:%.+]] = lshr i64 [[SET64]], 32
-; BITSET: [[SET64_HI:%.+]] = trunc i64 [[SET64_SHIFTED]] to i32
+; CHECK: [[I2:%.+]] = and i32 32, 63
+; CHECK: [[I2W:%.+]] = zext i32 [[I2]] to i64
+; CHECK: [[B2:%.+]] = shl i64 1, [[I2W]]
+; CHECK: [[SET64:%.+]] = or i64 {{.+}}, [[B2]]
+; CHECK: [[SET64_LO:%.+]] = trunc i64 [[SET64]] to i32
+; CHECK: [[SET64_SHIFTED:%.+]] = lshr i64 [[SET64]], 32
+; CHECK: [[SET64_HI:%.+]] = trunc i64 [[SET64_SHIFTED]] to i32
 	s_bitset1_b64 s[4:5], s3
-; BITSET: uitofp i32 [[SET64_LO]] to float
+; CHECK: uitofp i32 [[SET64_LO]] to float
 	s_cvt_f32_u32 s30, s4
-; BITSET: uitofp i32 [[SET64_HI]] to float
+; CHECK: uitofp i32 [[SET64_HI]] to float
 	s_cvt_f32_u32 s30, s5
 	s_mov_b32 s6, -1
 	s_mov_b32 s7, -1
-; BITSET: [[I3:%.+]] = and i32 32, 63
-; BITSET: [[I3W:%.+]] = zext i32 [[I3]] to i64
-; BITSET: [[B3:%.+]] = shl i64 1, [[I3W]]
-; BITSET: [[N3:%.+]] = xor i64 [[B3]], -1
-; BITSET: [[CLEARED64:%.+]] = and i64 {{.+}}, [[N3]]
-; BITSET: [[CLEARED64_LO:%.+]] = trunc i64 [[CLEARED64]] to i32
-; BITSET: [[CLEARED64_SHIFTED:%.+]] = lshr i64 [[CLEARED64]], 32
-; BITSET: [[CLEARED64_HI:%.+]] = trunc i64 [[CLEARED64_SHIFTED]] to i32
+; CHECK: [[I3:%.+]] = and i32 32, 63
+; CHECK: [[I3W:%.+]] = zext i32 [[I3]] to i64
+; CHECK: [[B3:%.+]] = shl i64 1, [[I3W]]
+; CHECK: [[N3:%.+]] = xor i64 [[B3]], -1
+; CHECK: [[CLEARED64:%.+]] = and i64 {{.+}}, [[N3]]
+; CHECK: [[CLEARED64_LO:%.+]] = trunc i64 [[CLEARED64]] to i32
+; CHECK: [[CLEARED64_SHIFTED:%.+]] = lshr i64 [[CLEARED64]], 32
+; CHECK: [[CLEARED64_HI:%.+]] = trunc i64 [[CLEARED64_SHIFTED]] to i32
 	s_bitset0_b64 s[6:7], s3
-; BITSET: uitofp i32 [[CLEARED64_LO]] to float
+; CHECK: uitofp i32 [[CLEARED64_LO]] to float
 	s_cvt_f32_u32 s30, s6
-; BITSET: uitofp i32 [[CLEARED64_HI]] to float
+; CHECK: uitofp i32 [[CLEARED64_HI]] to float
 	s_cvt_f32_u32 s30, s7
 	s_endpgm
 
@@ -254,103 +243,103 @@ bitset_kernel:
 	.globl	bitreplicate_kernel
 	.p2align	8
 	.type	bitreplicate_kernel,@function
-; REPLICATE-LABEL: define amdgpu_kernel void @bitreplicate_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @bitreplicate_kernel(
 bitreplicate_kernel:
 	s_mov_b32 s0, 0x80000003
-; REPLICATE: [[WIDE:%.+]] = zext i32 -2147483645 to i64
-; REPLICATE: [[SH16:%.+]] = shl i64 [[WIDE]], 16
-; REPLICATE: [[OR16:%.+]] = or i64 [[WIDE]], [[SH16]]
-; REPLICATE: [[K16:%.+]] = and i64 [[OR16]], 281470681808895
-; REPLICATE: [[SH8:%.+]] = shl i64 [[K16]], 8
-; REPLICATE: [[OR8:%.+]] = or i64 [[K16]], [[SH8]]
-; REPLICATE: [[K8:%.+]] = and i64 [[OR8]], 71777214294589695
-; REPLICATE: [[SH4:%.+]] = shl i64 [[K8]], 4
-; REPLICATE: [[OR4:%.+]] = or i64 [[K8]], [[SH4]]
-; REPLICATE: [[K4:%.+]] = and i64 [[OR4]], 1085102592571150095
-; REPLICATE: [[SH2:%.+]] = shl i64 [[K4]], 2
-; REPLICATE: [[OR2:%.+]] = or i64 [[K4]], [[SH2]]
-; REPLICATE: [[K2:%.+]] = and i64 [[OR2]], 3689348814741910323
-; REPLICATE: [[SH1:%.+]] = shl i64 [[K2]], 1
-; REPLICATE: [[OR1:%.+]] = or i64 [[K2]], [[SH1]]
-; REPLICATE: [[EVEN:%.+]] = and i64 [[OR1]], 6148914691236517205
-; REPLICATE: [[ODD:%.+]] = shl i64 [[EVEN]], 1
-; REPLICATE: [[BOTH:%.+]] = or i64 [[EVEN]], [[ODD]]
-; REPLICATE: [[LO:%.+]] = trunc i64 [[BOTH]] to i32
-; REPLICATE: [[SHIFTED:%.+]] = lshr i64 [[BOTH]], 32
-; REPLICATE: [[HI:%.+]] = trunc i64 [[SHIFTED]] to i32
+; CHECK: [[WIDE:%.+]] = zext i32 -2147483645 to i64
+; CHECK: [[SH16:%.+]] = shl i64 [[WIDE]], 16
+; CHECK: [[OR16:%.+]] = or i64 [[WIDE]], [[SH16]]
+; CHECK: [[K16:%.+]] = and i64 [[OR16]], 281470681808895
+; CHECK: [[SH8:%.+]] = shl i64 [[K16]], 8
+; CHECK: [[OR8:%.+]] = or i64 [[K16]], [[SH8]]
+; CHECK: [[K8:%.+]] = and i64 [[OR8]], 71777214294589695
+; CHECK: [[SH4:%.+]] = shl i64 [[K8]], 4
+; CHECK: [[OR4:%.+]] = or i64 [[K8]], [[SH4]]
+; CHECK: [[K4:%.+]] = and i64 [[OR4]], 1085102592571150095
+; CHECK: [[SH2:%.+]] = shl i64 [[K4]], 2
+; CHECK: [[OR2:%.+]] = or i64 [[K4]], [[SH2]]
+; CHECK: [[K2:%.+]] = and i64 [[OR2]], 3689348814741910323
+; CHECK: [[SH1:%.+]] = shl i64 [[K2]], 1
+; CHECK: [[OR1:%.+]] = or i64 [[K2]], [[SH1]]
+; CHECK: [[EVEN:%.+]] = and i64 [[OR1]], 6148914691236517205
+; CHECK: [[ODD:%.+]] = shl i64 [[EVEN]], 1
+; CHECK: [[BOTH:%.+]] = or i64 [[EVEN]], [[ODD]]
+; CHECK: [[LO:%.+]] = trunc i64 [[BOTH]] to i32
+; CHECK: [[SHIFTED:%.+]] = lshr i64 [[BOTH]], 32
+; CHECK: [[HI:%.+]] = trunc i64 [[SHIFTED]] to i32
 	s_bitreplicate_b64_b32 s[2:3], s0
-; REPLICATE: uitofp i32 [[LO]] to float
+; CHECK: uitofp i32 [[LO]] to float
 	s_cvt_f32_u32 s30, s2
-; REPLICATE: uitofp i32 [[HI]] to float
+; CHECK: uitofp i32 [[HI]] to float
 	s_cvt_f32_u32 s30, s3
 	s_endpgm
 
 	.globl	abs_kernel
 	.p2align	8
 	.type	abs_kernel,@function
-; ABS-LABEL: define amdgpu_kernel void @abs_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @abs_kernel(
 abs_kernel:
 ; The most negative input has no positive counterpart and the hardware keeps
 ; it, so the intrinsic is the one that does not make that poison.
 	s_mov_b32 s0, -5
-; ABS: [[NEG:%.+]] = call i32 @llvm.abs.i32(i32 -5, i1 false)
+; CHECK: [[NEG:%.+]] = call i32 @llvm.abs.i32(i32 -5, i1 false)
 	s_abs_i32 s1, s0
-; ABS: uitofp i32 [[NEG]] to float
+; CHECK: uitofp i32 [[NEG]] to float
 	s_cvt_f32_u32 s30, s1
 	s_mov_b32 s2, 5
-; ABS: [[POS:%.+]] = call i32 @llvm.abs.i32(i32 5, i1 false)
-; ABS: [[FLAG:%.+]] = icmp ne i32 [[POS]], 0
+; CHECK: [[POS:%.+]] = call i32 @llvm.abs.i32(i32 5, i1 false)
+; CHECK: [[FLAG:%.+]] = icmp ne i32 [[POS]], 0
 	s_abs_i32 s3, s2
-; ABS: uitofp i32 [[POS]] to float
+; CHECK: uitofp i32 [[POS]] to float
 	s_cvt_f32_u32 s30, s3
 ; s_abs writes SCC, and the move that follows it selects on the bit it wrote.
 	s_mov_b32 s4, 7
-; ABS: [[MOVED:%.+]] = select i1 [[FLAG]], i32 [[POS]], i32 7
+; CHECK: [[MOVED:%.+]] = select i1 [[FLAG]], i32 [[POS]], i32 7
 	s_cmov_b32 s4, s3
-; ABS: uitofp i32 [[MOVED]] to float
+; CHECK: uitofp i32 [[MOVED]] to float
 	s_cvt_f32_u32 s30, s4
 	s_endpgm
 
 	.globl	bcnt_kernel
 	.p2align	8
 	.type	bcnt_kernel,@function
-; BCNT-LABEL: define amdgpu_kernel void @bcnt_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @bcnt_kernel(
 bcnt_kernel:
 ; Half the bits of the source are set, so a count of ones and a count of zeros
 ; agree on the value and only the complement in front of one of them tells the
 ; two lowerings apart.
 	s_mov_b32 s0, 0xcccccccc
-; BCNT: [[FLIPPED:%.+]] = xor i32 -858993460, -1
-; BCNT: [[ZEROS:%.+]] = call i32 @llvm.ctpop.i32(i32 [[FLIPPED]])
+; CHECK: [[FLIPPED:%.+]] = xor i32 -858993460, -1
+; CHECK: [[ZEROS:%.+]] = call i32 @llvm.ctpop.i32(i32 [[FLIPPED]])
 	s_bcnt0_i32_b32 s1, s0
-; BCNT: uitofp i32 [[ZEROS]] to float
+; CHECK: uitofp i32 [[ZEROS]] to float
 	s_cvt_f32_u32 s30, s1
-; BCNT: [[ONES:%.+]] = call i32 @llvm.ctpop.i32(i32 -858993460)
+; CHECK: [[ONES:%.+]] = call i32 @llvm.ctpop.i32(i32 -858993460)
 	s_bcnt1_i32_b32 s2, s0
-; BCNT: uitofp i32 [[ONES]] to float
+; CHECK: uitofp i32 [[ONES]] to float
 	s_cvt_f32_u32 s30, s2
 ; A pair is counted whole and the count still comes out one dword wide.
 	s_mov_b32 s4, 0xcccccccc
 	s_mov_b32 s5, 0
-; BCNT: [[FLIPPED64:%.+]] = xor i64 {{.+}}, -1
-; BCNT: [[ZEROS64:%.+]] = call i64 @llvm.ctpop.i64(i64 [[FLIPPED64]])
-; BCNT: [[ZEROS64_LO:%.+]] = trunc i64 [[ZEROS64]] to i32
+; CHECK: [[FLIPPED64:%.+]] = xor i64 {{.+}}, -1
+; CHECK: [[ZEROS64:%.+]] = call i64 @llvm.ctpop.i64(i64 [[FLIPPED64]])
+; CHECK: [[ZEROS64_LO:%.+]] = trunc i64 [[ZEROS64]] to i32
 	s_bcnt0_i32_b64 s6, s[4:5]
-; BCNT: uitofp i32 [[ZEROS64_LO]] to float
+; CHECK: uitofp i32 [[ZEROS64_LO]] to float
 	s_cvt_f32_u32 s30, s6
-; BCNT: [[PAIR:%.+]] = or i64 {{.+}}, {{.+}}
-; BCNT: [[ONES64:%.+]] = call i64 @llvm.ctpop.i64(i64 [[PAIR]])
-; BCNT: [[ONES64_LO:%.+]] = trunc i64 [[ONES64]] to i32
-; BCNT: [[FLAG:%.+]] = icmp ne i32 [[ONES64_LO]], 0
+; CHECK: [[PAIR:%.+]] = or i64 {{.+}}, {{.+}}
+; CHECK: [[ONES64:%.+]] = call i64 @llvm.ctpop.i64(i64 [[PAIR]])
+; CHECK: [[ONES64_LO:%.+]] = trunc i64 [[ONES64]] to i32
+; CHECK: [[FLAG:%.+]] = icmp ne i32 [[ONES64_LO]], 0
 	s_bcnt1_i32_b64 s7, s[4:5]
-; BCNT: uitofp i32 [[ONES64_LO]] to float
+; CHECK: uitofp i32 [[ONES64_LO]] to float
 	s_cvt_f32_u32 s30, s7
 ; Every s_bcnt writes SCC, and the move that follows selects on the bit the
 ; last of them wrote.
 	s_mov_b32 s8, 7
-; BCNT: [[MOVED:%.+]] = select i1 [[FLAG]], i32 [[ONES64_LO]], i32 7
+; CHECK: [[MOVED:%.+]] = select i1 [[FLAG]], i32 [[ONES64_LO]], i32 7
 	s_cmov_b32 s8, s7
-; BCNT: uitofp i32 [[MOVED]] to float
+; CHECK: uitofp i32 [[MOVED]] to float
 	s_cvt_f32_u32 s30, s8
 	s_endpgm
 
@@ -360,12 +349,12 @@ bcnt_kernel:
 ; s_not_b32 writes SCC and s_cmov_b32 reads it. The thirteen opcodes here that
 ; leave SCC alone all run in between, so the select still taking the bit
 ; s_not_b32 produced is what says none of them touched it on the way.
-; SCC-LABEL: define amdgpu_kernel void @scc_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @scc_kernel(
 scc_kernel:
 ; The value s_cmov_b32 preserves when SCC is clear.
 	s_mov_b32 s2, 7
-; SCC: [[NOT:%.+]] = xor i32 {{.+}}, -1
-; SCC: [[BIT:%.+]] = icmp ne i32 [[NOT]], 0
+; CHECK: [[NOT:%.+]] = xor i32 {{.+}}, -1
+; CHECK: [[BIT:%.+]] = icmp ne i32 [[NOT]], 0
 	s_not_b32 s0, s1
 	s_ctz_i32_b32 s3, s0
 	s_ctz_i32_b64 s3, s[0:1]
@@ -380,9 +369,9 @@ scc_kernel:
 	s_bitset0_b64 s[4:5], s0
 	s_bitset1_b64 s[4:5], s0
 	s_bitreplicate_b64_b32 s[6:7], s0
-; SCC: [[MOVED:%.+]] = select i1 [[BIT]], i32 {{.+}}, i32 7
+; CHECK: [[MOVED:%.+]] = select i1 [[BIT]], i32 {{.+}}, i32 7
 	s_cmov_b32 s2, s3
-; SCC: uitofp i32 [[MOVED]] to float
+; CHECK: uitofp i32 [[MOVED]] to float
 	s_cvt_f32_u32 s30, s2
 	s_endpgm
 

--- a/amd/comgr/test-lit/hotswap/raiser/sop1_moves_scc.s
+++ b/amd/comgr/test-lit/hotswap/raiser/sop1_moves_scc.s
@@ -3,39 +3,28 @@
 ; RUN: %llvm-mc -triple=amdgpu9.42-amd-amdhsa -filetype=obj %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=sop1_moves_kernel | %FileCheck %s
+; RUN: %hotswap_transpile_cli %t.hsaco \
+; RUN:   --emit-ir=sop1_moves_kernel,special_dst_kernel,literal_kernel \
+; RUN:   --emit-ir=cmov_undef_kernel \
+; RUN:   | %FileCheck %s
 ; CHECK-LABEL: define amdgpu_kernel void @sop1_moves_kernel(
 
 ; A register nothing reads again holds a dead store, so the kernels below read
 ; each destination back through a bit reversal to keep the value in the lifted
 ; IR, and the checks look at what the reversal is handed.
 
-; A destination outside the general-purpose registers reaches its own slot.
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=special_dst_kernel \
-; RUN:   | %FileCheck %s --check-prefix=SPECIAL
-
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=literal_kernel \
-; RUN:   | %FileCheck %s --check-prefix=LITERAL
-
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=cmov_undef_kernel \
-; RUN:   | %FileCheck %s --check-prefix=CMOVUNDEF
-
-; A SOP1 opcode the handler does not lift is refused, not mislowered.
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=rfe_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=UNHANDLED
-; UNHANDLED: unsupported-instruction-form: s_rfe_b64
-
-; A register the raiser does not model is refused when the move writes it.
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=bad_dst_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=BADDST
-; BADDST:      unsupported-instruction-form: s_mov_b32
-; BADDST-SAME: register-decode: unsupported register 'XNACK_MASK_LO'
-
-; And when the move reads it.
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=bad_src_kernel 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=BADSRC
-; BADSRC:      unsupported-instruction-form: s_mov_b32
-; BADSRC-SAME: register-decode: unsupported register 'XNACK_MASK_LO'
+; A SOP1 opcode the handler does not lift is refused, not mislowered, and so is
+; a register the raiser does not model, whether the move writes it or reads it.
+; RUN: not %hotswap_transpile_cli %t.hsaco \
+; RUN:   --emit-ir=rfe_kernel,bad_dst_kernel,bad_src_kernel 2>&1 \
+; RUN:   | %FileCheck %s --check-prefix=REFUSE
+; REFUSE:      unsupported-instruction-form: s_rfe_b64
+; REFUSE:      unsupported-instruction-form: s_mov_b32
+; REFUSE-SAME: in kernel 'bad_dst_kernel'
+; REFUSE-SAME: register-decode: unsupported register 'XNACK_MASK_LO'
+; REFUSE:      unsupported-instruction-form: s_mov_b32
+; REFUSE-SAME: in kernel 'bad_src_kernel'
+; REFUSE-SAME: register-decode: unsupported register 'XNACK_MASK_LO'
 
 	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
 	.amdhsa_code_object_version 6
@@ -86,90 +75,91 @@ sop1_moves_kernel:
 	.p2align	8
 	.type	special_dst_kernel,@function
 special_dst_kernel:
-; SPECIAL-LABEL: define amdgpu_kernel void @special_dst_kernel(
+; A destination outside the general-purpose registers reaches its own slot.
+; CHECK-LABEL: define amdgpu_kernel void @special_dst_kernel(
 ; s0 is preloaded with the workgroup index, and reading M0 back hands the same
 ; value to the bit reversal.
-; SPECIAL: [[WGX:%.+]] = call i32 @llvm.amdgcn.workgroup.id.x()
+; CHECK: [[WGX:%.+]] = call i32 @llvm.amdgcn.workgroup.id.x()
 	s_mov_b32 m0, s0
 	s_mov_b32 s2, m0
-; SPECIAL: call i32 @llvm.bitreverse.i32(i32 [[WGX]])
+; CHECK: call i32 @llvm.bitreverse.i32(i32 [[WGX]])
 	s_brev_b32 s3, s2
 
 ; EXEC is stored at the wave width, and reading it back splits it into the two
 ; dword halves an SGPR pair holds.
 	s_mov_b64 exec, -1
 	s_mov_b64 s[4:5], exec
-; SPECIAL: [[EXECLO:%.+]] = trunc i64 -1 to i32
-; SPECIAL: [[EXECSHR:%.+]] = lshr i64 -1, 32
-; SPECIAL: [[EXECHI:%.+]] = trunc i64 [[EXECSHR]] to i32
+; CHECK: [[EXECLO:%.+]] = trunc i64 -1 to i32
+; CHECK: [[EXECSHR:%.+]] = lshr i64 -1, 32
+; CHECK: [[EXECHI:%.+]] = trunc i64 [[EXECSHR]] to i32
 	s_brev_b64 s[6:7], s[4:5]
 
 ; A VCC write is a per-lane bit, and reading VCC back reassembles the wave
 ; mask with a ballot.
 	s_mov_b32 vcc_lo, s0
 	s_mov_b32 s8, vcc_lo
-; SPECIAL: [[BALLOT:%.+]] = call i64 @llvm.amdgcn.ballot.i64(
-; SPECIAL: [[VCCLO:%.+]] = trunc i64 [[BALLOT]] to i32
-; SPECIAL: call i32 @llvm.bitreverse.i32(i32 [[VCCLO]])
+; CHECK: [[BALLOT:%.+]] = call i64 @llvm.amdgcn.ballot.i64(
+; CHECK: [[VCCLO:%.+]] = trunc i64 [[BALLOT]] to i32
+; CHECK: call i32 @llvm.bitreverse.i32(i32 [[VCCLO]])
 	s_brev_b32 s9, s8
 
 ; s_not_b64 reaches EXEC as well, and its SCC write is the 64-bit comparison.
 	s_not_b64 exec, exec
-; SPECIAL: [[NOTEXEC:%.+]] = xor i64 {{.+}}, -1
-; SPECIAL: icmp ne i64 [[NOTEXEC]], 0
+; CHECK: [[NOTEXEC:%.+]] = xor i64 {{.+}}, -1
+; CHECK: icmp ne i64 [[NOTEXEC]], 0
 	s_mov_b64 s[10:11], exec
-; SPECIAL: trunc i64 [[NOTEXEC]] to i32
+; CHECK: trunc i64 [[NOTEXEC]] to i32
 	s_brev_b64 s[12:13], s[10:11]
-; SPECIAL: ret void
+; CHECK: ret void
 	s_endpgm
 
 	.globl	literal_kernel
 	.p2align	8
 	.type	literal_kernel,@function
 literal_kernel:
-; LITERAL-LABEL: define amdgpu_kernel void @literal_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @literal_kernel(
 ; A 32-bit literal reaches the destination unchanged rather than truncated or
 ; re-signed: 0x12345678 is 305419896.
 	s_mov_b32 s0, 0x12345678
-; LITERAL: call i32 @llvm.bitreverse.i32(i32 305419896)
+; CHECK: call i32 @llvm.bitreverse.i32(i32 305419896)
 	s_brev_b32 s1, s0
 ; The 64-bit spelling of the same literal zero-extends into the high dword.
 	s_mov_b64 s[2:3], 0x12345678
-; LITERAL: [[LO:%.+]] = zext i32 305419896 to i64
-; LITERAL: [[HI:%.+]] = zext i32 0 to i64
-; LITERAL: [[SHL:%.+]] = shl i64 [[HI]], 32
-; LITERAL: [[JOIN:%.+]] = or i64 [[LO]], [[SHL]]
-; LITERAL: call i64 @llvm.bitreverse.i64(i64 [[JOIN]])
+; CHECK: [[LO:%.+]] = zext i32 305419896 to i64
+; CHECK: [[HI:%.+]] = zext i32 0 to i64
+; CHECK: [[SHL:%.+]] = shl i64 [[HI]], 32
+; CHECK: [[JOIN:%.+]] = or i64 [[LO]], [[SHL]]
+; CHECK: call i64 @llvm.bitreverse.i64(i64 [[JOIN]])
 	s_brev_b64 s[4:5], s[2:3]
-; LITERAL: ret void
+; CHECK: ret void
 	s_endpgm
 
 	.globl	cmov_undef_kernel
 	.p2align	8
 	.type	cmov_undef_kernel,@function
 cmov_undef_kernel:
-; CMOVUNDEF-LABEL: define amdgpu_kernel void @cmov_undef_kernel(
+; CHECK-LABEL: define amdgpu_kernel void @cmov_undef_kernel(
 ; s6 is never written before the move, so the value s_cmov_b32 preserves when
 ; SCC is clear is the undefined content of that register.
 	s_not_b32 s2, s2
-; CMOVUNDEF: [[NOT32:%.+]] = xor i32 undef, -1
-; CMOVUNDEF: [[SCC32:%.+]] = icmp ne i32 [[NOT32]], 0
+; CHECK: [[NOT32:%.+]] = xor i32 undef, -1
+; CHECK: [[SCC32:%.+]] = icmp ne i32 [[NOT32]], 0
 	s_cmov_b32 s6, s2
-; CMOVUNDEF: select i1 [[SCC32]], i32 [[NOT32]], i32 undef
+; CHECK: select i1 [[SCC32]], i32 [[NOT32]], i32 undef
 	s_brev_b32 s7, s6
 
 ; The 64-bit spelling reads both undefined dwords of the pair back.
 	s_not_b64 s[10:11], s[10:11]
-; CMOVUNDEF: [[NOT64:%.+]] = xor i64 {{.+}}, -1
-; CMOVUNDEF: [[SCC64:%.+]] = icmp ne i64 [[NOT64]], 0
+; CHECK: [[NOT64:%.+]] = xor i64 {{.+}}, -1
+; CHECK: [[SCC64:%.+]] = icmp ne i64 [[NOT64]], 0
 	s_cmov_b64 s[12:13], s[10:11]
-; CMOVUNDEF: [[KEEPLO:%.+]] = zext i32 undef to i64
-; CMOVUNDEF: [[KEEPHI:%.+]] = zext i32 undef to i64
-; CMOVUNDEF: [[KEEPSHL:%.+]] = shl i64 [[KEEPHI]], 32
-; CMOVUNDEF: [[KEEP:%.+]] = or i64 [[KEEPLO]], [[KEEPSHL]]
-; CMOVUNDEF: select i1 [[SCC64]], i64 {{.+}}, i64 [[KEEP]]
+; CHECK: [[KEEPLO:%.+]] = zext i32 undef to i64
+; CHECK: [[KEEPHI:%.+]] = zext i32 undef to i64
+; CHECK: [[KEEPSHL:%.+]] = shl i64 [[KEEPHI]], 32
+; CHECK: [[KEEP:%.+]] = or i64 [[KEEPLO]], [[KEEPSHL]]
+; CHECK: select i1 [[SCC64]], i64 {{.+}}, i64 [[KEEP]]
 	s_brev_b64 s[14:15], s[12:13]
-; CMOVUNDEF: ret void
+; CHECK: ret void
 	s_endpgm
 
 	.globl	rfe_kernel

--- a/amd/comgr/test-lit/hotswap/raiser/sop1_moves_wave32.s
+++ b/amd/comgr/test-lit/hotswap/raiser/sop1_moves_wave32.s
@@ -5,17 +5,9 @@
 ; RUN: %llvm-mc -triple=amdgpu12.50-amd-amdhsa -filetype=obj %s -o %t.o
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=literal64_kernel \
+; RUN: %hotswap_transpile_cli %t.hsaco \
+; RUN:   --emit-ir=literal64_kernel,exec_pair_kernel,vcc_pair_kernel \
 ; RUN:   | %FileCheck %s
-; CHECK-LABEL: define amdgpu_kernel void @literal64_kernel(
-
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=exec_pair_kernel \
-; RUN:   | %FileCheck %s --check-prefix=EXECPAIR
-; EXECPAIR-LABEL: define amdgpu_kernel void @exec_pair_kernel(
-
-; RUN: %hotswap_transpile_cli %t.hsaco --emit-ir=vcc_pair_kernel \
-; RUN:   | %FileCheck %s --check-prefix=VCCPAIR
-; VCCPAIR-LABEL: define amdgpu_kernel void @vcc_pair_kernel(
 
 	.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 	.amdhsa_code_object_version 6
@@ -24,6 +16,7 @@
 	.p2align	8
 	.type	literal64_kernel,@function
 literal64_kernel:
+; CHECK-LABEL: define amdgpu_kernel void @literal64_kernel(
 	s_mov_b64 s[0:1], 0x123456789abcdef
 ; Both halves of the literal reach the destination pair: 0x89abcdef read as a
 ; signed dword is -1985229329, and 0x01234567 is 19088743.
@@ -42,17 +35,18 @@ literal64_kernel:
 	.p2align	8
 	.type	exec_pair_kernel,@function
 exec_pair_kernel:
+; CHECK-LABEL: define amdgpu_kernel void @exec_pair_kernel(
 	s_mov_b32 s2, 0x1234
 	s_mov_b32 s3, -1
-; EXECPAIR: [[LO:%.+]] = zext i32 4660 to i64
-; EXECPAIR: [[HI:%.+]] = zext i32 -1 to i64
-; EXECPAIR: [[SHL:%.+]] = shl i64 [[HI]], 32
-; EXECPAIR: [[JOIN:%.+]] = or i64 [[LO]], [[SHL]]
-; EXECPAIR: [[MASK:%.+]] = trunc i64 [[JOIN]] to i32
+; CHECK: [[LO:%.+]] = zext i32 4660 to i64
+; CHECK: [[HI:%.+]] = zext i32 -1 to i64
+; CHECK: [[SHL:%.+]] = shl i64 [[HI]], 32
+; CHECK: [[JOIN:%.+]] = or i64 [[LO]], [[SHL]]
+; CHECK: [[MASK:%.+]] = trunc i64 [[JOIN]] to i32
 	s_mov_b64 exec, s[2:3]
-; EXECPAIR: call i32 @llvm.bitreverse.i32(i32 [[MASK]])
+; CHECK: call i32 @llvm.bitreverse.i32(i32 [[MASK]])
 	s_brev_b32 s0, exec_lo
-; EXECPAIR: ret void
+; CHECK: ret void
 	s_endpgm
 
 ; VCC is the other wave mask a pair can name, and it reads back the same way:
@@ -62,12 +56,13 @@ exec_pair_kernel:
 	.p2align	8
 	.type	vcc_pair_kernel,@function
 vcc_pair_kernel:
+; CHECK-LABEL: define amdgpu_kernel void @vcc_pair_kernel(
 	s_mov_b32 vcc_lo, 0x1234
-; VCCPAIR: [[BALLOT:%.+]] = call i32 @llvm.amdgcn.ballot.i32(
-; VCCPAIR: [[EXT:%.+]] = zext i32 [[BALLOT]] to i64
+; CHECK: [[BALLOT:%.+]] = call i32 @llvm.amdgcn.ballot.i32(
+; CHECK: [[EXT:%.+]] = zext i32 [[BALLOT]] to i64
 	s_mov_b64 s[0:1], vcc
 	s_brev_b64 s[2:3], s[0:1]
-; VCCPAIR: ret void
+; CHECK: ret void
 	s_endpgm
 
 	.section	.rodata,"a",@progbits

--- a/amd/comgr/test-lit/hotswap/raiser/sopp-gfx1250.s
+++ b/amd/comgr/test-lit/hotswap/raiser/sopp-gfx1250.s
@@ -6,12 +6,10 @@
 ; RUN:   --emit-ir=waits_kernel,sleep_kernel,monitor_sleep_kernel,wakeup_kernel \
 ; RUN:   --target-isa=gfx942 \
 ; RUN:   | %FileCheck %s --check-prefixes=GFX9,SLEEP,MONITOR-SLEEP,WAKEUP
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=setprio_kernel \
+; RUN: not %hotswap_transpile_cli %t.hsaco \
+; RUN:   --emit-ir=setprio_kernel,setprio_inc_wg_kernel \
 ; RUN:   --target-isa=gfx942 2>&1 \
 ; RUN:   | %FileCheck %s --check-prefix=PRIO-CROSS
-; RUN: not %hotswap_transpile_cli %t.hsaco --emit-ir=setprio_inc_wg_kernel \
-; RUN:   --target-isa=gfx942 2>&1 \
-; RUN:   | %FileCheck %s --check-prefix=PRIO-INC-CROSS
 
 	.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 	.amdhsa_code_object_version 6
@@ -67,7 +65,7 @@ setprio_kernel:
 	.type	setprio_inc_wg_kernel,@function
 
 setprio_inc_wg_kernel:
-; PRIO-INC-CROSS: unsupported-wave-priority: s_setprio_inc_wg [SOPP]
+; PRIO-CROSS: unsupported-wave-priority: s_setprio_inc_wg [SOPP]
 	s_setprio_inc_wg 1
 	s_endpgm
 

--- a/amd/comgr/test-lit/hotswap/raiser/vopc-integer-gfx1250.s
+++ b/amd/comgr/test-lit/hotswap/raiser/vopc-integer-gfx1250.s
@@ -4,10 +4,7 @@
 ; RUN: %ld.lld -shared %t.o -o %t.hsaco
 
 ; RUN: %hotswap_transpile_cli %t.hsaco --target-isa=gfx942 \
-; RUN:   --emit-ir=vopc_predicates | %FileCheck %s --check-prefix=PRED
-
-; RUN: %hotswap_transpile_cli %t.hsaco --target-isa=gfx942 \
-; RUN:   --emit-ir=vopc_exec_write | %FileCheck %s --check-prefix=EXEC
+; RUN:   --emit-ir=vopc_predicates,vopc_exec_write | %FileCheck %s
 
 ; RUN: not %hotswap_transpile_cli %t.hsaco --target-isa=gfx942 \
 ; RUN:   --emit-ir=vopc_vop3_encoding 2>&1 \
@@ -20,57 +17,57 @@
 	.globl	vopc_predicates
 	.p2align	8
 	.type	vopc_predicates,@function
-; PRED-LABEL: define amdgpu_kernel void @vopc_predicates(
+; CHECK-LABEL: define amdgpu_kernel void @vopc_predicates(
 vopc_predicates:
-; PRED: icmp slt i32
+; CHECK: icmp slt i32
 	v_cmp_lt_i32_e32 vcc_lo, v0, v1
-; PRED: icmp eq i32
+; CHECK: icmp eq i32
 	v_cmp_eq_i32_e32 vcc_lo, v0, v1
-; PRED: icmp sle i32
+; CHECK: icmp sle i32
 	v_cmp_le_i32_e32 vcc_lo, v0, v1
-; PRED: icmp sgt i32
+; CHECK: icmp sgt i32
 	v_cmp_gt_i32_e32 vcc_lo, v0, v1
-; PRED: icmp ne i32
+; CHECK: icmp ne i32
 	v_cmp_ne_i32_e32 vcc_lo, v0, v1
-; PRED: icmp sge i32
+; CHECK: icmp sge i32
 	v_cmp_ge_i32_e32 vcc_lo, v0, v1
-; PRED: icmp ult i32
+; CHECK: icmp ult i32
 	v_cmp_lt_u32_e32 vcc_lo, v0, v1
-; PRED: icmp eq i32
+; CHECK: icmp eq i32
 	v_cmp_eq_u32_e32 vcc_lo, v0, v1
-; PRED: icmp ule i32
+; CHECK: icmp ule i32
 	v_cmp_le_u32_e32 vcc_lo, v0, v1
-; PRED: icmp ugt i32
+; CHECK: icmp ugt i32
 	v_cmp_gt_u32_e32 vcc_lo, v0, v1
-; PRED: icmp ne i32
+; CHECK: icmp ne i32
 	v_cmp_ne_u32_e32 vcc_lo, v0, v1
-; PRED: icmp uge i32
+; CHECK: icmp uge i32
 	v_cmp_ge_u32_e32 vcc_lo, v0, v1
-; PRED: ret void
+; CHECK: ret void
 	s_endpgm
 
 	.globl	vopc_exec_write
 	.p2align	8
 	.type	vopc_exec_write,@function
-; EXEC-LABEL: define amdgpu_kernel void @vopc_exec_write(
+; CHECK-LABEL: define amdgpu_kernel void @vopc_exec_write(
 vopc_exec_write:
 ; The comparison reaches EXEC as a wave-level ballot, taken at the width of the
 ; wave the gfx1250 source believes it runs on and so narrowed from the gfx942
 ; target ballot, and ANDed into the EXEC the raiser is tracking.
-; EXEC: [[CMP:%.+]] = icmp sgt i32 {{.+}}, {{.+}}
-; EXEC: [[BALLOT:%.+]] = call i64 @llvm.amdgcn.ballot.i64(i1 [[CMP]])
-; EXEC: [[MASK:%.+]] = trunc i64 [[BALLOT]] to i32
-; EXEC: [[NARROWED:%.+]] = and i32 -1, [[MASK]]
+; CHECK: [[CMP:%.+]] = icmp sgt i32 {{.+}}, {{.+}}
+; CHECK: [[BALLOT:%.+]] = call i64 @llvm.amdgcn.ballot.i64(i1 [[CMP]])
+; CHECK: [[MASK:%.+]] = trunc i64 [[BALLOT]] to i32
+; CHECK: [[NARROWED:%.+]] = and i32 -1, [[MASK]]
 	v_cmpx_gt_i32_e32 v0, v1
 ; The vector write that follows is predicated on the narrowed EXEC, which is
 ; what makes the store observable: the lane-active bit is recomputed from it
 ; rather than from the EXEC in force before the comparison.
-; EXEC: [[LANE:%.+]] = lshr i32 [[NARROWED]], {{.+}}
-; EXEC: [[BIT:%.+]] = and i32 [[LANE]], 1
-; EXEC: [[ACTIVE:%.+]] = icmp ne i32 [[BIT]], 0
-; EXEC: br i1 [[ACTIVE]]
+; CHECK: [[LANE:%.+]] = lshr i32 [[NARROWED]], {{.+}}
+; CHECK: [[BIT:%.+]] = and i32 [[LANE]], 1
+; CHECK: [[ACTIVE:%.+]] = icmp ne i32 [[BIT]], 0
+; CHECK: br i1 [[ACTIVE]]
 	v_add_f32_e32 v2, v0, v1
-; EXEC: ret void
+; CHECK: ret void
 	s_endpgm
 
 	.globl	vopc_vop3_encoding


### PR DESCRIPTION
The raiser lit fixtures name one kernel per hotswap_transpile_cli invocation, which grows a column of near-identical command lines down each header. Merging them leaves one run per outcome, taking eleven fixtures from about seventy invocations to twenty-eight, movrel.s alone from 20 to 3.

--emit-ir=k1,k2,... raises a selection into one module in command-line order and CHECK-LABEL partitions the merged stream, so the kernels a fixture raises share a run. Two driver changes cover the refusals too: a failed batch retries the kernels one at a time so every refusal is reported rather than the first, and the mode options accumulate across occurrences so a long selection splits over several of them. Runs naming a different ISA stay separate, as do a fixture's successes and its refusals.