### PR TITLE
[Comgr][hotswap] Fix the raiser's wave32 EXEC check after the ISA profile removal

### DIFF
--- a/amd/comgr/src/hotswap/raiser/reg-file.cpp
+++ b/amd/comgr/src/hotswap/raiser/reg-file.cpp
@@ -532,7 +532,7 @@ void AllocaRegFile::writeReg64(IRBuilder<> &B, ParsedReg Pr, Value *V) {
     // lands the way a write to EXEC_LO does: narrowed to the EXEC storage
     // width the projection chose, and subject to its policy for a narrow
     // write. A wave64 source writes the mask whole.
-    if (Projection->sourceIsa().isWave32()) {
+    if (Projection->sourceWaveSize() == 32) {
       ParsedReg ExecLo = Pr;
       ExecLo.WidthInDwords = 1;
       ExecLo.BaseIdx = 0;


### PR DESCRIPTION
`amd-staging` does not build with `-DCOMGR_ENABLE_HOTSWAP_TRANSPILE=ON`:

```
amd/comgr/src/hotswap/raiser/reg-file.cpp:535:21: error:
  'const class COMGR::hotswap::WaveProjection' has no member named 'sourceIsa'
  535 |     if (Projection->sourceIsa().isWave32()) {
      |                     ^~~~~~~~~
```

This is a semantic conflict between two changes that merged cleanly:

- #4210 (2026-09-02) removed `WaveProjection::sourceIsa()` and `targetIsa()`, replacing the `ISAProfile` accessors with the `SourceSTI` / `TargetSTI` subtarget references.
- #4074 (2026-09-03) was written before that landed and calls `Projection->sourceIsa().isWave32()` in `writeReg64(EXEC)`.

Different files, no overlapping hunks, so there was nothing for git to flag.

The fix asks `sourceWaveSize() == 32` instead. That is the form the rest of the raiser already uses for this question — see `raise-context.cpp:126` and `register-state.cpp:249`, `:265`, `:694` — and it resolves to the same `FeatureWavefrontSize32` query the old `ISAProfile::isWave32` performed, so behavior is unchanged.

Worth noting for anyone tracking the breakage: this is not specific to any one merge PR. It reproduces on `amd-staging` at 2be02040578a directly. It went unnoticed because `COMGR_ENABLE_HOTSWAP_TRANSPILE` is off by default, so a default comgr build never compiles `reg-file.cpp`.

Verified at 2be02040578a with the option on: comgr builds clean, and the lit suite is 217 passed / 13 unsupported / 1 expectedly failed. The XFAIL is `hotswap/rewriter/hotswap-barrier-isfirst.s`, which is unrelated and addressed in #4270.
