### PR TITLE
[Divergence] unify up/down on clang/lib/Driver/ToolChains/Clang.cpp

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8435,15 +8435,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   // be added so both IR can be captured.
   if ((C.getDriver().isSaveTempsEnabled() ||
        JA.isHostOffloading(Action::OFK_OpenMP)) &&
-      !(C.getDriver().embedBitcodeInObject() && !getToolChain().isUsingLTO(Args)) &&
-      isa<CompileJobAction>(JA)) {
-    // We do not want to disable llvm opt passes if we are offloading
-    // amdgpu openmp code, and -save-temps is specified.
-    // We want the same opt passes run regardless of setting -save-temps.
-    if (!(Triple.isAMDGCN() && C.getDriver().isSaveTempsEnabled() &&
-          JA.getOffloadingDeviceKind() == Action::OFK_OpenMP))
-      CmdArgs.push_back("-disable-llvm-passes");
-  }
+      !(C.getDriver().embedBitcodeInObject() && !IsUsingLTO) &&
+      isa<CompileJobAction>(JA))
+    CmdArgs.push_back("-disable-llvm-passes");
 
   Args.AddAllArgs(CmdArgs, options::OPT_undef);
 


### PR DESCRIPTION
cleaning up commit 7f1dfb959

    make bc files for amdgcn target the same regardless of presence of -save-temps


