### PR TITLE
[AMDGPU][Disassembler] Remove `Object` component library

### DIFF
--- a/llvm/lib/Target/AMDGPU/Disassembler/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/Disassembler/CMakeLists.txt
@@ -10,7 +10,6 @@ add_llvm_component_library(LLVMAMDGPUDisassembler
   CodeGenTypes
   MC
   MCDisassembler
-  Object
   TargetParser
   Support
 


### PR DESCRIPTION
This was originally in place for the HSA code-object parser `Disassembler/CodeObject.cpp`, which has since been removed.

Part of effort to converge with upstream.


