### PR TITLE
[clang][Headers] Remove dead __cplusplus wrapper from llvm_libc_wrappers/string.h

### DIFF
--- a/clang/lib/Headers/llvm_libc_wrappers/string.h
+++ b/clang/lib/Headers/llvm_libc_wrappers/string.h
@@ -16,21 +16,6 @@
 
 #include_next <string.h>
 
-// The GNU headers provide non C-standard headers when in C++ mode. Manually
-// undefine it here so that the definitions agree with the C standard for our
-// purposes.
-#ifdef __cplusplus
-extern "C" {
-#pragma push_macro("__cplusplus")
-#undef __cplusplus
-#endif
-
-
-#pragma pop_macro("__cplusplus")
-#ifdef __cplusplus
-}
-#endif
-
 #if defined(__HIP__) || defined(__CUDA__) || defined(__SPIRV__)
 #define __LIBC_ATTRS __attribute__((device))
 #else


### PR DESCRIPTION
The extern \"C\" block that undefines __cplusplus wraps nothing: the
declarations it was meant to guard are no longer in this header, leaving
only blank lines between the push_macro and pop_macro.
It is also unbalanced. The push_macro is guarded by #ifdef __cplusplus but
the pop_macro is not, so including this header from C warns:
  pragma pop_macro could not pop '__cplusplus', no matching push_macro
Removing it makes the file identical to upstream.