### PR TITLE
[Comgr][hotswap] Ask the projection for the source wave size

### DIFF
--- a/amd/comgr/src/hotswap/raiser/reg-file.cpp
+++ b/amd/comgr/src/hotswap/raiser/reg-file.cpp
@@ -532,7 +532,7 @@ void AllocaRegFile::writeReg64(IRBuilder<> &B, ParsedReg Pr, Value *V) {
     // lands the way a write to EXEC_LO does: narrowed to the EXEC storage
     // width the projection chose, and subject to its policy for a narrow
     // write. A wave64 source writes the mask whole.
-    if (Projection->sourceIsa().isWave32()) {
+    if (Projection->sourceWaveSize() == 32) {
       ParsedReg ExecLo = Pr;
       ExecLo.WidthInDwords = 1;
       ExecLo.BaseIdx = 0;


### PR DESCRIPTION
The 64-bit EXEC write asks the projection whether the source is wave32 through
an accessor the projection no longer has: exposing the MC subtarget info
directly replaced `sourceIsa()` with the subtarget references and the two
wave-size accessors, and this caller was left behind.

Nothing that builds comgr with the transpiler enabled compiles today, on either
Linux or Windows, so this blocks every pull request targeting `amd-staging`.

The narrow-write check next to it already reads `sourceWaveSize()`, so this one
reads it the same way.

### Verification

`amd-staging` on its own fails to build `hotswap-raiser`; with this change the
hotswap object libraries build clean. `git clang-format` clean.