### PR TITLE
[Comgr][hotswap] Centralize width-selected source reads

### DIFF
--- a/amd/comgr/src/hotswap/raiser/handle-sop1.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-sop1.cpp
@@ -18,11 +18,6 @@ using namespace llvm;
 
 namespace COMGR::hotswap {
 
-// Read source 0 at the width the opcode operates on.
-static Expected<Value *> readSrc0(OperandResolver &Op, bool Is64) {
-  return Is64 ? Op.src64(0) : Op.src(0);
-}
-
 // Write V to Dst at the width the opcode operates on.
 static void writeDst(RegisterState &Registers, ParsedReg Dst, Value *V,
                      bool Is64) {
@@ -251,7 +246,7 @@ Error handleSOP1(RaiseContext &Ctx, const DecodedInst &Di,
     Expected<ParsedReg> Dst = Op.dst();
     if (!Dst)
       return Dst.takeError();
-    Expected<Value *> Src = readSrc0(Op, Is64);
+    Expected<Value *> Src = Op.src(0, Is64);
     if (!Src)
       return Src.takeError();
     writeDst(Ctx.registers(), *Dst, *Src, Is64);
@@ -264,7 +259,7 @@ Error handleSOP1(RaiseContext &Ctx, const DecodedInst &Di,
     Expected<ParsedReg> Dst = Op.dst();
     if (!Dst)
       return Dst.takeError();
-    Expected<Value *> Src = readSrc0(Op, Is64);
+    Expected<Value *> Src = Op.src(0, Is64);
     if (!Src)
       return Src.takeError();
     Value *Reversed = Ctx.B.CreateUnaryIntrinsic(Intrinsic::bitreverse, *Src,
@@ -279,7 +274,7 @@ Error handleSOP1(RaiseContext &Ctx, const DecodedInst &Di,
     Expected<ParsedReg> Dst = Op.dst();
     if (!Dst)
       return Dst.takeError();
-    Expected<Value *> Src = readSrc0(Op, Is64);
+    Expected<Value *> Src = Op.src(0, Is64);
     if (!Src)
       return Src.takeError();
     Value *Result = Ctx.B.CreateNot(*Src, "s_not");
@@ -298,7 +293,7 @@ Error handleSOP1(RaiseContext &Ctx, const DecodedInst &Di,
     Expected<ParsedReg> Dst = Op.dst();
     if (!Dst)
       return Dst.takeError();
-    Expected<Value *> Src = readSrc0(Op, Is64);
+    Expected<Value *> Src = Op.src(0, Is64);
     if (!Src)
       return Src.takeError();
     Expected<Value *> Old = Is64 ? Op.dstValue64() : Op.dstValue();

--- a/amd/comgr/src/hotswap/raiser/handle-sop1.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-sop1.cpp
@@ -383,7 +383,7 @@ Error handleSOP1(RaiseContext &Ctx, const DecodedInst &Di,
     Expected<ParsedReg> Dst = Op.dst();
     if (!Dst)
       return Dst.takeError();
-    Expected<Value *> Src = readSrc0(Op, Search->Is64);
+    Expected<Value *> Src = Op.src(0, Search->Is64);
     if (!Src)
       return Src.takeError();
     Ctx.registers().writeReg32(*Dst, emitBitSearch(Ctx.B, *Search, *Src));
@@ -487,7 +487,7 @@ Error handleSOP1(RaiseContext &Ctx, const DecodedInst &Di,
     Expected<ParsedReg> Dst = Op.dst();
     if (!Dst)
       return Dst.takeError();
-    Expected<Value *> Src = readSrc0(Op, Is64);
+    Expected<Value *> Src = Op.src(0, Is64);
     if (!Src)
       return Src.takeError();
     Value *Counted = CountsZeros ? Ctx.B.CreateNot(*Src, "s_bcnt0_bits") : *Src;

--- a/amd/comgr/src/hotswap/raiser/handle-vop3.cpp
+++ b/amd/comgr/src/hotswap/raiser/handle-vop3.cpp
@@ -72,11 +72,6 @@ Error requireNoIntegerSourceModifiers(RaiseContext &Ctx, const DecodedInst &Di,
   return Error::success();
 }
 
-/// Read source I at the width selected by Is64.
-Expected<Value *> readSrc(OperandResolver &Op, unsigned I, bool Is64) {
-  return Is64 ? Op.src64(I) : Op.src(I);
-}
-
 /// Raise a wrapping binary integer operation at the selected width.
 Error handleBinary(RaiseContext &Ctx, OperandResolver &Op,
                    Instruction::BinaryOps Opcode, bool Is64,
@@ -84,10 +79,10 @@ Error handleBinary(RaiseContext &Ctx, OperandResolver &Op,
   Expected<ParsedReg> Dst = Op.dst();
   if (!Dst)
     return Dst.takeError();
-  Expected<Value *> Src0 = readSrc(Op, 0, Is64);
+  Expected<Value *> Src0 = Op.src(0, Is64);
   if (!Src0)
     return Src0.takeError();
-  Expected<Value *> Src1 = readSrc(Op, 1, Is64);
+  Expected<Value *> Src1 = Op.src(1, Is64);
   if (!Src1)
     return Src1.takeError();
   Value *Lhs = Reverse ? *Src1 : *Src0;
@@ -745,10 +740,10 @@ Error handleVOP3(RaiseContext &Ctx, const DecodedInst &Di,
     Expected<ParsedReg> Dst = Op.dst();
     if (!Dst)
       return Dst.takeError();
-    Expected<Value *> Src0 = readSrc(Op, 0, Is64);
+    Expected<Value *> Src0 = Op.src(0, Is64);
     if (!Src0)
       return Src0.takeError();
-    Expected<Value *> Src1 = readSrc(Op, 1, Is64);
+    Expected<Value *> Src1 = Op.src(1, Is64);
     if (!Src1)
       return Src1.takeError();
     Intrinsic::ID Saturating =

--- a/amd/comgr/src/hotswap/raiser/operand-resolver.h
+++ b/amd/comgr/src/hotswap/raiser/operand-resolver.h
@@ -74,6 +74,10 @@ struct OperandResolver {
   llvm::Expected<llvm::Value *> src64(unsigned I) {
     return Ctx.registers().readOp64(Di, srcIdx(I));
   }
+  // Read the I-th source at the width selected by Is64.
+  llvm::Expected<llvm::Value *> src(unsigned I, bool Is64) {
+    return Is64 ? src64(I) : src(I);
+  }
   // Read the I-th source as a wave mask at target EXEC width.
   llvm::Expected<llvm::Value *> srcExecWidth(unsigned I) {
     return Ctx.registers().readOpExecWidth(Di, srcIdx(I));


### PR DESCRIPTION
Addresses:

> This is not the first time I see this, can we just fold this into the resolver once and for all? (separate patch)

_Originally posted by @ftynse in https://github.com/ROCm/llvm-project/pull/4234#discussion_r3924755928_
            