### PR TITLE
[DO NOT REVIEW][DO NOT MERGE][AMDGPU] Experiment with early loop fusion by default

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -323,6 +323,10 @@ static cl::opt<bool> EnableDevirtualizeSpeculatively(
     cl::desc("Enable speculative devirtualization optimization"),
     cl::init(false));
 
+static cl::opt<bool> EnableAMDGPUEarlyLoopFusion(
+  "amdgpu-enable-early-loop-fusion", cl::Hidden, cl::init(true),
+  cl::desc("Enable early loop fusion in the AMDGPU optimization pipeline"));
+
 extern cl::opt<std::string> UseCtxProfile;
 extern cl::opt<bool> PGOInstrumentColdFunctionOnly;
 
@@ -772,6 +776,8 @@ PassBuilder::buildFunctionSimplificationPipeline(OptimizationLevel Level,
   FPM.addPass(
       SimplifyCFGPass(SimplifyCFGOptions().convertSwitchRangeToICmp(true)));
   FPM.addPass(InstCombinePass());
+  if (TM && TM->getTargetTriple().isAMDGCN() && EnableAMDGPUEarlyLoopFusion)
+    FPM.addPass(LoopFusePass());
   // The loop passes in LPM2 (LoopIdiomRecognizePass, IndVarSimplifyPass,
   // LoopDeletionPass and LoopFullUnrollPass) do not preserve MemorySSA.
   // *All* loop passes must preserve it, in order to be able to use it.


### PR DESCRIPTION
[AMDGPU] Experiment with early loop fusion by default

Run LoopFusePass before the early full-unroll pipeline for AMDGCN targets. Keep the existing late opt-in invocation and provide amdgpu-enable-early-loop-fusion=false as an experimental opt-out.