### PR TITLE
[clang][OpenMP] Fix indentation in emitTargetParallelGenericLoopRegion

### DIFF
--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -9075,8 +9075,8 @@ void CodeGenFunction::EmitOMPTargetTeamsGenericLoopDeviceFunction(
 }
 
 static void emitTargetParallelGenericLoopRegion(
-  CodeGenFunction &CGF, const OMPTargetParallelGenericLoopDirective &S,
-  PrePostActionTy &Action) {
+    CodeGenFunction &CGF, const OMPTargetParallelGenericLoopDirective &S,
+    PrePostActionTy &Action) {
   Action.Enter(CGF);
   // Emit as 'parallel for'.
   auto &&CodeGen = [&S](CodeGenFunction &CGF, PrePostActionTy &Action) {


### PR DESCRIPTION
Re-indent the parameter continuation lines to 4 spaces to match upstream llvm-project/main. This is a whitespace-only change that eliminates the last divergent lines attributed to 7c2f245bc1fb, whose functional content was already upstreamed.


