### PR TITLE
[clang][OpenMP] Remove stale downstream comment on EmitOMPGenericLoop…

### DIFF
--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -8878,11 +8878,6 @@ void CodeGenFunction::EmitOMPTargetUpdateDirective(
   CGM.getOpenMPRuntime().emitTargetDataStandAloneCall(*this, S, IfCond, Device);
 }
 
-/// A 'loop' construct is supposed to be a work distribution construct by
-/// default unless its binding region is the innermost enclosing parallel
-/// region, in which case it is a worksharing region. Because we currently
-/// have no way to know if this is true at compile time, for now emit them
-/// as inlined loops.
 void CodeGenFunction::EmitOMPGenericLoopDirective(
     const OMPGenericLoopDirective &S) {
   // Always expect a bind clause on the loop directive. It it wasn't


### PR DESCRIPTION
…Directive

Drop the downstream-only doc comment above EmitOMPGenericLoopDirective. The codegen (emit 'loop' as an inlined directive) matches upstream llvm-project/main exactly; the comment described interim behavior that is now the settled upstream behavior. This eliminates the last divergent line attributed to f3df927f932a.


