### PR TITLE
[DWARF][NFC] Remove duplicate getMemorySpace declaration

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -1139,11 +1139,10 @@ LLVM_ABI unsigned getSubOperationEncoding(unsigned OpEncoding,
 LLVM_ABI unsigned getVirtuality(StringRef VirtualityString);
 LLVM_ABI unsigned getEnumKind(StringRef EnumKindString);
 LLVM_ABI unsigned getLanguage(StringRef LanguageString);
-LLVM_ABI unsigned getMemorySpace(StringRef LanguageString);
+LLVM_ABI unsigned getMemorySpace(StringRef MSString);
 LLVM_ABI unsigned getSourceLanguageName(StringRef SourceLanguageNameString);
 LLVM_ABI unsigned getLanguageDialect(StringRef LanguageDialectString);
 LLVM_ABI unsigned getCallingConvention(StringRef LanguageString);
-LLVM_ABI unsigned getMemorySpace(StringRef LanguageString);
 LLVM_ABI unsigned getAttributeEncoding(StringRef EncodingString);
 LLVM_ABI unsigned getMacinfo(StringRef MacinfoString);
 LLVM_ABI unsigned getMacro(StringRef MacroString);

--- a/llvm/lib/BinaryFormat/Dwarf.cpp
+++ b/llvm/lib/BinaryFormat/Dwarf.cpp
@@ -1089,8 +1089,8 @@ StringRef llvm::dwarf::RLEString(unsigned RLE) {
   }
 }
 
-unsigned llvm::dwarf::getMemorySpace(StringRef CCString) {
-  return StringSwitch<unsigned>(CCString)
+unsigned llvm::dwarf::getMemorySpace(StringRef MSString) {
+  return StringSwitch<unsigned>(MSString)
 #define HANDLE_DW_MSPACE(ID, NAME)                                             \
   .Case("DW_MSPACE_LLVM_" #NAME, DW_MSPACE_LLVM_##NAME)
 #include "llvm/BinaryFormat/Dwarf.def"


### PR DESCRIPTION
getMemorySpace was declared twice in Dwarf.h, and the parameter was named
LanguageString in the header and CCString in the definition, both
copy-paste artifacts from the neighbouring getLanguage and
getCallingConvention declarations. Keep one declaration and name the
parameter consistently.

This also matches the spelling proposed upstream in the patch adding the
DW_MSPACE_LLVM_* encodings, so the file converges when that lands.