### PR TITLE
[ci] bisection test commit (clang lit)

### DIFF
--- a/clang/test/Misc/cci-bisect-merge-inner.c
+++ b/clang/test/Misc/cci-bisect-merge-inner.c
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -fsyntax-only %s
+
+// cci-bisect exercise inner commit 1/4: passing Clang lit test.
+int cci_bisect_merge_inner(void) { return 0; }

--- a/clang/test/Misc/cci-bisect-merge-inner.c
+++ b/clang/test/Misc/cci-bisect-merge-inner.c
@@ -4,4 +4,5 @@
 // cci-bisect exercise inner commit 1/4: passing Clang lit test.
 // cci-bisect exercise inner commit 2/4: harmless marker.
 // cci-bisect exercise inner commit 3/4: intentional Clang lit failure.
+// cci-bisect exercise inner commit 4/4: harmless marker after the failure.
 int cci_bisect_merge_inner(void) { return 0; }

--- a/clang/test/Misc/cci-bisect-merge-inner.c
+++ b/clang/test/Misc/cci-bisect-merge-inner.c
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only %s
+// RUN: false
 
 // cci-bisect exercise inner commit 1/4: passing Clang lit test.
 // cci-bisect exercise inner commit 2/4: harmless marker.
+// cci-bisect exercise inner commit 3/4: intentional Clang lit failure.
 int cci_bisect_merge_inner(void) { return 0; }

--- a/clang/test/Misc/cci-bisect-merge-inner.c
+++ b/clang/test/Misc/cci-bisect-merge-inner.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only %s
 
 // cci-bisect exercise inner commit 1/4: passing Clang lit test.
+// cci-bisect exercise inner commit 2/4: harmless marker.
 int cci_bisect_merge_inner(void) { return 0; }


### PR DESCRIPTION
## Bisection experiment

This is an intentional merge-inner bisection exercise. Do not merge.

The branch contains four inner commits:

1. Add a passing Clang lit test
2. Add a harmless marker
3. Add an intentional failing `RUN: false` directive
4. Add another harmless marker

Expected CI behavior:

- compiler-runtime build succeeds
- `Clang Lit Tests` fails on `clang/test/Misc/cci-bisect-merge-inner.c`
- merge-inner bisection identifies `b6dbba5174f8` as the first bad inner commit

The failure is deliberate and limited to this test file.